### PR TITLE
Initial upstreaming of type aware allocator support

### DIFF
--- a/clang/docs/TypedMemoryOperations.rst
+++ b/clang/docs/TypedMemoryOperations.rst
@@ -1,0 +1,240 @@
+=======================
+Typed Memory Operations
+=======================
+
+.. contents::
+   :local:
+
+Introduction
+------------
+
+Typed memory operations provide a mechanism to support type isolating allocators
+even in type free C allocation APIs. There are four basic parts to this
+
+* An attribute used to indicate that a function is a typed memory operation, e.g.
+  an allocation function that is supported by a type isolating allocator.
+* An inference step to infer the actual type of the data the allocation is
+  expected to contain.
+* A type encoding mechanism to compress the inferred type into a representation
+  that the allocator can use. The current implementation only supports a single
+  model: the `type_descriptor`
+* The code generation phase which re-writes the call as written in code, into a
+  call to a specified type aware version of the target function and place the
+  additional type parameter.
+
+This allows even system allocation functions (like malloc, and similar) to be
+annotated in a way that permits automatic, transparent, and code-change free (in
+the general case) migration of existing C code to type isolating allocation.
+
+Using function agnostic attributes results in the functionality being generally
+available to user provided custom allocators as well: fully custom allocators
+can introduce type aware interfaces without requiring manual user adoption, and
+code that uses wrappers around allocators can also add type aware interfaces
+that can forward the type information to their underlying allocators, without
+depending on implicit knowledge by the compiler.
+
+
+``typed_memory_operation`` attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The core developer facing component of TMO is the `typed_memory_operation`
+function attribute. This attribute specifies the expression that should be used
+to infer the allocation type, and the function that should be used as the
+re-write target.
+
+The `typed_memory_operation` attribute has two parameters - the first is the
+1-based index of the size argument from which the allocation type should be
+inferred. The second parameter is the name of the type aware allocation function
+that will be called instead.
+
+The attribute can then be used as follows:
+
+.. code-block:: c
+
+  void *typed_malloc(size_t size, type_descriptor_t type);
+  void *malloc(size_t size) __attribute__((typed_memory_operation(1, typed_malloc)))
+
+This will result in the allocation of a call to `malloc` having a type inferred
+from the `size` argument, and the call being rewritten to `typed_malloc`. e.g.
+
+.. code-block:: c
+
+  malloc(sizeof(T));
+
+Gets emitted as a call to `typed_malloc`
+
+.. code-block:: c
+
+  typed_malloc(sizeof(T), [[type descriptor]]);
+
+When re-writing a type aware allocation the type information is passed as an
+inserted parameter following the inference target expression.
+
+.. code-block:: c
+
+  void *typed_custom_alloc(size_t size, context_t* ctx, type_descriptor_t type);
+  void *custom_alloc(size_t size, context_t* ctx)
+    __attribute__((typed_memory_operation(1, typed_custom_alloc)))
+  // ...
+  custom_alloc(sizeof(T), &context);
+
+results in a call to `typed_custom_alloc`
+
+.. code-block:: c
+
+  typed_custom_alloc(sizeof(T), [[type descriptor]], ctx);
+
+This design is intended to allow future support for functions with multiple
+inference targets.
+
+``__builtin_tmo_get_type_descriptor``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the primary attribute the `__builtin_tmo_get_type_descriptor`
+provides a mechanism to get the type descriptor for a known type. This makes it
+possible for developers to avoid trying to construct an expression that will
+infer the correct type when they already have full knowledge (as can occur with
+allocator macros, or C++ type aware allocators).
+
+.. code-block:: c
+
+  __builtin_tmo_get_type_descriptor(type)
+
+Computes the type descriptor for the given type such that the encoded type
+matches the type descriptor that would be produced by the inference pass.
+
+Type inference
+--------------
+
+Type inference is the most critical component of this feature as it is
+responsible for the core functional requirement: providing the allocation type.
+
+The inference algorithm should not be considered stable: the intention of this
+process is to provide the most accurately inferred type information that is
+possible, and so will be improved over time.
+
+The core inference algorithm is focused on the specified operation parameter,
+and currently matches all common allocation size idioms:
+
+  * Single objects and arrays, e.g. `sizeof(T)`, `sizeof(T)` * expression
+  * Prefixed arrays, both variations on `sizeof(Header) + sizeof(Tail) * expression`
+    and non-explicit tail allocations for types with flexible array members
+  * tuple allocations, like `sizeof(T) + sizeof(U)`
+
+The inference process also follows variable references if the assigned value
+can be trivially determined.
+
+The inference process also tracks casts and similar operations performed over
+the returned allocation to provide further information about the likely object
+type that is used either as a fallback if no type can be inferred by an
+allocation, or to fine tune the semantics of the inferred type.
+
+If the inference cannot determine an exact allocation structure it reduces the
+precision to an unspecified combination of all types referenced in the expression.
+
+Type descriptor format
+~~~~~~~~~~~~~~~~~~~~~~
+
+The type descriptor is a 64bit value containing a summary of the semantic
+features of the inferred type, and a hash of the structural identity of the
+type.
+
+Identity
+~~~~~~~~
+
+Typed memory operations work in terms of a type identity that is independent of C.
+Using something like a C type name, or a description of the type as specified,
+results in significant increases in code size while also producing large numbers
+of structurally identical types.
+
+Instead a structural identity is constructed by converting each type into a
+sequence of atoms representing the actual data stored in each atom of the type
+when realised in memory. Overlapping atoms (as occur in unions) have their
+properties unified.
+
+The result of this process is that multiple types or type definitions that have
+structurally equivalent types are reduced to the same identity, permitting an
+allocator to unify their allocations. This avoids an allocator having to manage
+an explosion of type buckets, even when a functionally limited number of unique
+types are actually being allocated.
+
+The information being tracked during this process is an approximation of the
+content, that is intended to be increased over time to improve both the
+unification and the isolation of types.
+
+Summary
+~~~~~~~
+
+The remainder of the descriptor is a summary of the semantic properties of the
+type[s] being allocated. This is laid out as follows.
+
+.. code-block:: text
+
+  Bits 31–16: Layout semantics
+  Bits 15–12: Type flags
+  Bits 11–10: Type kind
+  Bits  9– 6: Callsite flags
+  Bits  5– 2: Reserved
+  Bits  1– 0: Version (currently 0)
+
+The exact values and contents of these are specified in `TypedMemoryDescriptorBits.h`.
+
+Reserved and Version are self explanatory, as an overview of the other fields
+
+* Layout semantics is a bitfield to allow the allocator to identify whether the
+  type being allocated contains certain kinds of data, e.g. pointers, code
+  pointers, whether it is pure data, etc.
+* Type flags represents type specific semantics, current examples being the
+  existence of polymorphic objects, or unions containing different data types.
+* Type kind represents the originating language or allocation class (e.g. a C
+  like allocation, new/delete, swift based allocations).
+* Callsite flags represent information about the callsite rather than the type
+  itself - is the allocation fixed or variable size, array vs non-array, if
+  there is an object header.
+
+Inference failure
+~~~~~~~~~~~~~~~~~
+
+Type inference in these function calls is still just a heuristic, so can fail.
+In the event that the inference process cannot infer any type information the
+descriptor that is passed is produced by hashing the source code location of the
+allocation site, so that the allocator always has at least a semi-unique
+identity to use as a basis of type isolation.
+
+Future work
+-----------
+
+Full inferred-type encoding
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The current descriptor does not include the logic that encodes the full
+inferred type information. This is a regression to be fixed, but the additional
+complexity makes this already large feature larger.
+
+Descriptor abstraction layer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The current descriptor format is fixed and reflects one particular set of design
+choices about what information is useful at the runtime level. The RFC discussed
+this limitation, and there are other type encoding systems that are valuable in
+other contexts. A basic abstraction layer to make these encodings configurable
+is an obvious future step.
+
+Explicit return identification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As currently implemented the inference algorithm assumes that all allocation
+functions that return a pointer are returning the allocation, and incorporates
+that into its inference logic. This works for many cases, but in some cases is
+wrong and so the return value should be ignored as it may pollute the inference
+process. At the same time it also means that information that could be extracted
+from out parameters is lost.
+
+Variable reference inference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently the logic for performing inference through variable references is
+extremely limited: constant initialized variables. There are many trivial cases
+this misses as a result of code making sequential variable changes to reduce
+code complexity or to make the code easier to read. Most of these cases involve
+linear sequences of assignments that should be handled as such.

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -27,6 +27,7 @@
 #include "clang/AST/TemplateName.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeOrdering.h"
+#include "clang/AST/TypedMemoryInference.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/PartialDiagnostic.h"
@@ -147,6 +148,7 @@ class UsingShadowDecl;
 class VarTemplateDecl;
 class VTableContextBase;
 class XRayFunctionFilter;
+struct TypedMemoryDescriptorBits;
 
 /// A simple array of base specifiers.
 typedef SmallVector<CXXBaseSpecifier *, 4> CXXCastPath;
@@ -1557,6 +1559,32 @@ public:
 
   /// Return the "other" type-specific discriminator for the given type.
   uint16_t getPointerAuthTypeDiscriminator(QualType T);
+
+  //===--------------------------------------------------------------------===//
+  //                    TypedMemoryOperations Support
+  //===--------------------------------------------------------------------===//
+private:
+  mutable std::unique_ptr<TypedMemoryInference> TypeInference;
+  TypedMemoryInference &getTMOInference() const;
+
+public:
+  using TypedMemoryDescriptor = TypedMemoryInference::TypedMemoryDescriptor;
+  /// Return the descriptor for the provided type and callsite semantics
+  TypedMemoryDescriptor
+  getTypedMemoryDescriptor(QualType QT, OverloadedOperatorKind,
+                           TypedMemoryCallsiteFlags) const;
+  StringRef getTypeSummaryDescription(TypedMemorySummary Summary) const;
+
+  std::optional<InferredTypeInfo>
+  getInferredInfoForCall(const CallExpr *Call) const;
+  InferredTypeInfo inferTypedMemoryType(const CallExpr *Call,
+                                        const Expr &SizeArg,
+                                        const CastExpr *ContainingCast) const;
+  /// Only used when reading an external AST, such as a module or PCH.
+  void setInferredInfoForCall(const CallExpr *Call, InferredTypeInfo);
+
+  /// Find the flexible array member for a type if present
+  std::optional<QualType> findFlexibleArrayElementType(QualType T) const;
 
   /// Apply Objective-C protocol qualifiers to the given type.
   /// \param allowOnPointerType specifies if we can apply protocol

--- a/clang/include/clang/AST/TypedMemoryDescriptorBits.h
+++ b/clang/include/clang/AST/TypedMemoryDescriptorBits.h
@@ -1,0 +1,127 @@
+#ifndef LLVM_CLANG_AST_TYPEDMEMORYDESCRIPTORBITS_H
+#define LLVM_CLANG_AST_TYPEDMEMORYDESCRIPTORBITS_H
+
+#include "llvm/ADT/BitmaskEnum.h"
+#include "llvm/Support/Compiler.h"
+
+namespace clang {
+
+// Represent properties of (a region of) the memory layout of a type.
+enum class TypedMemoryLayoutSemantics : uint16_t {
+  None = 0,
+  DataPointer = 1 << 0,
+  StructPointer = 1 << 1,
+  ImmutablePointer = 1 << 2,
+  AnonymousPointer = 1 << 3,
+  ReferenceCount = 1 << 4,
+  ResourceHandle = 1 << 5,
+  SpatialBounds = 1 << 6,
+  TaintedData = 1 << 7,
+  GenericData = 1 << 8,
+
+  LLVM_MARK_AS_BITMASK_ENUM(/* LargestFlag = */ GenericData)
+};
+
+// Represent inherent properties of a type, which are not tied to a specific
+// region of its memory layout, bur rather convey information about overall
+// characteristics of the type itself.
+enum class TypedMemoryTypeFlags : uint8_t {
+  None = 0,
+  IsPolymorphic = 1 << 0,
+  HasMixedUnions = 1 << 1,
+
+  LLVM_MARK_AS_BITMASK_ENUM(/* LargestFlag = */ HasMixedUnions)
+};
+
+enum class TypedMemoryTypeKind : uint8_t {
+  KindC = 0,
+  KindObjectiveC = 1,
+  KindSwift = 2,
+  KindCxx = 3
+};
+
+enum class TypedMemoryCallsiteFlags : uint8_t {
+  None = 0,
+  FixedSize = 1 << 0,
+  Array = 1 << 1,
+  HeaderPrefixedArray = 1 << 2,
+
+  LLVM_MARK_AS_BITMASK_ENUM(/* LargestFlag = */ HeaderPrefixedArray)
+};
+
+struct TypedMemorySummary {
+  TypedMemorySummary()
+      : LayoutSemantics(TypedMemoryLayoutSemantics::None),
+        TypeFlags(TypedMemoryTypeFlags::None),
+        TypeKind(TypedMemoryTypeKind::KindC),
+        CallsiteFlags(TypedMemoryCallsiteFlags::None), Unused(0), Version(0) {}
+
+  static constexpr uint32_t kLayoutSemanticsBits = 16;
+  static constexpr uint8_t kTypeFlagsBits = 4;
+  static constexpr uint8_t kTypeKindBits = 2;
+  static constexpr uint8_t kCallsiteFlagBits = 4;
+  static constexpr uint8_t kUnusedBits = 4;
+  static constexpr uint8_t kVersionBits = 2;
+
+  static constexpr uint8_t kVersionShift = 0;
+  static constexpr uint8_t kUnusedShift = kVersionShift + kVersionBits;
+  static constexpr uint8_t kCallsiteFlagsShift = kUnusedShift + kUnusedBits;
+  static constexpr uint8_t kTypeKindShift =
+      kCallsiteFlagsShift + kCallsiteFlagBits;
+  static constexpr uint8_t kTypeFlagsShift = kTypeKindShift + kTypeKindBits;
+  static constexpr uint8_t kLayoutSemanticsShift =
+      kTypeFlagsShift + kTypeFlagsBits;
+
+  static constexpr uint32_t kSummaryBitSize =
+      kLayoutSemanticsShift + kLayoutSemanticsBits;
+  static_assert(kSummaryBitSize == sizeof(uint32_t) * 8);
+
+  TypedMemoryLayoutSemantics LayoutSemantics : kLayoutSemanticsBits;
+  TypedMemoryTypeFlags TypeFlags : kTypeFlagsBits;
+  TypedMemoryTypeKind TypeKind : kTypeKindBits;
+  TypedMemoryCallsiteFlags CallsiteFlags : kCallsiteFlagBits;
+  uint8_t Unused : kUnusedBits;
+  uint8_t Version : kVersionBits;
+
+  uint32_t value() const {
+    const uint64_t LayoutSemantics =
+        static_cast<uint64_t>(this->LayoutSemantics);
+    const uint64_t TypeFlags = static_cast<uint64_t>(this->TypeFlags);
+    const uint64_t TypeKind = static_cast<uint64_t>(this->TypeKind);
+    const uint64_t CallsiteFlags = static_cast<uint64_t>(this->CallsiteFlags);
+    const uint64_t Version = static_cast<uint64_t>(this->Version);
+    // Manually construct this to avoid accidental ABI changes from
+    // struct modification
+    // [llllllllllllllll][tttt][kk][cccc][uuuu][vv]
+    return (LayoutSemantics << kLayoutSemanticsShift) |
+           (TypeFlags << kTypeFlagsShift) | (TypeKind << kTypeKindShift) |
+           (CallsiteFlags << kCallsiteFlagsShift) | (Version << kVersionShift);
+  }
+} __attribute__((packed));
+
+struct TypedMemoryDescriptorBits {
+  TypedMemoryDescriptorBits() : Hash(0) {}
+
+  TypedMemorySummary Summary;
+  uint32_t Hash;
+
+  static constexpr uint8_t kHashShift = 0;
+  static constexpr uint8_t kHashBitSize = 32;
+  static constexpr uint8_t kSummaryShift = kHashShift + kHashBitSize;
+  static_assert(kSummaryShift + TypedMemorySummary::kSummaryBitSize == 64);
+
+  uint64_t value() const {
+    const uint64_t Summary = static_cast<uint64_t>(this->Summary.value());
+    // [ssssssssssssssssssssssssssssssss][hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh]
+    return (Summary << kSummaryShift) | (Hash << kHashShift);
+  }
+};
+
+static_assert(sizeof(TypedMemorySummary) == sizeof(uint32_t),
+              "Summary must be 32 bits");
+static_assert(sizeof(TypedMemoryDescriptorBits) == sizeof(uint64_t),
+              "Descriptor must be 64 bits");
+
+} // namespace clang
+
+#endif

--- a/clang/include/clang/AST/TypedMemoryInference.h
+++ b/clang/include/clang/AST/TypedMemoryInference.h
@@ -1,0 +1,286 @@
+#ifndef LLVM_CLANG_AST_TYPEDMEMORYINFERENCE_H
+#define LLVM_CLANG_AST_TYPEDMEMORYINFERENCE_H
+
+#include "clang/AST/Expr.h"
+#include "clang/AST/TypedMemoryDescriptorBits.h"
+#include "clang/Basic/OperatorKinds.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include <optional>
+#include <variant>
+
+namespace clang {
+
+class ASTContext;
+class Type;
+
+class InferredAllocationType {
+public:
+  enum class TypeKind {
+    Object = 1,
+    Array = 2,
+    PrefixedArray = 3,
+    Tuple = 4,
+    UnknownLayout = 5,
+  };
+
+  // We recognize four patterns: a single object, arrays, header + array, and
+  // tuples of multiple objects.
+  struct Object {
+    static const bool HasEntries = false;
+    static constexpr TypeKind Kind = TypeKind::Object;
+    bool isConstantSize() const { return true; }
+    std::optional<QualType> primaryType() const { return Type; }
+    QualType Type;
+
+    void extractRelatedTypes(SmallVectorImpl<QualType> &RelatedTypes) const {
+      RelatedTypes.push_back(Type);
+    }
+    void print(llvm::raw_ostream &OS,
+               llvm::function_ref<void(QualType)> QuoteType) const;
+  };
+
+  struct Array {
+    static constexpr TypeKind Kind = TypeKind::Array;
+    static const bool HasEntries = false;
+    bool isConstantSize() const { return IsConstantSize; }
+    std::optional<QualType> primaryType() const { return ElementType; }
+    bool IsConstantSize;
+    QualType ElementType;
+    void extractRelatedTypes(SmallVectorImpl<QualType> &RelatedTypes) const {
+      RelatedTypes.push_back(ElementType);
+    }
+    void print(llvm::raw_ostream &OS,
+               llvm::function_ref<void(QualType)> QuoteType) const;
+  };
+
+  struct PrefixedArray {
+    static constexpr TypeKind Kind = TypeKind::PrefixedArray;
+    static const bool HasEntries = false;
+    bool isConstantSize() const { return IsConstantSize; }
+    std::optional<QualType> primaryType() const { return HeaderType; }
+    QualType HeaderType;
+    bool IsConstantSize;
+    // We don't necessarily know the actual element type, as we consider
+    //   sizeof(T) + <some uninferrable expression>
+    // to be a prefixed array
+    std::optional<QualType> ElementType;
+    void extractRelatedTypes(SmallVectorImpl<QualType> &RelatedTypes) const {
+      RelatedTypes.push_back(HeaderType);
+      if (ElementType)
+        RelatedTypes.push_back(*ElementType);
+    }
+    void print(llvm::raw_ostream &OS,
+               llvm::function_ref<void(QualType)> QuoteType) const;
+  };
+
+  struct Tuple {
+    static constexpr TypeKind Kind = TypeKind::Tuple;
+    static const bool HasEntries = true;
+    bool isConstantSize() const { return true; }
+    std::optional<QualType> primaryType() const { return Entries[0]; }
+    SmallVector<QualType, 2> Entries;
+    void extractRelatedTypes(SmallVectorImpl<QualType> &RelatedTypes) const {
+      RelatedTypes.append(Entries);
+    }
+    void print(llvm::raw_ostream &OS,
+               llvm::function_ref<void(QualType)> QuoteType) const;
+  };
+
+  // Pattern matching has failed so just accrue any types we've seen
+  struct UnknownLayout {
+    static constexpr TypeKind Kind = TypeKind::UnknownLayout;
+    static const bool HasEntries = true;
+    bool isConstantSize() const { return IsConstantSize; }
+    std::optional<QualType> primaryType() const { return Entries[0]; }
+    SmallVector<QualType, 2> Entries;
+    bool IsConstantSize;
+    void extractRelatedTypes(SmallVectorImpl<QualType> &RelatedTypes) const {
+      RelatedTypes.append(Entries);
+    }
+    void print(llvm::raw_ostream &OS,
+               llvm::function_ref<void(QualType)> QuoteType) const;
+  };
+
+private:
+  using TypeUnionTy =
+      std::variant<Object, Array, PrefixedArray, Tuple, UnknownLayout>;
+  template <class FnType> auto visit(FnType &&F) const {
+    return std::visit(F, TypeUnion);
+  }
+  TypeUnionTy TypeUnion;
+
+public:
+  TypeKind kind() const {
+    return visit([](auto Type) { return decltype(Type)::Kind; });
+  }
+
+  bool isConstantSize() const {
+    return visit([](auto &Type) { return Type.isConstantSize(); });
+  }
+
+  static InferredAllocationType create(QualType T) {
+    InferredAllocationType IT;
+    IT.TypeUnion = Object{T};
+    return IT;
+  }
+
+  static InferredAllocationType createArray(QualType ElementType,
+                                            bool IsConstantSize) {
+    InferredAllocationType IT;
+    IT.TypeUnion = Array{IsConstantSize, ElementType};
+    return IT;
+  }
+
+  static InferredAllocationType
+  createPrefixedArray(QualType HeaderType, std::optional<QualType> ElementType,
+                      bool IsConstantSize) {
+    InferredAllocationType IT;
+    IT.TypeUnion = PrefixedArray{HeaderType, IsConstantSize, ElementType};
+    return IT;
+  }
+
+  static InferredAllocationType
+  createTuple(SmallVectorImpl<QualType> &&Entries) {
+    InferredAllocationType IT;
+    IT.TypeUnion = Tuple{std::move(Entries)};
+    return IT;
+  }
+
+  static InferredAllocationType
+  createUnknownLayout(SmallVectorImpl<QualType> &&Entries,
+                      bool IsConstantSize) {
+    InferredAllocationType Result;
+    SmallVector<QualType, 2> Types;
+    llvm::SmallDenseSet<QualType, 2> SeenTypes;
+    for (QualType Type : Entries) {
+      if (SeenTypes.insert(Type).second)
+        Types.push_back(Type);
+    }
+    Result.TypeUnion = UnknownLayout{std::move(Types), IsConstantSize};
+    return Result;
+  }
+
+  bool isPrefixedArray() const { return kind() == TypeKind::PrefixedArray; }
+  bool isUnknownLayout() const { return kind() == TypeKind::UnknownLayout; }
+  bool isArray() const { return kind() == TypeKind::Array; }
+
+  bool hasPrefixedArrayElementType() const {
+    auto *Prefixed = std::get_if<PrefixedArray>(&TypeUnion);
+    return Prefixed && Prefixed->ElementType;
+  }
+
+  std::optional<QualType> prefixedArrayElementType() const {
+    if (auto *Prefixed = std::get_if<PrefixedArray>(&TypeUnion))
+      return Prefixed->ElementType;
+    return std::nullopt;
+  }
+
+  const Object *asObject() const { return std::get_if<Object>(&TypeUnion); }
+  const Array *asArray() const { return std::get_if<Array>(&TypeUnion); }
+  const PrefixedArray *asPrefixedArray() const {
+    return std::get_if<PrefixedArray>(&TypeUnion);
+  }
+  const UnknownLayout *asUnknownLayout() const {
+    return std::get_if<UnknownLayout>(&TypeUnion);
+  }
+  const Tuple *asTuple() const { return std::get_if<Tuple>(&TypeUnion); }
+
+  std::string describe(const ASTContext &Ctx) const;
+  void print(llvm::raw_ostream &OS, const PrintingPolicy &Policy) const;
+
+  void appendEntries(SmallVectorImpl<QualType> &Entries) const {
+    if (hasEntries())
+      Entries.append(entries().begin(), entries().end());
+    else if (auto PT = primaryType())
+      Entries.push_back(*PT);
+    else
+      llvm_unreachable("fixed-size type has no primaryType");
+  }
+
+  void extractRelatedTypes(SmallVectorImpl<QualType> &RelatedTypes) const {
+    visit([&](auto &Type) { Type.extractRelatedTypes(RelatedTypes); });
+  }
+
+  bool hasEntries() const {
+    return visit([](auto Type) { return decltype(Type)::HasEntries; });
+  }
+  ArrayRef<QualType> entries() const {
+    return visit([](auto &Type) -> ArrayRef<QualType> {
+      if constexpr (std::remove_reference_t<decltype(Type)>::HasEntries)
+        return Type.Entries;
+      else
+        llvm_unreachable("Attempting to get entries from a non-entries type");
+    });
+  }
+  std::optional<QualType> primaryType() const {
+    return visit([](auto Type) { return Type.primaryType(); });
+  }
+};
+
+struct InferredTypeInfo {
+  std::optional<InferredAllocationType> Type;
+  const Expr *InferenceSourceExpression;
+  TypedMemoryCallsiteFlags InferredCallsiteFlags =
+      TypedMemoryCallsiteFlags::None;
+};
+
+class TypedMemoryInference {
+public:
+  TypedMemoryInference() = default;
+
+  struct TypedMemoryDescriptor {
+    uint32_t IdentityHash;
+    TypedMemorySummary Summary;
+    // Only set if diagnostics are enabled.
+    StringRef TypeDescription;
+
+    TypedMemoryDescriptorBits asBits() const {
+      TypedMemoryDescriptorBits Bits;
+      Bits.Summary = Summary;
+      Bits.Hash = IdentityHash;
+      return Bits;
+    }
+  };
+
+  TypedMemoryDescriptor getDescriptor(const ASTContext &Ctx, QualType QT,
+                                      OverloadedOperatorKind,
+                                      TypedMemoryCallsiteFlags);
+  StringRef getTypeSummaryDescription(TypedMemorySummary Summary);
+  void setInferredInfoForCall(const CallExpr *Call, InferredTypeInfo Info);
+  std::optional<InferredTypeInfo>
+  getInferredInfoForCall(const ASTContext &Ctx, const CallExpr *Call) const;
+  InferredTypeInfo inferType(const ASTContext &Ctx, const CallExpr *Call,
+                             const Expr &SizeArg,
+                             const CastExpr *ContainingCastExpr);
+
+private:
+  TypedMemoryInference(const TypedMemoryInference &) = delete;
+  TypedMemoryInference(TypedMemoryInference &&) = delete;
+
+  using TypeDescriptorMapKeyTy =
+      std::tuple<const Type *, TypedMemoryCallsiteFlags, TypedMemoryTypeKind>;
+  struct TypedMemoryDescriptorMapValueTy {
+    bool IsIncomplete;
+    uint32_t IdentityHash;
+    TypedMemorySummary Summary;
+    std::unique_ptr<std::string> TypeDescription;
+  };
+
+  using TypeDescriptorMapTy =
+      llvm::DenseMap<TypeDescriptorMapKeyTy, TypedMemoryDescriptorMapValueTy>;
+  TypeDescriptorMapTy TypeDescriptorMap;
+  using InferredTMOMapTy = llvm::DenseMap<const CallExpr *, InferredTypeInfo>;
+  InferredTMOMapTy InferredTMOCallTypes;
+  // Key is TypedMemorySummary::value()
+  using TypeSummaryDescriptionCacheTy =
+      llvm::DenseMap<uint32_t, std::unique_ptr<std::string>>;
+  TypeSummaryDescriptionCacheTy TypeSummaryDescriptionCache;
+};
+
+} // namespace clang
+
+#endif // LLVM_CLANG_AST_TYPEDMEMORYINFERENCE_H

--- a/clang/include/clang/AST/TypedMemoryLayoutBuilder.h
+++ b/clang/include/clang/AST/TypedMemoryLayoutBuilder.h
@@ -1,0 +1,49 @@
+#ifndef LLVM_CLANG_AST_TYPEDMEMORYLAYOUTBUILDER_H
+#define LLVM_CLANG_AST_TYPEDMEMORYLAYOUTBUILDER_H
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Type.h"
+#include <vector>
+
+namespace clang {
+
+struct TypedMemoryLayoutField {
+  QualType Type;
+  uint64_t Offset;
+  uint64_t Width;
+  const Decl *TypeOrFieldDecl;
+
+  TypedMemoryLayoutField(QualType T, uint64_t O, uint64_t W, const Decl *D)
+      : Type(T), Offset(O), Width(W), TypeOrFieldDecl(D) {}
+};
+
+using TypedMemoryFieldsVec = std::vector<TypedMemoryLayoutField>;
+
+struct TypedMemoryLayout {
+  uint64_t Width;
+  TypedMemoryFieldsVec Fields;
+};
+
+class TypedMemoryLayoutBuilder {
+
+public:
+  TypedMemoryLayoutBuilder(const TypedMemoryLayoutBuilder &) = delete;
+  TypedMemoryLayoutBuilder &
+  operator=(const TypedMemoryLayoutBuilder &) = delete;
+  TypedMemoryLayoutBuilder(const ASTContext &Ctx, QualType QT);
+  ~TypedMemoryLayoutBuilder() = default;
+
+  void build();
+
+  const TypedMemoryLayout &getLayout() const { return Layout; }
+  const TypedMemoryFieldsVec &getFields() const { return Layout.Fields; }
+
+protected:
+  const ASTContext &Context;
+  const QualType QType;
+  TypedMemoryLayout Layout;
+};
+
+} // namespace clang
+
+#endif

--- a/clang/include/clang/AST/TypedMemoryTypeDescriptor.h
+++ b/clang/include/clang/AST/TypedMemoryTypeDescriptor.h
@@ -1,0 +1,59 @@
+#ifndef LLVM_CLANG_AST_TYPEDMEMORYTYPEDESCRIPTOR_H
+#define LLVM_CLANG_AST_TYPEDMEMORYTYPEDESCRIPTOR_H
+
+#include "clang/AST/TypedMemoryDescriptorBits.h"
+#include "clang/AST/TypedMemoryLayoutBuilder.h"
+#include "llvm/ADT/SmallSet.h"
+
+namespace clang {
+
+class TypedMemoryTypeDescriptorBase {
+public:
+  TypedMemoryTypeDescriptorBase(const TypedMemoryTypeDescriptorBase &) = delete;
+  TypedMemoryTypeDescriptorBase &
+  operator=(const TypedMemoryTypeDescriptorBase &) = delete;
+  TypedMemoryTypeDescriptorBase() {}
+  virtual ~TypedMemoryTypeDescriptorBase() = default;
+
+  virtual bool initialize(const QualType &QT,
+                          const TypedMemoryLayout &Layout) = 0;
+};
+
+class TypedMemoryTypeDescriptor : public TypedMemoryTypeDescriptorBase {
+public:
+  struct LayoutSemanticsSpan {
+    uint64_t Offset;
+    uint64_t Width;
+    TypedMemoryLayoutSemantics Semantics;
+  };
+
+  using TypedMemoryTypeDescriptorBase::TypedMemoryTypeDescriptorBase;
+  virtual ~TypedMemoryTypeDescriptor() = default;
+  virtual bool initialize(const QualType &QT,
+                          const TypedMemoryLayout &Layout) override;
+
+  TypedMemoryLayoutSemantics getCoalescedLayoutSemantics() const {
+    return LayoutSemantics;
+  }
+  TypedMemoryTypeFlags getTypeFlags() const { return Flags; }
+  uint32_t computeTypeHash() const;
+
+  static uint32_t computeTypeNameHash(const QualType &QT);
+
+private:
+  TypedMemoryTypeFlags Flags;
+  llvm::SmallVector<LayoutSemanticsSpan> LayoutProperties;
+  llvm::SmallVector<LayoutSemanticsSpan> CoalescedLayoutProperties;
+  TypedMemoryLayoutSemantics LayoutSemantics;
+
+  TypedMemoryLayoutSemantics
+  getFieldSemantics(const TypedMemoryLayoutField *F) const;
+  TypedMemoryLayoutSemantics getTypeSemantics(const QualType &QT) const;
+
+  bool initializeLayoutProperties(const TypedMemoryLayout &Layout);
+  void initializeCoalescedLayoutProperties(const TypedMemoryLayout &Layout);
+};
+
+} // namespace clang
+
+#endif

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -5147,6 +5147,15 @@ def EnforceTCBLeaf : InheritableAttr {
   bit InheritEvenIfAlreadyPresent = 1;
 }
 
