### PR TITLE
[clang][deps] Fix bad merge of #194028

### DIFF
--- a/clang/include/clang/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/DependencyScanning/ModuleDepCollector.h
@@ -40,12 +40,11 @@ struct PrebuiltModuleDep {
   std::string ModuleName;
   std::string PCMFile;
   std::string ModuleMapFile;
-  std::optional<std::string> ModuleCacheKey;
+  std::string ModuleCacheKey;
 
   explicit PrebuiltModuleDep(const serialization::ModuleFile *MF)
       : ModuleName(MF->ModuleName), PCMFile(MF->FileName.str()),
-        ModuleMapFile(MF->ModuleMapPath),
-        ModuleCacheKey(MF->ModuleCacheKey){}
+        ModuleMapFile(MF->ModuleMapPath), ModuleCacheKey(MF->ModuleCacheKey) {}
 };
 
 /// Attributes loaded from AST files of prebuilt modules collected prior to

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -368,12 +368,12 @@ ModuleDepCollector::getInvocationAdjustedForModuleBuildWithoutOutputs(
 
   // Report the prebuilt modules this module uses.
   for (const auto &PrebuiltModule : Deps.PrebuiltModuleDeps) {
-    if (PrebuiltModule.ModuleCacheKey) {
+    if (!PrebuiltModule.ModuleCacheKey.empty()) {
       // canonicalize the PCM path if using CAS.
       auto PCMFile = llvm::sys::path::filename(PrebuiltModule.PCMFile);
       CI.getMutFrontendOpts().ModuleFiles.push_back(PCMFile.str());
       CI.getMutFrontendOpts().ModuleCacheKeys.emplace_back(
-          PCMFile, *PrebuiltModule.ModuleCacheKey);
+          PCMFile, PrebuiltModule.ModuleCacheKey);
     } else
       CI.getMutFrontendOpts().ModuleFiles.push_back(PrebuiltModule.PCMFile);
   }


### PR DESCRIPTION
For a missing cache key, `Module::getModuleCacheKey()` returned an empty optional, while `ModuleFile::ModuleCacheKey` returns an empty string. Align `PrebuiltModuleDep::ModuleCacheKey` to the new behavior.