### PR TITLE
[BoundsSafety] Start running macOS runtime tests in pull requests for open source swiftlang llvm-project

### DIFF
--- a/apple-ci/pr.sh
+++ b/apple-ci/pr.sh
@@ -7,6 +7,25 @@
 LLVM_PROJECT_SRC=$1
 LLVM_ENABLE_PROJECTS=${2:-"clang;clang-tools-extra"}
 
+# These flags are here so we can run the -fbounds-safety runtime tests inside
+# compiler-rt.
+# FIXME: We should be testing all of compiler-rt! Historically none of
+# compiler-rt was tested by this script so the `-DCOMPILER_RT_BUILD_<name>=Off`
+# lines are here to avoid building and testing as much as possible to minimize
+# the problems that suddenly testing all of compiler-rt could cause. We should
+# gradually start building and testing more of these runtimes (rdar://176397238).
+BOUNDS_SAFETY_CMAKE_FLAGS=( \
+  -DLLVM_ENABLE_RUNTIMES=compiler-rt \
+  -DCOMPILER_RT_TEST_BOUNDS_SAFETY=On \
+  -DCOMPILER_RT_BOUNDS_SAFETY_USE_LLDB=On \
+  -DCOMPILER_RT_BUILD_LIBFUZZER=Off \
+  -DCOMPILER_RT_BUILD_MEMPROF=Off \
+  -DCOMPILER_RT_BUILD_PROFILE=Off \
+  -DCOMPILER_RT_BUILD_ORC=Off \
+  -DCOMPILER_RT_BUILD_SANITIZERS=Off \
+  -DCOMPILER_RT_BUILD_XRAY=Off \
+)
+
 echo '--- CMake Config ---'
 cmake -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
@@ -14,6 +33,7 @@ cmake -G Ninja \
  -DLLVM_ENABLE_PROJECTS=${LLVM_ENABLE_PROJECTS} \
  '-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64' \
  '-DLLVM_LIT_ARGS=-v' \
+ "${BOUNDS_SAFETY_CMAKE_FLAGS[@]}" \
  ${LLVM_PROJECT_SRC}/llvm
 
 echo '--- Ninja Build ---'


### PR DESCRIPTION
This change builds on the -fbounds-safety runtime tests that were added
to compiler-rt in 300cd7f7c607fa93bc89395a158336a5acfcc614. In that
change running the tests wasn't enabled in PR testing because
`apple-ci/pr.sh` didn't build compiler-rt.

This patch enables building and testing compiler-rt in pull requests.
However, to try reduce the build/test time impact many parts of
compiler-rt are disabled (e.g. the sanitizers). What is implicitly
enabled is the building and testing the compiler-rt builtins (required
for properly bootstrapping the compiler) and the -fbounds-safety runtime
tests.

I think we should enable all of compiler-rt in PR testing
(rdar://176397238) but I think that should be done in a separate step
or we should have a separate script and CI test action that builds more
of llvm (e.g. `@swift-ci test llvm-clang-compiler-rt-lldb`).

This PR doesn't actually enable the -fbounds-safety runtime tests for
Linux because they are disabled on the CMake side. However, this patch
is technically enabling the compiler-rt builtins build and test even
when building for Linux. While technically we could add code to `pr.sh`
prevent that it really doesn't seem worth it given we really should be
testing the builtins anyway.

The intention is to enable the `-fbounds-safety` runtime tests on Linux
in a future patch.

The -fbounds-safety runtime tests optionally depend on LLDB. To force
that we use LLDB the `-DCOMPILER_RT_BOUNDS_SAFETY_USE_LLDB=On` option is
passed. This relies on the LLDB (and its python bindings) from the
toolchain on the CI testing nodes.

rdar://176405989

