### PR TITLE
[lldb] Prefer exact address match when looking up symbol by address 

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -507,15 +507,23 @@ uint32_t Module::ResolveSymbolContextForAddress(
       if (symtab && so_addr.IsSectionOffset()) {
         Symbol *matching_symbol = nullptr;
 
-        symtab->ForEachSymbolContainingFileAddress(
-            so_addr.GetFileAddress(),
-            [&matching_symbol](Symbol *symbol) -> bool {
-              if (symbol->GetType() != eSymbolTypeInvalid) {
-                matching_symbol = symbol;
-                return false; // Stop iterating
-              }
-              return true; // Keep iterating
-            });
+        addr_t file_address = so_addr.GetFileAddress();
+        Symbol *symbol_at_address =
+            symtab->FindSymbolAtFileAddress(file_address);
+        if (symbol_at_address &&
+            symbol_at_address->GetType() != lldb::eSymbolTypeInvalid) {
+          matching_symbol = symbol_at_address;
+        } else {
+          symtab->ForEachSymbolContainingFileAddress(
+              file_address, [&matching_symbol](Symbol *symbol) -> bool {
+                if (symbol->GetType() != eSymbolTypeInvalid) {
+                  matching_symbol = symbol;
+                  return false; // Stop iterating
+                }
+                return true; // Keep iterating
+              });
+        }
+
         sc.symbol = matching_symbol;
         if (!sc.symbol && resolve_scope & eSymbolContextFunction &&
             !(resolved_flags & eSymbolContextFunction)) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -181,13 +181,6 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
     return {};
 
   auto &triple = m_process.GetTarget().GetArchitecture().GetTriple();
-  // On Linux, there seems to be a bug where we can't reliably look for symbols by address,
-  // since these symbols have an actual size and can overlap.
-  // This could be an LLDB bug or a compiler bug.
-  // rdar://166344740
-  if (triple.isOSLinux())
-    return {};
-
   std::optional<Address> maybeAddr = remoteAddressToLLDBAddress(address);
   // This is not an assert, but should never happen.
   if (!maybeAddr)


### PR DESCRIPTION
    [lldb] Prefer exact address match when looking up symbol by address (#172055)

    The current behavior will pick the first symbol that contains the
    address, this causes LLDB to pick the wrong symbol when looking for
    swift reflection metadata on Linux, as in that case it is valid for a
    symbol to completely encompass another one.

    Instead, this function should prefer the symbol which is an exact, if it
    exists. As a bonus, this should also be faster in the vast majority of
    the cases, as we probably query symbols by their exact address most of
    the time.

    rdar://166344740