### PR TITLE
[lldb] Centralize arm64e testing logic

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbarm64e.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbarm64e.py
@@ -1,0 +1,11 @@
+from lldbsuite.test.lldbtest import TestBase
+from lldbsuite.test.decorators import *
+from lldbsuite.test import configuration
+
+
+@skipUnlessArm64eSupported
+class Arm64eTestBase(TestBase):
+    def build(self):
+        super().build(
+            dictionary={"TRIPLE": configuration.triple.replace("arm64-", "arm64e-")}
+        )

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/TestPtrAuthAuthTraps.py
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/TestPtrAuthAuthTraps.py
@@ -9,20 +9,15 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from lldbsuite.test import configuration
+from lldbsuite.test.lldbarm64e import Arm64eTestBase
 
 
-class TestPtrAuthAuthTraps(TestBase):
+class TestPtrAuthAuthTraps(Arm64eTestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False
 
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
-
-    @skipUnlessArm64eSupported
     def test_static_function_pointer(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
         )
@@ -37,9 +32,8 @@ class TestPtrAuthAuthTraps(TestBase):
             substrs=["execution was interrupted"],
         )
 
-    @skipUnlessArm64eSupported
     def test_indirect_call_through_caller(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
         )

--- a/lldb/test/API/commands/expression/ptrauth-objc/TestPtrAuthObjectiveC.py
+++ b/lldb/test/API/commands/expression/ptrauth-objc/TestPtrAuthObjectiveC.py
@@ -2,21 +2,15 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-from lldbsuite.test import configuration
+from lldbsuite.test.lldbarm64e import Arm64eTestBase
 
 
-class TestPtrAuthObjectiveC(TestBase):
+class TestPtrAuthObjectiveC(Arm64eTestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False
 
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
-
-    @skipUnlessArm64eSupported
     def test_objc_message_send(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -28,9 +22,8 @@ class TestPtrAuthObjectiveC(TestBase):
             result_value="42",
         )
 
-    @skipUnlessArm64eSupported
     def test_objc_message_send_with_arg(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -42,9 +35,8 @@ class TestPtrAuthObjectiveC(TestBase):
             result_value="30",
         )
 
-    @skipUnlessArm64eSupported
     def test_objc_alloc_and_message(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -57,9 +49,8 @@ class TestPtrAuthObjectiveC(TestBase):
             result_value="14",
         )
 
-    @skipUnlessArm64eSupported
     def test_objc_derived_class(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -77,9 +68,8 @@ class TestPtrAuthObjectiveC(TestBase):
             result_value="20",
         )
 
-    @skipUnlessArm64eSupported
     def test_objc_isa_check(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)

--- a/lldb/test/API/commands/expression/ptrauth-vtable/TestPtrAuthVTableExpressions.py
+++ b/lldb/test/API/commands/expression/ptrauth-vtable/TestPtrAuthVTableExpressions.py
@@ -8,20 +8,15 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+from lldbsuite.test.lldbarm64e import Arm64eTestBase
 
 
-class TestPtrAuthVTableExpressions(TestBase):
+class TestPtrAuthVTableExpressions(Arm64eTestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False
 
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
-
-    @skipUnlessArm64eSupported
     def test_virtual_call_on_debuggee_object(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )
@@ -29,18 +24,16 @@ class TestPtrAuthVTableExpressions(TestBase):
         self.expect_expr("d.value()", result_type="int", result_value="20")
         self.expect_expr("od.value()", result_type="int", result_value="30")
 
-    @skipUnlessArm64eSupported
     def test_virtual_call_through_base_pointer(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )
 
         self.expect_expr("base_ptr->value()", result_type="int", result_value="20")
 
-    @skipUnlessArm64eSupported
     def test_virtual_call_via_helper(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )

--- a/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
+++ b/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
@@ -2,25 +2,19 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-from lldbsuite.test import configuration
+from lldbsuite.test.lldbarm64e import Arm64eTestBase
 
 
-class TestPtrAuthExpressions(TestBase):
+class TestPtrAuthExpressions(Arm64eTestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False
 
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64-", "arm64e-")}
-        )
-
-    @skipUnlessArm64eSupported
     def test_static_function_pointer(self):
         """On arm64e, function pointers are automatically signed (PAC).
         Test that we can call a function through a static function pointer
         from the expression evaluator, which requires "fixing up" the pointer
         signing via the InjectPointerSigningFixups pass."""
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -38,13 +32,12 @@ class TestPtrAuthExpressions(TestBase):
             result_value="20",
         )
 
-    @skipUnlessArm64eSupported
     def test_indirect_call_through_caller(self):
         """Test that a function pointer passed to a debuggee function is
         correctly signed. The caller() function in the debuggee forces a
         genuine indirect call, preventing the compiler from folding the
         function pointer call into a direct call."""
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -62,14 +55,13 @@ class TestPtrAuthExpressions(TestBase):
             result_value="21",
         )
 
-    @skipUnlessArm64eSupported
     def test_debuggee_signed_pointer(self):
         """Test that a signed function pointer stored in the debuggee's memory
         can be read and called from a user expression. The global_fp variable
         is signed with the IB key (__ptrauth(1, 0, 0)), which is
         process-specific; this verifies that auth succeeds because expressions
         execute in the debuggee's process, not the debugger's."""
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -81,12 +73,11 @@ class TestPtrAuthExpressions(TestBase):
             result_value="30",
         )
 
-    @skipUnlessArm64eSupported
     def test_indirect_goto(self):
         """Test that computed gotos (GCC labels-as-values) work in the
         expression evaluator on arm64e, where -fptrauth-indirect-gotos signs
         label addresses and the indirect branch authenticates them."""
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)

--- a/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
+++ b/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
@@ -4,21 +4,15 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-from lldbsuite.test import configuration
+from lldbsuite.test.lldbarm64e import Arm64eTestBase
 
 
-class TestPtrAuth(TestBase):
+class TestPtrAuth(Arm64eTestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False
 
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
-
-    @skipUnlessArm64eSupported
     def test(self):
-        self.build_arm64e()
+        self.build()
         _, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, "// break in main", lldb.SBFileSpec("main.c")
         )


### PR DESCRIPTION
`build_arm64e` was defined in several test files and most of the implementations needed to be adjusted for correctness. Instead of fixing them individually, I introduce an "Arm64eBaseTest" class and override its `build` method. The base class is decorated so that these tests will be skipped if arm64e is unsupported.