### PR TITLE
[clang][ssaf] Add invoke-ssaf to driver feature availability list

### DIFF
--- a/clang/tools/driver/features.json
+++ b/clang/tools/driver/features.json
@@ -43,6 +43,9 @@
     },
     {
       "name": "print-headers-direct-per-file"
+    },
+    {
+      "name": "invoke-ssaf"
     }
   ]
 }


### PR DESCRIPTION
Registers the invoke-ssaf feature in features.json so that build systems and tools can query clang's feature availability and conditionally enable SSAF invocation support.