### PR TITLE
[stable/21.x][Support/SandboxingFileSystem] Allow matching an exact path to one of the allowed paths

### DIFF
--- a/llvm/lib/Support/SandboxingFileSystem.cpp
+++ b/llvm/lib/Support/SandboxingFileSystem.cpp
@@ -17,14 +17,16 @@
 using namespace llvm;
 
 // FIXME: Move to llvm/Support/Path.h?
-/// \returns true if \p Path is a nested directory in \p ParentPath.
-/// \p Path should be absolute. Returns false if \p ParentPath is relative.
+/// \returns true if \p Path is a nested directory in \p ParentPath or equal to
+/// it. \p Path should be absolute. Returns false if \p ParentPath is relative.
 static bool isPathNestedIn(StringRef Path, StringRef ParentPath) {
   assert(sys::path::is_absolute(Path));
-  if (Path.size() <= ParentPath.size())
+  if (Path.size() < ParentPath.size())
     return false;
   if (!Path.starts_with(ParentPath))
     return false;
+  if (Path.size() == ParentPath.size())
+    return true;
   return sys::path::is_separator(Path.drop_front(ParentPath.size()).front());
 }
 

--- a/llvm/unittests/Support/SandboxingFileSystemTest.cpp
+++ b/llvm/unittests/Support/SandboxingFileSystemTest.cpp
@@ -26,6 +26,8 @@ TEST(SandboxingFileSystemTest, Basic) {
       vfs::createSandboxingFileSystem(BaseFS, {"//root/dir1", "dir3"})
           .moveInto(SandBoxFS),
       Succeeded());
+  EXPECT_TRUE(SandBoxFS->exists("//root/dir1"));
+  EXPECT_TRUE(SandBoxFS->exists("//root/dir1/"));
   EXPECT_TRUE(SandBoxFS->exists("//root/dir1/a1"));
   EXPECT_FALSE(SandBoxFS->exists("//root/dir2/a2"));
   EXPECT_FALSE(SandBoxFS->exists("//root/dir1a/aa"));


### PR DESCRIPTION
(cherry picked from commit 836567aba8bdd95b28cfbdfe72eb877b5a69c382)