+def TypedMemory : InheritableAttr {
+  let Spellings = [Clang<"typed_memory_operation">];
+  let Subjects = SubjectList<[Function]>;
+  let Args = [DeclArgument<Function, "RewriteTarget">,
+              ParamIdxArgument<"InferredParameterIdx">];
+  let SemaHandler = 1;
+  let Documentation = [Undocumented];
+}
+
 def Error : InheritableAttr {
   let Spellings = [GCC<"error">, GCC<"warning">];
   let Accessors = [Accessor<"isError", [GCC<"error">]>,

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1996,3 +1996,6 @@ def ExperimentalOption : DiagGroup<"experimental-option">;
 
 // Warnings about unguarded usages of AMDGPU target specific constructs
 def UnguardedBuiltinUsageAMDGPU : DiagGroup<"amdgpu-unguarded-builtin-usage">;
+
+
+def TMODiagnosticRemarks : DiagGroup<"tmo-remarks">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11637,6 +11637,8 @@ def err_duplicate_attribute
     : Error<"attribute %0 is already applied with different arguments">;
 def err_disallowed_duplicate_attribute : Error<
   "attribute %0 cannot appear more than once on a declaration">;
+def err_incompatible_duplicate_attribute : Error<
+  "attribute %0 is already applied with different arguments">;
 
 def warn_sync_fetch_and_nand_semantics_change : Warning<
   "the semantics of this intrinsic changed with GCC "
@@ -15227,4 +15229,42 @@ def err_cuda_device_kernel_launch_not_supported
 def err_cuda_device_kernel_launch_require_rdc
     : Error<"kernel launch from __device__ or __global__ function requires "
             "relocatable device code (i.e. requires -fgpu-rdc)">;
+
+// TMO warnings and notes
+def err_tmo_non_function : Error<
+  "the typed_memory_operations attribute can only be applied to functions">;
+
+def err_tmo_invalid_inferred_parameter_type : Error<
+  "invalid parameter type for inference at index %0. %1 is not an integer type">;
+
+def err_tmo_function_kind_error : Error<
+  "%select{untyped|typed}0 memory operation %1 %select{cannot be a variadic function|cannot be an instance method|must have a prototype|must be a function}2">;
+
+def err_tmo_rewrite_target_is_overloaded : Error<
+  "typed memory operation %0 has multiple overloads">;
+
+def err_tmo_rewrite_target_type_mismatch : Error<
+  "typed memory operation %0 has incompatible type (%diff{$ vs $|}1,2)">;
+
+def note_tmo_rewrite_target_type_mismatch : Note<
+  "rewrite target here">;
+
+def warn_tmo_inference_failed
+    : Warning<"could not infer allocation type in call to %0">,
+      InGroup<DiagGroup<"typed-memory-inference-failure">>,
+      DefaultIgnore;
+def remark_tmo_passed_type : Remark<
+  "passing TMO information for %0%1 to %2%select{ (retargeted from %4)|}3">,
+  InGroup<TMODiagnosticRemarks>;
+
+def note_tmo_failed_inference_source
+    : Note<"unable to infer allocation type from expression %0">;
+def note_tmo_inference_result : Note<"inferred %0 from %select{expression|cast "
+                                     "of result from call to}1 %2">;
+def note_tmo_type_encoding : Note<"encoding %0%1 as %2. %3">;
+def remark_tmo_get_descriptor_info
+    : Remark<"__builtin_tmo_get_type_descriptor reported %0 as %1. Type "
+             "semantics: %2">,
+      InGroup<TMODiagnosticRemarks>;
+
 } // end of sema component.

--- a/clang/include/clang/Basic/Features.def
+++ b/clang/include/clang/Basic/Features.def
@@ -394,6 +394,9 @@ EXTENSION(cxx_type_aware_allocators, true)
 // Overflow behavior types
 EXTENSION(overflow_behavior_types, LangOpts.OverflowBehaviorTypes)
 
+// Typed memory operations
+FEATURE(typed_memory_operations, LangOpts.TypedMemoryOperations)
+
 // TODO(BoundsSafety): Deprecate this feature name
 FEATURE(bounds_attributes, LangOpts.BoundsSafety)
 /* TO_UPSTREAM(BoundsSafety) ON*/

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -548,6 +548,7 @@ LANGOPT(EnableLifetimeSafetyTUAnalysis, 1, 0, NotCompatible, "Lifetime safety at
 
 LANGOPT(PreserveVec3Type, 1, 0, NotCompatible, "Preserve 3-component vector type")
 LANGOPT(Reflection      , 1, 0, NotCompatible, "C++26 Reflection")
+LANGOPT(TypedMemoryOperations, 1, 0, NotCompatible, "Typed Memory Operations Callsite Rewriting")
 
 #undef LANGOPT
 #undef ENUM_LANGOPT

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -814,6 +814,8 @@ ALIAS("_pascal"      , __pascal   , KEYBORLAND)
 // Clang Extensions.
 KEYWORD(__builtin_convertvector          , KEYALL)
 UNARY_EXPR_OR_TYPE_TRAIT(__builtin_vectorelements, VectorElements, KEYALL)
+
+UNARY_EXPR_OR_TYPE_TRAIT(__builtin_tmo_get_type_descriptor, TMOGetTypeDescriptor, KEYALL)
 ALIAS("__char16_t"   , char16_t          , KEYCXX)
 ALIAS("__char32_t"   , char32_t          , KEYCXX)
 KEYWORD(__builtin_bit_cast               , KEYALL)

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -10162,3 +10162,10 @@ def wasm_opt : Flag<["--"], "wasm-opt">,
   Group<m_Group>,
   HelpText<"Enable the wasm-opt optimizer (default)">,
   MarshallingInfoNegativeFlag<LangOpts<"NoWasmOpt">>;
+
+defm typed_memory_operations : BoolFOption<"typed-memory-operations",
+  LangOpts<"TypedMemoryOperations">, DefaultFalse,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option], "Enable">,
+  NegFlag<SetFalse, [], [ClangOption, CC1Option], "Disable">,
+  BothFlags<[], [],
+          " typed memory operations call site rewriting">>;

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -4449,6 +4449,7 @@ private:
   bool tryParseOpenMPArrayShapingCastPart();
 
   ExprResult ParseBuiltinPtrauthTypeDiscriminator();
+  ExprResult ParseBuiltinTMOGetTypeDescriptor();
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
   //===--------------------------------------------------------------------===//

--- a/clang/include/clang/Sema/ScopeInfo.h
+++ b/clang/include/clang/Sema/ScopeInfo.h
@@ -23,6 +23,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Sema/CleanupInfo.h"
 #include "clang/Sema/DeclSpec.h"
+#include "clang/Sema/TypedMemoryCallsiteContext.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/MapVector.h"
@@ -113,6 +114,8 @@ protected:
 public:
   /// What kind of scope we are describing.
   ScopeKind Kind : 3;
+
+  TypedMemoryCallsiteContext TMOContext;
 
   /// Whether this function contains a VLA, \@try, try, C++
   /// initializer, or anything else that can't be jumped past.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -68,6 +68,7 @@
 #include "clang/Sema/SemaBase.h"
 #include "clang/Sema/SemaConcept.h"
 #include "clang/Sema/SemaRISCV.h"
+#include "clang/Sema/TypedMemoryCallsiteContext.h"
 #include "clang/Sema/TypoCorrection.h"
 #include "clang/Sema/Weak.h"
 #include "llvm/ADT/APInt.h"
@@ -16400,6 +16401,38 @@ public:
   void performFunctionEffectAnalysis(TranslationUnitDecl *TU);
 
   ///@}
+
+  //===--------------------------------------------------------------------===//
+  // Typed Memory Operations
+  //===--------------------------------------------------------------------===//
+  /// @{
+private:
+  // TMO context information used to track non-function scoped TMO calls, such
+  // as global or declaration scoped initializers and similar.
+  sema::TypedMemoryCallsiteContext NonFunctionTMOContext;
+  bool checkTMOGetTypeDescriptor(QualType T, SourceLocation Loc,
+                                 SourceRange ArgRange);
+
+  void emitTMODiagnosticsForTypeQuery(SourceLocation QueryLocation,
+                                      SourceRange ExpressionRange,
+                                      QualType QueriedType);
+
+public:
+  sema::TypedMemoryCallsiteContext &currentTMOContext() {
+    if (auto *EnclosingFunctionScope = getEnclosingFunction())
+      return EnclosingFunctionScope->TMOContext;
+    return NonFunctionTMOContext;
+  }
+
+  // While performing semantic analysis of full expressions or initializers
+  // we accumulate all the allocation calls in that expression, and the
+  // casts of the results of any such allocation calls. At the end of the
+  // expression analysis we perform the TMO inference and diagnostics of any
+  // such calls we've encountered.
+  void finalizeOutstandingTMOCandidates() {
+    currentTMOContext().finalizeOutstandingTMOCandidates(*this);
+  }
+  /// @}
 };
 
 DeductionFailureInfo

--- a/clang/include/clang/Sema/TypedMemoryCallsiteContext.h
+++ b/clang/include/clang/Sema/TypedMemoryCallsiteContext.h
@@ -1,0 +1,52 @@
+//===- TypedMemoryCallsiteContext.h - Context info for TMO calls -*-C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines TypedMemoryCallsiteContext, which contains semantic
+// information about the TMO calls in the current scope.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_SEMA_TYPEDMEMORYCALLSITECONTEXT_H
+#define LLVM_CLANG_SEMA_TYPEDMEMORYCALLSITECONTEXT_H
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace clang {
+
+class Expr;
+class CallExpr;
+class CastExpr;
+class Sema;
+
+namespace sema {
+
+class TypedMemoryCallsiteContext {
+  llvm::SmallVector<const CallExpr *, 4> Calls;
+  llvm::DenseMap<const CallExpr *, const CastExpr *> Casts;
+  bool ShouldSearchCasts = false;
+
+  void recordInfoForInferredCall(Sema &S, const CallExpr *Call);
+
+public:
+  void clear() {
+    ShouldSearchCasts = false;
+    Calls.clear();
+    Casts.clear();
+  }
+
+  void finalizeOutstandingTMOCandidates(Sema &);
+  void recordTMOInferenceCandidate(Sema &, const Expr *);
+  void recordCastForTMOInference(Sema &, const CastExpr *Cast);
+};
+
+} // namespace sema
+
+} // namespace clang
+
+#endif // LLVM_CLANG_SEMA_TYPEDMEMORYCALLSITECONTEXT_H

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -16595,3 +16595,18 @@ void ASTContext::recordOffsetOfEvaluation(const OffsetOfExpr *E) {
   if (FieldDecl *FD = Comp.getField(); isPFPField(FD))
     PFPFieldsWithEvaluatedOffset.insert(FD);
 }
