### PR TITLE
🍒 [lldb][Windows] Require exact match in LLDBMemoryReader::resolvePointerAsSymbol

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -204,6 +204,9 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
   }
 
   if (auto *symbol = addr.CalculateSymbolContextSymbol()) {
+    if (triple.isOSWindows() &&
+        addr.GetFileAddress() != symbol->GetAddressRef().GetFileAddress())
+      return {};
     auto mangledName = symbol->GetMangled().GetMangledName().GetStringRef();
     // MemoryReader requires this to be a Swift symbol. LLDB can also be
     // aware of local symbols, so avoid returning those.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -204,6 +204,10 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
   }
 
   if (auto *symbol = addr.CalculateSymbolContextSymbol()) {
+    // Require `addr` to point to the beginning of the symbol since the
+    // COFF export table is sparse and we can inadvertently misattribute
+    // private symbols to the preceding public symbol.
+    // See https://github.com/swiftlang/llvm-project/issues/12891
     if (triple.isOSWindows() &&
         addr.GetFileAddress() != symbol->GetAddressRef().GetFileAddress())
       return {};

--- a/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
+++ b/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
@@ -8,7 +8,6 @@ class TestSwiftObservation(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that types with private discriminators read from the file cache work"""
         self.build()

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -26,7 +26,6 @@ class TestSwiftRegex(TestBase):
 
     @swiftTest
     @skipIf(macos_version=["<", "13"])
-    @expectedFailureWindows
     def test_swift_regex_frame_var(self):
         """Test frame variable support for Swift regexes."""
         self.build()
@@ -63,7 +62,6 @@ class TestSwiftRegex(TestBase):
 
     @swiftTest
     @skipIf(macos_version=["<", "13"])
-    @expectedFailureWindows
     def test_swift_regex_expr(self):
         """Test expression support for Swift regexes."""
         self.build()

--- a/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
@@ -43,6 +43,8 @@ func main() {
     var myResult: Result<Int, Error> = .success(42)
     var myBox: Box<Int32> = Box(value: 99)
     var myPair: Pair<Int, String> = .first(7)
+    var myDictionary: [Int: String] = [1: "one", 2: "two"]
+    var mySet: Set<Int32> = [1, 2, 3]
     let constInt: Int = 100
     let constInt8: Int8 = -42
     let constUInt16: UInt16 = 1000
@@ -50,14 +52,14 @@ func main() {
     let constString: String = "world"
     print(myInt32, myBool, myUInt64, myFloat, myDouble,
           myString, myPoint, myDirection, myOptional, myNestedOptional, myArray,
-          myOptionalArray, myResult, myBox, myPair,
+          myOptionalArray, myResult, myBox, myPair, myDictionary, mySet,
           constInt, constInt8, constUInt16, constBool, constString)
 }
 
 main()
 
 #--- commands.input
-b main.swift:41
+b main.swift:43
 run
 frame variable
 
@@ -78,6 +80,8 @@ frame variable
 # CHECK: (Result<Int, Error>) myResult = success
 # CHECK: (main.Box<Int32>) myBox = (value = 99)
 # CHECK: (main.Pair<Int, String>) myPair = first
+# CHECK: ([Int : String]) myDictionary = 2 key/value pairs
+# CHECK: (Set<Int32>) mySet = 3 values
 # Local constants
 # CHECK: (Int) constInt = 100
 # CHECK: (Int8) constInt8 = -42


### PR DESCRIPTION
LLDBMemoryReader::resolvePointerAsSymbol will return a symbol if its argument points anywhere inside it. When we have sparse symbols for an image (for example, just COFF exports), we assume that the size of a given symbol is the distance between it and the next known symbol. However, this extent can actually include any number of private symbols.

Because of this, multiple symbols resolve to the name of the preceding public symbol, and the last one read can overwrite the others in the `TypeRefBuilder`'s cache.

This change adds a requirement on Windows that the pointer match the *start* of a symbol to keep the cache from being stomped.

See https://github.com/swiftlang/llvm-project/issues/12891 for details.

(original: https://github.com/swiftlang/llvm-project/pull/12894)