### PR TITLE
🍒 llvm: Use add_link_options for stack size flags

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -547,14 +547,15 @@ if( MSVC_IDE )
 endif()
 
 # set stack reserved size to ~10MB
+set(_is_exe "$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>")
 if(MSVC)
   # CMake previously automatically set this value for MSVC builds, but the
   # behavior was changed in CMake 2.8.11 (Issue 12437) to use the MSVC default
   # value (1 MB) which is not enough for us in tasks such as parsing recursive
   # C++ templates in Clang.
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_CXX_LINKER_WRAPPER_FLAG}/STACK:10000000")
+  add_link_options("$<${_is_exe}:LINKER:/STACK:10000000>")
 elseif(MINGW OR CYGWIN)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,16777216")
+  add_link_options("$<${_is_exe}:LINKER:--stack,16777216>")
 
   # Pass -mbig-obj to mingw gas to avoid COFF 2**16 section limit.
   if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Previously, LLVM was directly editing `CMAKE_EXE_LINKER_FLAGS`. This is a user-facing CMake cache variable not meant to be modified by project code. This was causing issues for downstream consumers building non-C/C++ targets as part of the LLVM build.

Modern CMake provides `add_link_options()`, a cleaner way to set linker flags that propagate to every target in a directory tree.

Generator expressions and the `LINKER:` prefix syntax ensure that this is only applied to executable targets with the proper language and linker argument wrapping.

Cherry-pick of llvm/llvm-project@4354248d10 (llvm/llvm-project#195034)