+
+std::optional<QualType>
+ASTContext::findFlexibleArrayElementType(QualType T) const {
+  const RecordDecl *RD = T->getAsRecordDecl();
+  if (!RD || !RD->hasFlexibleArrayMember())
+    return std::nullopt;
+  const FieldDecl *FlexibleArrayField = nullptr;
+  for (const FieldDecl *FD : RD->fields())
+    FlexibleArrayField = FD;
+  assert(FlexibleArrayField);
+  const IncompleteArrayType *IAT =
+      getAsIncompleteArrayType(FlexibleArrayField->getType());
+  assert(IAT);
+  return IAT->getElementType();
+}

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -133,6 +133,9 @@ add_clang_library(clangAST
   Type.cpp
   TypeLoc.cpp
   TypePrinter.cpp
+  TypedMemoryInference.cpp
+  TypedMemoryLayoutBuilder.cpp
+  TypedMemoryTypeDescriptor.cpp
   VTableBuilder.cpp
   VTTBuilder.cpp
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -19501,6 +19501,16 @@ bool IntExprEvaluator::VisitBinaryOperator(const BinaryOperator *E) {
   return ExprEvaluatorBaseTy::VisitBinaryOperator(E);
 }
 
+static bool HandleTMOTypeAnalysis(EvalInfo &Info, QualType Ty,
+                                  ASTContext::TypedMemoryDescriptor *OutDescr) {
+  if (Ty->isIncompleteType() || Ty->isVoidType() || Ty->isDependentType() ||
+      Ty->isFunctionType())
+    return false;
+  *OutDescr = Info.Ctx.getTypedMemoryDescriptor(Ty, OO_None,
+                                                TypedMemoryCallsiteFlags::None);
+  return true;
+}
+
 /// VisitUnaryExprOrTypeTraitExpr - Evaluate a sizeof, alignof or vec_step with
 /// a result as the expression's type.
 bool IntExprEvaluator::VisitUnaryExprOrTypeTraitExpr(
@@ -19617,6 +19627,13 @@ bool IntExprEvaluator::VisitUnaryExprOrTypeTraitExpr(
     // FIXME: Better diagnostic.
     Info.FFDiag(E->getBeginLoc());
     return false;
+  }
+  case UETT_TMOGetTypeDescriptor: {
+    QualType Ty = E->getTypeOfArgument();
+    ASTContext::TypedMemoryDescriptor TMD;
+    if (!HandleTMOTypeAnalysis(Info, Ty, &TMD))
+      return false;
+    return Success(TMD.asBits().value(), E);
   }
   }
 

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -5470,7 +5470,8 @@ recurse:
     case UETT_OpenMPRequiredSimdAlign:
     case UETT_VecStep:
     case UETT_PtrAuthTypeDiscriminator:
-    case UETT_DataSizeOf: {
+    case UETT_DataSizeOf:
+    case UETT_TMOGetTypeDescriptor: {
       DiagnosticsEngine &Diags = Context.getDiags();
       Diags.Report(E->getExprLoc(), diag::err_unsupported_itanium_expr_mangling)
           << getTraitSpelling(SAE->getKind());

--- a/clang/lib/AST/TypedMemoryInference.cpp
+++ b/clang/lib/AST/TypedMemoryInference.cpp
@@ -1,0 +1,731 @@
+//===- TypedMemoryInference.cpp - ASTContext TMO support. -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the TMO components of the ASTContext interface.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/PrettyPrinter.h"
+#include "clang/AST/StmtVisitor.h"
+#include "clang/AST/TypedMemoryTypeDescriptor.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticSema.h"
+#include "llvm/ADT/STLExtras.h"
+#include <variant>
+
+using namespace clang;
+namespace { // enum->string conversion namespace
+template <class T> struct EnumStringMap;
+
+template <> struct EnumStringMap<TypedMemoryLayoutSemantics> {
+  static constexpr std::pair<TypedMemoryLayoutSemantics, const char *> Map[] = {
+      {TypedMemoryLayoutSemantics::DataPointer, "DataPointer"},
+      {TypedMemoryLayoutSemantics::StructPointer, "StructPointer"},
+      {TypedMemoryLayoutSemantics::ImmutablePointer, "ImmutablePointer"},
+      {TypedMemoryLayoutSemantics::AnonymousPointer, "AnonymousPointer"},
+      {TypedMemoryLayoutSemantics::ReferenceCount, "ReferenceCount"},
+      {TypedMemoryLayoutSemantics::ResourceHandle, "ResourceHandle"},
+      {TypedMemoryLayoutSemantics::SpatialBounds, "SpatialBounds"},
+      {TypedMemoryLayoutSemantics::TaintedData, "TaintedData"},
+      {TypedMemoryLayoutSemantics::GenericData, "GenericData"}};
+};
+
+template <> struct EnumStringMap<TypedMemoryTypeFlags> {
+  static constexpr std::pair<TypedMemoryTypeFlags, const char *> Map[] = {
+      {TypedMemoryTypeFlags::IsPolymorphic, "IsPolymorphic"},
+      {TypedMemoryTypeFlags::HasMixedUnions, "HasMixedUnions"}};
+};
+
+template <> struct EnumStringMap<TypedMemoryTypeKind> {
+  static constexpr std::pair<TypedMemoryTypeKind, const char *> Map[] = {
+      {TypedMemoryTypeKind::KindC, "KindC"},
+      {TypedMemoryTypeKind::KindObjectiveC, "KindObjectiveC"},
+      {TypedMemoryTypeKind::KindSwift, "KindSwift"},
+      {TypedMemoryTypeKind::KindCxx, "KindCxx"}};
+};
+
+template <> struct EnumStringMap<TypedMemoryCallsiteFlags> {
+  static constexpr std::pair<TypedMemoryCallsiteFlags, const char *> Map[] = {
+      {TypedMemoryCallsiteFlags::FixedSize, "FixedSize"},
+      {TypedMemoryCallsiteFlags::Array, "Array"},
+      {TypedMemoryCallsiteFlags::HeaderPrefixedArray, "HeaderPrefixedArray"}};
+};
+
+template <class EnumType, class F>
+static std::enable_if_t<llvm::is_bitmask_enum<EnumType>::value, void>
+MapBitflag(EnumType Flags, F Callback) {
+  for (auto [Flag, Description] : EnumStringMap<EnumType>::Map) {
+    if ((Flags & Flag) != Flag)
+      continue;
+    Callback(Flag, Description);
+  }
+}
+
+template <class EnumType, class F>
+static std::enable_if_t<!llvm::is_bitmask_enum<EnumType>::value, void>
+MapBitflag(EnumType Flags, F Callback) {
+  for (auto [Flag, Description] : EnumStringMap<EnumType>::Map) {
+    if (Flags != Flag)
+      continue;
+    Callback(Flag, Description);
+  }
+}
+} // namespace
+
+void InferredAllocationType::Object::print(
+    llvm::raw_ostream &OS, llvm::function_ref<void(QualType)> QuoteType) const {
+  QuoteType(Type);
+}
+
+void InferredAllocationType::Array::print(
+    llvm::raw_ostream &OS, llvm::function_ref<void(QualType)> QuoteType) const {
+  QuoteType(ElementType);
+}
+
+void InferredAllocationType::PrefixedArray::print(
+    llvm::raw_ostream &OS, llvm::function_ref<void(QualType)> QuoteType) const {
+  OS << "header prefixed array of {";
+  QuoteType(HeaderType);
+  OS << ':';
+  if (ElementType)
+    QuoteType(*ElementType);
+  else
+    OS << "<unknown element type>";
+  OS << '}';
+}
+
+void InferredAllocationType::Tuple::print(
+    llvm::raw_ostream &OS, llvm::function_ref<void(QualType)> QuoteType) const {
+  OS << "tuple of (";
+  llvm::interleaveComma(Entries, OS, QuoteType);
+  OS << ')';
+}
+
+void InferredAllocationType::UnknownLayout::print(
+    llvm::raw_ostream &OS, llvm::function_ref<void(QualType)> QuoteType) const {
+  OS << "indeterminate set of {";
+  llvm::interleaveComma(Entries, OS, QuoteType);
+  OS << '}';
+}
+
+void InferredAllocationType::print(llvm::raw_ostream &OS,
+                                   const PrintingPolicy &Policy) const {
+  // This reimplements the diagnostic engine's type printing logic to minimize
+  // changes in test output.
+  auto QuoteType = [&](QualType Type) {
+    QualType UnqualifiedType = Type.getUnqualifiedType();
+    QualType DesugaredType(Type->getUnqualifiedDesugaredType(), 0);
+    std::string UnqualifiedTypeName;
+    llvm::raw_string_ostream UnqualifiedTypeStream(UnqualifiedTypeName);
+    UnqualifiedType.print(UnqualifiedTypeStream, Policy);
+    OS << "'" << UnqualifiedTypeName << "'";
+    if (const auto *VTy = UnqualifiedType->getAs<VectorType>()) {
+      const char *Values = VTy->getNumElements() > 1 ? "values" : "value";
+      OS << " (vector of " << VTy->getNumElements() << " '"
+         << VTy->getElementType().getAsString(Policy) << "' " << Values << ")";
+      return;
+    }
+    std::string DesugaredTypeName;
+    llvm::raw_string_ostream DesugaredTypeNameStream(DesugaredTypeName);
+    DesugaredType.print(DesugaredTypeNameStream, Policy);
+    if (DesugaredTypeName != UnqualifiedTypeName)
+      OS << " (aka '" << DesugaredTypeName << "')";
+  };
+  visit([&](const auto &V) { V.print(OS, QuoteType); });
+}
+
+std::string InferredAllocationType::describe(const ASTContext &Ctx) const {
+  std::string Result;
+  llvm::raw_string_ostream OS(Result);
+  print(OS, Ctx.getPrintingPolicy());
+  return Result;
+}
+
+TypedMemoryInference &ASTContext::getTMOInference() const {
+  if (!TypeInference)
+    TypeInference = std::make_unique<TypedMemoryInference>();
+  return *TypeInference;
+}
+
+StringRef
+TypedMemoryInference::getTypeSummaryDescription(TypedMemorySummary Summary) {
+  auto [Entry, Inserted] = TypeSummaryDescriptionCache.insert(
+      std::make_pair(Summary.value(), std::unique_ptr<std::string>{}));
+  if (!Inserted)
+    return *Entry->second;
+  std::string Str;
+  llvm::raw_string_ostream OS(Str);
+  auto LogFlags = [&OS](const char *Name, auto Flags) {
+    OS << '"' << Name << '"' << ": ";
+    constexpr bool IsBitfield = llvm::is_bitmask_enum<decltype(Flags)>::value;
+    if (IsBitfield)
+      OS << "[ ";
+    bool HasEmitted = false;
+    MapBitflag(Flags, [&OS, &HasEmitted](decltype(Flags) Flag,
+                                         const char *Description) {
+      OS << (HasEmitted ? ", " : "") << '"' << Description << '"';
+      HasEmitted = true;
+    });
+    if (IsBitfield)
+      OS << (HasEmitted ? " ]" : "]");
+  };
+  LogFlags("LayoutSemantics", Summary.LayoutSemantics);
+  OS << ", ";
+  LogFlags("TypeFlags", Summary.TypeFlags);
+  OS << ", ";
+  LogFlags("TypeKind", Summary.TypeKind);
+  OS << ", ";
+  LogFlags("CallsiteFlags", Summary.CallsiteFlags);
+  Entry->second = std::make_unique<std::string>(std::move(Str));
+  return *(Entry->second);
+}
+
+TypedMemoryInference::TypedMemoryDescriptor
+TypedMemoryInference::getDescriptor(const ASTContext &Ctx, QualType QT,
+                                    OverloadedOperatorKind OverloadedOperator,
+                                    TypedMemoryCallsiteFlags Flags) {
+  if (QT->isDependentType())
+    return TypedMemoryDescriptor{0, {}, ""};
+
+  QT = QT->getCanonicalTypeUnqualified();
+  bool IsCXXOperator = false;
+  switch (OverloadedOperator) {
+  case OO_Array_New:
+  case OO_Array_Delete:
+    Flags |= TypedMemoryCallsiteFlags::Array;
+    LLVM_FALLTHROUGH;
+  case OO_New:
+  case OO_Delete:
+    IsCXXOperator = true;
+    break;
+  case OO_None:
+    break;
+  default:
+    llvm_unreachable("Invalid allocation operator.");
+  }
+
+  TypedMemoryTypeKind TypeKind =
+      IsCXXOperator ? TypedMemoryTypeKind::KindCxx : TypedMemoryTypeKind::KindC;
+
+  TypeDescriptorMapKeyTy Key = {QT.getTypePtr(), Flags, TypeKind};
+  auto ViewForEntry = [](const TypedMemoryDescriptorMapValueTy &Entry) {
+    return TypedMemoryDescriptor{Entry.IdentityHash, Entry.Summary,
+                                 Entry.TypeDescription ? *Entry.TypeDescription
+                                                       : StringRef()};
+  };
+  auto InsertResult =
+      TypeDescriptorMap.insert({Key, TypedMemoryDescriptorMapValueTy{}});
+  auto Found = InsertResult.first;
+  bool Inserted = InsertResult.second;
+  if (!Inserted) {
+    if (!Found->second.IsIncomplete)
+      return ViewForEntry(Found->second);
+  }
+
+  auto FinalizeDescriptor = [this, &Ctx, &ViewForEntry, &Found,
+                             QT](TypedMemorySummary Summary,
+                                 uint32_t IdentityHash) {
+    TypedMemoryDescriptorMapValueTy Descriptor;
+    Descriptor.IsIncomplete = QT->isIncompleteType();
+    Descriptor.Summary = Summary;
+    Descriptor.IdentityHash = IdentityHash;
+
+    if (!Ctx.getDiagnostics().isIgnored(diag::remark_tmo_passed_type,
+                                        SourceLocation())) {
+      std::string Description;
+      llvm::raw_string_ostream OS(Description);
+      OS << "{ \"Summary\": { " << getTypeSummaryDescription(Descriptor.Summary)
+         << " }, \"TypeHash\": " << Descriptor.IdentityHash
+         << (QT->isIncompleteType() ? ", \"IncompleteType\": true" : "")
+         << " }";
+      Descriptor.TypeDescription = std::make_unique<std::string>(Description);
+    }
+    return ViewForEntry(Found->second = std::move(Descriptor));
+  };
+
+  TypedMemorySummary Summary;
+  Summary.Version = 0;
+  Summary.CallsiteFlags = Flags;
+  Summary.TypeKind = TypeKind;
+
+  if (QT->isIncompleteType())
+    return FinalizeDescriptor(
+        Summary, TypedMemoryTypeDescriptor::computeTypeNameHash(QT));
+
+  // Avoid pathological compile times on types larger than 4MB.
+  static const uint64_t MaximumTypeSizeInBits = 1U << 25;
+  if (Ctx.getTypeSize(QT) >= MaximumTypeSizeInBits)
+    return FinalizeDescriptor(
+        {}, TypedMemoryTypeDescriptor::computeTypeNameHash(QT));
+
+  // Build the flattened memory layout
+  TypedMemoryLayoutBuilder Builder(Ctx, QT);
+  Builder.build();
+
+  // Create the type descriptor
+  TypedMemoryTypeDescriptor TypeDescriptor;
+  TypeDescriptor.initialize(QT, Builder.getLayout());
+  Summary.LayoutSemantics = TypeDescriptor.getCoalescedLayoutSemantics();
+  Summary.TypeFlags = TypeDescriptor.getTypeFlags();
+  return FinalizeDescriptor(Summary, TypeDescriptor.computeTypeHash());
+}
+
+void TypedMemoryInference::setInferredInfoForCall(const CallExpr *Call,
+                                                  InferredTypeInfo Info) {
+  auto [InsertionPoint, Inserted] = InferredTMOCallTypes.insert({Call, Info});
+  // We are keyed on the Call expression itself, so shouldn't be recording this
+  // multiple times.
+  assert(Inserted);
+}
+
+std::optional<InferredTypeInfo>
+TypedMemoryInference::getInferredInfoForCall(const ASTContext &Ctx,
+                                             const CallExpr *Call) const {
+  if (!Ctx.getLangOpts().TypedMemoryOperations)
+    return std::nullopt;
+  if (Call->getDependence() != ExprDependence::None)
+    return std::nullopt;
+
+  if (auto Found = InferredTMOCallTypes.find(Call);
+      Found != InferredTMOCallTypes.end())
+    return Found->second;
+
+#ifndef NDEBUG
+  // If we get here something has gone wrong: either we've failed to perform
+  // inference on a call that we should have, or the caller has incorrectly
+  // called us on an inappropriate function. Either case is wrong so we assert
+  // in debug/relassert builds and warn in release.
+  //
+  // We're currently going to be forgiving as we don't want to break builds
+  // with error diagnostics until we're sure this does not actually fire in
+  // practice.
+  DiagnosticsEngine &Diags = Ctx.getDiagnostics();
+  const FunctionDecl *Callee = Call->getDirectCallee();
+  if (!Callee || !Callee->getAttr<TypedMemoryAttr>()) {
+    unsigned DiagID = Diags.getCustomDiagID(
+        DiagnosticsEngine::Warning,
+        "Requesting TMO inference result for non-TMO applicable call %0");
+    Diags.Report(Call->getBeginLoc(), DiagID) << Call << Call->getSourceRange();
+    return std::nullopt;
+  }
+
+  unsigned DiagID =
+      Diags.getCustomDiagID(DiagnosticsEngine::Warning,
+                            "Requesting inference result for %0 but not found");
+  Diags.Report(Call->getBeginLoc(), DiagID) << Call << Call->getSourceRange();
+#endif
+
+  return std::nullopt;
+}
+
+// Strip the trivial case of a variable reference: constant inited variables.
+//
+// TODO: Traverse linear assignment
+//   int_type_t sz = sizeof(X);
+//   sz += sizeof(Y);
+//   malloc(sz);
+//
+// this is seen a lot in real world, and we don't detect the types involved,
+// let alone accurately inferring the actual allocation type.
+static const Expr *stripDeclRef(const ASTContext &Ctx, const DeclRefExpr *DRE) {
+  const VarDecl *VD = dyn_cast<VarDecl>(DRE->getDecl());
+  if (!VD)
+    return DRE;
+  QualType DeclType = VD->getType();
+  if (!DeclType->isIntegerType() || !DeclType.isConstant(Ctx))
+    return DRE;
+  if (const Expr *Init = VD->getInit())
+    return Init;
+  return DRE;
+}
+
+// Handle multiplication (order independent):
+//   non-type * non-type => non-type
+//   type * non-type => array-type
+//   array-type * non-type => array-type
+//   type * type => indeterminate-type
+//   indeterminate-type * any => indeterminate-type
+static std::optional<InferredAllocationType>
+mergeMultiplies(std::optional<InferredAllocationType> LHS,
+                std::optional<InferredAllocationType> RHS) {
+  if (!LHS && !RHS)
+    return std::nullopt;
+
+  // If both sides are valid we have some variation of sizeof(A) * sizeof(B)
+  // which we can't really reason about
+  if (LHS && RHS) {
+    SmallVector<QualType, 2> Entries;
+    LHS->extractRelatedTypes(Entries);
+    RHS->extractRelatedTypes(Entries);
+    bool IsConstantSize = LHS->isConstantSize() && RHS->isConstantSize();
+    return InferredAllocationType::createUnknownLayout(std::move(Entries),
+                                                       IsConstantSize);
+  }
+
+  const InferredAllocationType &Type = LHS ? *LHS : *RHS;
+  // Already an array, so we've just got something like sizeof(A) * x * y
+  if (Type.isArray())
+    return Type;
+
+  // This has the effect of flattening (sizeof(A) + sizeof(B)) * x
+  // but for now that's ok
+  if (auto ElementType = Type.primaryType())
+    return InferredAllocationType::createArray(*ElementType,
+                                               /*IsConstantSize=*/false);
+  return std::nullopt;
+}
+
+// Handle addition all order independent, except tuples
+//   prefixed-array + indeterminate => prefixed-array
+//   prefixed-array + non-type => prefixed-array
+//   prefixed-array + prefixed-array => indeterminate
+//   array-type + array-type:
+//     if element type match
+//   type + (non-type or indeterminate):
+//     if type has a flexible array member => prefixed-array
+//     else => indeterminate
+//   type + array-type => prefixed-array
+//   type + type + ... => tuple-type (type, type, ...)
+static std::optional<InferredAllocationType>
+mergeAddition(const ASTContext &Ctx, std::optional<InferredAllocationType> LHS,
+              std::optional<InferredAllocationType> RHS) {
+  if (!LHS && !RHS)
+    return std::nullopt;
+
+  bool IsConstantSize =
+      LHS && RHS && LHS->isConstantSize() && RHS->isConstantSize();
+
+  auto ConstructUnknownLayout = [&]() {
+    llvm::SmallVector<QualType, 2> RelatedTypes;
+    if (LHS)
+      LHS->extractRelatedTypes(RelatedTypes);
+    if (RHS)
+      RHS->extractRelatedTypes(RelatedTypes);
+    return InferredAllocationType::createUnknownLayout(std::move(RelatedTypes),
+                                                       IsConstantSize);
+  };
+
+  // type-with-flexible-array + unknown => prefixed-array; else
+  // any + unknown => unknown
+  if (!LHS || !RHS || LHS->isUnknownLayout() || RHS->isUnknownLayout()) {
+    auto *Type = LHS ? LHS->asObject() : nullptr;
+    if (!Type)
+      Type = RHS ? RHS->asObject() : nullptr;
+    if (!Type)
+      return ConstructUnknownLayout();
+    std::optional<QualType> ElementType =
+        Ctx.findFlexibleArrayElementType(Type->Type);
+    if (!ElementType)
+      return ConstructUnknownLayout();
+    return InferredAllocationType::createPrefixedArray(Type->Type, *ElementType,
+                                                       IsConstantSize);
+  }
+
+  // Both LHS and RHS are present and have known layout from here on.
+  assert(LHS && RHS && !LHS->isUnknownLayout() && !RHS->isUnknownLayout());
+
+  // array<T> + array<T> => array<T>
+  // array<T> + array<U> => unknown
+  if (LHS->isArray() && RHS->isArray()) {
+    const auto &LeftType = *LHS->asArray();
+    const auto &RightType = *RHS->asArray();
+    if (!Ctx.hasSameUnqualifiedType(LeftType.ElementType,
+                                    RightType.ElementType))
+      return ConstructUnknownLayout();
+    return InferredAllocationType::createArray(LeftType.ElementType,
+                                               IsConstantSize);
+  }
+
+  // If both sides are header prefixed arrays, mark it as an indeterminate type
+  if (LHS->isPrefixedArray() && RHS->isPrefixedArray())
+    return ConstructUnknownLayout();
+
+  // Somewhat convoluted, but we need to handle
+  //   sizeof(Header) + sizeof(Element) * a + sizeof(Element) * b
+  auto ExtendPrefixedArray = [&](const InferredAllocationType &Header,
+                                 const InferredAllocationType &Tail)
+      -> std::optional<InferredAllocationType> {
+    if (!Header.isPrefixedArray() || !Tail.isArray())
+      return std::nullopt;
+    auto *PrefixedArrayType = Header.asPrefixedArray();
+    auto *ArrayType = Tail.asArray();
+    auto ElementType = PrefixedArrayType->ElementType;
+    if (!ElementType) {
+      return InferredAllocationType::createPrefixedArray(
+          PrefixedArrayType->HeaderType, ArrayType->ElementType,
+          IsConstantSize);
+    }
+    if (!Ctx.hasSameUnqualifiedType(*ElementType, *ArrayType->primaryType()))
+      return ConstructUnknownLayout();
+    return InferredAllocationType::createPrefixedArray(
+        PrefixedArrayType->HeaderType, *ElementType, IsConstantSize);
+  };
+  if (auto ExtendedPrefixedArray = ExtendPrefixedArray(*LHS, *RHS))
+    return ExtendedPrefixedArray;
+  if (auto ExtendedPrefixedArray = ExtendPrefixedArray(*RHS, *LHS))
+    return ExtendedPrefixedArray;
+
+  // Header prefixed arrays, we just assume any non prefixed-array or non-array
+  // type + an array is a prefixed-array
+  auto ConstructRealPrefixedArray = [&](const InferredAllocationType &Header,
+                                        const InferredAllocationType &Tail)
+      -> std::optional<InferredAllocationType> {
+    if (Header.isArray() || !Tail.isArray())
+      return std::nullopt;
+    std::optional<QualType> HeaderType = Header.primaryType();
+    std::optional<QualType> ElementType = Tail.primaryType();
+    if (!HeaderType || !ElementType)
+      return std::nullopt;
+    return InferredAllocationType::createPrefixedArray(
+        *HeaderType, *ElementType, IsConstantSize);
+  };
+  if (auto PrefixedArray = ConstructRealPrefixedArray(*LHS, *RHS))
+    return PrefixedArray;
+  if (auto PrefixedArray = ConstructRealPrefixedArray(*RHS, *LHS))
+    return PrefixedArray;
+
+  // Finally deal with the tuple case
+  if (!LHS->isArray() && !RHS->isArray()) {
+    SmallVector<QualType, 2> Entries;
+    LHS->extractRelatedTypes(Entries);
+    RHS->extractRelatedTypes(Entries);
+    return InferredAllocationType::createTuple(std::move(Entries));
+  }
+  return ConstructUnknownLayout();
+}
+
+namespace {
+
+class AllocationInferenceWalker
+    : public ConstStmtVisitor<AllocationInferenceWalker,
+                              std::optional<InferredAllocationType>> {
+  const ASTContext &Ctx;
+
+public:
+  explicit AllocationInferenceWalker(const ASTContext &Ctx) : Ctx(Ctx) {}
+
+  std::optional<InferredAllocationType>
+  VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *E) {
+    if (E->getKind() == UETT_SizeOf)
+      return InferredAllocationType::create(E->getTypeOfArgument());
+    return std::nullopt;
+  }
+
+  std::optional<InferredAllocationType>
+  VisitBinaryOperator(const BinaryOperator *E) {
+    switch (E->getOpcode()) {
+    case BO_Assign:
+      return Visit(E->getRHS());
+    case BO_Mul:
+    case BO_MulAssign:
+      return mergeMultiplies(Visit(E->getLHS()), Visit(E->getRHS()));
+    case BO_Add:
+    case BO_AddAssign:
+      return mergeAddition(Ctx, Visit(E->getLHS()), Visit(E->getRHS()));
+    case BO_Comma:
+      return Visit(E->getRHS());
+    default:
+      return VisitExpr(E);
+    }
+  }
+
+  std::optional<InferredAllocationType>
+  VisitUnaryOperator(const UnaryOperator *E) {
+    switch (E->getOpcode()) {
+    case UO_Minus:
+    case UO_Plus:
+      return Visit(E->getSubExpr());
+    default:
+      return VisitExpr(E);
+    }
+  }
+
+  std::optional<InferredAllocationType> VisitDeclRefExpr(const DeclRefExpr *E) {
+    const Expr *Stripped = stripDeclRef(Ctx, E);
+    if (Stripped != E)
+      return Visit(Stripped);
+    return std::nullopt;
+  }
+
+  std::optional<InferredAllocationType>
+  VisitOpaqueValueExpr(const OpaqueValueExpr *E) {
+    if (const Expr *Src = E->getSourceExpr())
+      return Visit(Src);
+    return std::nullopt;
+  }
+
+  std::optional<InferredAllocationType>
+  VisitGenericSelectionExpr(const GenericSelectionExpr *E) {
+    return Visit(E->getResultExpr());
+  }
+
+  // The final fallback for unrecognized expressions is to simply traverse all
+  // the children and accumulate all nested types.
+  // If there is a single non-trivial nested type we propogate it on the
+  // assumption that it is sufficiently complex inference to be reasonably
+  // accurate.
+  // Otherwise we report an UnknownLayout containing the union of all contained
+  // types.
+  std::optional<InferredAllocationType> VisitExpr(const Expr *E) {
+    SmallVector<InferredAllocationType, 2> NestedTypes;
+    size_t ChildCount = 0;
+    for (const Stmt *SubStmt : E->children()) {
+      const Expr *SubExpr = dyn_cast<Expr>(SubStmt);
+      if (!SubExpr)
+        continue;
+      ++ChildCount;
+      if (auto InferredType = Visit(SubExpr))
+        NestedTypes.push_back(std::move(*InferredType));
+    }
+    if (NestedTypes.empty())
+      return std::nullopt;
+    // We don't include single object matches here, as it is very easy for a
+    // complex expression to end up only referencing a single visible type,
+    // so we're likely overselling our knowledge if we simply propogate that.
+    if (NestedTypes.size() == 1 &&
+        (ChildCount == 1 || !NestedTypes[0].asObject()))
+      return NestedTypes[0];
+    llvm::SmallVector<QualType, 2> ReferencedTypes;
+    for (auto &Type : NestedTypes)
+      Type.extractRelatedTypes(ReferencedTypes);
+    return InferredAllocationType::createUnknownLayout(
+        std::move(ReferencedTypes),
+        /*IsConstantSize=*/false);
+  }
+};
+
+} // anonymous namespace
+
+static std::optional<InferredAllocationType>
+inferAllocationType(const ASTContext &Ctx, const Expr *E) {
+  return AllocationInferenceWalker(Ctx).Visit(E);
+}
+
+InferredTypeInfo
+TypedMemoryInference::inferType(const ASTContext &Ctx, const CallExpr *Call,
+                                const Expr &SizeArg,
+                                const CastExpr *ContainingCastExpr) {
+  assert(Call->getDependence() == ExprDependence::None);
+  assert(SizeArg.getDependence() == ExprDependence::None);
+  assert(!ContainingCastExpr ||
+         ContainingCastExpr->getDependence() == ExprDependence::None);
+
+  auto InsertionResult = InferredTMOCallTypes.insert({Call, {}});
+  // Capturing a structured binding is an C++20 extension which we warn about
+  auto Found = InsertionResult.first;
+  bool Inserted = InsertionResult.second;
+  if (!Inserted)
+    return Found->second;
+
+  auto RecordResult =
+      [&, Found](const Expr *InferredExpr,
+                 std::optional<InferredAllocationType> InferredType,
+                 TypedMemoryCallsiteFlags Flags) {
+        return (Found->second = {InferredType, InferredExpr->IgnoreImplicit(),
+                                 Flags});
+      };
+
+  QualType CastRecordTarget;
+  if (ContainingCastExpr && Call->getCallReturnType(Ctx)->isPointerType()) {
+    QualType CastDest = ContainingCastExpr->getType();
+    if (CastDest->isAnyPointerType()) {
+      CastDest = CastDest->getPointeeType();
+      if (const RecordType *CastRecord = CastDest->getAsStructureType())
+        CastRecordTarget = QualType(CastRecord, 0);
+    }
+  }
+  auto InferredType = inferAllocationType(Ctx, &SizeArg);
+  bool PreferCastType = false;
+  if (InferredType && !CastRecordTarget.isNull()) {
+    if (auto Inferred = InferredType->primaryType()) {
+      PreferCastType = (*Inferred)->isVoidPointerType() ||
+                       (*Inferred)->isVoidType() || (*Inferred)->isCharType();
+    }
+  }
+  if (InferredType && !PreferCastType) {
+    TypedMemoryCallsiteFlags Flags = TypedMemoryCallsiteFlags::None;
+    if (InferredType->isConstantSize())
+      Flags |= TypedMemoryCallsiteFlags::FixedSize;
+    if (InferredType->isArray())
+      Flags |= TypedMemoryCallsiteFlags::Array;
+    if (InferredType->isPrefixedArray())
+      Flags |= TypedMemoryCallsiteFlags::HeaderPrefixedArray;
+    if (auto *PrefixedArrayType = InferredType->asPrefixedArray();
+        PrefixedArrayType && !PrefixedArrayType->ElementType) {
+      if (auto PrefixedArrayElement =
+              Ctx.findFlexibleArrayElementType(PrefixedArrayType->HeaderType))
+        InferredType = InferredAllocationType::createPrefixedArray(
+            PrefixedArrayType->HeaderType, PrefixedArrayElement,
+            PrefixedArrayType->IsConstantSize);
+    }
+    return RecordResult(SizeArg.IgnoreImplicit(), InferredType, Flags);
+  }
+
+  if (!ContainingCastExpr || !Call->getCallReturnType(Ctx)->isPointerType())
+    return RecordResult(&SizeArg, std::nullopt, TypedMemoryCallsiteFlags::None);
+
+  QualType CastDest = ContainingCastExpr->getType();
+  if (!CastDest->isAnyPointerType())
+    return RecordResult(&SizeArg, std::nullopt, TypedMemoryCallsiteFlags::None);
+
+  QualType CastTarget = CastDest->getPointeeType();
+  if (InferredType) {
+    TypedMemoryCallsiteFlags Flags = TypedMemoryCallsiteFlags::None;
+    if (InferredType->isConstantSize())
+      Flags |= TypedMemoryCallsiteFlags::FixedSize;
+    if (auto *InferredArray = InferredType->asArray()) {
+      Flags |= TypedMemoryCallsiteFlags::Array;
+      return RecordResult(ContainingCastExpr,
+                          InferredAllocationType::createArray(
+                              CastTarget, InferredArray->IsConstantSize),
+                          Flags);
+    }
+    if (auto *PrefixedArray = InferredType->asPrefixedArray()) {
+      Flags |= TypedMemoryCallsiteFlags::HeaderPrefixedArray;
+      return RecordResult(ContainingCastExpr,
+                          InferredAllocationType::createPrefixedArray(
+                              CastDest->getPointeeType(),
+                              PrefixedArray->ElementType,
+                              PrefixedArray->IsConstantSize),
+                          Flags);
+    }
+  }
+  return RecordResult(
+      ContainingCastExpr,
+      InferredAllocationType::create(CastDest->getPointeeType()),
+      TypedMemoryCallsiteFlags::FixedSize);
+}
+
+StringRef
+ASTContext::getTypeSummaryDescription(TypedMemorySummary Summary) const {
+  return getTMOInference().getTypeSummaryDescription(Summary);
+}
+
+ASTContext::TypedMemoryDescriptor
+ASTContext::getTypedMemoryDescriptor(QualType QT, OverloadedOperatorKind Op,
+                                     TypedMemoryCallsiteFlags Flags) const {
+  return getTMOInference().getDescriptor(*this, QT, Op, Flags);
+}
+
+void ASTContext::setInferredInfoForCall(const CallExpr *Call,
+                                        InferredTypeInfo Info) {
+  getTMOInference().setInferredInfoForCall(Call, Info);
+}
+
+std::optional<InferredTypeInfo>
+ASTContext::getInferredInfoForCall(const CallExpr *Call) const {
+  return getTMOInference().getInferredInfoForCall(*this, Call);
+}
+
+InferredTypeInfo
+ASTContext::inferTypedMemoryType(const CallExpr *Call, const Expr &SizeArg,
+                                 const CastExpr *ContainingCastExpr) const {
+  return getTMOInference().inferType(*this, Call, SizeArg, ContainingCastExpr);
+}

--- a/clang/lib/AST/TypedMemoryLayoutBuilder.cpp
+++ b/clang/lib/AST/TypedMemoryLayoutBuilder.cpp
@@ -1,0 +1,140 @@
+#include "clang/AST/TypedMemoryLayoutBuilder.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclVisitor.h"
+#include "clang/AST/RecordLayout.h"
+#include "llvm/ADT/SmallSet.h"
+#include <cassert>
+
+using namespace clang;
+
+static TypedMemoryFieldsVec CollectFields(const ASTContext &Context,
+                                          QualType QT, const Decl *Parent);
+
+class TypedMemoryRecordVisitor
+    : public ConstDeclVisitor<TypedMemoryRecordVisitor> {
+  const ASTContext &Context;
+
+public:
+  TypedMemoryFieldsVec Fields;
+
+  TypedMemoryRecordVisitor(const ASTContext &Ctx) : Context(Ctx) {}
+
+  void VisitRecordDecl(const RecordDecl *D) {
+    if (D->isInvalidDecl()) {
+      Fields.clear();
+      return;
+    }
+
+    if (const CXXRecordDecl *CXXRD = dyn_cast_or_null<CXXRecordDecl>(D)) {
+      Visit(CXXRD);
+    } else {
+      for (auto F : D->fields())
+        Visit(F);
+    }
+  }
+
+  void VisitCXXRecordDecl(const CXXRecordDecl *D) {
+    processCXXDecl(D, 0, true);
+  }
+
+  void VisitFieldDecl(const FieldDecl *D) { processFieldDecl(D, 0); }
+
+  void processCXXDecl(const CXXRecordDecl *CXXRD, int64_t BaseClassOffset,
+                      bool ProcessVBases) {
+    if (CXXRD->isInvalidDecl()) {
+      Fields.clear();
+      return;
+    }
+
+    const ASTRecordLayout &RL = Context.getASTRecordLayout(CXXRD);
+    if ((CXXRD->isDynamicClass() && !RL.getPrimaryBase()) || RL.hasOwnVFPtr()) {
+      // add the vtable pointer
+      Fields.emplace_back(Context.VoidPtrTy, BaseClassOffset,
+                          Context.getTypeSize(Context.VoidPtrTy),
+                          /* Parent */ nullptr);
+    }
+
+    // process non-virtual bases
+    for (const CXXBaseSpecifier &BaseSpec : CXXRD->bases()) {
+      if (!BaseSpec.isVirtual()) {
+        const CXXRecordDecl *Base = BaseSpec.getType()->getAsCXXRecordDecl();
+        int64_t OffsetInBits = RL.getBaseClassOffset(Base).getQuantity() * 8;
+        processCXXDecl(Base, BaseClassOffset + OffsetInBits,
+                       /*ProcessVBases=*/false);
+      }
+    }
+
+    // process fields
+    for (auto F : CXXRD->fields())
+      processFieldDecl(F, BaseClassOffset);
+
+    // process virtual bases
+    if (ProcessVBases) {
+      for (const CXXBaseSpecifier &BaseSpec : CXXRD->vbases()) {
+        const CXXRecordDecl *VBase = BaseSpec.getType()->getAsCXXRecordDecl();
+        int64_t OffsetInBits = RL.getVBaseClassOffset(VBase).getQuantity() * 8;
+        processCXXDecl(VBase, BaseClassOffset + OffsetInBits,
+                       /*ProcessVBases=*/false);
+      }
+    }
+  }
+
+  void processFieldDecl(const FieldDecl *D, int64_t BaseClassOffset) {
+    if (D->isInvalidDecl() || D->getParent()->isInvalidDecl()) {
+      Fields.clear();
+      return;
+    }
+
+    const ASTRecordLayout *RL = &Context.getASTRecordLayout(D->getParent());
+    const QualType &QT = D->getType();
+    uint64_t FieldOffset =
+        RL->getFieldOffset(D->getFieldIndex()) + BaseClassOffset;
+    if (D->isBitField()) {
+      Fields.emplace_back(QT, FieldOffset, D->getBitWidthValue(),
+                          dyn_cast<Decl>(D));
+    } else {
+      for (auto &F : CollectFields(Context, QT, dyn_cast<Decl>(D))) {
+        Fields.emplace_back(F.Type, F.Offset + FieldOffset, F.Width,
+                            F.TypeOrFieldDecl);
+      }
+    }
+  }
+};
+
+static TypedMemoryFieldsVec CollectFields(const ASTContext &Context,
+                                          QualType QT, const Decl *Parent) {
+  TypedMemoryFieldsVec Fields;
+  if (QT->isRecordType()) {
+    if (!QT->getAsRecordDecl()->isInvalidDecl()) {
+      TypedMemoryRecordVisitor RV(Context);
+      RV.Visit(QT->getAs<RecordType>()->getDecl());
+      Fields = std::move(RV.Fields);
+    }
+  } else if (QT->isConstantArrayType()) {
+    const ConstantArrayType *CAT = Context.getAsConstantArrayType(QT);
+    QualType ElemType = CAT->getElementType();
+    unsigned ElemWidth = Context.getTypeSize(ElemType);
+    uint64_t Count = CAT->getSize().getZExtValue();
+    assert(Context.getTypeSize(QT) >= Count * ElemWidth);
+    auto ElemFields = CollectFields(Context, ElemType, /* Parent */ nullptr);
+    for (uint64_t I = 0; I < Count; I++) {
+      for (auto &EF : ElemFields) {
+        Fields.emplace_back(EF.Type, EF.Offset + I * ElemWidth, EF.Width,
+                            Parent);
+      }
+    }
+  } else {
+    Fields.emplace_back(QT, 0, Context.getTypeSize(QT), Parent);
+  }
+  return Fields;
+}
+
+TypedMemoryLayoutBuilder::TypedMemoryLayoutBuilder(const ASTContext &Ctx,
+                                                   QualType QT)
+    : Context(Ctx), QType(QT), Layout({}) {}
+
+void TypedMemoryLayoutBuilder::build() {
+  assert(Layout.Fields.empty());
+  Layout.Width = Context.getTypeSize(QType);
+  Layout.Fields = CollectFields(Context, QType, /* Parent */ nullptr);
+}

--- a/clang/lib/AST/TypedMemoryTypeDescriptor.cpp
+++ b/clang/lib/AST/TypedMemoryTypeDescriptor.cpp
@@ -1,0 +1,141 @@
+#include "clang/AST/TypedMemoryTypeDescriptor.h"
+#include "clang/AST/DeclCXX.h"
+#include "llvm/Support/SipHash.h"
+
+namespace clang {
+
+bool TypedMemoryTypeDescriptor::initialize(const QualType &QT,
+                                           const TypedMemoryLayout &Layout) {
+  Flags = TypedMemoryTypeFlags::None;
+
+  initializeLayoutProperties(Layout);
+
+  if (const CXXRecordDecl *RD = QT->getAsCXXRecordDecl()) {
+    if (RD->isPolymorphic()) {
+      Flags |= TypedMemoryTypeFlags::IsPolymorphic;
+    }
+  }
+
+  return true;
+}
+
+bool TypedMemoryTypeDescriptor::initializeLayoutProperties(
+    const TypedMemoryLayout &Layout) {
+  LayoutProperties.clear();
+  LayoutSemantics = TypedMemoryLayoutSemantics::None;
+
+  auto &Fields = Layout.Fields;
+  for (auto &F : Fields) {
+    if (F.Width > 0) {
+      auto S = getFieldSemantics(&F);
+      LayoutSemantics |= S;
+      LayoutProperties.push_back({F.Offset, F.Width, S});
+    }
+  }
+
+  llvm::stable_sort(LayoutProperties,
+                    [&](LayoutSemanticsSpan L, LayoutSemanticsSpan R) {
+                      return L.Offset < R.Offset;
+                    });
+
+  initializeCoalescedLayoutProperties(Layout);
+  return true;
+}
+
+void TypedMemoryTypeDescriptor::initializeCoalescedLayoutProperties(
+    const TypedMemoryLayout &Layout) {
+  CoalescedLayoutProperties.clear();
+  if (LayoutProperties.empty() || Layout.Width == 0)
+    return;
+
+  SmallVector<TypedMemoryLayoutSemantics> Unfolded;
+  Unfolded.resize(Layout.Width, TypedMemoryLayoutSemantics::None);
+
+  for (auto &Cur : LayoutProperties) {
+    for (size_t I = Cur.Offset; I < Cur.Offset + Cur.Width; I++) {
+      if (Unfolded[I] != TypedMemoryLayoutSemantics::None &&
+          Unfolded[I] != Cur.Semantics) {
+        Flags |= TypedMemoryTypeFlags::HasMixedUnions;
+      }
+      Unfolded[I] |= Cur.Semantics;
+    }
+  }
+
+  CoalescedLayoutProperties.push_back({0, 0, Unfolded.front()});
+  for (size_t I = 0; I < Unfolded.size(); I++) {
+    LayoutSemanticsSpan &Last = CoalescedLayoutProperties.back();
+    if (Unfolded[I] == Last.Semantics) {
+      Last.Width += 1;
+    } else {
+      CoalescedLayoutProperties.push_back({I, 1, Unfolded[I]});
+    }
+  }
+}
+
+TypedMemoryLayoutSemantics TypedMemoryTypeDescriptor::getFieldSemantics(
+    const TypedMemoryLayoutField *F) const {
+  // TODO: Process any field attribute here
+  return getTypeSemantics(F->Type);
+}
+
+TypedMemoryLayoutSemantics
+TypedMemoryTypeDescriptor::getTypeSemantics(const QualType &QType) const {
+
+  QualType QT = QType;
+  TypedMemoryLayoutSemantics S = TypedMemoryLayoutSemantics::None;
+
+  // For _Atomic-qualified types, retrieve the value type, so that we compute
+  // the encoding of the underlying semantics of the type.
+  if (auto *AT = QT->getAs<AtomicType>())
+    QT = AT->getValueType();
+
+  QualType Pointee = QT->getPointeeType();
+  if (!Pointee.isNull()) {
+    if (Pointee->isIntegerType()) {
+      // pointer-to-data
+      S |= TypedMemoryLayoutSemantics::DataPointer;
+    } else if (Pointee->isRecordType() || Pointee->isUnionType()) {
+      // pointer-to-structure
+      S |= TypedMemoryLayoutSemantics::StructPointer;
+    } else {
+      // anonymous-pointer
+      S |= TypedMemoryLayoutSemantics::AnonymousPointer;
+    }
+
+    if ((QT.isConstQualified() || Pointee.isConstQualified()) ||
+        QT.getLocalQualifiers().getPointerAuth().withoutKeyNone()) {
+      // immutable-pointer
+      S |= TypedMemoryLayoutSemantics::ImmutablePointer;
+    }
+  } else {
+    // TODO: For now, we don't have other encodings.
+    S |= TypedMemoryLayoutSemantics::GenericData;
+
+    // There are magic pointer-like values that are ostensibly
+    // opaque "data", that for now we will simply report as
+    // GenericData | AnonymousPointer. If some of these special
+    // values become sufficiently important we can add additional
+    // diversification in future.
+    if (QT->hasPointerRepresentation())
+      S |= TypedMemoryLayoutSemantics::AnonymousPointer;
+  }
+
+  return S;
+}
+
+uint32_t TypedMemoryTypeDescriptor::computeTypeHash() const {
+  std::string layoutString;
+  llvm::raw_string_ostream layoutStream(layoutString);
+  for (auto &S : CoalescedLayoutProperties) {
+    layoutStream << "[" << S.Offset << "," << S.Width << ":"
+                 << static_cast<uint16_t>(S.Semantics) << "]";
+  }
+  return llvm::getTypedMemoryDescriptorStableSipHash(layoutString) & 0xffffffff;
+}
+
+uint32_t TypedMemoryTypeDescriptor::computeTypeNameHash(const QualType &QT) {
+  std::string TypeName = QT.getAsString();
+  return llvm::getTypedMemoryDescriptorStableSipHash(TypeName) & 0xffffffff;
+}
+
+} // namespace clang

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -7345,6 +7345,13 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
         MD && MD->isImplicitObjectMemberFunction())
       return EmitCXXOperatorMemberCallExpr(CE, MD, ReturnValue, CallOrInvoke);
 
+  auto *CalleeExpr = E->getCallee();
+
+  if (auto *CalleeDecl = CalleeExpr->getReferencedDeclOfCallee()) {
+    if (auto *TMA = CalleeDecl->getAttr<TypedMemoryAttr>())
+      return EmitTypedMemoryCall(E, TMA, ReturnValue);
+  }
+
   CGCallee callee = EmitCallee(E->getCallee());
 
   if (callee.isBuiltin()) {
@@ -7603,6 +7610,10 @@ CGCallee CodeGenFunction::EmitCallee(const Expr *E) {
   CGPointerAuthInfo pointerAuth = CGM.getFunctionPointerAuthInfo(functionType);
   CGCallee callee(calleeInfo, calleePtr, pointerAuth);
   return callee;
+}
+
+CGCallee CodeGenFunction::EmitCallee(const FunctionDecl *FD) {
+  return EmitDirectCallee(*this, GlobalDecl(FD));
 }
 
 LValue CodeGenFunction::EmitBinaryOperatorLValue(const BinaryOperator *E) {

--- a/clang/lib/CodeGen/CGTypedMemory.cpp
+++ b/clang/lib/CodeGen/CGTypedMemory.cpp
@@ -1,0 +1,138 @@
+//===--- CGTypedMemory.cpp - Code Generation for Typed Memory Operations --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements code generation for typed memory operations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CGCall.h"
+#include "CGDebugInfo.h"
+#include "CodeGenFunction.h"
+#include "CodeGenModule.h"
+#include "ConstantEmitter.h"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Type.h"
+#include "clang/AST/TypedMemoryDescriptorBits.h"
+#include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/CodeGen/MachineStableHash.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/Support/xxhash.h"
+
+using namespace clang;
+using namespace CodeGen;
+
+// The implementation is borrowed from SourceLocation::print but the file path
+// is removed from the filename.
+static void GetLocationHashTMO(llvm::raw_string_ostream &OS,
+                               const SourceManager &SM, SourceLocation Loc) {
+  if (!Loc.isValid()) {
+    OS << "<invalid loc>";
+    return;
+  }
+
+  if (Loc.isFileID()) {
+    PresumedLoc PLoc = SM.getPresumedLoc(Loc);
+
+    if (PLoc.isInvalid()) {
+      OS << "<invalid>";
+      return;
+    }
+    // The macro expansion and spelling pos is identical for file locs.
+    OS << llvm::sys::path::filename(PLoc.getFilename()) << ':' << PLoc.getLine()
+       << ':' << PLoc.getColumn();
+    return;
+  }
+
+  GetLocationHashTMO(OS, SM, SM.getExpansionLoc(Loc));
+
+  OS << " <Spelling=";
+  GetLocationHashTMO(OS, SM, SM.getSpellingLoc(Loc));
+  OS << '>';
+}
+
+static llvm::stable_hash GetLocationHash(const CodeGenModule &CGM,
+                                         SourceLocation Loc) {
+  std::string LocationString;
+  auto &SM = CGM.getContext().getSourceManager();
+  llvm::raw_string_ostream OS(LocationString);
+  GetLocationHashTMO(OS, SM, Loc);
+  return llvm::xxh3_64bits(LocationString);
+}
+
+RValue CodeGenFunction::EmitTypedMemoryCall(const CallExpr *E,
+                                            TypedMemoryAttr *TMA,
+                                            ReturnValueSlot ReturnValue) {
+  assert(CGM.getLangOpts().TypedMemoryOperations);
+  auto *Target = TMA->getRewriteTarget();
+  auto *TargetPrototype = cast<FunctionProtoType>(Target->getFunctionType());
+  auto *OriginalDecl = E->getDirectCallee();
+  auto *OriginalType = OriginalDecl->getType()->getAs<FunctionProtoType>();
+  auto &Context = getContext();
+  CGCallee Callee = EmitCallee(Target);
+  auto PropertyDescriptorType = Context.getBitIntType(true, 64);
+  CallArgList CallArgs;
+  EmitCallArgs(CallArgs, OriginalType, E->arguments());
+
+  auto InferredParamIndex = TMA->getInferredParameterIdx().getLLVMIndex();
+  auto *InferredParameter = E->getArg(InferredParamIndex);
+
+  TypedMemoryDescriptorBits Descriptor;
+  if (auto InferredInfo = Context.getInferredInfoForCall(E);
+      InferredInfo && InferredInfo->Type) {
+    if (auto PrimaryType = InferredInfo->Type->primaryType()) {
+      auto TypeDescriptor = Context.getTypedMemoryDescriptor(
+          *PrimaryType, OO_None, InferredInfo->InferredCallsiteFlags);
+      Descriptor = TypeDescriptor.asBits();
+    }
+  } else {
+    auto LocationHash = GetLocationHash(CGM, E->getExprLoc());
+    // We leave all descriptor flags as empty if we were unable to
+    // infer the type for an expression, and use a hash of the call location
+    // to allow callsite discrimination by the client.
+    Descriptor.Hash = static_cast<uint32_t>(LocationHash);
+  }
+  Descriptor.Summary.TypeKind = TypedMemoryTypeKind::KindC;
+
+  auto *DescriptorId = llvm::ConstantInt::get(CGM.Int64Ty, Descriptor.value());
+  DescriptorId->setName("type_descriptor");
+  auto *ConvertedValue = EmitScalarConversion(
+      DescriptorId, PropertyDescriptorType,
+      TargetPrototype->getParamType(InferredParamIndex + 1),
+      InferredParameter->getExprLoc());
+  auto InferredTypeArg =
+      CallArg(RValue::get(ConvertedValue), PropertyDescriptorType);
+  CallArgs.insert(CallArgs.begin() + InferredParamIndex + 1, InferredTypeArg);
+
+  const CGFunctionInfo &FnInfo =
+      CGM.getTypes().arrangeFreeFunctionCall(CallArgs, TargetPrototype, false);
+  llvm::CallBase *CallOrInvoke = nullptr;
+  RValue Call = EmitCall(FnInfo, Callee, ReturnValue, CallArgs, &CallOrInvoke,
+                         /*IsMustTail=*/false, E->getExprLoc());
+
+  // Add Annotation metadata to make the type descriptor available for tests.
+  const std::string DescriptorValue = std::to_string(Descriptor.value());
+  const std::string DescriptorHash = std::to_string(Descriptor.Hash);
+  StringRef TypeSummaryDesc =
+      Context.getTypeSummaryDescription(Descriptor.Summary);
+  CallOrInvoke->addAnnotationMetadata(
+      {"type-descriptor", DescriptorValue, DescriptorHash, TypeSummaryDesc});
+
+  // Generate function declaration DISuprogram in order to be used
+  // in debug info about call sites.
+  if (CGDebugInfo *DI = getDebugInfo()) {
+    if (auto *CalleeDecl = dyn_cast_or_null<FunctionDecl>(Target))
+      DI->EmitFuncDeclForCallSite(CallOrInvoke, Target->getType(), CalleeDecl);
+  }
+  return Call;
+}

--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -96,6 +96,7 @@ add_clang_library(clangCodeGen
   CGRecordLayoutBuilder.cpp
   CGStmt.cpp
   CGStmtOpenMP.cpp
+  CGTypedMemory.cpp
   CGVTT.cpp
   CGVTables.cpp
   CodeGenABITypes.cpp

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -4713,6 +4713,10 @@ public:
                             llvm::CallBase **CallOrInvoke = nullptr);
   CGCallee EmitCallee(const Expr *E);
 
+  RValue EmitTypedMemoryCall(const CallExpr *E, TypedMemoryAttr *TMA,
+                             ReturnValueSlot ReturnValue);
+  CGCallee EmitCallee(const FunctionDecl *FD);
+
   void checkTargetFeatures(const CallExpr *E, const FunctionDecl *TargetDecl);
   void checkTargetFeatures(SourceLocation Loc, const FunctionDecl *TargetDecl);
 

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -744,6 +744,26 @@ ExprResult Parser::ParseBuiltinPtrauthTypeDiscriminator() {
       /*isType=*/true, Ty.get().getAsOpaquePtr(), SourceRange(Loc, EndLoc));
 }
 
+ExprResult Parser::ParseBuiltinTMOGetTypeDescriptor() {
+  SourceLocation Loc = ConsumeToken();
+
+  BalancedDelimiterTracker T(*this, tok::l_paren);
+  if (T.expectAndConsume())
+    return ExprError();
+
+  TypeResult Ty = ParseTypeName();
+  if (Ty.isInvalid()) {
+    SkipUntil(tok::r_paren, StopAtSemi);
+    return ExprError();
+  }
+
+  SourceLocation EndLoc = Tok.getLocation();
+  T.consumeClose();
+  return Actions.ActOnUnaryExprOrTypeTraitExpr(
+      Loc, UETT_TMOGetTypeDescriptor,
+      /*isType=*/true, Ty.get().getAsOpaquePtr(), SourceRange(Loc, EndLoc));
+}
+
 ExprResult
 Parser::ParseCastExpression(CastParseKind ParseKind, bool isAddressOfOperand,
                             bool &NotCastExpr,
@@ -1582,6 +1602,9 @@ Parser::ParseCastExpression(CastParseKind ParseKind, bool isAddressOfOperand,
       *NotPrimaryExpression = true;
     Res = ParseExpressionTrait();
     break;
+
+  case tok::kw___builtin_tmo_get_type_descriptor:
+    return ParseBuiltinTMOGetTypeDescriptor();
 
   case tok::at: {
     if (NotPrimaryExpression)

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -105,6 +105,7 @@ add_clang_library(clangSema
   SemaTemplateVariadic.cpp
   SemaType.cpp
   SemaTypeTraits.cpp
+  SemaTypedMemory.cpp
   SemaWasm.cpp
   SemaX86.cpp
   TypeLocBuilder.cpp

--- a/clang/lib/Sema/ScopeInfo.cpp
+++ b/clang/lib/Sema/ScopeInfo.cpp
@@ -59,6 +59,7 @@ void FunctionScopeInfo::Clear() {
   Blocks.clear();
   ByrefBlockVars.clear();
   AddrLabels.clear();
+  TMOContext.clear();
 }
 
 static const NamedDecl *getBestPropertyDecl(const ObjCPropertyRefExpr *PropE) {

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -162,6 +162,7 @@ namespace {
             Self.CurFPFeatureOverrides());
       }
       updatePartOfExplicitCastFlags(castExpr);
+      Self.currentTMOContext().recordCastForTMOInference(Self, castExpr);
       return castExpr;
     }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4703,6 +4703,27 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
     return true;
   }
 
+  auto *OldTypedMemoryAttr = Old->getAttr<TypedMemoryAttr>();
+  auto *NewTypedMemoryAttr = New->getAttr<TypedMemoryAttr>();
+  if (OldTypedMemoryAttr && NewTypedMemoryAttr) {
+    if (OldTypedMemoryAttr->getRewriteTarget() !=
+        NewTypedMemoryAttr->getRewriteTarget()) {
+      Diag(NewTypedMemoryAttr->getLocation(),
+           diag::err_incompatible_duplicate_attribute)
+          << NewTypedMemoryAttr;
+      Diag(OldTypedMemoryAttr->getLocation(), diag::note_conflicting_attribute);
+      return true;
+    }
+    if (OldTypedMemoryAttr->getInferredParameterIdx() !=
+        NewTypedMemoryAttr->getInferredParameterIdx()) {
+      Diag(NewTypedMemoryAttr->getLocation(),
+           diag::err_incompatible_duplicate_attribute)
+          << NewTypedMemoryAttr;
+      Diag(OldTypedMemoryAttr->getLocation(), diag::note_conflicting_attribute);
+      return true;
+    }
+  }
+
   /*TO_UPSTREAM(BoundsSafety) ON */
   if (getLangOpts().BoundsSafetyAttributes) {
     // This is the same logic to suppress warnings in system headers.
@@ -14900,6 +14921,7 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
   llvm::scope_exit ResetDeclForInitializer([this]() {
     if (!this->ExprEvalContexts.empty())
       this->ExprEvalContexts.back().DeclForInitializer = nullptr;
+    finalizeOutstandingTMOCandidates();
   });
 
   // If there is no declaration, there was an error parsing it.  Just ignore

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8703,6 +8703,180 @@ static void handleEnforceTCBAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   D->addAttr(AttrTy::Create(S.Context, Argument, AL));
 }
 
+static bool typedMemoryTypesAreEquivalentOrDependent(const ASTContext &Context,
+                                                     QualType SourceType,
+                                                     QualType DestinationType) {
+  SourceType = Context.getCanonicalType(SourceType).getUnqualifiedType();
+  DestinationType =
+      Context.getCanonicalType(DestinationType).getUnqualifiedType();
+  if (SourceType->isDependentType() || DestinationType->isDependentType())
+    return true;
+  return SourceType == DestinationType;
+}
+
+static void handleTypedMemory(Sema &S, Decl *D, const ParsedAttr &AL) {
+  if (!S.getLangOpts().TypedMemoryOperations)
+    return;
+
+  FunctionDecl *SourceDecl = D->getAsFunction();
+  if (isFunctionOrMethodVariadic(D) || isInstanceMethod(D)) {
+    S.Diag(SourceDecl->getBeginLoc(), diag::err_tmo_function_kind_error)
+        << 0 << SourceDecl << (isFunctionOrMethodVariadic(D) ? 0 : 1);
+    AL.setInvalid();
+    return;
+  }
+
+  auto Loc = AL.getLoc();
+  if (!SourceDecl) {
+    auto *ND = cast<NamedDecl>(D);
+    S.Diag(Loc, diag::err_tmo_function_kind_error) << 0 << ND << 3;
+    AL.setInvalid();
+    return;
+  }
+  if (AL.getNumArgs() < 2) {
+    S.Diag(Loc, diag::err_attribute_too_few_arguments) << AL;
+    AL.setInvalid();
+    return;
+  }
+  if (AL.getNumArgs() > 3) {
+    S.Diag(Loc, diag::err_attribute_too_many_arguments) << AL;
+    AL.setInvalid();
+    return;
+  }
+  Expr *TargetExpr = AL.getArgAsExpr(0);
+  FunctionDecl *TargetDecl = nullptr;
+  DeclarationNameInfo TargetName;
+  if (auto *DRE = dyn_cast<DeclRefExpr>(TargetExpr)) {
+    TargetDecl = dyn_cast<FunctionDecl>(DRE->getDecl());
+    TargetName = DRE->getNameInfo();
+    if (!TargetDecl) {
+      S.Diag(Loc, diag::err_tmo_function_kind_error)
+          << DRE->getSourceRange() << 1 << DRE->getNameInfo().getName() << 3;
+      AL.setInvalid();
+      return;
+    }
+  } else if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(TargetExpr)) {
+    TargetDecl = S.ResolveSingleFunctionTemplateSpecialization(ULE, true);
+    TargetName = ULE->getNameInfo();
+    if (!TargetDecl) {
+      S.Diag(Loc, diag::err_tmo_rewrite_target_is_overloaded)
+          << TargetName.getName();
+      if (ULE->getType() == S.Context.OverloadTy)
+        S.NoteAllOverloadCandidates(ULE);
+      AL.setInvalid();
+      return;
+    }
+  } else {
+    S.Diag(Loc, diag::err_tmo_function_kind_error)
+        << TargetExpr->getSourceRange() << 1 << TargetExpr << 3;
+    AL.setInvalid();
+    return;
+  }
+
+  TargetDecl = TargetDecl->getCanonicalDecl();
+  ParamIdx InferredParameterIdx;
+  if (!S.checkFunctionOrMethodParameterIndex(D, AL, 1, AL.getArgAsExpr(1),
+                                             InferredParameterIdx))
+    return;
+
+  auto *InferredParam =
+      SourceDecl->getParamDecl(InferredParameterIdx.getASTIndex());
+  auto SizeType = InferredParam->getType();
+  auto isIntegerOrDependentNonArrayType = [](QualType QT) -> bool {
+    auto *T = QT->getUnqualifiedDesugaredType();
+    if (T->isIntegerType())
+      return true;
+    if (T->isDependentSizedArrayType())
+      return false;
+    return T->isDependentType();
+  };
+  if (!isIntegerOrDependentNonArrayType(SizeType)) {
+    S.Diag(Loc, diag::err_tmo_invalid_inferred_parameter_type)
+        << InferredParameterIdx.getSourceIndex() << SizeType
+        << InferredParam->getLocation();
+    AL.setInvalid();
+    return;
+  }
+
+  if (!hasFunctionProto(TargetDecl) || isFunctionOrMethodVariadic(TargetDecl) ||
+      isInstanceMethod(TargetDecl)) {
+    unsigned MessageSelector = !hasFunctionProto(TargetDecl)            ? 2u
+                               : isFunctionOrMethodVariadic(TargetDecl) ? 1u
+                                                                        : 0u;
+    S.Diag(Loc, diag::err_tmo_function_kind_error)
+        << 1 << TargetDecl << MessageSelector;
+    AL.setInvalid();
+    return;
+  }
+
+  auto reportTargetTypeMismatchError = [&]() {
+    std::vector<QualType> ExpectedArguments;
+    for (size_t I = 0; I < InferredParameterIdx.getSourceIndex(); I++)
+      ExpectedArguments.push_back(SourceDecl->getParamDecl(I)->getType());
+    ExpectedArguments.push_back(S.Context.getIntTypeForBitwidth(64, false));
+    for (size_t I = InferredParameterIdx.getSourceIndex();
+         I < SourceDecl->getNumParams(); I++)
+      ExpectedArguments.push_back(SourceDecl->getParamDecl(I)->getType());
+    FunctionProtoType::ExtProtoInfo EPI = {};
+    auto ExpectedType = S.Context.getFunctionType(SourceDecl->getReturnType(),
+                                                  ExpectedArguments, EPI);
+    S.Diag(Loc, diag::err_tmo_rewrite_target_type_mismatch)
+        << TargetDecl->getNameInfo().getName() << ExpectedType
+        << TargetDecl->getType();
+    S.Diag(TargetDecl->getLocation(),
+           diag::note_tmo_rewrite_target_type_mismatch);
+    AL.setInvalid();
+  };
+
+  if (!typedMemoryTypesAreEquivalentOrDependent(S.Context,
+                                                TargetDecl->getReturnType(),
+                                                SourceDecl->getReturnType())) {
+    reportTargetTypeMismatchError();
+    return;
+  }
+
+  if (getFunctionOrMethodNumParams(TargetDecl) !=
+      getFunctionOrMethodNumParams(SourceDecl) + 1) {
+    reportTargetTypeMismatchError();
+    return;
+  }
+
+  auto *TargetTypeDescriptorParam = getFunctionOrMethodParam(
+      TargetDecl, InferredParameterIdx.getASTIndex() + 1);
+  auto TargetTypeDescriptorType = TargetTypeDescriptorParam->getType();
+  if (!TargetTypeDescriptorType->isDependentType()) {
+    if (!TargetTypeDescriptorType->isIntegerType() ||
+        S.Context.getTypeSize(TargetTypeDescriptorType) != 64) {
+      reportTargetTypeMismatchError();
+      return;
+    }
+  }
+
+  size_t SourceParameterIdx = 0;
+  size_t TargetParameterIdx = 0;
+  for (; SourceParameterIdx < getFunctionOrMethodNumParams(SourceDecl);
+       SourceParameterIdx++, TargetParameterIdx++) {
+    auto *SourceParamDecl =
+        getFunctionOrMethodParam(SourceDecl, SourceParameterIdx);
+    auto *TargetParamDecl =
+        getFunctionOrMethodParam(TargetDecl, TargetParameterIdx);
+    if (!typedMemoryTypesAreEquivalentOrDependent(S.Context,
+                                                  SourceParamDecl->getType(),
+                                                  TargetParamDecl->getType())) {
+      reportTargetTypeMismatchError();
+      return;
+    }
+    if (SourceParameterIdx == InferredParameterIdx.getASTIndex())
+      TargetParameterIdx++;
+  }
+  if (AL.isInvalid())
+    return;
+
+  auto *TMA = ::new (S.Context)
+      TypedMemoryAttr(S.Context, AL, TargetDecl, InferredParameterIdx);
+  D->addAttr(TMA);
+}
+
 template <typename AttrTy, typename ConflictingAttrTy>
 static AttrTy *mergeEnforceTCBAttrImpl(Sema &S, Decl *D, const AttrTy &AL) {
   // Check if the new redeclaration has different leaf-ness in the same TCB.
@@ -9916,6 +10090,10 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
 
   case ParsedAttr::AT_EnforceTCBLeaf:
     handleEnforceTCBAttr<EnforceTCBLeafAttr, EnforceTCBAttr>(S, D, AL);
+    break;
+
+  case ParsedAttr::AT_TypedMemory:
+    handleTypedMemory(S, D, AL);
     break;
 
   case ParsedAttr::AT_BuiltinAlias:

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -4816,6 +4816,10 @@ static bool CheckExtensionTraitOperandType(Sema &S, QualType T,
       return false;
     }
   }
+  if ((T->isVoidType() || T->isFunctionType()) &&
+      TraitKind == UETT_TMOGetTypeDescriptor) {
+    return true;
+  }
   return true;
 }
 
@@ -5208,6 +5212,9 @@ bool Sema::CheckUnaryExprOrTypeTraitOperand(QualType ExprType,
   if (ExprKind == UETT_PtrAuthTypeDiscriminator)
     return checkPtrAuthTypeDiscriminatorOperandType(*this, ExprType, OpLoc,
                                                     ExprRange);
+
+  if (ExprKind == UETT_TMOGetTypeDescriptor)
+    return checkTMOGetTypeDescriptor(ExprType, OpLoc, ExprRange);
 
   // Explicitly list some types as extensions.
   if (!CheckExtensionTraitOperandType(*this, ExprType, OpLoc, ExprRange,
@@ -7326,6 +7333,7 @@ ExprResult Sema::ActOnCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
     DiagCompat(Fn->getExprLoc(), diag_compat::adl_only_template_id)
         << ULE->getName();
   }
+  currentTMOContext().recordTMOInferenceCandidate(*this, Call.get());
 
   if (LangOpts.OpenMP)
     Call = OpenMP().ActOnOpenMPCall(Call, Scope, LParenLoc, ArgExprs, RParenLoc,

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -7764,6 +7764,8 @@ ExprResult Sema::ActOnFinishFullExpr(Expr *FE, SourceLocation CC,
                                      bool IsTemplateArgument) {
   ExprResult FullExpr = FE;
 
+  finalizeOutstandingTMOCandidates();
+
   if (!FullExpr.get())
     return ExprError();
 

--- a/clang/lib/Sema/SemaTypedMemory.cpp
+++ b/clang/lib/Sema/SemaTypedMemory.cpp
@@ -1,0 +1,288 @@
+//===--- SemaExpr.cpp - Semantic Analysis for Typed Memory Operations -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements semantic analysis for typed memory operations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTStructuralEquivalence.h"
+#include "clang/AST/CXXInheritance.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/ExprObjC.h"
+#include "clang/AST/RecordLayout.h"
+#include "clang/Basic/PartialDiagnostic.h"
+#include "clang/Basic/TargetInfo.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Sema/Initialization.h"
+#include "clang/Sema/SemaHLSL.h"
+#include "clang/Sema/SemaObjC.h"
+#include "clang/Sema/SemaRISCV.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+
+using namespace clang;
+using namespace sema;
+
+static void emitTMODescriptorRemarks(
+    Sema &S, const Expr *CallExpr, const FunctionDecl *Callee,
+    const FunctionDecl *TargetFunction, SourceRange TypeRange,
+    ASTContext::TypedMemoryDescriptor TMD,
+    const InferredAllocationType &InferredType) {
+  if (S.Diags.isIgnored(diag::remark_tmo_passed_type, CallExpr->getBeginLoc()))
+    return;
+  SourceRange CallRange = CallExpr->getSourceRange();
+
+  TypedMemoryDescriptorBits TypeDescriptor = TMD.asBits();
+
+  bool IsArrayAlloc =
+      (TMD.Summary.CallsiteFlags & TypedMemoryCallsiteFlags::Array) ==
+      TypedMemoryCallsiteFlags::Array;
+  bool IsConstantArray =
+      IsArrayAlloc &&
+      !!(TMD.Summary.CallsiteFlags & TypedMemoryCallsiteFlags::FixedSize);
+
+  StringRef Note = "";
+  if (IsConstantArray)
+    Note = "constant sized array of ";
+  else if (IsArrayAlloc)
+    Note = "array of ";
+
+  std::string InferredTypeName = InferredType.describe(S.getASTContext());
+  S.Diag(CallRange.getBegin(), diag::remark_tmo_passed_type)
+      << Twine(Note, "type ") << *InferredType.primaryType() << TargetFunction
+      << (Callee == TargetFunction) << Callee << TypeRange;
+  // Note: we still only encode the primary type, not the full inferred
+  // structure
+  S.Diag(CallRange.getBegin(), diag::note_tmo_type_encoding)
+      << Note << *InferredType.primaryType() << TypeDescriptor.value()
+      << TMD.TypeDescription << TypeRange;
+}
+
+static void emitTMOInferenceDiagnostics(Sema &S, const Expr *CallExpr,
+                                        const FunctionDecl *Callee,
+                                        std::optional<QualType> Type,
+                                        const InferredTypeInfo &TypeInfo,
+                                        const FunctionDecl *RewriteTarget) {
+  assert(S.getLangOpts().TypedMemoryOperations);
+  assert(RewriteTarget);
+
+  // Don't do any work if logging is not enabled
+  bool WarnOnInferenceFailure = !S.Diags.isIgnored(
+      diag::warn_tmo_inference_failed, CallExpr->getBeginLoc());
+  bool EmitTMORemarks =
+      !S.Diags.isIgnored(diag::remark_tmo_passed_type, CallExpr->getBeginLoc());
+  if (!WarnOnInferenceFailure && !EmitTMORemarks)
+    return;
+
+  const InferredAllocationType *InferredType =
+      TypeInfo.Type ? &*TypeInfo.Type : nullptr;
+
+  const Expr *InferenceSourceExpression = TypeInfo.InferenceSourceExpression;
+  SourceRange TypeSourceRange;
+  if (const ExplicitCastExpr *CastExpr =
+          dyn_cast<ExplicitCastExpr>(InferenceSourceExpression))
+    TypeSourceRange =
+        CastExpr->getTypeInfoAsWritten()->getTypeLoc().getSourceRange();
+  else
+    TypeSourceRange = InferenceSourceExpression->getSourceRange();
+
+  llvm::scope_exit LogRewriteIfNecessary([&]() {
+    if (!EmitTMORemarks)
+      return;
+    if (!Type) {
+      S.Diag(TypeSourceRange.getBegin(), diag::note_tmo_failed_inference_source)
+          << InferenceSourceExpression << TypeSourceRange;
+      return;
+    }
+    bool WasInferredFromCast = isa<const CastExpr>(InferenceSourceExpression);
+    const Expr *EffectiveExpr = InferenceSourceExpression;
+    SourceRange EffectiveRange = TypeSourceRange;
+    if (EffectiveRange.isInvalid()) {
+      // A number of parts of sema introduce explicit CStyleCasts and similar
+      // instead of ImplicitCastExprs, but also don't include the source range
+      // of the cast sub expression either so we just substitute in the call
+      // expression itself here.
+      EffectiveExpr = CallExpr;
+      EffectiveRange = CallExpr->getSourceRange();
+    }
+    assert(InferredType);
+    const char *NotePrefix = InferredType->isArray() ? "array of " : "";
+    std::string NoteDisplay = InferredType->describe(S.getASTContext());
+    S.Diag(EffectiveRange.getBegin(), diag::note_tmo_inference_result)
+        << Twine(NotePrefix, NoteDisplay) << WasInferredFromCast
+        << EffectiveExpr->IgnoreUnlessSpelledInSource();
+  });
+
+  if (!Type) {
+    S.Diag(CallExpr->getBeginLoc(), diag::warn_tmo_inference_failed) << Callee;
+    return;
+  }
+
+  if (!EmitTMORemarks)
+    return;
+
+  assert(!(*Type)->isDependentType());
+  TypedMemoryCallsiteFlags Flags = TypeInfo.InferredCallsiteFlags;
+  ASTContext::TypedMemoryDescriptor TypeDescriptor =
+      S.getASTContext().getTypedMemoryDescriptor(
+          *Type, Callee->getDeclName().getCXXOverloadedOperator(), Flags);
+  assert(InferredType);
+  emitTMODescriptorRemarks(S, CallExpr, Callee, RewriteTarget, TypeSourceRange,
+                           TypeDescriptor, *InferredType);
+}
+
+void TypedMemoryCallsiteContext::recordInfoForInferredCall(
+    Sema &S, const CallExpr *Call) {
+  if (S.CurContext->isDependentContext())
+    return;
+
+  if (!S.getLangOpts().TypedMemoryOperations)
+    return;
+
+  const FunctionDecl *CalleeDecl = Call->getDirectCallee();
+  if (!CalleeDecl)
+    return;
+  const TypedMemoryAttr *TMA = CalleeDecl->getAttr<TypedMemoryAttr>();
+  if (!TMA)
+    return;
+  FunctionDecl *Target = TMA->getRewriteTarget();
+  unsigned InferredParamIndex = TMA->getInferredParameterIdx().getLLVMIndex();
+  const Expr *InferredParameter = Call->getArg(InferredParamIndex);
+  const CastExpr *CastExpr = nullptr;
+  if (auto FoundCast = Casts.find(Call); FoundCast != Casts.end())
+    CastExpr = FoundCast->second;
+  InferredTypeInfo InferredInfo = S.getASTContext().inferTypedMemoryType(
+      Call, *InferredParameter, CastExpr);
+
+  std::optional<QualType> PrimaryType;
+  if (InferredInfo.Type)
+    PrimaryType = InferredInfo.Type->primaryType();
+  emitTMOInferenceDiagnostics(S, Call, CalleeDecl, PrimaryType, InferredInfo,
+                              Target);
+}
+
+void TypedMemoryCallsiteContext::finalizeOutstandingTMOCandidates(Sema &S) {
+  if (!S.getLangOpts().TypedMemoryOperations)
+    return;
+  if (auto *EnclosingFunctionScope = S.getEnclosingFunction()) {
+    // Don't clear any TMO tracking information when finishing a statement
+    // expression as we may be casting the result. This is suboptimal as it
+    // means we'll maintain this across multiple substatements, but for now
+    // this is fine.
+    if (EnclosingFunctionScope->CompoundScopes.size() &&
+        EnclosingFunctionScope->CompoundScopes.back().IsStmtExpr)
+      return;
+  }
+
+  ShouldSearchCasts = false;
+
+  for (const CallExpr *Call : Calls)
+    recordInfoForInferredCall(S, Call);
+
+  Calls.clear();
+  Casts.clear();
+}
+
+void TypedMemoryCallsiteContext::recordCastForTMOInference(
+    Sema &S, const CastExpr *Cast) {
+  if (!S.getLangOpts().TypedMemoryOperations)
+    return;
+
+  if (S.CurContext->isDependentContext())
+    return;
+
+  if (Cast->getType()->isVoidPointerType())
+    return;
+
+  if (isa<ImplicitCastExpr>(Cast))
+    return;
+
+  const Expr *PotentialCall = Cast->getSubExpr();
+  const Expr *LastPotentialCall = nullptr;
+  // We need to walk through all casts and implicit nodes between the cast
+  // node and the actual underlying expression.
+  do {
+    LastPotentialCall = PotentialCall;
+    PotentialCall = PotentialCall->IgnoreParens();
+    PotentialCall = PotentialCall->IgnoreImplicit();
+    PotentialCall = PotentialCall->IgnoreCasts();
+    if (auto *OpaqueValue = dyn_cast<OpaqueValueExpr>(PotentialCall))
+      PotentialCall = OpaqueValue->getSourceExpr();
+    if (auto *SE = dyn_cast<StmtExpr>(PotentialCall)) {
+      const CompoundStmt *SubStmt = SE->getSubStmt();
+      if (auto *LastExpr = dyn_cast_or_null<Expr>(SubStmt->body_back()))
+        PotentialCall = LastExpr;
+    }
+  } while (LastPotentialCall != PotentialCall);
+
+  const CallExpr *Call = dyn_cast_or_null<CallExpr>(PotentialCall);
+  if (!Call)
+    return;
+
+  const FunctionDecl *Callee = Call->getDirectCallee();
+  if (!Callee || !Callee->getAttr<TypedMemoryAttr>())
+    return;
+  assert(ShouldSearchCasts);
+  // We prioritize the deepest non-implicit, non-void* cast
+  auto [It, Inserted] = Casts.try_emplace(Call, Cast);
+  if (!Inserted && It->second->getType()->isVoidPointerType())
+    It->second = Cast;
+}
+
+void Sema::emitTMODiagnosticsForTypeQuery(SourceLocation QueryLocation,
+                                          SourceRange ExpressionRange,
+                                          QualType QueriedType) {
+  // Don't do any work if logging is not enabled
+  if (Diags.isIgnored(diag::remark_tmo_passed_type, QueryLocation))
+    return;
+
+  if (QueriedType->isDependentType() || QueriedType->isIncompleteType())
+    return;
+
+  ASTContext::TypedMemoryDescriptor Descriptor =
+      Context.getTypedMemoryDescriptor(QueriedType, OO_None,
+                                       TypedMemoryCallsiteFlags::None);
+  TypedMemoryDescriptorBits TMDB;
+  TMDB.Summary = Descriptor.Summary;
+  TMDB.Hash = Descriptor.IdentityHash;
+  Diag(QueryLocation, diag::remark_tmo_get_descriptor_info)
+      << QueriedType << TMDB.value() << Descriptor.TypeDescription
+      << ExpressionRange;
+}
+
+bool Sema::checkTMOGetTypeDescriptor(QualType T, SourceLocation Loc,
+                                     SourceRange ArgRange) {
+  if (RequireCompleteSizedType(
+          Loc, Context.getBaseElementType(T),
+          diag::err_sizeof_alignof_incomplete_or_sizeless_type,
+          getTraitSpelling(UETT_TMOGetTypeDescriptor), ArgRange))
+    return true;
+  assert(!T->isVoidType());
+  emitTMODiagnosticsForTypeQuery(Loc, ArgRange, T);
+  return false;
+}
+
+void TypedMemoryCallsiteContext::recordTMOInferenceCandidate(Sema &S,
+                                                             const Expr *Call) {
+  if (!S.getLangOpts().TypedMemoryOperations)
+    return;
+  if (S.CurContext->isDependentContext())
+    return;
+  const auto *CE = dyn_cast_or_null<CallExpr>(Call);
+  if (!CE)
+    return;
+  auto *CalleeDecl = CE->getDirectCallee();
+  if (!CalleeDecl)
+    return;
+  if (!CalleeDecl->hasAttr<TypedMemoryAttr>())
+    return;
+  Calls.push_back(CE);
+  ShouldSearchCasts = true;
+}

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -1064,6 +1064,52 @@ void ASTStmtReader::VisitOMPIteratorExpr(OMPIteratorExpr *E) {
   }
 }
 
+static InferredTypeInfo readInferredTypeInfo(ASTRecordReader &Record) {
+  auto Flags = static_cast<TypedMemoryCallsiteFlags>(Record.readInt());
+  if (!Record.readBool())
+    return {std::nullopt, nullptr, Flags};
+
+  auto Kind = static_cast<InferredAllocationType::TypeKind>(Record.readInt());
+  auto MarshalResult = [&](InferredAllocationType &&Inferred) {
+    return InferredTypeInfo{std::move(Inferred), nullptr, Flags};
+  };
+  switch (Kind) {
+  case InferredAllocationType::TypeKind::Object:
+    return MarshalResult(InferredAllocationType::create(Record.readType()));
+  case InferredAllocationType::TypeKind::Array: {
+    bool IsConstantSize = Record.readBool();
+    return MarshalResult(
+        InferredAllocationType::createArray(Record.readType(), IsConstantSize));
+  }
+  case InferredAllocationType::TypeKind::PrefixedArray: {
+    bool IsConstantSize = Record.readBool();
+    QualType HeaderType = Record.readType();
+    std::optional<QualType> ElemType;
+    if (Record.readBool())
+      ElemType = Record.readType();
+    return MarshalResult(InferredAllocationType::createPrefixedArray(
+        HeaderType, ElemType, IsConstantSize));
+  }
+  case InferredAllocationType::TypeKind::Tuple:
+  case InferredAllocationType::TypeKind::UnknownLayout: {
+    bool IsConstantSize = true;
+    if (Kind == InferredAllocationType::TypeKind::UnknownLayout)
+      IsConstantSize = Record.readBool();
+    size_t Count = Record.readUInt32();
+    SmallVector<QualType, 2> Entries;
+    Entries.reserve(Count);
+    for (size_t I = 0; I < Count; ++I)
+      Entries.push_back(Record.readType());
+    if (Kind == InferredAllocationType::TypeKind::Tuple)
+      return MarshalResult(
+          InferredAllocationType::createTuple(std::move(Entries)));
+    return MarshalResult(InferredAllocationType::createUnknownLayout(
+        std::move(Entries), IsConstantSize));
+  }
+  }
+  llvm_unreachable("Unrecognised inferrence kind.");
+}
+
 void ASTStmtReader::VisitCallExpr(CallExpr *E) {
   VisitExpr(E);
 
@@ -1074,6 +1120,7 @@ void ASTStmtReader::VisitCallExpr(CallExpr *E) {
   bool HasFPFeatures = CurrentUnpackingBits->getNextBit();
   E->setCoroElideSafe(CurrentUnpackingBits->getNextBit());
   E->setUsesMemberSyntax(CurrentUnpackingBits->getNextBit());
+  bool HasTMOInfo = CurrentUnpackingBits->getNextBit();
   assert((NumArgs == E->getNumArgs()) && "Wrong NumArgs!");
   E->setRParenLoc(readSourceLocation());
   E->setCallee(Record.readSubExpr());
@@ -1083,6 +1130,9 @@ void ASTStmtReader::VisitCallExpr(CallExpr *E) {
   if (HasFPFeatures)
     E->setStoredFPFeatures(
         FPOptionsOverride::getFromOpaqueInt(Record.readInt()));
+
+  if (HasTMOInfo)
+    Record.getContext().setInferredInfoForCall(E, readInferredTypeInfo(Record));
 
   if (E->getStmtClass() == Stmt::CallExprClass)
     E->updateTrailingSourceLoc();

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -998,6 +998,45 @@ void ASTStmtWriter::VisitOMPIteratorExpr(OMPIteratorExpr *E) {
   Code = serialization::EXPR_OMP_ITERATOR;
 }
 
+static void writeInferredTypeInfo(ASTRecordWriter &Record,
+                                  InferredTypeInfo &TMOInference) {
+  Record.push_back(static_cast<uint64_t>(TMOInference.InferredCallsiteFlags));
+  if (!TMOInference.Type) {
+    Record.writeBool(false);
+    return;
+  }
+  Record.writeBool(true);
+
+  const InferredAllocationType &Type = *TMOInference.Type;
+  InferredAllocationType::TypeKind Kind = Type.kind();
+  Record.push_back(static_cast<uint64_t>(Kind));
+  if (auto *Fixed = Type.asObject()) {
+    Record.AddTypeRef(Fixed->Type);
+    return;
+  }
+  if (auto *Array = Type.asArray()) {
+    Record.writeBool(Array->IsConstantSize);
+    Record.AddTypeRef(Array->ElementType);
+    return;
+  }
+  if (auto *PrefixedArrayType = Type.asPrefixedArray()) {
+    Record.writeBool(PrefixedArrayType->IsConstantSize);
+    Record.AddTypeRef(PrefixedArrayType->HeaderType);
+    auto ElementType = PrefixedArrayType->ElementType;
+    Record.writeBool(ElementType.has_value());
+    if (ElementType)
+      Record.AddTypeRef(*ElementType);
+    return;
+  }
+  assert(Type.asTuple() || Type.asUnknownLayout());
+  if (auto *UnknownLayout = Type.asUnknownLayout())
+    Record.writeBool(UnknownLayout->isConstantSize());
+  ArrayRef<QualType> Entries = Type.entries();
+  Record.writeUInt32(Entries.size());
+  for (QualType E : Entries)
+    Record.AddTypeRef(E);
+}
+
 void ASTStmtWriter::VisitCallExpr(CallExpr *E) {
   VisitExpr(E);
 
@@ -1008,6 +1047,10 @@ void ASTStmtWriter::VisitCallExpr(CallExpr *E) {
   CurrentPackingBits.addBit(E->isCoroElideSafe());
   CurrentPackingBits.addBit(E->usesMemberSyntax());
 
+  std::optional<InferredTypeInfo> TMOInference =
+      Record.getASTContext().getInferredInfoForCall(E);
+  CurrentPackingBits.addBit(TMOInference.has_value());
+
   Record.AddSourceLocation(E->getRParenLoc());
   Record.AddStmt(E->getCallee());
   for (CallExpr::arg_iterator Arg = E->arg_begin(), ArgEnd = E->arg_end();
@@ -1016,9 +1059,11 @@ void ASTStmtWriter::VisitCallExpr(CallExpr *E) {
 
   if (E->hasStoredFPFeatures())
     Record.push_back(E->getFPFeatures().getAsOpaqueInt());
+  if (TMOInference)
+    writeInferredTypeInfo(Record, *TMOInference);
 
   if (!E->hasStoredFPFeatures() && !static_cast<bool>(E->getADLCallKind()) &&
-      !E->isCoroElideSafe() && !E->usesMemberSyntax() &&
+      !E->isCoroElideSafe() && !E->usesMemberSyntax() && !TMOInference &&
       E->getStmtClass() == Stmt::CallExprClass)
     AbbrevToUse = Writer.getCallExprAbbrev();
 

--- a/clang/test/CodeGen/attr-typed-memory-operation-sizeof-compound.c
+++ b/clang/test/CodeGen/attr-typed-memory-operation-sizeof-compound.c
@@ -1,0 +1,103 @@
+// RUN: %clang_cc1 -Wtyped-memory-inference-failure -ftyped-memory-operations -DTMO=1 \
+// RUN:            -triple x86_64-apple-macos -nostdsysteminc -O0 -fsyntax-only \
+// RUN:            -verify -Rtmo-remarks %s
+// RUN: %clang_cc1 -ftyped-memory-operations -DTMO=1 -triple x86_64-apple-macos -nostdsysteminc -O0 \
+// RUN:            -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fno-typed-memory-operations -DTMO=0 -triple x86_64-apple-macos -nostdsysteminc -O0 \
+// RUN:            -disable-llvm-passes -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-DISABLED %s
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_real_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_real_malloc, 1);
+
+struct Header {
+  int count;
+  void *base;
+};
+
+struct Element {
+  int data;
+};
+
+// CHECK-LABEL: @test_header_prefixed_array
+void *test_header_prefixed_array(__SIZE_TYPE__ n) {
+  return malloc(sizeof(struct Header) + sizeof(struct Element) * n);
+  // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred header prefixed array of {'struct Header':'struct Element'} from expression 'sizeof(struct Header) + sizeof(struct Element) * n'}}
+  // expected-note@-3 {{encoding 'struct Header' as 74310495310558338. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "HeaderPrefixedArray" ] }, "TypeHash": 1947317378 }}}
+  // CHECK:       call ptr @typed_real_malloc(i64 noundef %add, i64 noundef 74310495310558338)
+  // CHECK-DISABLED: call ptr @malloc
+}
+
+// CHECK-LABEL:  @test_header_prefixed_array_commuted
+void *test_header_prefixed_array_commuted(__SIZE_TYPE__ n) {
+  return malloc(sizeof(struct Element) * n + sizeof(struct Header));
+  // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred header prefixed array of {'struct Header':'struct Element'} from expression 'sizeof(struct Element) * n + sizeof(struct Header)'}}
+  // expected-note@-3 {{encoding 'struct Header' as 74310495310558338. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "HeaderPrefixedArray" ] }, "TypeHash": 1947317378 }}}
+  // CHECK:       call ptr @typed_real_malloc(i64 noundef %add, i64 noundef 74310495310558338)
+  // CHECK-DISABLED: call ptr @malloc
+}
+
+// CHECK-LABEL: @test_multi_header_prefixed_array
+void *test_multi_header_prefixed_array(__SIZE_TYPE__ n) {
+  return malloc(sizeof(struct Header) + sizeof(int) + sizeof(struct Element) * n);
+  // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred header prefixed array of {'struct Header':'struct Element'} from expression 'sizeof(struct Header) + sizeof(int) + sizeof(struct Element) * n'}}
+  // expected-note@-3 {{encoding 'struct Header' as 74310495310558338. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "HeaderPrefixedArray" ] }, "TypeHash": 1947317378 }}}
+  // CHECK:       call ptr @typed_real_malloc(i64 noundef %add, i64 noundef 74310495310558338)
+  // CHECK-DISABLED: call ptr @malloc
+}
+
+// CHECK-LABEL: @test_tuple_different_types
+void *test_tuple_different_types(void) {
+  return malloc(sizeof(struct Header) + sizeof(struct Element));
+  // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred tuple of ('struct Header', 'struct Element') from expression 'sizeof(struct Header) + sizeof(struct Element)'}}
+  // expected-note@-3 {{encoding 'struct Header' as 74309670676837506. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1947317378 }}}
+  // CHECK: call ptr @typed_real_malloc(i64 noundef 20, i64 noundef 74309670676837506)
+  // CHECK-DISABLED: call ptr @malloc
+}
+
+// CHECK-LABEL: define {{.*}} @test_var_sizeof_header_array
+void *test_var_sizeof_header_array(__SIZE_TYPE__ n) {
+  __SIZE_TYPE__ hdr_sz = sizeof(struct Header);
+  return malloc(hdr_sz + sizeof(struct Element) * n);
+  // expected-remark@-1 {{passing TMO information for type 'struct Element' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred indeterminate set of {'struct Element'} from expression 'hdr_sz + sizeof(struct Element) * n'}}
+  // expected-note@-3 {{encoding 'struct Element' as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+  // CHECK: call ptr @typed_real_malloc(i64 noundef %add, i64 noundef 72057595422605840)
+  // CHECK-DISABLED: call ptr @malloc
+}
+
+// CHECK-LABEL: @test_homogeneous_header_array
+void *test_homogeneous_header_array(__SIZE_TYPE__ n) {
+  return malloc(sizeof(struct Header) + sizeof(struct Header) * n);
+  // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred header prefixed array of {'struct Header':'struct Header'} from expression 'sizeof(struct Header) + sizeof(struct Header) * n'}}
+  // expected-note@-3 {{encoding 'struct Header' as 74310495310558338. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "HeaderPrefixedArray" ] }, "TypeHash": 1947317378 }}}
+  // CHECK: call ptr @typed_real_malloc(i64 noundef %add, i64 noundef 74310495310558338)
+  // CHECK-DISABLED: call ptr @malloc
+}
+
+void *test_prefixed_array_comma(__SIZE_TYPE__ n) {
+  return malloc(((void)0, sizeof(struct Header) + sizeof(struct Element) * n));
+  // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred header prefixed array of {'struct Header':'struct Element'} from expression '(void)0 , sizeof(struct Header) + sizeof(struct Element) * n'}}
+  // expected-note@-3 {{encoding 'struct Header' as 74310495310558338. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "HeaderPrefixedArray" ] }, "TypeHash": 1947317378 }}}
+}
+
+void *test_array_comma(__SIZE_TYPE__ n) {
+  return malloc(((void)0, sizeof(struct Element) * n));
+  // expected-remark@-1 {{passing TMO information for array of type 'struct Element' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred array of 'struct Element' from expression '(void)0 , sizeof(struct Element) * n'}}
+  // expected-note@-3 {{encoding array of 'struct Element' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+}
+
+void *test_tuple_comma(void) {
+  return malloc(((void)0, sizeof(struct Header) + sizeof(struct Element)));
+  // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@-2 {{inferred tuple of ('struct Header', 'struct Element') from expression '(void)0 , sizeof(struct Header) + sizeof(struct Element)'}}
+  // expected-note@-3 {{encoding 'struct Header' as 74309670676837506. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1947317378 }}}
+}

--- a/clang/test/CodeGen/attr-typed-memory-operation-sizeof.c
+++ b/clang/test/CodeGen/attr-typed-memory-operation-sizeof.c
@@ -1,0 +1,141 @@
+// RUN: %clang_cc1 -Rtmo-remarks -verify=tmo,tmowarn  -Wtyped-memory-inference-failure -fsyntax-only \
+// RUN:               -ftyped-memory-operations -DTMO=1 -triple x86_64-apple-macos -nostdsysteminc -O0 -disable-llvm-passes %s
+// RUN: %clang_cc1 -Rtmo-remarks -verify=notmoremarks -Wtyped-memory-inference-failure -fsyntax-only \
+// RUN:            -fno-typed-memory-operations -DTMO=0 -triple x86_64-apple-macos -nostdsysteminc -O0 -disable-llvm-passes %s
+// RUN: %clang_cc1    -ftyped-memory-operations -DTMO=1 -triple x86_64-apple-macos -nostdsysteminc -O0 -disable-llvm-passes -emit-llvm -o - %s | FileCheck --check-prefix=CHECK          %s
+// RUN: %clang_cc1 -fno-typed-memory-operations -DTMO=0 -triple x86_64-apple-macos -nostdsysteminc -O0 -disable-llvm-passes -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-DISABLED %s
+// notmoremarks-no-diagnostics
+#if TMO
+_Static_assert(__has_feature(typed_memory_operations), "");
+#else
+_Static_assert(!__has_feature(typed_memory_operations), "");
+#endif
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+typedef unsigned int uint32_t;
+
+void *typed_real_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_real_malloc, 1);
+
+void *typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *my_malloc(__SIZE_TYPE__ size) _TYPED(typed_malloc, 1);
+void *f() {
+   return my_malloc(sizeof(__UINT32_TYPE__) * 2 * 2); // #alloc1
+  // tmo-remark@#alloc1 {{passing TMO information for array of type 'unsigned int' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // tmo-note@#alloc1 {{inferred array of 'unsigned int' from expression 'sizeof(unsigned int) * 2 * 2'}}
+  // tmo-note@#alloc1 {{encoding array of 'unsigned int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: call ptr @typed_malloc(i64 noundef 16, i64 noundef [[ARRAY32_DESC:72058145178419728]])
+}
+void *g() {
+   return my_malloc(sizeof(__UINT32_TYPE__) * 2); // #alloc2
+  // tmo-remark@#alloc2 {{passing TMO information for array of type 'unsigned int' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // tmo-note@#alloc2 {{inferred array of 'unsigned int' from expression 'sizeof(unsigned int) * 2'}}
+  // tmo-note@#alloc2 {{encoding array of 'unsigned int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: call ptr @typed_malloc(i64 noundef 8, i64 noundef [[ARRAY32_DESC]])
+}
+void *h() {
+   return my_malloc(sizeof(__UINT32_TYPE__) * 4 * 2); // #alloc3
+  // tmo-remark@#alloc3 {{passing TMO information for array of type 'unsigned int' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // tmo-note@#alloc3 {{inferred array of 'unsigned int' from expression 'sizeof(unsigned int) * 4 * 2'}}
+  // tmo-note@#alloc3 {{encoding array of 'unsigned int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: call ptr @typed_malloc(i64 noundef 32, i64 noundef [[ARRAY32_DESC]])
+}
+
+void test_expression_sizeof_uint() {
+  malloc(sizeof(uint32_t)); // #alloc4
+  // tmo-remark@#alloc4 {{passing TMO information for type 'uint32_t' (aka 'unsigned int') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc4 {{inferred 'uint32_t' (aka 'unsigned int') from expression 'sizeof(uint32_t)'}}
+  // tmo-note@#alloc4 {{encoding 'uint32_t' (aka 'unsigned int') as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC:72057870300512784]])
+  // CHECK-DISABLED: %call = call ptr @malloc
+  malloc(sizeof(uint32_t) * 2); // #alloc5
+  // tmo-remark@#alloc5 {{passing TMO information for array of type 'uint32_t' (aka 'unsigned int') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc5 {{inferred array of 'uint32_t' (aka 'unsigned int') from expression 'sizeof(uint32_t) * 2'}}
+  // tmo-note@#alloc5 {{encoding array of 'uint32_t' (aka 'unsigned int') as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call1 = call ptr @typed_real_malloc(i64 noundef 8, i64 noundef [[ARRAY32_DESC]])
+  // CHECK-DISABLED: %call1 = call ptr @malloc
+  malloc(sizeof(uint32_t) * 2 * 2); // #alloc6
+  // tmo-remark@#alloc6 {{passing TMO information for array of type 'uint32_t' (aka 'unsigned int') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc6 {{inferred array of 'uint32_t' (aka 'unsigned int') from expression 'sizeof(uint32_t) * 2 * 2'}}
+  // tmo-note@#alloc6 {{encoding array of 'uint32_t' (aka 'unsigned int') as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call2 = call ptr @typed_real_malloc(i64 noundef 16, i64 noundef [[ARRAY32_DESC]])
+  // CHECK-DISABLED: %call2 = call ptr @malloc
+  malloc(sizeof(uint32_t) * 4 * 2); // #alloc7
+  // tmo-remark@#alloc7 {{passing TMO information for array of type 'uint32_t' (aka 'unsigned int') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc7 {{inferred array of 'uint32_t' (aka 'unsigned int') from expression 'sizeof(uint32_t) * 4 * 2'}}
+  // tmo-note@#alloc7 {{encoding array of 'uint32_t' (aka 'unsigned int') as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call3 = call ptr @typed_real_malloc(i64 noundef 32, i64 noundef [[ARRAY32_DESC]])
+  // CHECK-DISABLED: %call3 = call ptr @malloc
+}
+
+void *typed_real_calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size, unsigned long long);
+void *calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size) _TYPED(typed_real_calloc, 2);
+
+// CHECK: test_expression_sizeof_calloc
+void test_expression_sizeof_calloc() {
+  calloc(5, sizeof(int)); // #alloc8
+  // tmo-remark@#alloc8 {{passing TMO information for type 'int' to 'typed_real_calloc' (retargeted from 'calloc')}}
+  // tmo-note@#alloc8 {{inferred 'int' from expression 'sizeof(int)'}}
+  // tmo-note@#alloc8 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call = call ptr @typed_real_calloc(i64 noundef 5, i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call = call ptr @calloc
+  calloc(1, sizeof(unsigned) * 4 * 2); // #alloc9
+  // tmo-remark@#alloc9 {{passing TMO information for array of type 'unsigned int' to 'typed_real_calloc' (retargeted from 'calloc')}}
+  // tmo-note@#alloc9 {{inferred array of 'unsigned int' from expression 'sizeof(unsigned int) * 4 * 2'}}
+  // tmo-note@#alloc9 {{encoding array of 'unsigned int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call1 = call ptr @typed_real_calloc(i64 noundef 1, i64 noundef 32, i64 noundef [[ARRAY32_DESC]])
+  // CHECK-DISABLED: %call1 = call ptr @calloc
+}
+// CHECK: test_expression_sizeof_uint_arbitrary_expr
+void test_expression_sizeof_uint_arbitrary_expr() {
+  malloc(sizeof(uint32_t) + 0); // #alloc10
+  // tmo-remark@#alloc10 {{passing TMO information for type 'uint32_t' (aka 'unsigned int') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc10 {{inferred indeterminate set of {'uint32_t' (aka 'unsigned int')} from expression 'sizeof(uint32_t) + 0'}}
+  // tmo-note@#alloc10 {{encoding 'uint32_t' (aka 'unsigned int') as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef 72057595422605840)
+  // CHECK-DISABLED: %call = call ptr @malloc
+  malloc(sizeof(uint32_t) + sizeof(uint32_t)); // #alloc11
+  // tmo-remark@#alloc11 {{passing TMO information for type 'uint32_t' (aka 'unsigned int') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc11 {{inferred tuple of ('uint32_t' (aka 'unsigned int'), 'uint32_t' (aka 'unsigned int')) from expression 'sizeof(uint32_t) + sizeof(uint32_t)'}}
+  // tmo-note@#alloc11 {{encoding 'uint32_t' (aka 'unsigned int') as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call1 = call ptr @typed_real_malloc(i64 noundef 8, i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call1 = call ptr @malloc
+  malloc(sizeof(uint32_t) * (2 + 2)); // #alloc12
+  // tmo-remark@#alloc12 {{passing TMO information for array of type 'uint32_t' (aka 'unsigned int') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc12 {{inferred array of 'uint32_t' (aka 'unsigned int') from expression 'sizeof(uint32_t) * (2 + 2)'}}
+  // tmo-note@#alloc12 {{encoding array of 'uint32_t' (aka 'unsigned int') as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call2 = call ptr @typed_real_malloc(i64 noundef 16, i64 noundef [[ARRAY32_DESC]])
+  // CHECK-DISABLED: %call2 = call ptr @malloc
+}
+
+struct T {
+  int i;
+  void (*f)();
+  void *p;
+};
+// CHECK: test_struct_t
+void test_struct_t() {
+  malloc(sizeof(struct T) * 2 * 2); // #alloc13
+  // tmo-remark@#alloc13 {{passing TMO information for array of type 'struct T' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc13 {{inferred array of 'struct T' from expression 'sizeof(struct T) * 2 * 2'}}
+  // tmo-note@#alloc13 {{encoding array of 'struct T' as 74309946902329154. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 3294902082 }}}
+  // CHECK: %call = call ptr @typed_real_malloc(i64 noundef 96, i64 noundef [[ARRAY_T_DESC:74309946902329154]])
+  // CHECK-DISABLED: %call = call ptr @malloc
+  malloc(sizeof(struct T) * 4); // #alloc14
+  // tmo-remark@#alloc14 {{passing TMO information for array of type 'struct T' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc14 {{inferred array of 'struct T' from expression 'sizeof(struct T) * 4'}}
+  // tmo-note@#alloc14 {{encoding array of 'struct T' as 74309946902329154. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 3294902082 }}}
+  // CHECK: %call1 = call ptr @typed_real_malloc(i64 noundef 96, i64 noundef [[ARRAY_T_DESC]])
+  // CHECK-DISABLED: %call1 = call ptr @malloc
+  malloc(sizeof(struct T) + sizeof(struct T) + sizeof(struct T) + sizeof(struct T)); // #alloc15
+  // tmo-remark@#alloc15 {{passing TMO information for type 'struct T' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc15 {{inferred tuple of ('struct T', 'struct T', 'struct T', 'struct T') from expression 'sizeof(struct T) + sizeof(struct T) + sizeof(struct T) + sizeof(struct T)'}}
+  // tmo-note@#alloc15 {{encoding 'struct T' as 74309672024422210. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3294902082 }}}
+  // CHECK: %call2 = call ptr @typed_real_malloc(i64 noundef 96, i64 noundef [[T_DESC:74309672024422210]])
+  // CHECK-DISABLED: %call2 = call ptr @malloc
+}
+
+// CHECK: !{!"type-descriptor", !"[[ARRAY32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[GENERICDATA32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[ARRAY_T_DESC]]", !"3294902082", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[T_DESC]]", !"3294902082", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}

--- a/clang/test/CodeGen/attr-typed-memory-operation.c
+++ b/clang/test/CodeGen/attr-typed-memory-operation.c
@@ -1,0 +1,582 @@
+// RUN: %clang_cc1 -Rtmo-remarks -verify -fsyntax-only \
+// RUN:               -ftyped-memory-operations -DTMO=1 -DTMO_REMARKS -triple x86_64-apple-macos -nostdsysteminc -Wno-alloc-size -O0 %s
+// RUN: %clang_cc1    -ftyped-memory-operations -DTMO=1 -triple x86_64-apple-macos -nostdsysteminc -Wno-alloc-size -O0 -disable-llvm-passes -emit-llvm -o - %s | FileCheck --check-prefix=CHECK          %s
+// RUN: %clang_cc1 -fno-typed-memory-operations -DTMO=0 -triple x86_64-apple-macos -nostdsysteminc -Wno-alloc-size -O0 -disable-llvm-passes -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-DISABLED %s
+// RUN: %clang_cc1    -ftyped-memory-operations -DTMO=1 -triple x86_64-apple-macos -nostdsysteminc -Wno-alloc-size -O0 -disable-llvm-passes -emit-llvm -o - %s | FileCheck --check-prefix=CHECK          %s
+
+#if TMO
+_Static_assert(__has_feature(typed_memory_operations), "");
+#else
+_Static_assert(!__has_feature(typed_memory_operations), "");
+#endif
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *typed_calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size, unsigned long long);
+void typed_unusual_alloc(float, unsigned, unsigned long long, const char*);
+
+void *my_malloc(__SIZE_TYPE__ size) _TYPED(typed_malloc, 1);
+void *my_calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size) _TYPED(typed_calloc, 2);
+void unusual_alloc(float, unsigned, const char*) _TYPED(typed_unusual_alloc, 2);
+
+void *typed_real_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *typed_real_calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size, unsigned long long);
+void *typed_real_realloc(void *, __SIZE_TYPE__ size, unsigned long long);
+void *typed_real_aligned_alloc(unsigned long align, unsigned long size, unsigned long long);
+int typed_real_posix_memalign(void **, __SIZE_TYPE__, __SIZE_TYPE__, unsigned long long);
+
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_real_malloc, 1);
+void *calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size) _TYPED(typed_real_calloc, 2);
+void *realloc(void *, __SIZE_TYPE__ size) _TYPED(typed_real_realloc, 2);
+void *aligned_alloc(unsigned long align, unsigned long size) _TYPED(typed_real_aligned_alloc, 2);
+int posix_memalign(void **, __SIZE_TYPE__, __SIZE_TYPE__) _TYPED(typed_real_posix_memalign, 3);
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+struct S2 {
+  int i;
+};
+
+union U1 {
+  int i;
+};
+
+union U2 {
+  int i;
+  void* v;
+};
+
+
+// We use these functions to test order of evaluation in some of
+// these tests as there the override forwarding is some logical
+// argument reordering but we need to maintain the C semantic
+// ordering.
+extern int f1(void);
+extern int f2(void);
+typedef struct S1 S1Mk2;
+void f(void);
+void f(void) {
+  // Basic codegen tests
+  malloc(5); // #alloc1
+  // CHECK: %call = call ptr @typed_real_malloc(i64 noundef 5, i64 noundef [[LOC1_DESC:[0-9]+]])
+  // CHECK-DISABLED: %call = call ptr @malloc(i64 noundef 5)
+  malloc(sizeof(int)); // #alloc2
+  // expected-remark@#alloc2 {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc2 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#alloc2 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call1 = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC:72057870300512784]])
+  // CHECK-DISABLED: %call1 = call ptr @malloc(i64 noundef 4)
+  malloc(sizeof(struct S1)); // #alloc3
+  // expected-remark@#alloc3 {{passing TMO information for type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc3 {{inferred 'struct S1' from expression 'sizeof(struct S1)'}}
+  // expected-note@#alloc3 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call2 = call ptr @typed_real_malloc(i64 noundef 24, i64 noundef [[S1_DESC:74309672738655766]])
+  // CHECK-DISABLED: %call2 = call ptr @malloc(i64 noundef 24)
+  malloc(sizeof(struct S1) * 5); // #alloc4
+  // expected-remark@#alloc4 {{passing TMO information for array of type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc4 {{inferred array of 'struct S1' from expression 'sizeof(struct S1) * 5'}}
+  // expected-note@#alloc4 {{encoding array of 'struct S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call3 = call ptr @typed_real_malloc(i64 noundef 120, i64 noundef [[ARRAY_S1_DESC:74309947616562710]])
+  // CHECK-DISABLED: %call3 = call ptr @malloc(i64 noundef 120)
+  malloc(sizeof(struct S1) + sizeof(struct S2)); // #alloc5
+  // expected-remark@#alloc5 {{passing TMO information for type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc5 {{inferred tuple of ('struct S1', 'struct S2') from expression 'sizeof(struct S1) + sizeof(struct S2)'}}
+  // expected-note@#alloc5 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call4 = call ptr @typed_real_malloc(i64 noundef 28, i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call4 = call ptr @malloc(i64 noundef 28)
+  my_malloc(5); // #alloc6
+  // CHECK: %call5 = call ptr @typed_malloc(i64 noundef 5, i64 noundef [[LOC2_DESC:[0-9]+]])
+  // CHECK-DISABLED: %call5 = call ptr @my_malloc(i64 noundef 5)
+  my_malloc(sizeof(int)); // #alloc7
+  // expected-remark@#alloc7 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // expected-note@#alloc7 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#alloc7 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call6 = call ptr @typed_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call6 = call ptr @my_malloc(i64 noundef 4)
+  my_malloc(sizeof(S1Mk2)); // #alloc8
+  // expected-remark@#alloc8 {{passing TMO information for type 'S1Mk2' (aka 'struct S1') to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // expected-note@#alloc8 {{inferred 'S1Mk2' (aka 'struct S1') from expression 'sizeof(S1Mk2)'}}
+  // expected-note@#alloc8 {{encoding 'S1Mk2' (aka 'struct S1') as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call7 = call ptr @typed_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call7 = call ptr @my_malloc(i64 noundef 24)
+  my_malloc(sizeof(struct S1) * 5); // #alloc9
+  // expected-remark@#alloc9 {{passing TMO information for array of type 'struct S1' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // expected-note@#alloc9 {{inferred array of 'struct S1' from expression 'sizeof(struct S1) * 5'}}
+  // expected-note@#alloc9 {{encoding array of 'struct S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call8 = call ptr @typed_malloc(i64 noundef 120, i64 noundef [[ARRAY_S1_DESC]])
+  // CHECK-DISABLED: %call8 = call ptr @my_malloc(i64 noundef 120)
+  my_malloc(sizeof(struct S1) + sizeof(union U1)); // #alloc10
+  // expected-remark@#alloc10 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // expected-note@#alloc10 {{inferred tuple of ('struct S1', 'union U1') from expression 'sizeof(struct S1) + sizeof(union U1)'}}
+  // expected-note@#alloc10 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call9 = call ptr @typed_malloc(i64 noundef 28, i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call9 = call ptr @my_malloc(i64 noundef 28)
+
+  // Ordering of argument evaluation
+  my_calloc(f1(), f2()); // #alloc11
+  // CHECK: %call10 = call i32 @f1()
+  // CHECK: %conv = sext i32 %call10 to i64
+  // CHECK: %call11 = call i32 @f2()
+  // CHECK: %conv12 = sext i32 %call11 to i64
+  // CHECK: %call13 = call ptr @typed_calloc(i64 noundef %conv, i64 noundef %conv12, i64 noundef [[LOC3_DESC:[0-9]+]])
+  // CHECK-DISABLED: %call13 = call ptr @my_calloc
+  my_calloc(f1(), sizeof(int) * f2()); // #alloc12
+  // expected-remark@#alloc12 {{passing TMO information for array of type 'int' to 'typed_calloc' (retargeted from 'my_calloc')}}
+  // expected-note@#alloc12 {{inferred array of 'int' from expression 'sizeof(int) * f2()'}}
+  // expected-note@#alloc12 {{encoding array of 'int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call14 = call i32 @f1()
+  // CHECK: %conv15 = sext i32 %call14 to i64
+  // CHECK: %call16 = call i32 @f2()
+  // CHECK: %conv17 = sext i32 %call16 to i64
+  // CHECK: %mul = mul i64 4, %conv17
+  // CHECK: %call18 = call ptr @typed_calloc(i64 noundef %conv15, i64 noundef %mul, i64 noundef [[ARRAY_INT32_DESC:72058145178419728]])
+  // CHECK-DISABLED: %call18 = call ptr @my_calloc
+  my_calloc(f1(), f2() * sizeof(double)); // #alloc13
+  // expected-remark@#alloc13 {{passing TMO information for array of type 'double' to 'typed_calloc' (retargeted from 'my_calloc')}}
+  // expected-note@#alloc13 {{inferred array of 'double' from expression 'f2() * sizeof(double)'}}
+  // expected-note@#alloc13 {{encoding array of 'double' as 72058143796969239. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 3227415 }}}
+  // CHECK: %call19 = call i32 @f1()
+  // CHECK: %conv20 = sext i32 %call19 to i64
+  // CHECK: %call21 = call i32 @f2()
+  // CHECK: %conv22 = sext i32 %call21 to i64
+  // CHECK: %mul23 = mul i64 %conv22, 8
+  // CHECK: %call24 = call ptr @typed_calloc(i64 noundef %conv20, i64 noundef %mul23, i64 noundef [[ARRAY_DOUBLE_DESC:72058143796969239]])
+  // CHECK-DISABLED: %call24 = call ptr @my_calloc
+
+  // Order of arguments passed to target
+  unusual_alloc(0.5, sizeof(int) * f1(), "womp"); // #alloc14
+  // expected-remark@#alloc14 {{passing TMO information for array of type 'int' to 'typed_unusual_alloc' (retargeted from 'unusual_alloc')}}
+  // expected-note@#alloc14 {{inferred array of 'int' from expression 'sizeof(int) * f1()'}}
+  // expected-note@#alloc14 {{encoding array of 'int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call25 = call i32 @f1()
+  // CHECK: %conv26 = sext i32 %call25 to i64
+  // CHECK: %mul27 = mul i64 4, %conv26
+  // CHECK: %conv28 = trunc i64 %mul27 to i32
+  // CHECK: call void @typed_unusual_alloc(float noundef 5.000000e-01, i32 noundef %conv28, i64 noundef [[ARRAY_INT32_DESC]], ptr noundef @.str)
+  // CHECK-DISABLED: call void @unusual_alloc
+
+  malloc(sizeof(struct S1)); // #alloc15
+  // expected-remark@#alloc15 {{passing TMO information for type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc15 {{inferred 'struct S1' from expression 'sizeof(struct S1)'}}
+  // expected-note@#alloc15 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call29 = call ptr @typed_real_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call29 = call ptr @malloc
+  malloc(sizeof(struct S2)); // #alloc16
+  // expected-remark@#alloc16 {{passing TMO information for type 'struct S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc16 {{inferred 'struct S2' from expression 'sizeof(struct S2)'}}
+  // expected-note@#alloc16 {{encoding 'struct S2' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call30 = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call30 = call ptr @malloc
+  malloc(sizeof(union U1)); // #alloc17
+  // expected-remark@#alloc17 {{passing TMO information for type 'union U1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc17 {{inferred 'union U1' from expression 'sizeof(union U1)'}}
+  // expected-note@#alloc17 {{encoding 'union U1' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call31 = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call31 = call ptr @malloc
+  malloc(sizeof(union U2)); // #alloc18
+  // expected-remark@#alloc18 {{passing TMO information for type 'union U2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc18 {{inferred 'union U2' from expression 'sizeof(union U2)'}}
+  // expected-note@#alloc18 {{encoding 'union U2' as 74344853696240142. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ "HasMixedUnions" ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 594631182 }}}
+  // CHECK: %call32 = call ptr @typed_real_malloc(i64 noundef 8, i64 noundef [[U2_DESC:74344853696240142]])
+  // CHECK-DISABLED: %call32 = call ptr @malloc
+}
+
+void *size_attributed_malloc(__SIZE_TYPE__) __attribute__((alloc_size(1))) _TYPED(typed_malloc, 1);
+void *size_attributed_typed_malloc(__SIZE_TYPE__, unsigned long long) __attribute__((alloc_size(1)));
+void *unattributed_malloc(__SIZE_TYPE__) _TYPED(size_attributed_typed_malloc, 1);
+
+
+int attribute_test() {
+  size_attributed_malloc(1); // #alloc19
+  // CHECK: %call = call ptr @typed_malloc(i64 noundef 1, i64 noundef [[LOC4_DESC:[0-9]+]])
+  size_attributed_typed_malloc(2, 0); // #alloc20
+  // CHECK: %call1 = call ptr @size_attributed_typed_malloc(i64 noundef 2, i64 noundef 0) [[ATTR:#[0-9]+]]
+  unattributed_malloc(3); // #alloc21
+  // CHECK: %call2 = call ptr @size_attributed_typed_malloc(i64 noundef 3, i64 noundef [[LOC5_DESC:[0-9]+]]) [[ATTR]]
+  typed_malloc(4, 0); // #alloc22
+  // CHECK: %call3 = call ptr @typed_malloc(i64 noundef 4, i64 noundef 0)
+  malloc(4); // #alloc23
+  // CHECK: %call4 = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[LOC6_DESC:[0-9]+]])
+  return 0;
+}
+
+int genericTest() {
+  malloc(_Generic(0.5f, int: sizeof(struct S1), float: sizeof(struct S2))); // #alloc24
+  // expected-remark@#alloc24 {{passing TMO information for type 'struct S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc24 {{inferred 'struct S2' from expression '_Generic(0.5F, int: sizeof(struct S1), float: sizeof(struct S2))'}}
+  // expected-note@#alloc24 {{encoding 'struct S2' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  malloc(_Generic(0, int: sizeof(struct S1), float: sizeof(struct S2))); // #alloc25
+  // expected-remark@#alloc25 {{passing TMO information for type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc25 {{inferred 'struct S1' from expression '_Generic(0, int: sizeof(struct S1), float: sizeof(struct S2))'}}
+  // expected-note@#alloc25 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call1 = call ptr @typed_real_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
+  malloc(_Generic("foo", int: sizeof(struct S1), char*: 5)); // #alloc26
+  // CHECK: %call2 = call ptr @typed_real_malloc(i64 noundef 5, i64 noundef [[LOC7_DESC:[0-9]+]])
+  malloc(_Generic("foo", int: 7, char*: sizeof(struct S2))); // #alloc27
+  // expected-remark@#alloc27 {{passing TMO information for type 'struct S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc27 {{inferred 'struct S2' from expression '_Generic("foo", int: 7, char *: sizeof(struct S2))'}}
+  // expected-note@#alloc27 {{encoding 'struct S2' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call3 = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  return 0;
+}
+
+void* f3(__SIZE_TYPE__ a);
+
+void f3_test1() {
+  f3(sizeof(int)); // #alloc28
+  // rdar://102172111 (Handle use of TMO rewritten function used before the canonical TMO attribute is specified)
+  // CHECK: %call = call ptr @f3
+}
+
+void* f3(__SIZE_TYPE__ a) _TYPED(typed_malloc, 1);
+
+void f3_test2() {
+  f3(sizeof(int)); // #alloc29
+  // expected-remark@#alloc29 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'f3')}}
+  // expected-note@#alloc29 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#alloc29 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call = call ptr @typed_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+}
+
+void test_expression_sizeof() {
+  malloc(sizeof(5)); // #alloc30
+  // expected-remark@#alloc30 {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc30 {{inferred 'int' from expression 'sizeof (5)'}}
+  // expected-note@#alloc30 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call = call ptr @malloc
+  malloc(sizeof(5 * sizeof(int))); // #alloc31
+  // expected-remark@#alloc31 {{passing TMO information for type '__size_t' (aka 'unsigned long') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc31 {{inferred '__size_t' (aka 'unsigned long') from expression 'sizeof (5 * sizeof(int))'}}
+  // expected-note@#alloc31 {{encoding '__size_t' (aka 'unsigned long') as 72057868919062295. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3227415 }}}
+  // CHECK: %call1 = call ptr @typed_real_malloc(i64 noundef 8, i64 noundef [[GENERICDATA64_DESC:72057868919062295]])
+  // CHECK-DISABLED: %call1 = call ptr @malloc
+  malloc(sizeof(sizeof(unsigned))); // #alloc32
+  // expected-remark@#alloc32 {{passing TMO information for type '__size_t' (aka 'unsigned long') to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc32 {{inferred '__size_t' (aka 'unsigned long') from expression 'sizeof (sizeof(unsigned int))'}}
+  // expected-note@#alloc32 {{encoding '__size_t' (aka 'unsigned long') as 72057868919062295. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3227415 }}}
+  // CHECK: %call2 = call ptr @typed_real_malloc(i64 noundef 8, i64 noundef [[GENERICDATA64_DESC]])
+  // CHECK-DISABLED: %call2 = call ptr @malloc
+  struct S1 s;
+  (void)malloc(sizeof(s.fptr)); // #alloc33
+  // expected-remark@#alloc33 {{passing TMO information for type 'void (*)()' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc33 {{inferred 'void (*)()' from expression 'sizeof (s.fptr)'}}
+  // expected-note@#alloc33 {{encoding 'void (*)()' as 2252077784904504. { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3093312312 }}}
+  // CHECK: %call3 = call ptr @typed_real_malloc(i64 noundef 8, i64 noundef [[ANONPTR_DESC:2252077784904504]])
+  // CHECK-DISABLED: %call3 = call ptr @malloc
+}
+
+void test_conflicting_types() {
+  struct S1* s = (struct S1*)malloc(sizeof(struct S2)); // #alloc34
+  // expected-remark@#alloc34 {{passing TMO information for type 'struct S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc34 {{inferred 'struct S2' from expression 'sizeof(struct S2)'}}
+  // expected-note@#alloc34 {{encoding 'struct S2' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK-NOT: %call3 = call ptr @typed_real_malloc(i64 noundef %[[LOC:[0-9]+]], i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call3 = call ptr @malloc
+}
+
+
+typedef int __attribute__((vector_size(16))) ivector16;
+typedef int __attribute__((vector_size(16))) ivector16_2;
+ivector16 *typed_ivalloc(__SIZE_TYPE__, unsigned long long descriptor);
+ivector16 *ivalloc1(__SIZE_TYPE__) _TYPED(typed_ivalloc, 1);
+ivector16_2 *ivalloc2(__SIZE_TYPE__) _TYPED(typed_ivalloc, 1);
+
+void test_sugared_types(void) {
+  ivector16 *a = ivalloc1(sizeof(ivector16)); // #alloc35
+  // expected-remark@#alloc35 {{passing TMO information for type 'ivector16' (vector of 4 'int' values) to 'typed_ivalloc' (retargeted from 'ivalloc1')}}
+  // expected-note@#alloc35 {{inferred 'ivector16' (vector of 4 'int' values) from expression 'sizeof(ivector16)'}}
+  // expected-note@#alloc35 {{encoding 'ivector16' (vector of 4 'int' values) as 72057870075255784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1159420904 }}}
+  // CHECK: call ptr @typed_ivalloc(i64 noundef 16, i64 noundef [[GENERICDATA128_DESC:72057870075255784]])
+  ivector16 *b = ivalloc2(sizeof(ivector16)); // #alloc36
+  // expected-remark@#alloc36 {{passing TMO information for type 'ivector16' (vector of 4 'int' values) to 'typed_ivalloc' (retargeted from 'ivalloc2')}}
+  // expected-note@#alloc36 {{inferred 'ivector16' (vector of 4 'int' values) from expression 'sizeof(ivector16)'}}
+  // expected-note@#alloc36 {{encoding 'ivector16' (vector of 4 'int' values) as 72057870075255784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1159420904 }}}
+  // CHECK: call ptr @typed_ivalloc(i64 noundef 16, i64 noundef [[GENERICDATA128_DESC]])
+  ivector16_2 *c = ivalloc1(sizeof(ivector16)); // #alloc37
+  // expected-remark@#alloc37 {{passing TMO information for type 'ivector16' (vector of 4 'int' values) to 'typed_ivalloc' (retargeted from 'ivalloc1')}}
+  // expected-note@#alloc37 {{inferred 'ivector16' (vector of 4 'int' values) from expression 'sizeof(ivector16)'}}
+  // expected-note@#alloc37 {{encoding 'ivector16' (vector of 4 'int' values) as 72057870075255784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1159420904 }}}
+  // CHECK: call ptr @typed_ivalloc(i64 noundef 16, i64 noundef [[GENERICDATA128_DESC]])
+  ivector16_2 *d = ivalloc2(sizeof(ivector16)); // #alloc38
+  // expected-remark@#alloc38 {{passing TMO information for type 'ivector16' (vector of 4 'int' values) to 'typed_ivalloc' (retargeted from 'ivalloc2')}}
+  // expected-note@#alloc38 {{inferred 'ivector16' (vector of 4 'int' values) from expression 'sizeof(ivector16)'}}
+  // expected-note@#alloc38 {{encoding 'ivector16' (vector of 4 'int' values) as 72057870075255784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1159420904 }}}
+  // CHECK: call ptr @typed_ivalloc(i64 noundef 16, i64 noundef [[GENERICDATA128_DESC]])
+}
+
+void test_explicit_cast_inference(void) {
+  __SIZE_TYPE__ s;
+
+  void *typed_malloc_test_cast(__SIZE_TYPE__ size, unsigned long long);
+  void *malloc_test_cast(__SIZE_TYPE__ size) _TYPED(typed_malloc_test_cast, 1);
+
+  // Check that we can associate an explicit cast
+  int *i = (int *)malloc_test_cast(s); // #alloc39
+  // expected-remark@#alloc39 {{passing TMO information for type 'int' to 'typed_malloc_test_cast' (retargeted from 'malloc_test_cast')}}
+  // expected-note@#alloc39 {{inferred 'int' from cast of result from call to '(int *)malloc_test_cast(s)'}}
+  // expected-note@#alloc39 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call = call ptr @typed_malloc_test_cast(i64 noundef %[[LOC:[0-9]+]], i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call = call ptr @malloc_test_cast
+
+  // Check that a non-void cast always dominates a void cast
+  int *i2 = (int *)(void *)malloc_test_cast(s); // #alloc40
+  // expected-remark@#alloc40 {{passing TMO information for type 'int' to 'typed_malloc_test_cast' (retargeted from 'malloc_test_cast')}}
+  // expected-note@#alloc40 {{inferred 'int' from cast of result from call to '(int *)(void *)malloc_test_cast(s)'}}
+  // expected-note@#alloc40 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call1 = call ptr @typed_malloc_test_cast(i64 noundef %[[LOC:[0-9]+]], i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call1 = call ptr @malloc_test_cast
+  int *i3 = (void *)(int *)malloc_test_cast(s); // #alloc41
+  // expected-remark@#alloc41 {{passing TMO information for type 'int' to 'typed_malloc_test_cast' (retargeted from 'malloc_test_cast')}}
+  // expected-note@#alloc41 {{inferred 'int' from cast of result from call to '(int *)malloc_test_cast(s)'}}
+  // expected-note@#alloc41 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call2 = call ptr @typed_malloc_test_cast(i64 noundef %[[LOC:[0-9]+]], i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call2 = call ptr @malloc_test_cast
+
+  // Check that we can associate casts across GNU statement expressions
+  void *vp_s1 = (struct S1 *)({ // #castLocation
+    __SIZE_TYPE__ s2 = s;
+    malloc_test_cast(s2); // #alloc42
+  });
+  // expected-remark@#alloc42 {{passing TMO information for type 'struct S1' to 'typed_malloc_test_cast' (retargeted from 'malloc_test_cast')}}
+  // expected-note@#castLocation {{inferred 'struct S1' from cast of result from call to '(struct S1 *)({}}
+  // expected-note@#alloc42 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call3 = call ptr @typed_malloc_test_cast(i64 noundef %[[LOC:[0-9]+]], i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call3 = call ptr @malloc_test_cast
+
+  // Check that we don't associate non-pointer casts
+  __UINTPTR_TYPE__ *uptr_true = malloc_test_cast(sizeof(__UINTPTR_TYPE__)); // #alloc43
+  // expected-remark@#alloc43 {{passing TMO information for type 'unsigned long' to 'typed_malloc_test_cast' (retargeted from 'malloc_test_cast')}}
+  // expected-note@#alloc43 {{inferred 'unsigned long' from expression 'sizeof(unsigned long)'}}
+  // expected-note@#alloc43 {{encoding 'unsigned long' as 72057868919062295. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3227415 }}}
+  // CHECK: %call4 = call ptr @typed_malloc_test_cast(i64 noundef [[LOC:[0-9]+]], i64 noundef [[GENERICDATA64_DESC]])
+  // CHECK-DISABLED: %call4 = call ptr @malloc_test_cast
+  __UINTPTR_TYPE__ uptr0 = (__UINTPTR_TYPE__)malloc_test_cast(s); // #alloc44
+  // CHECK-NOT: %call5 = call ptr @typed_malloc_test_cast(i64 noundef %[[LOC:[0-9]+]], i64 noundef [[GENERICDATA64_DESC]])
+  // CHECK-DISABLED: %call5 = call ptr @malloc_test_cast
+  __UINTPTR_TYPE__ uptr1 = (__UINTPTR_TYPE__)malloc_test_cast(s); // #alloc45
+  // CHECK-NOT: %call6 = call ptr @typed_malloc_test_cast(i64 noundef [[LOC:[0-9]+]], i64 noundef [[GENERICDATA64_DESC]])
+  // CHECK-DISABLED: %call6 = call ptr @malloc_test_cast
+
+  // Check that we don't associate casts to interfaces returning a non-pointer type
+  posix_memalign(&vp_s1, 0, sizeof(int)); // #alloc46
+  // expected-remark@#alloc46 {{passing TMO information for type 'int' to 'typed_real_posix_memalign' (retargeted from 'posix_memalign')}}
+  // expected-note@#alloc46 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#alloc46 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call7 = call i32 @typed_real_posix_memalign(ptr noundef %vp_s1, i64 noundef 0, i64 noundef [[LOC:[0-9]+]], i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call7 = call i32 @posix_memalign
+
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wint-to-pointer-cast"
+  #pragma clang diagnostic ignored "-Wunused-value"
+  (int *)posix_memalign(&vp_s1, 0, s); // #alloc47
+  #pragma clang diagnostic pop
+
+  // CHECK-NOT: %call8 = call i32 @typed_real_posix_memalign(ptr noundef %vp_s1, i64 noundef 0, i64 noundef [[LOC:[0-9]+]], i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call8 = call i32 @posix_memalign
+
+  // Check we don't pick up unrelated explicit casts
+  void *func(void *p);
+  int *r0 = (int *)func(malloc_test_cast(s)); // #alloc48
+  // CHECK-NOT: %call9 = call ptr @typed_malloc_test_cast(i64 noundef [[LOC:[0-9]+]], i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call9 = call ptr @malloc_test_cast
+}
+
+void test_explicit_cast_inference_perf() {
+  __SIZE_TYPE__ s;
+  #define A1                     \
+    do {                         \
+      int *p = (int *)malloc(s); \
+    } while (0)
+  #define A4 A1; A1; A1; A1
+  #define A16 A4; A4; A4; A4
+  #define A64 A16; A16; A16; A16
+  #define A256 A64; A64; A64; A64
+  #define A1024 A256; A256; A256; A256
+  #define A4096 A1024; A1024; A1024; A1024
+  #define A16384 A4096; A4096; A4096; A4096
+
+  #ifdef TMO_REMARKS
+  A64; // #alloc49
+  #else
+  A16384;
+  #endif
+  // expected-remark@#alloc49 64 {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#alloc49 64 {{inferred 'int' from cast of result from call to '(int *)malloc(s)'}}
+  // expected-note@#alloc49 64 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+}
+
+void test_assignment_expressions() {
+  __SIZE_TYPE__ sz;
+  void *ptr;
+
+  // Simple assignment - should get struct S1 type descriptor
+  malloc((sz = sizeof(struct S1))); //#tae_assign
+  // expected-remark@#tae_assign {{passing TMO information for type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_assign {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // expected-note@#tae_assign {{inferred 'struct S1' from expression 'sz = sizeof(struct S1)'}}
+  // CHECK: call ptr @typed_real_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: call ptr @malloc(i64 noundef 24)
+
+  // Nested assignment - should get int type descriptor
+  __SIZE_TYPE__ sz2;
+  malloc((sz = sz2 = sizeof(int))); // #tae_nestedassign
+  // expected-remark@#tae_nestedassign {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_nestedassign {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // expected-note@#tae_nestedassign {{inferred 'int' from expression 'sz = sz2 = sizeof(int)'}}
+  // CHECK: %call1 = call ptr @typed_real_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: call ptr @malloc(i64 noundef 4)
+
+  // Compound assignment - should get int type descriptor
+  sz = 0;
+  malloc((sz += sizeof(int))); // #tae_addassign
+  // expected-remark@#tae_addassign {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_addassign {{encoding 'int' as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+  // expected-note@#tae_addassign {{inferred indeterminate set of {'int'} from expression 'sz += sizeof(int)'}}
+  // FIXME: it's not clear why we
+  // CHECK: %call2 = call ptr @typed_real_malloc(i64 noundef %add, i64 noundef [[INDETERMINATE_INT:72057595422605840]])
+  // CHECK-DISABLED: call ptr @malloc
+  // Equivalent non-compound form of += above - should also get int type descriptor
+  sz = 0;
+  malloc((sz = sz + sizeof(int))); // #tae_add
+  // expected-remark@#tae_add {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_add {{encoding 'int' as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+  // expected-note@#tae_add {{inferred indeterminate set of {'int'} from expression 'sz = sz + sizeof(int)'}}
+  // CHECK: %call4 = call ptr @typed_real_malloc(i64 noundef %add3, i64 noundef [[INDETERMINATE_INT]])
+  // CHECK-DISABLED: call ptr @malloc
+  // Compound assignment with *= - should get struct S2 type descriptor
+  sz = 10;
+  malloc((sz *= sizeof(struct S2))); // #tae_mulassign
+  // expected-remark@#tae_mulassign {{passing TMO information for array of type 'struct S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_mulassign {{encoding array of 'struct S2' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // expected-note@#tae_mulassign {{inferred array of 'struct S2' from expression 'sz *= sizeof(struct S2)'}}
+  // CHECK: %call5 = call ptr @typed_real_malloc(i64 noundef %mul, i64 noundef [[ARRAY_INT32_DESC]])
+  // CHECK-DISABLED: call ptr @malloc
+
+  // Equivalent non-compound form of *= above - should also get struct S2 type descriptor
+  sz = 10;
+  malloc((sz = sz * sizeof(struct S2))); // #tae_mul
+  // expected-remark@#tae_mul {{passing TMO information for array of type 'struct S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_mul {{encoding array of 'struct S2' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // expected-note@#tae_mul {{inferred array of 'struct S2' from expression 'sz = sz * sizeof(struct S2)'}}
+  // CHECK: %call7 = call ptr @typed_real_malloc(i64 noundef %mul6, i64 noundef [[ARRAY_INT32_DESC]])
+  // CHECK-DISABLED: call ptr @malloc
+
+  sz = 72;
+  malloc((sz /= sizeof(int))); // #tae_divassign
+  // expected-remark@#tae_divassign {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_divassign {{encoding 'int' as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+  // expected-note@#tae_divassign {{inferred indeterminate set of {'int'} from expression 'sz /= sizeof(int)'}}
+  // CHECK: %call8 = call ptr @typed_real_malloc(i64 noundef %div, i64 noundef [[INDETERMINATE_INT]])
+  // CHECK-DISABLED: call ptr @malloc
+
+  sz = 72;
+  malloc((sz -= sizeof(int))); // #tae_subassign
+  // expected-remark@#tae_subassign {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_subassign {{encoding 'int' as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+  // expected-note@#tae_subassign {{inferred indeterminate set of {'int'} from expression 'sz -= sizeof(int)'}}
+  // CHECK: %call9 = call ptr @typed_real_malloc(i64 noundef %sub, i64 noundef [[INDETERMINATE_INT]])
+  // CHECK-DISABLED: call ptr @malloc
+
+  // Assignment with multiplication (verify no regression)
+  malloc((sz = 2 * sizeof(struct S2))); // #tae_constmult
+  // expected-remark@#tae_constmult {{passing TMO information for array of type 'struct S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_constmult {{encoding array of 'struct S2' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // expected-note@#tae_constmult {{inferred array of 'struct S2' from expression 'sz = 2 * sizeof(struct S2)'}}
+  // CHECK: %call10 = call ptr @typed_real_malloc(i64 noundef 8, i64 noundef [[ARRAY_INT32_DESC]])
+  // CHECK-DISABLED: call ptr @malloc(i64 noundef 8)
+
+  // Test calloc with assignment in size parameter
+  calloc(1, (sz = sizeof(struct S1))); // #tae_calloc
+  // expected-remark@#tae_calloc {{passing TMO information for type 'struct S1' to 'typed_real_calloc' (retargeted from 'calloc')}}
+  // expected-note@#tae_calloc {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // expected-note@#tae_calloc {{inferred 'struct S1' from expression 'sz = sizeof(struct S1)'}}
+  // CHECK: %call11 = call ptr @typed_real_calloc(i64 noundef 1, i64 noundef 24, i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call11 = call ptr @calloc(i64 noundef 1, i64 noundef 24)
+
+  // Test realloc with assignment - allocate initial memory then realloc larger
+  ptr = malloc(2 * sizeof(struct S1)); // #tae_malloc_for_realloc
+  // expected-remark@#tae_malloc_for_realloc {{passing TMO information for array of type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tae_malloc_for_realloc {{encoding array of 'struct S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+  // expected-note@#tae_malloc_for_realloc {{inferred array of 'struct S1' from expression '2 * sizeof(struct S1)'}}
+
+  realloc(ptr, (sz = 10 * sizeof(struct S1))); // #tae_realloc
+  // expected-remark@#tae_realloc {{passing TMO information for array of type 'struct S1' to 'typed_real_realloc' (retargeted from 'realloc')}}
+  // expected-note@#tae_realloc {{encoding array of 'struct S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+  // expected-note@#tae_realloc {{inferred array of 'struct S1' from expression 'sz = 10 * sizeof(struct S1)'}}
+  // CHECK: %call13 = call ptr @typed_real_realloc(ptr noundef %{{[0-9]+}}, i64 noundef 240, i64 noundef [[ARRAY_S1_DESC]])
+  // CHECK-DISABLED: %call13 = call ptr @realloc(ptr noundef %{{[0-9]+}}, i64 noundef 240)
+
+  // Test aligned_alloc with assignment
+  aligned_alloc(16, (sz = sizeof(struct S1))); // #tae_aligned_alloc
+  // expected-remark@#tae_aligned_alloc {{passing TMO information for type 'struct S1' to 'typed_real_aligned_alloc' (retargeted from 'aligned_alloc')}}
+  // expected-note@#tae_aligned_alloc {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // expected-note@#tae_aligned_alloc {{inferred 'struct S1' from expression 'sz = sizeof(struct S1)'}}
+  // CHECK: %call14 = call ptr @typed_real_aligned_alloc(i64 noundef 16, i64 noundef 24, i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call14 = call align 16 ptr @aligned_alloc(i64 noundef 16, i64 noundef 24)
+
+  // Test posix_memalign with assignment
+  void *memptr;
+  posix_memalign(&memptr, 16, (sz = sizeof(struct S1))); // #tae_memalign
+  // expected-remark@#tae_memalign {{passing TMO information for type 'struct S1' to 'typed_real_posix_memalign' (retargeted from 'posix_memalign')}}
+  // expected-note@#tae_memalign {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // expected-note@#tae_memalign {{inferred 'struct S1' from expression 'sz = sizeof(struct S1)'}}
+  // CHECK: %call15 = call i32 @typed_real_posix_memalign(ptr noundef %memptr, i64 noundef 16, i64 noundef 24, i64 noundef [[S1_DESC]])
+  // CHECK-DISABLED: %call15 = call i32 @posix_memalign(ptr noundef %memptr, i64 noundef 16, i64 noundef 24)
+}
+
+void test_size_vs_cast(void) {
+  __SIZE_TYPE__ n;
+
+  struct S1 *p1 = (struct S1 *)malloc(sizeof(char) * n); // #cast_dom1
+  // expected-remark@#cast_dom1 {{passing TMO information for array of type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#cast_dom1 {{inferred array of 'struct S1' from cast of result from call to '(struct S1 *)malloc(sizeof(char) * n)'}}
+  // expected-note@#cast_dom1 {{encoding array of 'struct S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+
+  struct S2 *p2 = (struct S2 *)malloc(sizeof(struct S1) * n); // #size_dom1
+  // expected-remark@#size_dom1 {{passing TMO information for array of type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#size_dom1 {{inferred array of 'struct S1' from expression 'sizeof(struct S1) * n'}}
+  // expected-note@#size_dom1 {{encoding array of 'struct S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+
+  void *p3 = (void *)(struct S1 *)malloc(sizeof(char) * n); // #cast_dom2
+  // expected-remark@#cast_dom2 {{passing TMO information for array of type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#cast_dom2 {{inferred array of 'struct S1' from cast of result from call to '(struct S1 *)malloc(sizeof(char) * n)'}}
+  // expected-note@#cast_dom2 {{encoding array of 'struct S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+
+  void *p4 = (struct S1 *)(void *)malloc(sizeof(char) * n); // #cast_dom3
+  // expected-remark@#cast_dom3 {{passing TMO information for array of type 'struct S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#cast_dom3 {{inferred array of 'struct S1' from cast of result from call to '(struct S1 *)(void *)malloc(sizeof(char) * n)'}}
+  // expected-note@#cast_dom3 {{encoding array of 'struct S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+
+  void *p5 = (struct S1 *)malloc(sizeof(struct S2) * n); // #size_dom2
+  // expected-remark@#size_dom2 {{passing TMO information for array of type 'struct S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#size_dom2 {{inferred array of 'struct S2' from expression 'sizeof(struct S2) * n'}}
+  // expected-note@#size_dom2 {{encoding array of 'struct S2' as 72058145178419728}}
+}
+
+// CHECK: attributes [[ATTR]] = { allocsize(0) }
+
+// CHECK: !{!"type-descriptor", !"[[LOC1_DESC]]", !"[[LOC1_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[GENERICDATA32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S1_DESC]]", !"4009135638", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[ARRAY_S1_DESC]]", !"4009135638", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[LOC2_DESC]]", !"[[LOC2_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[LOC3_DESC]]", !"[[LOC3_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[ARRAY_INT32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[ARRAY_DOUBLE_DESC]]", !"3227415", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[U2_DESC]]", !"594631182", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ \22HasMixedUnions\22 ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"} 
+// CHECK: !{!"type-descriptor", !"[[LOC4_DESC]]", !"[[LOC4_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[LOC5_DESC]]", !"[[LOC5_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[LOC6_DESC]]", !"[[LOC6_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[LOC7_DESC]]", !"[[LOC7_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[GENERICDATA64_DESC]]", !"3227415", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[ANONPTR_DESC]]", !"3093312312", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[GENERICDATA128_DESC]]", !"1159420904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[INDETERMINATE_INT]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}

--- a/clang/test/CodeGen/builtin-tmo-get-type-descriptor.cpp
+++ b/clang/test/CodeGen/builtin-tmo-get-type-descriptor.cpp
@@ -1,0 +1,383 @@
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -fblocks -O0 -Rtmo-remarks -verify -fsyntax-only %s
+// RUN: %clang_cc1 -triple arm64-apple-darwin -fblocks -O0 -Rtmo-remarks -verify -fsyntax-only -fptrauth-intrinsics -fptrauth-calls %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm -fblocks -O0 %s -o - 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-darwin -emit-llvm -fblocks -O0 %s -o - 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-darwin -fptrauth-intrinsics -emit-llvm -fblocks -O0 %s -o - 2>&1 | FileCheck %s
+// CHECK: %struct.Check = type { i8 }
+
+_Static_assert(__has_builtin(__builtin_tmo_get_type_descriptor), "No type descriptor builtin");
+
+typedef __INT8_TYPE__ uint8_t;
+typedef unsigned __INT32_TYPE__ uint32_t;
+typedef unsigned __INT64_TYPE__ uint64_t;
+
+extern "C" void printf(const char *, uint32_t s) {}
+
+#define SUMMARY_SHIFT                 32
+#define SUMMARY_LAYOUT_SHIFT          (SUMMARY_SHIFT + 16)
+#define SUMMARY_TYPE_FLAGS_SHIFT      (SUMMARY_SHIFT + 12)
+#define SUMMARY_CALLSITE_FLAGS_SHIFT  (SUMMARY_SHIFT + 8)
+#define SUMMARY_VERSION_SHIFT         (SUMMARY_SHIFT + 0)
+
+#define SUMMARY_LAYOUT_BIT(b)         (1ULL << (SUMMARY_LAYOUT_SHIFT + b))
+#define SUMMARY_TYPE_FLAGS_BIT(b)     (1ULL << (SUMMARY_TYPE_FLAGS_SHIFT + b))
+
+#define SUMMARY_DATA_POINTER      SUMMARY_LAYOUT_BIT(0)
+#define SUMMARY_STRUCT_POINTER    SUMMARY_LAYOUT_BIT(1)
+#define SUMMARY_IMMUTABLE_POINTER SUMMARY_LAYOUT_BIT(2)
+#define SUMMARY_ANONYMOUS_POINTER SUMMARY_LAYOUT_BIT(3)
+#define SUMMARY_REFERENCE_COUNT   SUMMARY_LAYOUT_BIT(4)
+#define SUMMARY_RESOURCE_HANDLE   SUMMARY_LAYOUT_BIT(5)
+#define SUMMARY_SPATIAL_BOUNDS    SUMMARY_LAYOUT_BIT(6)
+#define SUMMARY_TAINTED_DATA      SUMMARY_LAYOUT_BIT(7)
+#define SUMMARY_GENERIC_DATA      SUMMARY_LAYOUT_BIT(8)
+
+#define SUMMARY_IS_POLYMORPHIC    SUMMARY_TYPE_FLAGS_BIT(0)
+#define SUMMARY_HAS_MIXED_UNIONS  SUMMARY_TYPE_FLAGS_BIT(1)
+#define SUMMARY_FIXED_SIZE        (1 << 20)
+#define SUMMARY_VERSION           (0x3 << 0)
+#define SUMMARY_MASK              (0xffffffff00000000)
+#define SUMMARY_MASK_LAYOUT       (0xffff000000000000)
+#define SUMMARY_MASK_FLAGS        (0x0000f00000000000)
+#define SUMMARY_MASK_CALLSITE     (0x00000f0000000000)
+
+
+#define GET_DESCRIPTOR(e) __builtin_tmo_get_type_descriptor(e)
+#define _GET_DESCRIPTOR_BITS(e, t, m) (static_cast<t>(e) & m)
+#define GET_SUMMARY(e) \
+  (_GET_DESCRIPTOR_BITS(e, uint32_t, SUMMARY_MASK) >> SUMMARY_SHIFT)
+#define GET_HASH(e) _GET_DESCRIPTOR_BITS(e, uint32_t, ~SUMMARY_MASK)
+
+template<typename T, uint64_t M, uint64_t C>
+struct Check {
+  static constexpr const uint64_t descr = GET_DESCRIPTOR(T); // #Check_descr
+  static constexpr const uint64_t info = descr & M; // #Check_info
+  static_assert((info ^ C) == 0, "check failed"); // #Check_static_assert
+};
+
+template<typename T, uint64_t C>
+using CheckLayout = Check<T, SUMMARY_MASK_LAYOUT, C>;
+
+template<typename T, uint64_t C>
+using CheckFlags = Check<T, SUMMARY_MASK_FLAGS, C>;
+
+template<typename T0, typename T1, bool Eq>
+struct CompareHash {
+  static constexpr const uint64_t d0 = GET_DESCRIPTOR(T0); // #CompareHashT0
+  static constexpr const uint64_t d1 = GET_DESCRIPTOR(T1); // #CompareHashT1
+  static_assert((d0 == d1) == Eq, "comparison failed"); // #ComparisonStaticAssert
+};
+
+struct S0 {
+  int *d;
+};
+CheckLayout<S0, SUMMARY_DATA_POINTER> t0;
+// expected-note@-1 {{in instantiation of template class 'Check<S0, 18446462598732840960, 281474976710656>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S0' as 281476107670517. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1130959861 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S0, 18446462598732840960, 281474976710656>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S0, 18446462598732840960, 281474976710656>::descr' requested here}}
+
+CheckFlags<S0, 0> t0f;
+// expected-note@-1 {{in instantiation of template class 'Check<S0, 263882790666240, 0>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S0' as 281476107670517. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1130959861 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S0, 263882790666240, 0>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S0, 263882790666240, 0>::descr' requested here}}
+
+struct S1 {
+  void *p;
+};
+CheckLayout<S1, SUMMARY_ANONYMOUS_POINTER> t1;
+// expected-note@-1 {{in instantiation of template class 'Check<S1, 18446462598732840960, 2251799813685248>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S1' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S1, 18446462598732840960, 2251799813685248>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S1, 18446462598732840960, 2251799813685248>::descr' requested here}}
+
+struct S2 {
+  struct S1 *p;
+};
+CheckLayout<S2, SUMMARY_STRUCT_POINTER> t2;
+// expected-note@-1 {{in instantiation of template class 'Check<S2, 18446462598732840960, 562949953421312>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S2' as 562952428289801. Type semantics: { "Summary": { "LayoutSemantics": [ "StructPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 2474868489 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S2, 18446462598732840960, 562949953421312>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S2, 18446462598732840960, 562949953421312>::descr' requested here}}
+
+struct S3a {
+  const void *p;
+};
+struct S3b {
+  void *const p;
+};
+CheckLayout<S3a, SUMMARY_ANONYMOUS_POINTER | SUMMARY_IMMUTABLE_POINTER> t3a;
+// expected-note@-1 {{in instantiation of template class 'Check<S3a, 18446462598732840960, 3377699720527872>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S3a' as 3377702818697837. Type semantics: { "Summary": { "LayoutSemantics": [ "ImmutablePointer", "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3098169965 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S3a, 18446462598732840960, 3377699720527872>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S3a, 18446462598732840960, 3377699720527872>::descr' requested here}}
+
+CheckLayout<S3b, SUMMARY_ANONYMOUS_POINTER | SUMMARY_IMMUTABLE_POINTER> t3b; // #t3b
+// expected-note@#t3b {{in instantiation of template class 'Check<S3b, 18446462598732840960, 3377699720527872>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S3b' as 3377702818697837. Type semantics: { "Summary": { "LayoutSemantics": [ "ImmutablePointer", "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3098169965 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S3b, 18446462598732840960, 3377699720527872>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S3b, 18446462598732840960, 3377699720527872>::descr' requested here}}
+
+struct S4 {
+  char d[8];
+};
+CheckLayout<S4, SUMMARY_GENERIC_DATA> t4; // #t4
+// expected-note@#t4 {{in instantiation of template class 'Check<S4, 18446462598732840960, 72057594037927936>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S4' as 72057594041155351. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3227415 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S4, 18446462598732840960, 72057594037927936>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S4, 18446462598732840960, 72057594037927936>::descr' requested here}}
+
+struct S5 {
+  union {
+    void *pointer;
+    uint64_t data;
+  };
+};
+CheckLayout<S5, SUMMARY_GENERIC_DATA | SUMMARY_ANONYMOUS_POINTER> t5; // #t5
+// expected-note@#t5 {{in instantiation of template class 'Check<S5, 18446462598732840960, 74309393851613184>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S5' as 74344580619983834. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ "HasMixedUnions" ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 2396281818 }}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S5, 18446462598732840960, 74309393851613184>::descr' requested here}}
+
+CheckFlags<S5, SUMMARY_HAS_MIXED_UNIONS> t5f; // #t5f
+// expected-note@#t5f {{in instantiation of template class 'Check<S5, 263882790666240, 35184372088832>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S5' as 74344580619983834. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ "HasMixedUnions" ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 2396281818 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S5, 263882790666240, 35184372088832>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S5, 263882790666240, 35184372088832>::descr' requested here}}
+
+struct S6 {
+  virtual void f() = 0;
+  uint64_t d;
+};
+CheckLayout<S5, SUMMARY_GENERIC_DATA | SUMMARY_ANONYMOUS_POINTER> t6;
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S5, 18446462598732840960, 74309393851613184>::info' requested here}}
+
+CheckFlags<S6, SUMMARY_IS_POLYMORPHIC> t6f; // #t6f
+// expected-note@#t6f {{in instantiation of template class 'Check<S6, 263882790666240, 17592186044416>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S6' as 74326990272095183. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ "IsPolymorphic" ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 4234437583 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S6, 263882790666240, 17592186044416>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S6, 263882790666240, 17592186044416>::descr' requested here}}
+
+struct S7 {
+  struct S0 s0;
+  struct S1 s1;
+  struct S5 s5;
+  virtual void f() = 0;
+};
+CheckLayout<S7, SUMMARY_DATA_POINTER | SUMMARY_ANONYMOUS_POINTER | SUMMARY_GENERIC_DATA> t7; // #t7
+// expected-note@#t7 {{in instantiation of template class 'Check<S7, 18446462598732840960, 74590868828323840>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S7' as 74643647262773326. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer", "AnonymousPointer", "GenericData" ], "TypeFlags": [ "IsPolymorphic", "HasMixedUnions" ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1876316238 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S7, 18446462598732840960, 74590868828323840>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S7, 18446462598732840960, 74590868828323840>::descr' requested here}}
+
+CheckFlags<S7, SUMMARY_HAS_MIXED_UNIONS | SUMMARY_IS_POLYMORPHIC> t7f; // #t7f
+// expected-note@#t7f {{in instantiation of template class 'Check<S7, 263882790666240, 52776558133248>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S7' as 74643647262773326. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer", "AnonymousPointer", "GenericData" ], "TypeFlags": [ "IsPolymorphic", "HasMixedUnions" ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1876316238 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S7, 263882790666240, 52776558133248>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S7, 263882790666240, 52776558133248>::descr' requested here}}
+
+struct S8a {
+  int *p;
+  uint64_t u;
+};
+struct S8b {
+  int *c;
+  uint32_t a;
+  uint32_t b;
+};
+struct S8c {
+  char *c;
+  char d0[2];
+  char d1[4];
+  char d2[2];
+};
+struct S8d {
+  uint64_t u;
+  int *p;
+};
+CompareHash<S8a, S8b, true> t8ca; // #t8ca
+// expected-note@#t8ca {{in instantiation of template class 'CompareHash<S8a, S8b, true>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'S8a' as 72339073273557324. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 4258918732 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S8a, S8b, true>::d0' requested here}}
+// expected-note@#t8ca {{in instantiation of template class 'CompareHash<S8a, S8b, true>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'S8b' as 72339073273557324. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 4258918732 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S8a, S8b, true>::d1' requested here}}
+
+CompareHash<S8a, S8c, true> t8cb; // #t8cb
+// expected-note@#t8cb {{in instantiation of template class 'CompareHash<S8a, S8c, true>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'S8a' as 72339073273557324. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 4258918732 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S8a, S8c, true>::d0' requested here}}
+// expected-note@#t8cb {{in instantiation of template class 'CompareHash<S8a, S8c, true>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'S8c' as 72339073273557324. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 4258918732 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S8a, S8c, true>::d1' requested here}}
+CompareHash<S8a, S8d, false> t8cc; // #t8cc
+// expected-note@#t8cc {{in instantiation of template class 'CompareHash<S8a, S8d, false>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'S8a' as 72339073273557324. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 4258918732 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S8a, S8d, false>::d0' requested here}}
+// expected-note@#t8cc {{in instantiation of template class 'CompareHash<S8a, S8d, false>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'S8d' as 72339070195402188. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1180763596 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S8a, S8d, false>::d1' requested here}}
+struct ForwardStruct;
+
+CompareHash<void *, const void *, false> th0; // #th0
+// expected-note@#th0 {{in instantiation of template class 'CompareHash<void *, const void *, false>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'void *' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<void *, const void *, false>::d0' requested here}}
+// expected-note@#th0 {{in instantiation of template class 'CompareHash<void *, const void *, false>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'const void *' as 3377702818697837. Type semantics: { "Summary": { "LayoutSemantics": [ "ImmutablePointer", "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3098169965 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<void *, const void *, false>::d1' requested here}}
+CompareHash<void *, void const*, false> th1;
+
+CompareHash<void *, void **, true> th2; // #th2
+// expected-note@#th2 {{in instantiation of template class 'CompareHash<void *, void **, true>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'void *' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<void *, void **, true>::d0' requested here}}
+// expected-note@#th2 {{in instantiation of template class 'CompareHash<void *, void **, true>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'void **' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<void *, void **, true>::d1' requested here}}
+
+CompareHash<void *, int *, false> th3; // #th3
+// expected-note@#th3 {{in instantiation of template class 'CompareHash<void *, int *, false>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'void *' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<void *, int *, false>::d0' requested here}}
+// expected-note@#th3 {{in instantiation of template class 'CompareHash<void *, int *, false>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'int *' as 281476107670517. Type semantics: { "Summary": { "LayoutSemantics": [ "DataPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1130959861 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<void *, int *, false>::d1' requested here}}
+
+CompareHash<uint64_t, uint32_t[2], true> th4; // #th4
+// expected-note@#th4 {{in instantiation of template class 'CompareHash<unsigned long long, unsigned int[2], true>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'unsigned long long' as 72057594041155351. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3227415 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<unsigned long long, unsigned int[2], true>::d0' requested here}}
+// expected-note@#th4 {{in instantiation of template class 'CompareHash<unsigned long long, unsigned int[2], true>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'unsigned int[2]' as 72057594041155351. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3227415 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<unsigned long long, unsigned int[2], true>::d1' requested here}}
+
+CompareHash<ForwardStruct *, void *, false> th5; // #th5
+// expected-note@#th5 {{in instantiation of template class 'CompareHash<ForwardStruct *, void *, false>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'ForwardStruct *' as 562952428289801. Type semantics: { "Summary": { "LayoutSemantics": [ "StructPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 2474868489 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<ForwardStruct *, void *, false>::d0' requested here}}
+// expected-note@#th5 {{in instantiation of template class 'CompareHash<ForwardStruct *, void *, false>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'void *' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<ForwardStruct *, void *, false>::d1' requested here}}
+
+CompareHash<S8a *, ForwardStruct *, true> th6; // #th6
+// expected-note@#th6 {{in instantiation of template class 'CompareHash<S8a *, ForwardStruct *, true>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'S8a *' as 562952428289801. Type semantics: { "Summary": { "LayoutSemantics": [ "StructPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 2474868489 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S8a *, ForwardStruct *, true>::d0' requested here}}
+// expected-note@#th6 {{in instantiation of template class 'CompareHash<S8a *, ForwardStruct *, true>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'ForwardStruct *' as 562952428289801. Type semantics: { "Summary": { "LayoutSemantics": [ "StructPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 2474868489 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S8a *, ForwardStruct *, true>::d1' requested here}}
+
+struct S9a {
+  union {
+    char d[16];
+    struct {
+      char c[4];
+      void *p;
+    } __attribute__((packed));
+  };
+};
+CheckFlags<S9a, SUMMARY_HAS_MIXED_UNIONS> t9af; // #t9af
+// expected-note@#t9af {{in instantiation of template class 'Check<S9a, 263882790666240, 35184372088832>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S9a' as 74344578286568980. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ "HasMixedUnions" ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 62866964 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S9a, 263882790666240, 35184372088832>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S9a, 263882790666240, 35184372088832>::descr' requested here}}
+
+struct S10 {
+  void (*f)(int);
+};
+CheckLayout<S10, SUMMARY_ANONYMOUS_POINTER> t10; // #t10
+// expected-note@#t10 {{in instantiation of template class 'Check<S10, 18446462598732840960, 2251799813685248>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'S10' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<S10, 18446462598732840960, 2251799813685248>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<S10, 18446462598732840960, 2251799813685248>::descr' requested here}}
+
+struct S11a {
+  int a[];
+};
+struct S11b {
+};
+struct S11c {
+  union {
+    int a[];
+    char b[];
+    void *p[];
+  };
+};
+struct S11d {
+  int a;
+  int b[];
+};
+struct S11e {
+  int a;
+};
+CompareHash<S11a, S11b, true> th7; // #th7
+// expected-note@#th7 {{in instantiation of template class 'CompareHash<S11a, S11b, true>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'S11a' as 170574065. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 170574065 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S11a, S11b, true>::d0' requested here}}
+// expected-note@#th7 {{in instantiation of template class 'CompareHash<S11a, S11b, true>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'S11b' as 170574065. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 170574065 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S11a, S11b, true>::d1' requested here}}
+
+CompareHash<S11a, S11c, true> th8; // #th8
+// expected-note@#th8 {{in instantiation of template class 'CompareHash<S11a, S11c, true>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'S11a' as 170574065. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 170574065 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S11a, S11c, true>::d0' requested here}}
+// expected-note@#th8 {{in instantiation of template class 'CompareHash<S11a, S11c, true>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'S11c' as 170574065. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 170574065 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S11a, S11c, true>::d1' requested here}}
+
+CompareHash<S11d, S11e, true> th9; // #th9
+// expected-note@#th9 {{in instantiation of template class 'CompareHash<S11d, S11e, true>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'S11d' as 72057595422605840. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S11d, S11e, true>::d0' requested here}}
+// expected-note@#th9 {{in instantiation of template class 'CompareHash<S11d, S11e, true>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'S11e' as 72057595422605840. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S11d, S11e, true>::d1' requested here}}
+
+CompareHash<S11a, S11d, false> th10; // #th10
+// expected-note@#th10 {{in instantiation of template class 'CompareHash<S11a, S11d, false>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'S11a' as 170574065. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 170574065 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S11a, S11d, false>::d0' requested here}}
+// expected-note@#th10 {{in instantiation of template class 'CompareHash<S11a, S11d, false>' requested here}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'S11d' as 72057595422605840. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<S11a, S11d, false>::d1' requested here}}
+
+// rdar://104683319
+struct TypeA_104683319 {
+  uint8_t d[1 << 22];
+};
+
+struct TypeB_104683319 {
+  uint8_t d[1 << 22];
+};
+
+struct TypeC_104683319 {
+  uint8_t d[1 << 21];
+};
+
+CompareHash<TypeA_104683319, TypeB_104683319, false> th1_104683319; // #th1_104683319
+// expected-note@#th1_104683319 {{in instantiation of template class 'CompareHash<TypeA_104683319, TypeB_104683319, false>' requested here}}
+// expected-remark@#CompareHashT0 {{__builtin_tmo_get_type_descriptor reported 'TypeA_104683319' as 2646530002. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 2646530002 }}}
+// expected-note@#th1_104683319 {{in instantiation of template class 'CompareHash<TypeA_104683319, TypeB_104683319, false>' requested here}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<TypeA_104683319, TypeB_104683319, false>::d0' requested her}}
+// expected-remark@#CompareHashT1 {{__builtin_tmo_get_type_descriptor reported 'TypeB_104683319' as 865981442. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 865981442 }}}
+// expected-note@#ComparisonStaticAssert {{in instantiation of static data member 'CompareHash<TypeA_104683319, TypeB_104683319, false>::d1' requested her}}
+
+CheckLayout<TypeA_104683319, 0> t1_104683319; // #t1_104683319
+// expected-note@#t1_104683319 {{in instantiation of template class 'Check<TypeA_104683319, 18446462598732840960, 0>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'TypeA_104683319' as 2646530002. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 2646530002 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<TypeA_104683319, 18446462598732840960, 0>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<TypeA_104683319, 18446462598732840960, 0>::descr' requested here}}
+
+CheckLayout<TypeB_104683319, 0> t2_104683319; // #t2_104683319
+// expected-note@#t2_104683319 {{in instantiation of template class 'Check<TypeB_104683319, 18446462598732840960, 0>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'TypeB_104683319' as 865981442. Type semantics: { "Summary": { "LayoutSemantics": [ ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 865981442 }}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<TypeB_104683319, 18446462598732840960, 0>::info' requested here}}
+// expected-note@#Check_info {{in instantiation of static data member 'Check<TypeB_104683319, 18446462598732840960, 0>::descr' requested here}}
+
+CheckLayout<TypeC_104683319, SUMMARY_GENERIC_DATA> t3_104683319; // #t3_104683319
+// expected-note@#t3_104683319 {{in instantiation of template class 'Check<TypeC_104683319, 18446462598732840960, 72057594037927936>' requested here}}
+// expected-remark@#Check_descr {{__builtin_tmo_get_type_descriptor reported 'TypeC_104683319' as 72057594228667364. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 190739428 }}} 
+// expected-note@#Check_info {{in instantiation of static data member 'Check<TypeC_104683319, 18446462598732840960, 72057594037927936>::descr' requested here}}
+// expected-note@#Check_static_assert {{in instantiation of static data member 'Check<TypeC_104683319, 18446462598732840960, 72057594037927936>::info' requested here}}

--- a/clang/test/CodeGen/late-attr-typed-memory-operation.c
+++ b/clang/test/CodeGen/late-attr-typed-memory-operation.c
@@ -1,0 +1,63 @@
+// RUN: %clang_cc1 -ftyped-memory-operations -triple x86_64-apple-macos -nostdsysteminc -O0 %s \
+// RUN:            -Rtmo-remarks -verify -fsyntax-only
+// RUN: %clang_cc1 -ftyped-memory-operations -triple x86_64-apple-macos -nostdsysteminc -O0 %s \
+// RUN:            -disable-llvm-passes -emit-llvm -o - | FileCheck --check-prefix=CHECK %s
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_real_malloc(__SIZE_TYPE__ size, unsigned long long);
+
+struct S {
+  int i;
+  void (*f)(int);
+  void *ptr;
+};
+
+void *malloc(__SIZE_TYPE__ size);
+void test_malloc1() {
+  // CHECK-LABEL: void @test_malloc1()
+  struct S* s1 = malloc(sizeof(struct S));
+  // CHECK: @malloc(i64 noundef 24)
+  struct S* s2 = malloc(sizeof(struct S) * 5);
+  // CHECK: @malloc(i64 noundef 120)
+  struct S* s3 = (struct S*)malloc(100);
+  // CHECK: @malloc(i64 noundef 100)
+  void* s4 = malloc(sizeof(struct S));
+  // CHECK: @malloc(i64 noundef 24)
+  void* s5 = (struct S*)malloc(100);
+  // CHECK: @malloc(i64 noundef 100)
+}
+
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_real_malloc, 1);
+
+void test_malloc2() {
+  // CHECK-LABEL: @test_malloc2()
+  struct S* s1 = malloc(sizeof(struct S)); //#test2_s1
+  // CHECK: @typed_real_malloc(i64 noundef 24, i64 noundef [[S_DESC:74309672024422210]])
+  // expected-remark@#test2_s1 {{passing TMO information for type 'struct S' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#test2_s1 {{inferred 'struct S' from expression 'sizeof(struct S)'}}
+  // expected-note@#test2_s1 {{encoding 'struct S' as 74309672024422210. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3294902082 }}}
+  struct S* s2 = malloc(sizeof(struct S) * 5); //#test2_s2
+  // CHECK: @typed_real_malloc(i64 noundef 120, i64 noundef [[S_DESC_ARRAY:74309946902329154]])
+  // expected-remark@#test2_s2 {{passing TMO information for array of type 'struct S' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#test2_s2 {{inferred array of 'struct S' from expression 'sizeof(struct S) * 5'}}
+  // expected-note@#test2_s2 {{encoding array of 'struct S' as 74309946902329154. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 3294902082 }}}
+  struct S* s3 = (struct S*)malloc(100); //#test2_s3
+  // CHECK: @typed_real_malloc(i64 noundef 100, i64 noundef [[S_DESC]])
+  // expected-remark@#test2_s3 {{passing TMO information for type 'struct S' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#test2_s3 {{inferred 'struct S' from cast of result from call to '(struct S *)malloc(100)'}}
+  // expected-note@#test2_s3 {{encoding 'struct S' as 74309672024422210. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3294902082 }}}
+  void* s4 = malloc(sizeof(struct S)); //#test2_s4
+  // CHECK: @typed_real_malloc(i64 noundef 24, i64 noundef [[S_DESC]])
+  // expected-remark@#test2_s4 {{passing TMO information for type 'struct S' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#test2_s4 {{inferred 'struct S' from expression 'sizeof(struct S)'}}
+  // expected-note@#test2_s4 {{encoding 'struct S' as 74309672024422210. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3294902082 }}}
+  void* s5 = (struct S*)malloc(100); //#test2_s5
+  // CHECK: @typed_real_malloc(i64 noundef 100, i64 noundef [[S_DESC]])
+  // expected-remark@#test2_s5 {{passing TMO information for type 'struct S' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // expected-note@#test2_s5 {{inferred 'struct S' from cast of result from call to '(struct S *)malloc(100)'}}
+  // expected-note@#test2_s5 {{encoding 'struct S' as 74309672024422210. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3294902082 }}}
+}
+
+// CHECK: !{!"type-descriptor", !"[[S_DESC]]", !"3294902082", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S_DESC_ARRAY]]", !"3294902082", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}

--- a/clang/test/CodeGenCXX/attr-typed-memory-operation-nested-expression-statements.cpp
+++ b/clang/test/CodeGenCXX/attr-typed-memory-operation-nested-expression-statements.cpp
@@ -1,0 +1,106 @@
+// RUN: %clang_cc1 -Rtmo-remarks -verify -fsyntax-only \
+// RUN:               -ftyped-memory-operations -fblocks -triple x86_64-apple-macos -nostdsysteminc -O0 %s
+// RUN: %clang_cc1    -ftyped-memory-operations -fblocks -triple x86_64-apple-macos -nostdsysteminc -O0 -disable-llvm-passes -emit-llvm -o - %s | FileCheck --check-prefix=CHECK          %s
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+extern "C" void *typed_func1(float, __SIZE_TYPE__ size, unsigned long long);
+extern "C" void *test_func1(float, __SIZE_TYPE__ size) _TYPED(typed_func1, 2);
+extern "C" void *typed_func2(__SIZE_TYPE__ size, unsigned long long, float);
+extern "C" void *test_func2(__SIZE_TYPE__ size, float) _TYPED(typed_func2, 1);
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+struct S2 {
+  void *p;
+  int i;
+  int j;
+};
+struct S3 {
+  void *p1;
+  void *p2;
+  int j;
+};
+struct S4 {
+  void *p1;
+  int j;
+  void *p2;
+};
+struct S5 {
+  int j;
+  void *p1;
+  void *p2;
+};
+
+extern "C" void f(void) {
+  // CHECK-LABEL: define void @f()
+  struct S1* alloc1 = (struct S1*)test_func1(({0;}), 100); // #alloc1
+  // CHECK: call ptr @typed_func1(float {{.*}}, i64 noundef 100, i64 noundef [[S1_DESC:74309672738655766]])
+  // expected-remark@#alloc1 {{passing TMO information for type 'struct S1' to 'typed_func1' (retargeted from 'test_func1')}}
+  // expected-note@#alloc1 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)test_func1(({}}
+  // expected-note@#alloc1 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1* alloc2 = (struct S1*)test_func2(100, ({0;})); // #alloc2
+  // CHECK: call ptr @typed_func2(i64 noundef 100, i64 noundef [[S1_DESC]], float {{.*}})
+  // expected-remark@#alloc2 {{passing TMO information for type 'struct S1' to 'typed_func2' (retargeted from 'test_func2')}}
+  // expected-note@#alloc2 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)test_func2(100, ({}}
+  // expected-note@#alloc2 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1* alloc3 = (struct S1*)test_func1((^(){return 0.0;})(), 100); // #alloc3
+  // CHECK: call ptr @typed_func1(float {{.*}}, i64 noundef 100, i64 noundef [[S1_DESC]])
+  // expected-remark@#alloc3 {{passing TMO information for type 'struct S1' to 'typed_func1' (retargeted from 'test_func1')}}
+  // expected-note@#alloc3 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)test_func1((^{ })(), 100)'}}
+  // expected-note@#alloc3 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1* alloc4 = (struct S1*)test_func2(100, ([](){return 0.0;})()); // #alloc4
+  // CHECK: call ptr @typed_func2(i64 noundef 100, i64 noundef [[S1_DESC]], float {{.*}})
+  // expected-remark@#alloc4 {{passing TMO information for type 'struct S1' to 'typed_func2' (retargeted from 'test_func2')}}
+  // expected-note@#alloc4 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)test_func2(100, ([]() {}}
+  // expected-note@#alloc4 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1* alloc5 = (struct S1*)test_func1((^(){return 0.0;})(), 100); // #alloc5
+  // CHECK: call ptr @typed_func1(float {{.*}}, i64 noundef 100, i64 noundef [[S1_DESC]])
+  // expected-remark@#alloc5 {{passing TMO information for type 'struct S1' to 'typed_func1' (retargeted from 'test_func1')}}
+  // expected-note@#alloc5 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)test_func1((^{ })(), 100)'}}
+  // expected-note@#alloc5 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1* alloc6 = (struct S1*)test_func2(100, ([](){return 0.0;})()); // #alloc6
+  // CHECK: call ptr @typed_func2(i64 noundef 100, i64 noundef [[S1_DESC]], float noundef %conv15)
+  // expected-remark@#alloc6 {{passing TMO information for type 'struct S1' to 'typed_func2' (retargeted from 'test_func2')}}
+  // expected-note@#alloc6 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)test_func2(100, ([]() {}}
+  // expected-note@#alloc6 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S2* alloc7 = (struct S2*)test_func1((^(){ // #alloc7
+    // expected-remark@#alloc7 {{passing TMO information for type 'struct S2' to 'typed_func1' (retargeted from 'test_func1')}}
+    // expected-note@#alloc7 {{inferred 'struct S2' from cast of result from call to '(struct S2 *)test_func1((^{ })(), 100)'}}
+    // expected-note@#alloc7 {{encoding 'struct S2' as 74309672963957711. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4234437583 }}}
+    struct S3* alloc8 = (struct S3*)test_func1(({0;}), 100); // #alloc8
+    // expected-remark@#alloc8 {{passing TMO information for type 'struct S3' to 'typed_func1' (retargeted from 'test_func1')}}
+    // expected-note@#alloc8 {{inferred 'struct S3' from cast of result from call to '(struct S3 *)test_func1(({}}
+    // expected-note@#alloc8 {{encoding 'struct S3' as 74309670376583829. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1647063701 }}}
+    return (!!alloc8) * 0.0;
+  })(), 100);
+  // CHECK: call ptr @typed_func1(float {{.*}}, i64 noundef 100, i64 noundef [[S2_DESC:74309672963957711]])
+
+  struct S4* alloc9 = (struct S4*)test_func2(100, ([](){ // #alloc9
+  // expected-remark@#alloc9 {{passing TMO information for type 'struct S4' to 'typed_func2' (retargeted from 'test_func2')}}
+  // expected-note@#alloc9 {{inferred 'struct S4' from cast of result from call to '(struct S4 *)test_func2(100, ([]() {}} }}
+  // expected-note@#alloc9 {{encoding 'struct S4' as 74309671930320854. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3200800726 }}}
+    struct S5* alloc10 = (struct S5*)test_func1(({0;}), 100); // #alloc10
+    // expected-remark@#alloc10 {{passing TMO information for type 'struct S5' to 'typed_func1' (retargeted from 'test_func1')}}
+    // expected-note@#alloc10 {{inferred 'struct S5' from cast of result from call to '(struct S5 *)test_func1(({}}
+    // expected-note@#alloc10 {{encoding 'struct S5' as 74309672024422210. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3294902082 }}}
+    return 0.0;
+  })());
+  // CHECK: call ptr @typed_func2(i64 noundef 100, i64 noundef [[S4_DESC:74309671930320854]], float {{.*}})
+}
+
+// CHECK-LABEL: double @__f_block_invoke_3
+// CHECK: call ptr @typed_func1(float {{.*}}, i64 noundef 100, i64 noundef [[S3_DESC:74309670376583829]])
+
+// CHECK-LABEL: double @"_ZZ1fENK3$_2clEv"
+// CHECK: call ptr @typed_func1(float noundef %conv, i64 noundef 100, i64 noundef [[S5_DESC:74309672024422210]])
+
+// CHECK: !{!"type-descriptor", !"[[S1_DESC]]", !"4009135638", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S2_DESC]]", !"4234437583", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S4_DESC]]", !"3200800726", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S3_DESC]]", !"1647063701", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S5_DESC]]", !"3294902082", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}

--- a/clang/test/CodeGenCXX/attr-typed-memory-operation.cpp
+++ b/clang/test/CodeGenCXX/attr-typed-memory-operation.cpp
@@ -1,0 +1,351 @@
+// RUN: %clang_cc1 -Rtmo-remarks -fsyntax-only -verify=tmo \
+// RUN:               -ftyped-memory-operations -DTMO=1 -nostdsysteminc -O0 -disable-llvm-passes -no-enable-noundef-analysis %s
+// RUN: %clang_cc1 -Rtmo-remarks -fsyntax-only -verify=tmo,tmowarn -Wtyped-memory-inference-failure \
+// RUN:               -ftyped-memory-operations -DTMO=1 -nostdsysteminc -O0 -disable-llvm-passes -no-enable-noundef-analysis %s
+// RUN: %clang_cc1 -Rtmo-remarks -fsyntax-only -verify=tmo \
+// RUN:               -ftyped-memory-operations -DTMO=1 -nostdsysteminc -O0 -disable-llvm-passes -no-enable-noundef-analysis %s
+// RUN: %clang_cc1 -Rtmo-remarks -fsyntax-only -verify=tmo,tmowarn -Wtyped-memory-inference-failure \
+// RUN:               -ftyped-memory-operations -DTMO=1 -nostdsysteminc -O0 -disable-llvm-passes -no-enable-noundef-analysis %s
+// RUN: %clang_cc1               -fsyntax-only -verify=notmoremarks \
+// RUN:               -ftyped-memory-operations -DTMO=1 -nostdsysteminc -O0 -disable-llvm-passes -no-enable-noundef-analysis %s
+// RUN: %clang_cc1               -verify=notmoremarks -fsyntax-only \
+// RUN:             -fno-typed-memory-operations -Rtmo-remarks -DTMO=0 -nostdsysteminc -O0 -disable-llvm-passes -no-enable-noundef-analysis %s
+// RUN: %clang_cc1    -ftyped-memory-operations -DTMO=1 -nostdsysteminc -O0 -disable-llvm-passes -no-enable-noundef-analysis -emit-llvm -o - %s | FileCheck --check-prefix=CHECK          %s
+// RUN: %clang_cc1 -fno-typed-memory-operations -DTMO=0 -nostdsysteminc -O0 -disable-llvm-passes -no-enable-noundef-analysis -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-DISABLED %s
+
+// notmoremarks-no-diagnostics
+#if TMO
+static_assert(__has_feature(typed_memory_operations));
+#else
+static_assert(!__has_feature(typed_memory_operations));
+#endif
+
+#define TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *typed_calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size, unsigned long long);
+void typed_unusual_alloc(float, unsigned, unsigned long long, const char*);
+
+void *my_malloc(__SIZE_TYPE__ size) TYPED(typed_malloc, 1);
+void *my_calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size) TYPED(typed_calloc, 2);
+void unusual_alloc(float, unsigned, const char*) TYPED(typed_unusual_alloc, 2);
+
+extern "C" {
+
+void *typed_real_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *typed_real_calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size, unsigned long long);
+void *typed_real_realloc(void *, __SIZE_TYPE__ size, unsigned long long);
+void *typed_real_aligned_alloc(unsigned long long align, unsigned long long size, unsigned long long);
+int typed_real_posix_memalign(void **, __SIZE_TYPE__, __SIZE_TYPE__, unsigned long long);
+
+void *malloc(__SIZE_TYPE__ size) TYPED(typed_real_malloc, 1);
+void *calloc(__SIZE_TYPE__ count, __SIZE_TYPE__ size) TYPED(typed_real_calloc, 2);
+void *realloc(void *, __SIZE_TYPE__ size) TYPED(typed_real_realloc, 2);
+void *aligned_alloc(unsigned long long align, unsigned long long size) TYPED(typed_real_aligned_alloc, 2);
+int posix_memalign(void **, __SIZE_TYPE__, __SIZE_TYPE__) TYPED(typed_real_posix_memalign, 3);
+}
+
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+struct S2 : S1 {
+
+};
+
+struct S3 {
+  virtual ~S3();
+};
+
+struct S4 : S3 {
+
+};
+
+struct S4_2 : S3 {
+  int i;
+};
+
+struct S5 {
+  int i;
+};
+
+struct S6 : S5 {
+  void *p;
+};
+
+struct S7 : virtual S5 {
+  void *p;
+};
+struct S8 : virtual S5 {
+};
+
+union U1 {
+  int i;
+};
+
+union U2 {
+  int i;
+  void* v;
+};
+
+
+// We use these functions to test order of evaluation in some of
+// these tests as there the override forwarding is some logical
+// argument reordering but we need to maintain the C semantic
+// ordering.
+extern "C" int f1();
+extern "C" int f2();
+
+extern "C" void f();
+extern "C" void f() {
+  // Basic codegen tests
+  malloc(5); // #alloc1
+  // tmowarn-warning@#alloc1 {{could not infer allocation type in call to 'malloc'}}
+  // tmowarn-note@#alloc1 {{unable to infer allocation type from expression '5'}}
+  // tmo@alloc1 {{unable to infer allocation type from expression '5'}}
+  // CHECK: %call = call ptr @typed_real_malloc(i64 5, i64 [[LOC1_DESC:[0-9]+]])
+  // CHECK-DISABLED: %call = call ptr @malloc(i64 5)
+  malloc(sizeof(int)); // #alloc2
+  // tmo-remark@#alloc2 {{passing TMO information for type 'int' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc2 {{inferred 'int' from expression 'sizeof(int)'}}
+  // tmo-note@#alloc2 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call1 = call ptr @typed_real_malloc(i64 4, i64 [[GENERICDATA32_DESC:72057870300512784]])
+  // CHECK-DISABLED: %call1 = call ptr @malloc(i64 4)
+  malloc(sizeof(S1)); // #alloc3
+  // tmo-remark@#alloc3 {{passing TMO information for type 'S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc3 {{inferred 'S1' from expression 'sizeof(S1)'}}
+  // tmo-note@#alloc3 {{encoding 'S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call2 = call ptr @typed_real_malloc(i64 24, i64 [[S1_DESC:74309672738655766]])
+  // CHECK-DISABLED: %call2 = call ptr @malloc(i64 24)
+  malloc(sizeof(S1) * 5); // #alloc4
+  // tmo-remark@#alloc4 {{passing TMO information for array of type 'S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc4 {{inferred array of 'S1' from expression 'sizeof(S1) * 5'}}
+  // tmo-note@#alloc4 {{encoding array of 'S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call3 = call ptr @typed_real_malloc(i64 120, i64 [[ARRAY_S1_DESC:74309947616562710]])
+  // CHECK-DISABLED: %call3 = call ptr @malloc(i64 120)
+  malloc(sizeof(S1) + sizeof(S2)); // #alloc5
+  // tmo-remark@#alloc5 {{passing TMO information for type 'S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc5 {{inferred tuple of ('S1', 'S2') from expression 'sizeof(S1) + sizeof(S2)'}}
+  // tmo-note@#alloc5 {{encoding 'S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call4 = call ptr @typed_real_malloc(i64 48, i64 [[S1_DESC]])
+  // CHECK-DISABLED: %call4 = call ptr @malloc(i64 48)
+  my_malloc(5); // #alloc6
+  // tmowarn-warning@#alloc6 {{could not infer allocation type in call to 'my_malloc'}}
+  // tmowarn-note@#alloc6 {{unable to infer allocation type from expression '5'}}
+  // tmo@alloc6 {{unable to infer allocation type from expression '5'}}
+  // CHECK: %call5 = call ptr @_Z12typed_mallocmy(i64 5, i64 [[LOC2_DESC:[0-9]+]])
+  // CHECK-DISABLED: %call5 = call ptr @_Z9my_mallocm(i64 5)
+  my_malloc(sizeof(int)); // #alloc7
+  // tmo-remark@#alloc7 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // tmo-note@#alloc7 {{inferred 'int' from expression 'sizeof(int)'}}
+  // tmo-note@#alloc7 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call6 = call ptr @_Z12typed_mallocmy(i64 4, i64 [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call6 = call ptr @_Z9my_mallocm(i64 4)
+  my_malloc(sizeof(S1)); // #alloc8
+  // tmo-remark@#alloc8 {{passing TMO information for type 'S1' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // tmo-note@#alloc8 {{inferred 'S1' from expression 'sizeof(S1)'}}
+  // tmo-note@#alloc8 {{encoding 'S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call7 = call ptr @_Z12typed_mallocmy(i64 24, i64 [[S1_DESC]])
+  // CHECK-DISABLED: %call7 = call ptr @_Z9my_mallocm(i64 24)
+  my_malloc(sizeof(S1) * 5); // #alloc9
+  // tmo-remark@#alloc9 {{passing TMO information for array of type 'S1' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // tmo-note@#alloc9 {{inferred array of 'S1' from expression 'sizeof(S1) * 5'}}
+  // tmo-note@#alloc9{{encoding array of 'S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call8 = call ptr @_Z12typed_mallocmy(i64 120, i64 [[ARRAY_S1_DESC]])
+  // CHECK-DISABLED: %call8 = call ptr @_Z9my_mallocm(i64 120)
+  my_malloc(sizeof(S1) + sizeof(U1)); // #alloc10
+  // tmo-remark@#alloc10 {{passing TMO information for type 'S1' to 'typed_malloc' (retargeted from 'my_malloc')}}
+  // tmo-note@#alloc10 {{inferred tuple of ('S1', 'U1') from expression 'sizeof(S1) + sizeof(U1)'}}
+  // tmo-note@#alloc10 {{encoding 'S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call9 = call ptr @_Z12typed_mallocmy(i64 28, i64 [[S1_DESC]])
+  // CHECK-DISABLED: %call9 = call ptr @_Z9my_mallocm(i64 28)
+
+  // Ordering of argument evaluation
+  my_calloc(f1(), f2()); // #alloc11
+  // tmowarn-warning@#alloc11 {{could not infer allocation type in call to 'my_calloc'}}
+  // tmowarn-note@#alloc11 {{unable to infer allocation type from expression 'f2()'}}
+  // CHECK: %call10 = call i32 @f1()
+  // CHECK: %conv = sext i32 %call10 to i64
+  // CHECK: %call11 = call i32 @f2()
+  // CHECK: %conv12 = sext i32 %call11 to i64
+  // CHECK: %call13 = call ptr @_Z12typed_callocmmy(i64 %conv, i64 %conv12, i64 [[LOC3_DESC:[0-9]+]])
+  // CHECK-DISABLED: %call13 = call ptr @_Z9my_callocmm
+  my_calloc(f1(), sizeof(int) * f2()); // #alloc12
+  // tmo-remark@#alloc12 {{passing TMO information for array of type 'int' to 'typed_calloc' (retargeted from 'my_calloc')}}
+  // tmo-note@#alloc12 {{inferred array of 'int' from expression 'sizeof(int) * f2()'}}
+  // tmo-note@#alloc12 {{encoding array of 'int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call14 = call i32 @f1()
+  // CHECK: %conv15 = sext i32 %call14 to i64
+  // CHECK: %call16 = call i32 @f2()
+  // CHECK: %conv17 = sext i32 %call16 to i64
+  // CHECK: %mul = mul i64 4, %conv17
+  // CHECK: %call18 = call ptr @_Z12typed_callocmmy(i64 %conv15, i64 %mul, i64 [[ARRAY_INT32_DESC:72058145178419728]])
+  // CHECK-DISABLED: %call18 = call ptr @_Z9my_callocmm
+  my_calloc(f1(), f2() * sizeof(double)); // #alloc13
+  // tmo-remark@#alloc13 {{passing TMO information for array of type 'double' to 'typed_calloc' (retargeted from 'my_calloc')}}
+  // tmo-note@#alloc13 {{inferred array of 'double' from expression 'f2() * sizeof(double)'}}
+  // tmo-note@#alloc13 {{encoding array of 'double' as 72058143796969239. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 3227415 }}}
+  // CHECK: %call19 = call i32 @f1()
+  // CHECK: %conv20 = sext i32 %call19 to i64
+  // CHECK: %call21 = call i32 @f2()
+  // CHECK: %conv22 = sext i32 %call21 to i64
+  // CHECK: %mul23 = mul i64 %conv22, 8
+  // CHECK: %call24 = call ptr @_Z12typed_callocmmy(i64 %conv20, i64 %mul23, i64 [[ARRAY_DOUBLE_DESC:72058143796969239]])
+  // CHECK-DISABLED: %call24 = call ptr @_Z9my_callocmm
+
+  // Order of arguments passed to target
+  unusual_alloc(0.5, sizeof(int) * f1(), "womp"); // #alloc14
+  // tmo-remark@#alloc14 {{passing TMO information for array of type 'int' to 'typed_unusual_alloc' (retargeted from 'unusual_alloc')}}
+  // tmo-note@#alloc14 {{inferred array of 'int' from expression 'sizeof(int) * f1()'}}
+  // tmo-note@#alloc14 {{encoding array of 'int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call25 = call i32 @f1()
+  // CHECK: %conv26 = sext i32 %call25 to i64
+  // CHECK: %mul27 = mul i64 4, %conv26
+  // CHECK: %conv28 = trunc i64 %mul27 to i32
+  // CHECK: call void @_Z19typed_unusual_allocfjyPKc(float 5.000000e-01, i32 %conv28, i64 [[ARRAY_INT32_DESC]], ptr @.str)
+  // CHECK-DISABLED: call void @_Z13unusual_allocfjPKc
+
+ 
+  malloc(sizeof(S3)); // #alloc15
+  // tmo-remark@#alloc15 {{passing TMO information for type 'S3' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc15 {{inferred 'S3' from expression 'sizeof(S3)'}}
+  // tmo-note@#alloc15 {{encoding 'S3' as 2269669970948920. { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ "IsPolymorphic" ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3093312312 }}}
+  // CHECK: %call29 = call ptr @typed_real_malloc(i64 8, i64 [[S3_DESC:2269669970948920]])
+  // CHECK-DISABLED: %call29 = call ptr @malloc
+  malloc(sizeof(S4)); // #alloc16
+  // tmo-remark@#alloc16 {{passing TMO information for type 'S4' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc16 {{inferred 'S4' from expression 'sizeof(S4)'}}
+  // tmo-note@#alloc16 {{encoding 'S4' as 2269669970948920. { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ "IsPolymorphic" ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3093312312 }}}
+  // CHECK: %call30 = call ptr @typed_real_malloc(i64 8, i64 [[S3_DESC]])
+  // CHECK-DISABLED: %call30 = call ptr @malloc
+  malloc(sizeof(S5)); // #alloc17
+  // tmo-remark@#alloc17 {{passing TMO information for type 'S5' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc17 {{inferred 'S5' from expression 'sizeof(S5)'}}
+  // tmo-note@#alloc17 {{encoding 'S5' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call31 = call ptr @typed_real_malloc(i64 4, i64 [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call31 = call ptr @malloc
+  malloc(sizeof(S6)); // #alloc18
+  // tmo-remark@#alloc18 {{passing TMO information for type 'S6' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc18 {{inferred 'S6' from expression 'sizeof(S6)'}}
+  // tmo-note@#alloc18 {{encoding 'S6' as 74309670676837506. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1947317378 }}}
+  // CHECK: %call32 = call ptr @typed_real_malloc(i64 16, i64 [[S6_DESC:74309670676837506]])
+  // CHECK-DISABLED: %call32 = call ptr @malloc
+  malloc(sizeof(S7)); // #alloc19
+  // tmo-remark@#alloc19 {{passing TMO information for type 'S7' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc19 {{inferred 'S7' from expression 'sizeof(S7)'}}
+  // tmo-note@#alloc19 {{encoding 'S7' as 74309670376583829. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1647063701 }}}
+  // CHECK: %call33 = call ptr @typed_real_malloc(i64 24, i64 [[S7_DESC:74309670376583829]])
+  // CHECK-DISABLED: %call33 = call ptr @malloc
+  malloc(sizeof(S8)); // #alloc20
+  // tmo-remark@#alloc20 {{passing TMO information for type 'S8' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc20 {{inferred 'S8' from expression 'sizeof(S8)'}}
+  // tmo-note@#alloc20 {{encoding 'S8' as 74309671181593780. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 2452073652 }}}
+  // CHECK: %call34 = call ptr @typed_real_malloc(i64 16, i64 [[S8_DESC:74309671181593780]])
+  // CHECK-DISABLED: %call34 = call ptr @malloc
+  malloc(sizeof(U1)); // #alloc21
+  // tmo-remark@#alloc21 {{passing TMO information for type 'U1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc21 {{inferred 'U1' from expression 'sizeof(U1)'}}
+  // tmo-note@#alloc21 {{encoding 'U1' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  // CHECK: %call35 = call ptr @typed_real_malloc(i64 4, i64 [[GENERICDATA32_DESC]])
+  // CHECK-DISABLED: %call35 = call ptr @malloc
+  malloc(sizeof(U2)); // #alloc22
+  // tmo-remark@#alloc22 {{passing TMO information for type 'U2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc22 {{inferred 'U2' from expression 'sizeof(U2)'}}
+  // tmo-note@#alloc22 {{encoding 'U2' as 74344853696240142. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ "HasMixedUnions" ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 594631182 }}}
+  // CHECK: %call36 = call ptr @typed_real_malloc(i64 8, i64 [[U2_DESC:74344853696240142]])
+  // CHECK-DISABLED: %call36 = call ptr @malloc
+  malloc(sizeof(S1)); // #alloc23
+  // tmo-remark@#alloc23 {{passing TMO information for type 'S1' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc23 {{inferred 'S1' from expression 'sizeof(S1)'}}
+  // tmo-note@#alloc23 {{encoding 'S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK: %call37 = call ptr @typed_real_malloc(i64 24, i64 [[S1_DESC]])
+  // CHECK-DISABLED: %call37 = call ptr @malloc
+  malloc(sizeof(S2)); // #alloc24
+  // tmo-remark@#alloc24 {{passing TMO information for type 'S2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc24 {{inferred 'S2' from expression 'sizeof(S2)'}}
+  // tmo-note@#alloc24 {{encoding 'S2' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  // CHECK-DISABLED: %call38 = call ptr @malloc
+  // CHECK: %call38 = call ptr @typed_real_malloc(i64 24, i64 [[S1_DESC]])
+  malloc(sizeof(S3)); // #alloc25
+  // tmo-remark@#alloc25 {{passing TMO information for type 'S3' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc25 {{inferred 'S3' from expression 'sizeof(S3)'}}
+  // tmo-note@#alloc25 {{encoding 'S3' as 2269669970948920. { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ "IsPolymorphic" ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3093312312 }}}
+  // CHECK-DISABLED: %call39 = call ptr @malloc
+  // CHECK: %call39 = call ptr @typed_real_malloc(i64 8, i64 [[S3_DESC]])
+  malloc(sizeof(S4_2)); // #alloc26
+  // tmo-remark@#alloc26 {{passing TMO information for type 'S4_2' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc26 {{inferred 'S4_2' from expression 'sizeof(S4_2)'}}
+  // tmo-note@#alloc26 {{encoding 'S4_2' as 74327263367638196. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ "IsPolymorphic" ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 2452073652 }}}
+  // CHECK-DISABLED: %call40 = call ptr @malloc
+  // CHECK: %call40 = call ptr @typed_real_malloc(i64 16, i64 [[S4_2_DESC:74327263367638196]])
+
+  malloc(sizeof(nullptr)); // #alloc27
+  // tmo-remark@#alloc27 {{passing TMO information for type 'std::nullptr_t' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc27 {{inferred 'std::nullptr_t' from expression 'sizeof (nullptr)'}}
+  // tmo-note@#alloc27 {{encoding 'std::nullptr_t' as 74309671125801946. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 2396281818 }}}
+  // CHECK-DISABLED: %call41 = call ptr @malloc
+  // CHECK: %call41 = call ptr @typed_real_malloc(i64 8, i64 [[NULLPTR_DESC:74309671125801946]])
+
+  // Unique enough type just to avoid conflating the descriptor with others
+  struct NullptrStruct {
+    decltype(nullptr) field1;
+    int field2;
+    double field3;
+    char field4;
+    double field5;
+  };
+  malloc(sizeof(NullptrStruct)); // #alloc28
+  // tmo-remark@#alloc28 {{passing TMO information for type 'NullptrStruct' to 'typed_real_malloc' (retargeted from 'malloc')}}
+  // tmo-note@#alloc28 {{inferred 'NullptrStruct' from expression 'sizeof(NullptrStruct)'}}
+  // tmo-note@#alloc28 {{encoding 'NullptrStruct' as 74309671971610988. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 3242090860 }}}
+  // CHECK-DISABLED: %call42 = call ptr @malloc
+  // CHECK: %call42 = call ptr @typed_real_malloc(i64 40, i64 [[NULLPTRSTRUCT_DESC:74309671971610988]])
+}
+
+class C {
+
+  struct I {
+    int a;
+    void *p;
+    int b;
+  };
+
+  struct I *p;
+
+public:
+  void m() {
+    __SIZE_TYPE__ sz;
+    p = reinterpret_cast<struct I *>(malloc(sz)); // #alloc29
+    // tmo-remark@#alloc29 {{passing TMO information for type 'struct I' to 'typed_real_malloc' (retargeted from 'malloc')}}
+    // tmo-note@#alloc29 {{inferred 'struct I' from cast of result from call to 'reinterpret_cast<struct I *>(malloc(sz))'}}
+    // tmo-note@#alloc29 {{encoding 'struct I' as 74309669678308648. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 948788520 }}}
+    // CHECK-DISABLED: %call = call ptr @malloc(i64 %0)
+    // CHECK: %call = call ptr @typed_real_malloc(i64 %0, i64 [[I_DESC:74309669678308648]])
+  }
+};
+
+void g() {
+  C().m();
+}
+
+// CHECK: !{!"type-descriptor", !"[[LOC1_DESC]]", !"[[LOC1_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[GENERICDATA32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S1_DESC]]", !"4009135638", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[ARRAY_S1_DESC]]", !"4009135638", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[LOC2_DESC]]", !"[[LOC2_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[LOC3_DESC]]", !"[[LOC3_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[ARRAY_INT32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[ARRAY_DOUBLE_DESC]]", !"3227415", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S3_DESC]]", !"3093312312", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22 ], \22TypeFlags\22: [ \22IsPolymorphic\22 ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S6_DESC]]", !"1947317378", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S7_DESC]]", !"1647063701", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S8_DESC]]", !"2452073652", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[U2_DESC]]", !"594631182", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ \22HasMixedUnions\22 ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S4_2_DESC]]", !"2452073652", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ \22IsPolymorphic\22 ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[NULLPTR_DESC]]", !"2396281818", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[NULLPTRSTRUCT_DESC]]", !"3242090860", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[I_DESC]]", !"948788520", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}

--- a/clang/test/PCH/Inputs/tmo_allocation.h
+++ b/clang/test/PCH/Inputs/tmo_allocation.h
@@ -1,0 +1,78 @@
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_malloc, 1);
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+void in_pch_function() {
+  void *iptr_failed_inference = malloc(1000); // #pch_failed_inference
+  // expected-warning@#pch_failed_inference {{could not infer allocation type in call to 'malloc'}}
+  // expected-note@#pch_failed_inference {{unable to infer allocation type from expression '1000'}}
+  int *iptr1 = malloc(sizeof(int)); // #pch_iptr1
+  // expected-remark@#pch_iptr1 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_iptr1 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#pch_iptr1 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  int *iptr2 = (int *)malloc(sizeof(int)); // #pch_iptr2
+  // expected-remark@#pch_iptr2 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_iptr2 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#pch_iptr2 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  int *iptr3 = (int *)malloc(100); // #pch_iptr3
+  // expected-remark@#pch_iptr3 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_iptr3 {{inferred 'int' from cast of result from call to '(int *)malloc(100)'}}
+  // expected-note@#pch_iptr3 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  struct S1 *s1ptr1 = malloc(sizeof(struct S1)); // #pch_s1ptr1
+  // expected-remark@#pch_s1ptr1 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_s1ptr1 {{inferred 'struct S1' from expression 'sizeof(struct S1)'}}
+  // expected-note@#pch_s1ptr1 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1 *s1ptr2 = (struct S1 *)malloc(sizeof(struct S1)); // #pch_s1ptr2
+  // expected-remark@#pch_s1ptr2 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_s1ptr2 {{inferred 'struct S1' from expression 'sizeof(struct S1)'}}
+  // expected-note@#pch_s1ptr2 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1 *s1ptr3 = (struct S1 *)malloc(100); // #pch_s1ptr3
+  // expected-remark@#pch_s1ptr3 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_s1ptr3 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)malloc(100)'}}
+  // expected-note@#pch_s1ptr3 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+}
+
+struct Elem {
+  int value;
+};
+
+struct PrefixedArrayHeader {
+  int count;
+  struct Elem items[];
+};
+
+void in_pch_fam_function(__SIZE_TYPE__ n) {
+  struct Elem *ep = malloc(sizeof(struct Elem) * n); // #pch_fam_array
+  // expected-remark@#pch_fam_array {{passing TMO information for array of type 'struct Elem' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_fam_array {{inferred array of 'struct Elem' from expression 'sizeof(struct Elem) * n'}}
+  // expected-note@#pch_fam_array {{encoding array of 'struct Elem' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+
+  struct PrefixedArrayHeader *fp1 = malloc(sizeof(struct PrefixedArrayHeader) + sizeof(struct Elem) * n); // #pch_fam_explicit
+  // expected-remark@#pch_fam_explicit {{passing TMO information for type 'struct PrefixedArrayHeader' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_fam_explicit {{inferred header prefixed array of {'struct PrefixedArrayHeader':'struct Elem'} from expression 'sizeof(struct PrefixedArrayHeader) + sizeof(struct Elem) * n'}}
+  // expected-note@#pch_fam_explicit {{encoding 'struct PrefixedArrayHeader' as 72058694934233616. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "HeaderPrefixedArray" ] }, "TypeHash": 1384677904 }}}
+
+  struct PrefixedArrayHeader *fp2 = malloc(sizeof(struct PrefixedArrayHeader) + n); // #pch_fam_resolved
+  // expected-remark@#pch_fam_resolved {{passing TMO information for type 'struct PrefixedArrayHeader' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_fam_resolved {{inferred header prefixed array of {'struct PrefixedArrayHeader':'struct Elem'} from expression 'sizeof(struct PrefixedArrayHeader) + n'}}
+  // expected-note@#pch_fam_resolved {{encoding 'struct PrefixedArrayHeader' as 72058694934233616. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "HeaderPrefixedArray" ] }, "TypeHash": 1384677904 }}}
+
+  void *tuple1 = malloc(sizeof(struct S1) + sizeof(struct Elem)); // #pch_fam_tuple
+  // expected-remark@#pch_fam_tuple {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_fam_tuple {{inferred tuple of ('struct S1', 'struct Elem') from expression 'sizeof(struct S1) + sizeof(struct Elem)'}}
+  // expected-note@#pch_fam_tuple {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+
+  void *unknown1 = malloc(sizeof(struct Elem) + n); // #pch_fam_unknown
+  // expected-remark@#pch_fam_unknown {{passing TMO information for type 'struct Elem' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_fam_unknown {{inferred indeterminate set of {'struct Elem'} from expression 'sizeof(struct Elem) + n'}}
+  // expected-note@#pch_fam_unknown {{encoding 'struct Elem' as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+}

--- a/clang/test/PCH/Inputs/tmo_allocation_kinds.h
+++ b/clang/test/PCH/Inputs/tmo_allocation_kinds.h
@@ -1,0 +1,26 @@
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_malloc, 1);
+
+struct KindTypeA {
+  int value;
+};
+
+struct KindTypeB {
+  int count;
+  void *ptr;
+};
+
+void in_pch_kinds_function(__SIZE_TYPE__ n) {
+  void *tuple_alloc = malloc(sizeof(struct KindTypeA) + sizeof(struct KindTypeB)); // #pch_kinds_tuple
+  // expected-remark@#pch_kinds_tuple {{passing TMO information for type 'struct KindTypeA' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_kinds_tuple {{inferred tuple of ('struct KindTypeA', 'struct KindTypeB') from expression 'sizeof(struct KindTypeA) + sizeof(struct KindTypeB)'}}
+  // expected-note@#pch_kinds_tuple {{encoding 'struct KindTypeA' as 72057870300512784}}
+
+  void *unknown_alloc = malloc(sizeof(struct KindTypeA) + n); // #pch_kinds_unknown
+  // expected-remark@#pch_kinds_unknown {{passing TMO information for type 'struct KindTypeA' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_kinds_unknown {{inferred indeterminate set of {'struct KindTypeA'} from expression 'sizeof(struct KindTypeA) + n'}}
+  // expected-note@#pch_kinds_unknown {{encoding 'struct KindTypeA' as 72057595422605840}}
+}

--- a/clang/test/PCH/Inputs/tmo_allocation_late_attr.h
+++ b/clang/test/PCH/Inputs/tmo_allocation_late_attr.h
@@ -1,0 +1,25 @@
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *malloc(__SIZE_TYPE__ size);
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+void in_pch_function1() {
+  int *iptr1 = malloc(sizeof(int)); // #pch_iptr1
+}
+
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_malloc, 1);
+
+void in_pch_function2() {
+  int *iptr2 = malloc(sizeof(int) * 2); // #pch_iptr2
+  // expected-remark@#pch_iptr2 {{passing TMO information for array of type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_iptr2 {{inferred array of 'int' from expression 'sizeof(int) * 2'}}
+  // expected-note@#pch_iptr2 {{encoding array of 'int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+}

--- a/clang/test/PCH/tmo-with-pch-kinds.c
+++ b/clang/test/PCH/tmo-with-pch-kinds.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -Wtyped-memory-inference-failure -verify -fsyntax-only \
+// RUN:            -std=c23 -include %S/Inputs/tmo_allocation_kinds.h -o - %s
+
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation_kinds.h
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -Wtyped-memory-inference-failure -verify -fsyntax-only \
+// RUN:            -std=c23 -include-pch %t %s
+
+static void call_in_pch_kinds_function(__SIZE_TYPE__ n) {
+  in_pch_kinds_function(n);
+}
+
+void out_of_pch_kinds_function(__SIZE_TYPE__ n) {
+  void *tuple_alloc = malloc(sizeof(struct KindTypeA) + sizeof(struct KindTypeB)); // #kinds_tuple
+  // expected-remark@#kinds_tuple {{passing TMO information for type 'struct KindTypeA' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#kinds_tuple {{inferred tuple of ('struct KindTypeA', 'struct KindTypeB') from expression 'sizeof(struct KindTypeA) + sizeof(struct KindTypeB)'}}
+  // expected-note@#kinds_tuple {{encoding 'struct KindTypeA' as 72057870300512784}}
+
+  void *unknown_alloc = malloc(sizeof(struct KindTypeA) + n); // #kinds_unknown
+  // expected-remark@#kinds_unknown {{passing TMO information for type 'struct KindTypeA' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#kinds_unknown {{inferred indeterminate set of {'struct KindTypeA'} from expression 'sizeof(struct KindTypeA) + n'}}
+  // expected-note@#kinds_unknown {{encoding 'struct KindTypeA' as 72057595422605840}}
+}

--- a/clang/test/PCH/tmo-with-pch-late-attr.c
+++ b/clang/test/PCH/tmo-with-pch-late-attr.c
@@ -1,0 +1,37 @@
+// Test this without pch.
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -verify -fsyntax-only \
+// RUN:                                           -std=c23 -include %S/Inputs/tmo_allocation_late_attr.h %s
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -verify -emit-llvm -o - \
+// RUN:                                           -std=c23 -include %S/Inputs/tmo_allocation_late_attr.h %s | FileCheck %s
+
+// Test with pch.
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation_late_attr.h
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t -emit-llvm -o - %s | FileCheck %s
+
+// Test with pch and remarks.
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation_late_attr.h
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -verify -fsyntax-only \
+// RUN:                                                         -std=c23 -include-pch %t %s
+
+static void call_in_pch_function1(void) {
+    in_pch_function1();
+}
+// CHECK-LABEL: @in_pch_function1()
+// CHECK-LABEL: call ptr @malloc(i64 noundef 4)
+
+static void call_in_pch_function2(void) {
+    in_pch_function2();
+}
+// CHECK-LABEL: @in_pch_function2()
+// CHECK: call ptr @typed_malloc(i64 noundef 8, i64 noundef [[GENERICDATA32_DESC:72058145178419728]])
+
+void out_of_pch_function() {
+  int *iptr1 = malloc(sizeof(int) * 3); // #iptr1
+  // expected-remark@#iptr1 {{passing TMO information for array of type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#iptr1 {{inferred array of 'int' from expression 'sizeof(int) * 3'}}
+  // expected-note@#iptr1 {{encoding array of 'int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+}
+// CHECK-LABEL: @out_of_pch_function()
+// CHECK: call ptr @typed_malloc(i64 noundef 12, i64 noundef [[GENERICDATA32_DESC]])
+// CHECK: !{!"type-descriptor", !"[[GENERICDATA32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}

--- a/clang/test/PCH/tmo-with-pch.c
+++ b/clang/test/PCH/tmo-with-pch.c
@@ -1,0 +1,94 @@
+// Test this without pch.
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include %S/Inputs/tmo_allocation.h -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -Wtyped-memory-inference-failure  -verify -fsyntax-only \
+// RUN:                                           -std=c23 -include %S/Inputs/tmo_allocation.h -o - %s
+
+// Test with pch.
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t -emit-llvm -o - %s | FileCheck %s
+
+// Test with pch and remarks.
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -Wtyped-memory-inference-failure -verify -fsyntax-only \
+// RUN:                                                         -std=c23 -include-pch %t %s
+
+// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
+// RUN: not %clang_cc1 -x c -std=c23 -include-pch %t %s 2>&1 | FileCheck --check-prefix=PCH_HAS_TMO %s
+// PCH_HAS_TMO: Typed Memory Operations Callsite Rewriting was enabled in precompiled file
+// RUN: %clang_cc1 -x c -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
+// RUN: not %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t %s 2>&1 | FileCheck --check-prefix=PCH_NO_TMO %s
+// PCH_NO_TMO: Typed Memory Operations Callsite Rewriting was disabled in precompiled file
+static void call_in_pch_function(void) {
+    in_pch_function();
+}
+// CHECK-LABEL: in_pch_function
+// CHECK: call ptr @typed_malloc(i64 noundef 1000, i64 noundef [[LOC1_DESC:[0-9]+]])
+// CHECK: call ptr @typed_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC:72057870300512784]])
+// CHECK: call ptr @typed_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+// CHECK: call ptr @typed_malloc(i64 noundef 100, i64 noundef [[GENERICDATA32_DESC]])
+// CHECK: call ptr @typed_malloc(i64 noundef 24, i64 noundef [[S1_DESC:74309672738655766]])
+// CHECK: call ptr @typed_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
+// CHECK: call ptr @typed_malloc(i64 noundef 100, i64 noundef [[S1_DESC]])
+
+static void call_in_pch_fam_function(__SIZE_TYPE__ n) {
+    in_pch_fam_function(n);
+}
+// CHECK-LABEL: in_pch_fam_function
+// CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[ELEM_ARRAY_DESC:72058145178419728]])
+// CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[PREFIX_HEADER_HPA_DESC:72058694934233616]])
+// CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[PREFIX_HEADER_HPA_DESC]])
+// CHECK: call ptr @typed_malloc(i64 noundef 28, i64 noundef [[S1_DESC]])
+// CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[ELEM_INDETERMINATE_DESC:72057595422605840]])
+
+// CHECK-LABEL: out_of_pch_function
+void out_of_pch_function() {
+  __SIZE_TYPE__ n;
+  int *iptr1 = malloc(sizeof(int)); // #iptr1
+  // CHECK: call ptr @typed_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC:72057870300512784]])
+  // expected-remark@#iptr1 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#iptr1 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#iptr1 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  int *iptr2 = (int *)malloc(sizeof(int)); // #iptr2
+  // CHECK: call ptr @typed_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC]])
+  // expected-remark@#iptr2 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#iptr2 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#iptr2 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  int *iptr3 = (int *)malloc(10); // #iptr3
+  // CHECK: call ptr @typed_malloc(i64 noundef 10, i64 noundef [[GENERICDATA32_DESC]])
+  // expected-remark@#iptr3 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#iptr3 {{inferred 'int' from cast of result from call to '(int *)malloc(10)'}}
+  // expected-note@#iptr3 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  struct S1 *s1ptr1 = malloc(sizeof(struct S1)); // #s1ptr1
+  // CHECK: call ptr @typed_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
+  // expected-remark@#s1ptr1 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#s1ptr1 {{inferred 'struct S1' from expression 'sizeof(struct S1)'}}
+  // expected-note@#s1ptr1 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1 *s1ptr2 = (struct S1 *)malloc(sizeof(struct S1)); // #s1ptr2
+  // CHECK: call ptr @typed_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
+  // expected-remark@#s1ptr2 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#s1ptr2 {{inferred 'struct S1' from expression 'sizeof(struct S1)'}}
+  // expected-note@#s1ptr2 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  struct S1 *s1ptr3 = (struct S1 *)malloc(100); // #s1ptr3
+  // CHECK: call ptr @typed_malloc(i64 noundef 100, i64 noundef [[S1_DESC]])
+  // expected-remark@#s1ptr3 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#s1ptr3 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)malloc(100)'}}
+  // expected-note@#s1ptr3 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  void *tuple1 = malloc(sizeof(struct S1) + sizeof(struct Elem)); // #tuple1
+  // CHECK: call ptr @typed_malloc(i64 noundef 28, i64 noundef [[S1_DESC]])
+  // expected-remark@#tuple1 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#tuple1 {{inferred tuple of ('struct S1', 'struct Elem') from expression 'sizeof(struct S1) + sizeof(struct Elem)'}}
+  // expected-note@#tuple1 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  void *unknown1 = malloc(sizeof(struct Elem) + n); // #unknown1
+  // CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[ELEM_INDETERMINATE_DESC]])
+  // expected-remark@#unknown1 {{passing TMO information for type 'struct Elem' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#unknown1 {{inferred indeterminate set of {'struct Elem'} from expression 'sizeof(struct Elem) + n'}}
+  // expected-note@#unknown1 {{encoding 'struct Elem' as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+}
+
+// CHECK: !{!"type-descriptor", !"[[LOC1_DESC]]", !"[[LOC1_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[GENERICDATA32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[S1_DESC]]", !"4009135638", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[ELEM_ARRAY_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[PREFIX_HEADER_HPA_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22HeaderPrefixedArray\22 ]"}
+// CHECK: !{!"type-descriptor", !"[[ELEM_INDETERMINATE_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}

--- a/clang/test/Parser/builtin-tmo-get-type-descriptor.cpp
+++ b/clang/test/Parser/builtin-tmo-get-type-descriptor.cpp
@@ -1,0 +1,106 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wno-unused %s
+// RUN: %clang_cc1 -Rtmo-remarks -fsyntax-only -verify=expected,tmoremarks -Wno-unused %s
+
+_Static_assert(__has_builtin(__builtin_tmo_get_type_descriptor), "No type descriptor builtin");
+
+typedef unsigned __INT64_TYPE__ uint64_t;
+
+struct Test {
+  int x;
+  void *p;
+};
+
+void bad_syntax(int var) {
+  // expected-error@+1{{expected '('}}
+  __builtin_tmo_get_type_descriptor;
+
+  // expected-error@+1{{expected '('}}
+  __builtin_tmo_get_type_descriptor{};
+
+  // expected-error@+1{{expected a type}}
+  __builtin_tmo_get_type_descriptor();
+
+  // expected-error@+1{{expected '('}}
+  __builtin_tmo_get_type_descriptor{var};
+
+  // expected-error@+1{{expected '('}}
+  __builtin_tmo_get_type_descriptor var;
+}
+
+void non_struct_type(int var) {
+  __builtin_tmo_get_type_descriptor(int);
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'int' as 72057595422605840. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+  __builtin_tmo_get_type_descriptor(typeof(var));
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'typeof (var)' (aka 'int') as 72057595422605840. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+}
+
+void void_type(const void *p) {
+  // expected-error@+1{{invalid application of '__builtin_tmo_get_type_descriptor' to an incomplete type 'void'}}
+  __builtin_tmo_get_type_descriptor(void);
+  __builtin_tmo_get_type_descriptor(typeof(p));
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'typeof (p)' (aka 'const void *') as 3377702818697837. Type semantics: { "Summary": { "LayoutSemantics": [ "ImmutablePointer", "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3098169965 }}}
+  __builtin_tmo_get_type_descriptor(typeof(&p));
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'typeof (&p)' (aka 'const void **') as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+  __builtin_tmo_get_type_descriptor(void **);
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'void **' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+}
+
+void forward_decl() {
+  // expected-note@+1{{forward declaration of 'Forward'}}
+  struct Forward;
+  // expected-error@+1{{invalid application of '__builtin_tmo_get_type_descriptor' to an incomplete type 'Forward'}}
+  __builtin_tmo_get_type_descriptor(Forward);
+}
+
+template <typename T> struct X {
+  uint64_t s = __builtin_tmo_get_type_descriptor(T);
+};
+
+template <typename T> struct X_static {
+  static uint64_t s;
+};
+
+template <typename T>
+uint64_t X_static<T>::s = __builtin_tmo_get_type_descriptor(T);
+
+template <int N> struct ValueTempl { int array[N]; };
+uint64_t sv = __builtin_tmo_get_type_descriptor(ValueTempl<2>);
+// tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'ValueTempl<2>' as 72057594041155351. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3227415 }}}
+
+ValueTempl<2> InstValueTempl;
+uint64_t svi = __builtin_tmo_get_type_descriptor(typeof(InstValueTempl));
+// tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'typeof (InstValueTempl)' (aka 'ValueTempl<2>') as 72057594041155351. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3227415 }}}
+
+template <typename T> struct TA { T t; };
+struct TB {
+  TA<int> f;
+};
+static uint64_t sTB = __builtin_tmo_get_type_descriptor(TB);
+// tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'TB' as 72057595422605840. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
+void usage(struct Test s) {
+  struct Test *p = &s;
+
+  struct {
+    char a;
+    char b;
+  } x;
+
+  __builtin_tmo_get_type_descriptor(struct Test);
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'struct Test' as 74309395798930562. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1947317378 }}}
+  __builtin_tmo_get_type_descriptor(typeof(s));
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'typeof (s)' (aka 'struct Test') as 74309395798930562. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1947317378 }}}
+  __builtin_tmo_get_type_descriptor(typeof(*p));
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'typeof (*p)' (aka 'struct Test') as 74309395798930562. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1947317378 }}}
+  __builtin_tmo_get_type_descriptor(typeof(x));
+  // tmoremarks-remark@-1 {{as 72057597225271395. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3187343459 }}}
+  __builtin_tmo_get_type_descriptor(X<int>);
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'X<int>' as 72057594041155351. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3227415 }}}
+  __builtin_tmo_get_type_descriptor(X<void>);
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'X<void>' as 72057594041155351. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3227415 }}}
+  __builtin_tmo_get_type_descriptor(X<ValueTempl<1>>);
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'X<ValueTempl<1>>' as 72057594041155351. Type semantics: { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3227415 }}}
+  __builtin_tmo_get_type_descriptor(void(*)(int));
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'void (*)(int)' as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+  __builtin_tmo_get_type_descriptor(typeof(&usage));
+  // tmoremarks-remark@-1 {{__builtin_tmo_get_type_descriptor reported 'typeof (&usage)' (aka 'void (*)(struct Test)') as 2251802906997560. Type semantics: { "Summary": { "LayoutSemantics": [ "AnonymousPointer" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 3093312312 }}}
+}

--- a/clang/test/Sema/attr-index-typed-memory-operation.c
+++ b/clang/test/Sema/attr-index-typed-memory-operation.c
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -ftyped-memory-operations -fsyntax-only -verify %s
+
+#define _TYPED_ALLOC(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *malloc(unsigned long);
+void *typed_malloc(__SIZE_TYPE__, unsigned long long);
+void *calloc(unsigned long, unsigned long);
+void *typed_calloc(unsigned, unsigned, unsigned long long);
+// expected-note@-1 {{rewrite target here}}
+
+// Some function defs that don't match the required interface
+void *invalid_typed_malloc1();
+void *invalid_typed_malloc2(double);
+// expected-note@-1 {{rewrite target here}}
+int invalid_typed_malloc3(unsigned);
+// expected-note@-1 {{rewrite target here}}
+// expected-note@-2 {{rewrite target here}}
+// expected-note@-3 {{rewrite target here}}
+int invalid_typed_malloc4(__SIZE_TYPE__, unsigned long long);
+void* invalid_typed_malloc5(__SIZE_TYPE__, int);
+
+
+void *my_malloc2(__SIZE_TYPE__ size) _TYPED_ALLOC(typed_malloc, 1);
+void *my_malloc3(double size) _TYPED_ALLOC(typed_malloc, 1);
+// expected-error@-1 {{invalid parameter type for inference at index 1. 'double' is not an integer type}}
+void *my_malloc4(unsigned size) _TYPED_ALLOC(typed_malloc, -1);
+// expected-error@-1 {{'typed_memory_operation' attribute parameter 1 is out of bounds}}
+void *my_malloc4(unsigned size) _TYPED_ALLOC(typed_malloc, 0);
+// expected-error@-1 {{'typed_memory_operation' attribute parameter 1 is out of bounds}}
+void *my_malloc6(unsigned size) _TYPED_ALLOC(typed_malloc, 2);
+// expected-error@-1 {{'typed_memory_operation' attribute parameter 1 is out of bounds}}
+
+void *my_malloc_invalid1(unsigned size) _TYPED_ALLOC(invalid_typed_malloc0, 1);
+// expected-error@-1 {{use of undeclared identifier 'invalid_typed_malloc0'}}
+void *my_malloc_invalid2(unsigned size) _TYPED_ALLOC(invalid_typed_malloc1, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc1' must have a prototype}}
+void *my_malloc_invalid3(unsigned size) _TYPED_ALLOC(invalid_typed_malloc2, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc2' has incompatible type ('void *(unsigned int, unsigned long)' vs 'void *(double)')}}
+void *my_malloc_invalid4(unsigned size) _TYPED_ALLOC(invalid_typed_malloc3, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc3' has incompatible type ('void *(unsigned int, unsigned long)' vs 'int (unsigned int)')}}
+// intentionally using the wrong function
+void *my_malloc_invalid5(unsigned size) _TYPED_ALLOC(invalid_typed_malloc3, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc3' has incompatible type ('void *(unsigned int, unsigned long)' vs 'int (unsigned int)')}}
+void *my_malloc_invalid6(unsigned size) _TYPED_ALLOC(invalid_typed_malloc3, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc3' has incompatible type ('void *(unsigned int, unsigned long)' vs 'int (unsigned int)')}}
+
+void *my_malloc12(__SIZE_TYPE__ size) _TYPED_ALLOC(calloc, 1);
+void *my_malloc13(unsigned size) _TYPED_ALLOC(typed_calloc, 1);
+// expected-error@-1 {{typed memory operation 'typed_calloc' has incompatible type ('void *(unsigned int, unsigned long)' vs 'void *(unsigned int, unsigned int, unsigned long long)')}}
+
+void *my_calloc1(unsigned count, unsigned size) _TYPED_ALLOC(typed_calloc, 2);
+
+// Redeclarations
+void *typed_for_redecl(unsigned long long, unsigned long long, unsigned long long);
+void *typed_for_redecl2(unsigned long long, unsigned long long, unsigned long long);
+void *my_calloc2(unsigned long long count, unsigned long long size) _TYPED_ALLOC(typed_for_redecl, 2);
+void *my_calloc2(unsigned long long count, unsigned long long size) _TYPED_ALLOC(typed_for_redecl, 2);
+// expected-note@-1 2 {{conflicting attribute is here}}
+void *my_calloc2(unsigned long long count, unsigned long long size) _TYPED_ALLOC(typed_for_redecl, 1);
+// expected-error@-1 {{attribute 'typed_memory_operation' is already applied with different arguments}}
+void *my_calloc2(unsigned long long count, unsigned long long size) _TYPED_ALLOC(typed_for_redecl2, 2);
+// expected-error@-1 {{attribute 'typed_memory_operation' is already applied with different arguments}}

--- a/clang/test/Sema/attr-typed-memory-operation.c
+++ b/clang/test/Sema/attr-typed-memory-operation.c
@@ -1,0 +1,68 @@
+// RUN: %clang_cc1 -ftyped-memory-operations -triple arm64-apple-ios -Rtmo-remarks -fsyntax-only -verify %s
+// RUN: %clang_cc1 -ftyped-memory-operations -triple arm64-apple-ios -fsyntax-only -verify %s
+
+#define _TYPED_ALLOC(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_alloc1(__SIZE_TYPE__ size, unsigned long long descriptor);
+// expected-note@-1 {{rewrite target}}
+// expected-note@-2 {{rewrite target}}
+void typed_alloc2(__SIZE_TYPE__ size, unsigned long long descriptor, void **out);
+// expected-note@-1 {{rewrite target}}
+void typed_alloc3(void** out, __SIZE_TYPE__ size, unsigned long long descriptor);
+void *incorrect_descriptor(__SIZE_TYPE__ size, char descriptor);
+// expected-note@-1 {{rewrite target here}}
+
+void *alloc1(__SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc1, 1);
+void *alloc2(__SIZE_TYPE__ size) _TYPED_ALLOC(incorrect_descriptor, 1);
+// expected-error@-1 {{typed memory operation 'incorrect_descriptor' has incompatible type ('void *(unsigned long, unsigned long)' vs 'void *(unsigned long, char)')}}
+void *alloc3(__SIZE_TYPE__ size) _TYPED_ALLOC(missing, 1);
+// expected-error@-1 {{use of undeclared identifier 'missing'}}
+void *alloc4(__SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc2, 1);
+// expected-error@-1 {{typed memory operation 'typed_alloc2' has incompatible type ('void *(unsigned long, unsigned long)' vs 'void (unsigned long, unsigned long long, void **)')}}
+void alloc5(__SIZE_TYPE__ size, void **out) _TYPED_ALLOC(typed_alloc2, 1);
+void alloc6(__SIZE_TYPE__ size, void **out) _TYPED_ALLOC(typed_alloc2, 2);
+// expected-error@-1 {{invalid parameter type for inference at index 2. 'void **' is not an integer type}}
+void alloc7(__SIZE_TYPE__ size, void **out) _TYPED_ALLOC(typed_alloc1, 1);
+// expected-error@-1 {{typed memory operation 'typed_alloc1' has incompatible type ('void (unsigned long, unsigned long, void **)' vs 'void *(unsigned long, unsigned long long)')}}
+void alloc8(void **out, __SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc3, 2);
+void alloc9(void **out, __SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc1, 2);
+// expected-error@-1 {{typed memory operation 'typed_alloc1' has incompatible type ('void (void **, unsigned long, unsigned long)' vs 'void *(unsigned long, unsigned long long)')}}
+
+int wrong_thing;
+void alloc10(__SIZE_TYPE__) _TYPED_ALLOC(wrong_thing, 1);
+// expected-error@-1 {{typed memory operation 'wrong_thing' must be a function}}
+
+void alloc11(__SIZE_TYPE__) _TYPED_ALLOC(1, 1);
+// expected-error@-1 {{typed memory operation '1' must be a function}}
+
+typedef int __attribute__((vector_size(16))) ivector16;
+typedef int __attribute__((vector_size(16))) ivector16_2;
+typedef int __attribute__((vector_size(32))) ivector32;
+
+ivector16 *typed_ivalloc(__SIZE_TYPE__, unsigned long long descriptor);
+// expected-note@-1 2 {{rewrite target here}}
+ivector16 *ivalloc1(__SIZE_TYPE__) _TYPED_ALLOC(typed_ivalloc, 1);
+ivector16_2 *ivalloc2(__SIZE_TYPE__) _TYPED_ALLOC(typed_ivalloc, 1);
+ivector32 *ivalloc3(__SIZE_TYPE__) _TYPED_ALLOC(typed_ivalloc, 1);
+// expected-error@-1 {{typed memory operation 'typed_ivalloc' has incompatible type ('ivector32 *(unsigned long, unsigned long)' vs 'ivector16 *(unsigned long, unsigned long long)')}}
+int *ivalloc4(__SIZE_TYPE__) _TYPED_ALLOC(typed_ivalloc, 1);
+// expected-error@-1 {{typed memory operation 'typed_ivalloc' has incompatible type ('int *(unsigned long, unsigned long)' vs 'ivector16 *(unsigned long, unsigned long long)')}}
+
+// clang doesn't see pointer alignment as part of the type, so these
+// types are considered the same. It's possible we'll want to check
+// for this in future given we are after all an allocation related
+// attribute.
+typedef int *__attribute__((aligned(16))) aligned16_ptr;
+typedef int *__attribute__((aligned(32))) aligned32_ptr;
+
+aligned16_ptr typed_aligned_alloc(__SIZE_TYPE__, unsigned long long descriptor);
+aligned16_ptr aligned_alloc16(__SIZE_TYPE__) _TYPED_ALLOC(typed_aligned_alloc, 1);
+aligned32_ptr aligned_alloc32(__SIZE_TYPE__) _TYPED_ALLOC(typed_aligned_alloc, 1);
+
+typedef int _Atomic * atomic_ptr;
+atomic_ptr typed_atomic_alloc(__SIZE_TYPE__, unsigned long long descriptor);
+// expected-note@-1 {{rewrite target here}}
+atomic_ptr atomic_alloc(__SIZE_TYPE__) _TYPED_ALLOC(typed_atomic_alloc, 1);
+int *unatomic_alloc(__SIZE_TYPE__) _TYPED_ALLOC(typed_atomic_alloc, 1);
+// expected-error@-1 {{typed memory operation 'typed_atomic_alloc' has incompatible type ('int *(unsigned long, unsigned long)' vs 'atomic_ptr (unsigned long, unsigned long long)' (aka '_Atomic(int) *(unsigned long, unsigned long long)'))}}
+

--- a/clang/test/SemaCXX/attr-index-typed-memory-operation.cpp
+++ b/clang/test/SemaCXX/attr-index-typed-memory-operation.cpp
@@ -1,0 +1,106 @@
+// RUN: %clang_cc1 -ftyped-memory-operations -fsyntax-only -verify %s
+#define _TYPED_ALLOC(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *malloc(unsigned long);
+void *typed_malloc(unsigned long, unsigned long long);
+// expected-note@-1 {{rewrite target here}}
+void *typed_malloc2(unsigned long, unsigned long long);
+void *calloc(unsigned long, unsigned long);
+void *typed_calloc(unsigned long, unsigned long, unsigned long long);
+// expected-note@-1 2 {{rewrite target here}}
+void *typed_calloc2(unsigned long, unsigned long, unsigned long long);
+
+// Some function defs that don't match the required interface
+void *invalid_typed_malloc1();
+// expected-note@-1 {{rewrite target here}}
+void *invalid_typed_malloc2(double);
+// expected-note@-1 {{rewrite target here}}
+int invalid_typed_malloc3(unsigned);
+// expected-note@-1 3 {{rewrite target here}}
+int invalid_typed_malloc4(__SIZE_TYPE__, unsigned long long);
+void* invalid_typed_malloc5(__SIZE_TYPE__, int);
+
+struct Foo {
+  static void *malloc(unsigned long);
+  // expected-note@-1 {{rewrite target here}}
+  template <typename T> static void *template_malloc(__SIZE_TYPE__, unsigned long long);
+  // expected-note@-1 {{candidate function template}}
+  template <typename T> static void *test_malloc1(T) _TYPED_ALLOC(typed_malloc, 1);
+  static void *typed_malloc_method(unsigned, unsigned long long);
+  void *invalid_typed_malloc_method(unsigned, unsigned long long);
+  void *method_malloc(unsigned) _TYPED_ALLOC(typed_malloc_method, 1);
+  // expected-error@-1 {{typed memory operation 'method_malloc' cannot be an instance method}}
+  void *method_malloc2(unsigned) _TYPED_ALLOC(invalid_typed_malloc_method, 1);
+  // expected-error@-1 {{call to non-static member function without an object argument}}
+  static void *class_typed_malloc(__SIZE_TYPE__, __SIZE_TYPE__);
+  static void *class_malloc(__SIZE_TYPE__) _TYPED_ALLOC(class_typed_malloc, 1);
+};
+
+template <typename T> struct Bar {
+  static void *class_typed_malloc(__SIZE_TYPE__, T);
+  static void *class_malloc(__SIZE_TYPE__) _TYPED_ALLOC(class_typed_malloc, 1);
+};
+
+void *my_malloc2(int size) _TYPED_ALLOC(typed_malloc, 1);
+// expected-error@-1 {{typed memory operation 'typed_malloc' has incompatible type ('void *(int, unsigned long)' vs 'void *(unsigned long, unsigned long long)')}}
+void *my_malloc3(double size) _TYPED_ALLOC(typed_malloc, 1);
+// expected-error@-1 {{invalid parameter type for inference at index 1. 'double' is not an integer type}}
+void *my_malloc4(unsigned size) _TYPED_ALLOC(typed_malloc, -1);
+// expected-error@-1 {{'typed_memory_operation' attribute parameter 1 is out of bounds}}
+void *my_malloc4(unsigned size) _TYPED_ALLOC(typed_malloc, 0);
+// expected-error@-1 {{'typed_memory_operation' attribute parameter 1 is out of bounds}}
+void *my_malloc6(unsigned size) _TYPED_ALLOC(typed_malloc, 2);
+// expected-error@-1 {{'typed_memory_operation' attribute parameter 1 is out of bounds}}
+
+void *my_malloc_invalid1(unsigned size) _TYPED_ALLOC(invalid_typed_malloc0, 1);
+// expected-error@-1 {{use of undeclared identifier 'invalid_typed_malloc0'}}
+void *my_malloc_invalid2(unsigned size) _TYPED_ALLOC(invalid_typed_malloc1, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc1' has incompatible type ('void *(unsigned int, unsigned long)' vs 'void *()')}}
+void *my_malloc_invalid3(unsigned size) _TYPED_ALLOC(invalid_typed_malloc2, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc2' has incompatible type ('void *(unsigned int, unsigned long)' vs 'void *(double)')}}
+void *my_malloc_invalid4(unsigned size) _TYPED_ALLOC(invalid_typed_malloc3, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc3' has incompatible type ('void *(unsigned int, unsigned long)' vs 'int (unsigned int)')}}
+// intentionally using the wrong function
+void *my_malloc_invalid5(unsigned size) _TYPED_ALLOC(invalid_typed_malloc3, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc3' has incompatible type ('void *(unsigned int, unsigned long)' vs 'int (unsigned int)')}}
+void *my_malloc_invalid6(unsigned size) _TYPED_ALLOC(invalid_typed_malloc3, 1);
+// expected-error@-1 {{typed memory operation 'invalid_typed_malloc3' has incompatible type ('void *(unsigned int, unsigned long)' vs 'int (unsigned int)')}}
+
+void *my_malloc12(unsigned long size) _TYPED_ALLOC(calloc, 1);
+void *my_malloc13(unsigned size) _TYPED_ALLOC(typed_calloc, 1);
+// expected-error@-1 {{typed memory operation 'typed_calloc' has incompatible type ('void *(unsigned int, unsigned long)' vs 'void *(unsigned long, unsigned long, unsigned long long)')}}
+
+void *my_malloc14(unsigned size) _TYPED_ALLOC(Foo::malloc, 1);
+// expected-error@-1 {{typed memory operation 'malloc' has incompatible type ('void *(unsigned int, unsigned long)' vs 'void *(unsigned long)')}}
+void *my_malloc15(unsigned size) _TYPED_ALLOC(Foo::template_malloc, 1);
+// expected-error@-1 {{typed memory operation 'template_malloc' has multiple overloads}}
+void *my_malloc16(__SIZE_TYPE__ size) _TYPED_ALLOC(Foo::template_malloc<unsigned>, 1);
+void *my_malloc17(__SIZE_TYPE__ size) _TYPED_ALLOC(Foo::template_malloc<double>, 1);
+
+void *my_calloc1(unsigned count, unsigned size) _TYPED_ALLOC(typed_calloc, 2);
+// expected-error@-1 {{typed memory operation 'typed_calloc' has incompatible type ('void *(unsigned int, unsigned int, unsigned long)' vs 'void *(unsigned long, unsigned long, unsigned long long)')}}
+
+// Overloading vs. rewrite
+
+void alloc_overload_target1(__SIZE_TYPE__, __SIZE_TYPE__, float);
+void alloc_overload_target2(__SIZE_TYPE__, __SIZE_TYPE__, int);
+void alloc_overload(__SIZE_TYPE__, float) _TYPED_ALLOC(alloc_overload_target1, 1);
+void alloc_overload(__SIZE_TYPE__, int) _TYPED_ALLOC(alloc_overload_target2, 1);
+
+// Redeclarations
+void *typed_for_redecl(unsigned long long, unsigned long long, unsigned long long);
+void *typed_for_redecl2(unsigned long long, unsigned long long, unsigned long long);
+void *my_calloc2(unsigned long long count, unsigned long long size) _TYPED_ALLOC(typed_for_redecl, 2);
+void *my_calloc2(unsigned long long count, unsigned long long size) _TYPED_ALLOC(typed_for_redecl, 2);
+// expected-note@-1 2 {{conflicting attribute is here}}
+void *my_calloc2(unsigned long long count, unsigned long long size) _TYPED_ALLOC(typed_for_redecl, 1);
+// expected-error@-1 {{attribute 'typed_memory_operation' is already applied with different arguments}}
+void *my_calloc2(unsigned long long count, unsigned long long size) _TYPED_ALLOC(typed_for_redecl2, 2);
+// expected-error@-1 {{attribute 'typed_memory_operation' is already applied with different arguments}}
+
+void f(){
+  my_malloc17(1);
+  Bar<float>::class_malloc(10);
+  Bar<__SIZE_TYPE__>::class_malloc(10);
+  
+}

--- a/clang/test/SemaCXX/attr-typed-memory-operation.cpp
+++ b/clang/test/SemaCXX/attr-typed-memory-operation.cpp
@@ -1,0 +1,57 @@
+// RUN: %clang_cc1 -Rtmo-remarks -ftyped-memory-operations -triple arm64-apple-ios -fsyntax-only -verify %s
+// RUN: %clang_cc1 -ftyped-memory-operations -triple arm64-apple-ios -fsyntax-only -verify %s
+
+#define _TYPED_ALLOC(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_alloc1(__SIZE_TYPE__ size, unsigned long long descriptor);
+// expected-note@-1 3 {{rewrite target here}}
+void typed_alloc2(__SIZE_TYPE__ size, unsigned long long descriptor, void **out);
+// expected-note@-1 {{rewrite target here}}
+void typed_alloc3(void** out, __SIZE_TYPE__ size, unsigned long long descriptor);
+// expected-note@-1 {{rewrite target here}}
+void *incorrect_descriptor(__SIZE_TYPE__ size, char descriptor);
+// expected-note@-1 {{rewrite target here}}
+void *typed_alloc_to_shadow(__SIZE_TYPE__ size, unsigned long long);
+// expected-note@-1 {{candidate function}}
+void *typed_alloc_to_shadow(__SIZE_TYPE__ size, float descriptor);
+// expected-note@-1 {{candidate function}}
+template <typename T> T* templated_typed_alloc1(__SIZE_TYPE__ size, unsigned long long);
+// expected-note@-1 {{rewrite target here}}
+template <typename T> void* templated_typed_alloc2(__SIZE_TYPE__ size, T);
+// expected-note@-1 {{rewrite target here}}
+template <typename T> void* templated_typed_alloc3(T size, unsigned long long);
+// expected-note@-1 3 {{rewrite target here}}
+
+void *alloc1(__SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc1, 1);
+void *alloc2(__SIZE_TYPE__ size) _TYPED_ALLOC(incorrect_descriptor, 1);
+// expected-error@-1 {{typed memory operation 'incorrect_descriptor' has incompatible type ('void *(unsigned long, unsigned long)' vs 'void *(unsigned long, char)')}}
+void *alloc3(__SIZE_TYPE__ size) _TYPED_ALLOC(missing_func, 1);
+// expected-error@-1 {{use of undeclared identifier 'missing_func'}}
+void *alloc4(__SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc2, 1);
+// expected-error@-1 {{typed memory operation 'typed_alloc2' has incompatible type ('void *(unsigned long, unsigned long)' vs 'void (unsigned long, unsigned long long, void **)')}}
+void alloc5(__SIZE_TYPE__ size, void **out) _TYPED_ALLOC(typed_alloc2, 1);
+void alloc6(__SIZE_TYPE__ size, void **out) _TYPED_ALLOC(typed_alloc2, 2);
+// expected-error@-1 {{invalid parameter type for inference at index 2. 'void **' is not an integer type}}
+void alloc7(__SIZE_TYPE__ size, void **out) _TYPED_ALLOC(typed_alloc1, 1);
+// expected-error@-1 {{typed memory operation 'typed_alloc1' has incompatible type ('void (unsigned long, unsigned long, void **)' vs 'void *(unsigned long, unsigned long long)')}}
+void alloc8(void **out, __SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc3, 2);
+void alloc9(void **out, __SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc1, 2);
+// expected-error@-1 {{typed memory operation 'typed_alloc1' has incompatible type ('void (void **, unsigned long, unsigned long)' vs 'void *(unsigned long, unsigned long long)')}}
+void *alloc10(__SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc_to_shadow, 1);
+// expected-error@-1 {{typed memory operation 'typed_alloc_to_shadow' has multiple overloads}}
+int *alloc11(__SIZE_TYPE__ size) _TYPED_ALLOC(templated_typed_alloc1<int>, 1);
+float *alloc12(__SIZE_TYPE__ size) _TYPED_ALLOC(templated_typed_alloc1<int>, 1);
+// expected-error@-1 {{typed memory operation 'templated_typed_alloc1' has incompatible type ('float *(unsigned long, unsigned long)' vs 'int *(unsigned long, unsigned long long)')}}
+void *alloc13(__SIZE_TYPE__ size) _TYPED_ALLOC(templated_typed_alloc2<unsigned long long>, 1);
+void *alloc14(__SIZE_TYPE__ size) _TYPED_ALLOC(templated_typed_alloc2<int>, 1);
+// expected-error@-1 {{typed memory operation 'templated_typed_alloc2' has incompatible type ('void *(unsigned long, unsigned long)' vs 'void *(unsigned long, int)')}}
+void *alloc15(__SIZE_TYPE__ size) _TYPED_ALLOC(templated_typed_alloc3<unsigned long long>, 1);
+// expected-error@-1 {{typed memory operation 'templated_typed_alloc3' has incompatible type ('void *(unsigned long, unsigned long)' vs 'void *(unsigned long long, unsigned long long)')}}
+void *alloc16(__SIZE_TYPE__ size) _TYPED_ALLOC(templated_typed_alloc3<unsigned>, 1);
+// expected-error@-1 {{typed memory operation 'templated_typed_alloc3' has incompatible type ('void *(unsigned long, unsigned long)' vs 'void *(unsigned int, unsigned long long)')}}
+void *alloc17(int size) _TYPED_ALLOC(templated_typed_alloc3<unsigned>, 1);
+// expected-error@-1 {{typed memory operation 'templated_typed_alloc3' has incompatible type ('void *(int, unsigned long)' vs 'void *(unsigned int, unsigned long long)')}}
+void *alloc18(int size) _TYPED_ALLOC(typed_alloc1, 1);
+// expected-error@-1 {{typed memory operation 'typed_alloc1' has incompatible type ('void *(int, unsigned long)' vs 'void *(unsigned long, unsigned long long)')}}
+void alloc19(char** out, __SIZE_TYPE__ size) _TYPED_ALLOC(typed_alloc3, 2);
+// expected-error@-1 {{typed memory operation 'typed_alloc3' has incompatible type ('void (char **, unsigned long, unsigned long)' vs 'void (void **, unsigned long, unsigned long long)')}}

--- a/clang/test/SemaCXX/typed-memory-inference-failure-diag.cpp
+++ b/clang/test/SemaCXX/typed-memory-inference-failure-diag.cpp
@@ -1,0 +1,73 @@
+// RUN: %clang_cc1 -verify=default-expected -ftyped-memory-operations -fsyntax-only -nostdsysteminc %s
+// RUN: %clang_cc1 -verify -ftyped-memory-operations -Wtyped-memory-inference-failure -fsyntax-only -nostdsysteminc %s
+// RUN: %clang_cc1 -verify=disabled-expected -fno-typed-memory-operations -Wtyped-memory-inference-failure -fsyntax-only -nostdsysteminc %s
+
+// default-expected-no-diagnostics
+// disabled-expected-no-diagnostics
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_malloc, 1);
+
+template<typename T, __SIZE_TYPE__ S>
+void f() {
+  __SIZE_TYPE__ sz;
+  int *p;
+  void *v;
+
+  malloc(sizeof(int));
+  malloc(sizeof(T));
+  malloc(S); // #f_malloc_S
+
+  p = (int *)malloc(sz);
+  
+  p = (int *)malloc(S);
+  malloc(sz);// #f_malloc_sz
+  v = (void *)malloc(S); // #f_voidptr_malloc_S
+  
+  p = reinterpret_cast<int *>(malloc(sz));
+  p = static_cast<int *>(malloc(sz));
+  
+  p = reinterpret_cast<int *>(malloc(sizeof(T)));
+  p = static_cast<int *>(malloc(sizeof(T)));
+  
+  p = reinterpret_cast<int *>(malloc(S));
+  p = static_cast<int *>(malloc(S));
+}
+
+template<__SIZE_TYPE__ S>
+void i() {
+  malloc(S); // #i_malloc_S
+  void *v = (void *)malloc(S);  // #i_void_malloc
+}
+
+void g() {
+  f<int, sizeof(int)>(); // #f_call
+  // expected-note@#f_call {{in instantiation of function template specialization 'f<int, 4UL>' requested here}}
+  // expected-warning@#f_malloc_S{{could not infer allocation type in call to 'malloc'}}
+  // expected-warning@#f_malloc_sz {{could not infer allocation type in call to 'malloc'}}
+  // expected-warning@#f_voidptr_malloc_S{{could not infer allocation type in call to 'malloc'}}
+
+  i<sizeof(int)>();
+  // expected-note@-1 {{in instantiation of function template specialization 'i<4UL>' requested here}}
+  // expected-warning@#i_malloc_S {{could not infer allocation type in call to 'malloc'}}
+  // expected-warning@#i_void_malloc {{could not infer allocation type in call to 'malloc'}}
+}
+
+void h() {
+  __SIZE_TYPE__ sz;
+  int *p;
+  void *v;
+
+  malloc(sizeof(int));
+
+  p = (int *)malloc(sz);
+
+  malloc(sz);
+  // expected-warning@-1{{could not infer allocation type in call to 'malloc'}}
+  
+  p = reinterpret_cast<int *>(malloc(sizeof(int)));
+  
+  p = reinterpret_cast<int *>(malloc(sz));
+  p = static_cast<int *>(malloc(sz));
+}

--- a/llvm/include/llvm/Support/SipHash.h
+++ b/llvm/include/llvm/Support/SipHash.h
@@ -55,6 +55,8 @@ LLVM_ABI uint64_t getStableSipHash(StringRef Str);
 /// in the ABI that use a constant zero.
 LLVM_ABI uint16_t getPointerAuthStableSipHash(StringRef S);
 
+LLVM_ABI uint64_t getTypedMemoryDescriptorStableSipHash(StringRef S);
+
 } // end namespace llvm
 
 #endif

--- a/llvm/lib/Support/SipHash.cpp
+++ b/llvm/lib/Support/SipHash.cpp
@@ -59,3 +59,12 @@ uint16_t llvm::getPointerAuthStableSipHash(StringRef Str) {
              << " of: " << Str << "\n");
   return Discriminator;
 }
+
+uint64_t llvm::getTypedMemoryDescriptorStableSipHash(StringRef Str) {
+  static const uint8_t K[16] = {0xb5, 0xd4, 0xc9, 0xeb, 0x79, 0x10, 0x4a, 0x79,
+                                0x6f, 0xec, 0x8b, 0x1b, 0x42, 0x87, 0x81, 0xd4};
+
+  uint8_t RawHashBytes[8];
+  getSipHash_2_4_64(arrayRefFromStringRef(Str), K, RawHashBytes);
+  return endian::read64le(RawHashBytes);
+}


### PR DESCRIPTION
The RFC for typed allocator support was approved quite a while ago, and this PR actually begins the actual upstreaming process.

This PR includes all of the code machinery: the annotations, the type inference, the encoding of the inferred type, and the final call re-writing.

Due to the complexity of the inference especially, I've broken the implementation into separate files, SemaTypedMemory.cpp containing the attribute parsing and diagnostics, and CGTypedMemory.cpp to actually handle the destination rewriting and planting the descriptors.

The core inference is handled in TypedMemoryInference.cpp, with the other TypedMemory* files providing supporting functionality.

The core details can be found in clang/docs/TypedMemoryOperations.rst and the original RFC at https://discourse.llvm.org/t/rfc-typed-allocator-support/79720