### PR TITLE
[lldb][test] Add embedded Swift test category

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -216,7 +216,18 @@ def _skipForVariant(variant_name, expected_fn, bugnumber=None):
         if isinstance(func, type) and issubclass(func, unittest.TestCase):
             raise Exception("Decorator can only be used to decorate a test method")
         skip_dict = getattr(func, "__variant_skip__", {})
-        skip_dict[variant_name] = expected_fn
+        existing_fn = skip_dict.get(variant_name)
+        if existing_fn:
+            # Chain the decorator with the existing one.
+            def chained_fn(**kwargs):
+                reason = expected_fn(**kwargs)
+                if reason:
+                    return reason
+                return existing_fn(**kwargs)
+
+            skip_dict[variant_name] = chained_fn
+        else:
+            skip_dict[variant_name] = expected_fn
         func.__variant_skip__ = skip_dict
         return func
 

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -995,6 +995,33 @@ def swiftTest(func):
 
     return skipTestIfFn(is_not_swift_compatible)(func)
 
+def skipEmbeddedSwift(func):
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded == "swift_embedded":
+            return "not supported in embedded Swift"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
+
+def skipEmbeddedSwiftOnLinux(func):
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded == "swift_embedded" and lldbplatformutil.getPlatform() == "linux":
+            return "not supported in embedded Swift on Linux"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
+
+def skipEmbeddedSwiftOnWindows(func):
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded == "swift_embedded" and lldbplatformutil.getPlatform() == "windows":
+            return "not supported in embedded Swift on Windows"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
+
+def skipUnlessEmbeddedSwift(func):
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded != "swift_embedded":
+            return "Only supported in embedded Swift"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
 
 def skipIfHostIncompatibleWithTarget(func):
     """Decorate the item to skip tests when the host and target are incompatible."""

--- a/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
@@ -107,6 +107,7 @@ class PlaygroundREPLTest(TestBase):
         error = self.get_stream_data(result)
         print("Crash Error: {}".format(error))
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_playgrounds(self):
         # Build

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -576,6 +576,8 @@ class Base(unittest.TestCase):
         if not cls.mydir:
             raise Exception("Subclasses must override the 'mydir' attribute.")
 
+        cls.extra_make_flags = {}
+
         # Save old working directory.
         cls.oldcwd = os.getcwd()
 
@@ -1539,6 +1541,8 @@ class Base(unittest.TestCase):
         if command is None:
             raise Exception("Don't know how to build binary")
 
+        command += [f"{k}={v}" for k, v in self.extra_make_flags.items()]
+
         self.runBuildCommand(command)
 
     def runBuildCommand(self, command):
@@ -1944,6 +1948,14 @@ def _swift_module_importer_setup(test_instance, variant_value):
     elif variant_value == "clangimporter":
         test_instance.runCmd("settings set symbols.use-swift-clangimporter true")
 
+def _embedded_swift_setup(test_instance, variant_value):
+    if variant_value == "swift_embedded":
+        test_instance.extra_make_flags["SWIFT_EMBEDDED_MODE"] = "1"
+    elif variant_value == "swift":
+        test_instance.extra_make_flags["SWIFT_EMBEDDED_MODE"] = "0"
+    else:
+        assert False, f"Unknown variant: {variant_value}"
+
 
 _test_variants = [
     TestVariant(
@@ -1951,6 +1963,13 @@ _test_variants = [
         values=test_categories.swift_module_importer_categories,
         predicate=lambda m: getattr(m, "__swift_test__", False),
         setup_fn=_swift_module_importer_setup,
+        attrs_to_preserve=("debug_info",),
+    ),
+    TestVariant(
+        name="swift_embedded",
+        values=test_categories.embedded_swift_categories,
+        predicate=lambda m: getattr(m, "__swift_test__", False),
+        setup_fn=_embedded_swift_setup,
         attrs_to_preserve=("debug_info",),
     ),
 ]

--- a/lldb/packages/Python/lldbsuite/test/test_categories.py
+++ b/lldb/packages/Python/lldbsuite/test/test_categories.py
@@ -25,6 +25,11 @@ swift_module_importer_categories = {
     "dwarfimporter": True,
 }
 
+embedded_swift_categories = {
+    "swift": True,
+    "swift_embedded": True,
+}
+
 all_categories = {
     "basic_process": "Basic process execution sniff tests.",
     "cmdline": "Tests related to the LLDB command-line interface",
@@ -56,6 +61,8 @@ all_categories = {
     "watchpoint": "Watchpoint-related tests",
     "clangimporter": "Tests run with the Swift ClangImporter",
     "dwarfimporter": "Tests run with the Swift DWARFImporter",
+    "swift_embedded": "Tests are compiled as embedded Swift",
+    "swift": "Tests are compiled as normal Swift",
 }
 
 

--- a/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173245096
     def test_swift_po_address(self):
@@ -21,6 +22,7 @@ class TestCase(TestBase):
         self.expect(f"dwim-print -O -- 0x{hex_addr}", patterns=[f"Object@0x0*{hex_addr}"])
         self.expect(f"dwim-print -O -- {addr}", patterns=[f"Object@0x0*{hex_addr}"])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173245096
     def test_swift_po_non_address_hex(self):
@@ -31,6 +33,7 @@ class TestCase(TestBase):
         )
         self.expect(f"dwim-print -O -- 0x1000", substrs=["4096"])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173245096
     def test_print_swift_object_does_not_show_name(self):

--- a/lldb/test/API/commands/expression/persistent_result/swift/TestSwiftPersistentResult.py
+++ b/lldb/test/API/commands/expression/persistent_result/swift/TestSwiftPersistentResult.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_enable_persistent_result(self):
         """Test explicitly enabling result variables persistence."""
         self.build()
@@ -21,6 +22,7 @@ class TestCase(TestBase):
         self.expect("expression $R0", startstr="(Int) $R1 = 30")
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_disable_persistent_result(self):
         """Test explicitly disabling persistent result variables."""
         self.build()
@@ -32,6 +34,7 @@ class TestCase(TestBase):
         self.expect("expression $R0", error=True)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_expression_persists_result(self):
         """Test `expression`'s default behavior is to persist a result variable."""
         self.build()
@@ -42,6 +45,7 @@ class TestCase(TestBase):
         self.expect("expression $R0", startstr="(Int) $R1 = 30")
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_p_does_not_persist_results(self):
         """Test `p` does not persist a result variable."""
         self.build()

--- a/lldb/test/API/commands/frame/var/direct-ivar/swift/TestSwiftFrameVarDirectIvar.py
+++ b/lldb/test/API/commands/frame/var/direct-ivar/swift/TestSwiftFrameVarDirectIvar.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_objc_self(self):
@@ -12,6 +13,7 @@ class TestCase(TestBase):
         lldbutil.run_to_source_breakpoint(self, "check self", lldb.SBFileSpec("main.swift"))
         self.expect("frame variable _prop", startstr="(Int) _prop = 30")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_objc_self_capture_idiom(self):

--- a/lldb/test/API/commands/target/modules/swift/TestSwiftImageLookupPC.py
+++ b/lldb/test/API/commands/target/modules/swift/TestSwiftImageLookupPC.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftAddressExpressionTest(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test that you can use register names in image lookup in a swift frame."""
         self.build()

--- a/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
+++ b/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
@@ -25,6 +25,7 @@ class AsanSwiftTestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftErrorBreakpoint(TestBase):
+    @skipEmbeddedSwift
     @decorators.skipIfLinux  # <rdar://problem/30909618>
     @swiftTest
     def test_swift_error_no_typename(self):
@@ -27,18 +28,21 @@ class TestSwiftErrorBreakpoint(TestBase):
         self.build()
         self.do_tests(None)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_error_matching_base_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests("EnumError")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_error_matching_full_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests("a.EnumError")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_swift_error_bogus_typename(self):

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that a breakpoint on a property accessor can be set by name."""

--- a/lldb/test/API/functionalities/data-formatter/poarray/TestPrintObjectArray.py
+++ b/lldb/test/API/functionalities/data-formatter/poarray/TestPrintObjectArray.py
@@ -10,12 +10,14 @@ from lldbsuite.test import lldbutil
 
 
 class PrintObjectArrayTestCase(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     def test_print_array(self):
         """Test that expr -O -Z works"""
         self.build()
         self.printarray_data_formatter_commands()
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     def test_print_array_no_const(self):
         """Test that expr -O -Z works"""

--- a/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftTypeAliasFormatters(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_type_alias_formatters(self):
         """Test that Swift typealiases get formatted properly"""
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/swift-unsafe/TestSwiftUnsafeTypeFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-unsafe/TestSwiftUnsafeTypeFormatters.py
@@ -5,4 +5,4 @@ Test that Swift unsafe types get formatted properly
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
@@ -9,6 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_array_slice_formatters(self):
         """Test ArraySlice synthetic types."""
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/swift/bridged-string/TestSwiftBridgedStringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/bridged-string/TestSwiftBridgedStringFormatters.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/functionalities/data-formatter/swift/date/TestSwiftDateFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/date/TestSwiftDateFormatters.py
@@ -11,6 +11,7 @@ import sys
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessFoundation
     @swiftTest
     def test_swift_date_formatters(self):

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
@@ -11,6 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessFoundation
     @swiftTest
     def test_swift_string_index_formatters(self):

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -9,6 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_substring_formatters(self):
         """Test Subtring summary strings."""

--- a/lldb/test/API/functionalities/mtc/swift-property/TestSwiftMTCProperty.py
+++ b/lldb/test/API/functionalities/mtc/swift-property/TestSwiftMTCProperty.py
@@ -13,6 +13,7 @@ import json
 
 
 class MTCSwiftPropertyTestCase(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/functionalities/mtc/swift/TestSwiftMTC.py
+++ b/lldb/test/API/functionalities/mtc/swift/TestSwiftMTC.py
@@ -13,6 +13,7 @@ import json
 
 
 class MTCSwiftTestCase(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -15,6 +15,7 @@ class TestSwiftProgressReporting(TestBase):
         self.listener = lldbutil.start_listening_from(self.broadcaster,
                                         lldb.SBDebugger.eBroadcastBitProgress)
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/functionalities/swift-runtime-reporting/exclusivity-violation/TestExclusivityViolation.py
+++ b/lldb/test/API/functionalities/swift-runtime-reporting/exclusivity-violation/TestExclusivityViolation.py
@@ -25,6 +25,7 @@ class SwiftRuntimeReportingExclusivityViolationTestCase(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.skipEmbeddedSwift
     @decorators.skipIfLinux
     @decorators.expectedFailureWindows
     def test_swift_runtime_reporting(self):

--- a/lldb/test/API/functionalities/tsan/swift-access-race/TestSwiftTsanAccessRace.py
+++ b/lldb/test/API/functionalities/tsan/swift-access-race/TestSwiftTsanAccessRace.py
@@ -25,6 +25,7 @@ class TsanSwiftAccessRaceTestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/functionalities/tsan/swift/TestSwiftTsan.py
+++ b/lldb/test/API/functionalities/tsan/swift/TestSwiftTsan.py
@@ -24,6 +24,7 @@ class TsanSwiftTestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/lang/swift/accelerate_simd/TestAccelerateSIMD.py
+++ b/lldb/test/API/lang/swift/accelerate_simd/TestAccelerateSIMD.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
+++ b/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
@@ -44,6 +44,7 @@ class TestSwiftAddressOf(lldbtest.TestBase):
         self.assertSuccess(error)
 
         
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
+++ b/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
@@ -23,6 +23,7 @@ class TestSwiftAnyType(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_any_type(self):
         """Test the Any type"""

--- a/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftAnyObjectType(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_any_object_type(self):
         """Test the AnyObject type"""
         self.build()

--- a/lldb/test/API/lang/swift/anytype_array/TestAnyTypeArray.py
+++ b/lldb/test/API/lang/swift/anytype_array/TestAnyTypeArray.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
@@ -6,18 +6,22 @@ import lldbsuite.test.lldbutil as lldbutil
 
 @skipIfWindows
 class TestArchetypeInConditionalBreakpoint(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_stops_free_function(self):
         self.stops("break here for free function")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_doesnt_stop_free_function(self):
         self.doesnt_stop("break here for free function")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_stops_class(self):
         self.stops("break here for class")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_doesnt_stop_class(self):
         self.doesnt_stop("break here for class")

--- a/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
+++ b/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestArchetypeInExpression(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests that a user can refer to the archetypes in their expressions"""         

--- a/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
+++ b/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftArchetypeResolution(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173245096
     def test_swift_archetype_resolution(self):

--- a/lldb/test/API/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
+++ b/lldb/test/API/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/array_bridged_enum/TestArrayBridgedEnum.py
+++ b/lldb/test/API/lang/swift/array_bridged_enum/TestArrayBridgedEnum.py
@@ -1,4 +1,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessFoundation])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+        swiftTest, skipUnlessFoundation])

--- a/lldb/test/API/lang/swift/array_element/TestSwiftArrayElement.py
+++ b/lldb/test/API/lang/swift/array_element/TestSwiftArrayElement.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/array_enum/TestArrayEnum.py
+++ b/lldb/test/API/lang/swift/array_enum/TestArrayEnum.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
+++ b/lldb/test/API/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
@@ -1,5 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin,
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+        swiftTest, skipUnlessDarwin,
     expectedFailureAll(archs=['arm64_32'], bugnumber="<rdar://problem/58065423>")])

--- a/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
+++ b/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftArrayUninitialized(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test unitialized global arrays"""

--- a/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
+++ b/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftArtificialSubclass(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessObjCInterop
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/associated_self_type/TestSwiftAssociatedSelfType.py
+++ b/lldb/test/API/lang/swift/associated_self_type/TestSwiftAssociatedSelfType.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftArchetypeResolution(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_associated_type_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -6,6 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""

--- a/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
+++ b/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
@@ -8,6 +8,7 @@ class TestSwiftAsyncFnArgs(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://176009590
     def test_unsafe_continuation_printing(self):
@@ -34,6 +35,7 @@ class TestCase(TestBase):
             ],
         )
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://176009590
     def test_checked_continuation_printing(self):

--- a/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
+++ b/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
@@ -8,6 +8,7 @@ class TestSwiftAsyncExpressions(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_top_level_task(self):
         """Test Task synthetic child provider for top-level Task."""
@@ -33,6 +34,7 @@ class TestCase(TestBase):
             ],
         )
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfLinux
     def test_current_task(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://176009590
     def test_summary_contains_name(self):
@@ -16,6 +17,7 @@ class TestCase(TestBase):
         )
         self.expect("v task", patterns=[r'"Chore" id:[1-9]'])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://176009590
     @skipIfLinux  # rdar://151471067

--- a/lldb/test/API/lang/swift/async/formatters/task/parent/TestSwiftSyntheticTaskParent.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/parent/TestSwiftSyntheticTaskParent.py
@@ -9,6 +9,7 @@ ADDR_PATTERN = "(0x[0-9a-f]{6,})"
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -6,6 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test summary formatter for TaskPriority."""

--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -7,6 +7,7 @@ class TestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
@@ -67,6 +67,7 @@ class TestCase(lldbtest.TestBase):
             myvar = frame.FindVariable("myvar")
             lldbutil.check_variable(self, myvar, False, value=expected_value)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
+++ b/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
@@ -6,6 +6,7 @@ import re
 
 
 class TestCase(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
@@ -8,6 +8,7 @@ class TestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     @skipIf(macos_version=["<", "26.0"], asan=True) # rdar://138777205

--- a/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
@@ -28,6 +28,7 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.assertEqual(thread.frames[0].GetFunctionName(), expected_func_name)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -17,6 +17,7 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):
@@ -39,6 +40,7 @@ class TestCase(lldbtest.TestBase):
             self.check_is_in_line(thread, expected_line_num)
             self.check_x_is_available(thread.frames[0])
 
+    @skipEmbeddedSwift
     @skipIfOutOfTreeDebugserver
     @swiftTest
     @skipIf(oslist=["windows", "linux"])

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
@@ -12,6 +12,7 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test_nothrow(self):
@@ -31,6 +32,7 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.check_is_in_line(thread, expected_line_num)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test_throw(self):

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_print_task_group(self):
         """Print a TaskGroup and verify its children."""
@@ -16,6 +17,7 @@ class TestCase(TestBase):
         )
         self.do_test_print()
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_print_throwing_task_group(self):
         """Print a ThrowingTaskGroup and verify its children."""
@@ -59,6 +61,7 @@ class TestCase(TestBase):
             ],
         )
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_api_task_group(self):
         """Verify a TaskGroup contains its expected children."""
@@ -68,6 +71,7 @@ class TestCase(TestBase):
         )
         self.do_test_api(process)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_api_throwing_task_group(self):
         """Verify a ThrowingTaskGroup contains its expected children."""

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_backtrace_task_variable(self):
         self.build()
@@ -13,6 +14,7 @@ class TestCase(TestBase):
         )
         self.do_backtrace("task")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_backtrace_task_address(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_backtrace_selected_task_variable(self):
         self.build()
@@ -13,6 +14,7 @@ class TestCase(TestBase):
         )
         self.do_backtrace_selected_task("task")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_backtrace_selected_task_address(self):
         self.build()
@@ -36,6 +38,7 @@ class TestCase(TestBase):
             ],
         )
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_navigate_stack_of_selected_task_variable(self):
         self.build()
@@ -44,6 +47,7 @@ class TestCase(TestBase):
         )
         self.do_test_navigate_selected_task_stack(process, "task")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_navigate_stack_of_selected_task_address(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
+++ b/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
@@ -13,6 +13,7 @@ def _tail(output):
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_compare_printed_task_variable_to_task_info(self):
@@ -27,6 +28,7 @@ class TestCase(TestBase):
         task_info_output = self.res.GetOutput()
         self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_compare_printed_task_variable_to_task_info_with_address(self):

--- a/lldb/test/API/lang/swift/async/tasks/list/TestSwiftTaskList.py
+++ b/lldb/test/API/lang/swift/async/tasks/list/TestSwiftTaskList.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessPlatform(["macosx"])
     @swiftTest
     def test_task_list(self):

--- a/lldb/test/API/lang/swift/async/tasks/tree/TestSwiftTaskTree.py
+++ b/lldb/test/API/lang/swift/async/tasks/tree/TestSwiftTaskTree.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessPlatform(["macosx"])
     @swiftTest
     def test_task_tree(self):

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestDisableLanguageUnwinder(lldbtest.TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/hidden_frames/TestSwiftAsyncHiddenFrames.py
+++ b/lldb/test/API/lang/swift/async/unwind/hidden_frames/TestSwiftAsyncHiddenFrames.py
@@ -8,6 +8,7 @@ class TestSwiftAsyncHiddenFrames(lldbtest.TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
@@ -12,6 +12,7 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
@@ -8,6 +8,7 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -154,6 +154,7 @@ class TestCase(lldbtest.TestBase):
         for expected_name, actual_name in zip(expected_funcnames, actual_funcnames):
             self.assertIn(expected_name, actual_name, f"Unexpected backtrace: {frames}")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
@@ -10,6 +10,7 @@ class TestCase(lldbtest.TestBase):
 
     unwind_fail_range_cache = dict()
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     @skipIf(archs=["arm64e"])

--- a/lldb/test/API/lang/swift/async/unwind/unwind_register_pressure/TestSwiftAsyncUnwindRegisterPressure.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_register_pressure/TestSwiftAsyncUnwindRegisterPressure.py
@@ -51,6 +51,7 @@ class TestCase(lldbtest.TestBase):
         for expected_name, actual_name in zip(expected_funcnames, actual_funcnames):
             self.assertIn(expected_name, actual_name, f"Unexpected backtrace: {frames}")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/variables/TestSwiftAsyncVariables.py
+++ b/lldb/test/API/lang/swift/async/variables/TestSwiftAsyncVariables.py
@@ -8,6 +8,7 @@ class TestSwiftAsyncVariables(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
     def test(self):

--- a/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
+++ b/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/lang/swift/async_breakpoints_over_many_funclets/TestSwiftAsyncBreakpointsOverManyFunclets.py
+++ b/lldb/test/API/lang/swift/async_breakpoints_over_many_funclets/TestSwiftAsyncBreakpointsOverManyFunclets.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureWindows
     @skipIfLinux

--- a/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
@@ -34,6 +34,7 @@ class TestAvailability(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['linux', 'windows'])
     def testAvailability(self):

--- a/lldb/test/API/lang/swift/big_multi_payload_enum/TestSwiftBigMultiPayloadEnum.py
+++ b/lldb/test/API/lang/swift/big_multi_payload_enum/TestSwiftBigMultiPayloadEnum.py
@@ -6,6 +6,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftBigMultiPayloadEnum(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnLinux # Linker failure with arc4random_buf
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftPartialBreakTest(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_partial_break(self):
         """Tests that we can break on a partial name of a Swift function"""
         self.build()

--- a/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
+++ b/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
@@ -9,6 +9,7 @@ import os
 
 
 class TestSwiftBridgedMetatype(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test_swift_bridged_metatype(self):

--- a/lldb/test/API/lang/swift/bridged_url/TestSwiftBridgedURL.py
+++ b/lldb/test/API/lang/swift/bridged_url/TestSwiftBridgedURL.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
+++ b/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
@@ -19,6 +19,7 @@ import os
 
 
 class TestSwiftBacktracePrinting(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_backtrace_printing(self):
         """Test printing Swift backtrace"""

--- a/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
+++ b/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftCTypeIvar(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
     def test(self):

--- a/lldb/test/API/lang/swift/cf/uuid/TestCFUUID.py
+++ b/lldb/test/API/lang/swift/cf/uuid/TestCFUUID.py
@@ -9,6 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -7,6 +7,7 @@ class TestSwiftWerror(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
+++ b/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
@@ -21,6 +21,7 @@ class TestSwiftBridgingHeaderHeadermap(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClangImporterCaching(TestBase):
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(swift_module_importer="dwarfimporter")
     @skipIf(setting=("symbols.swift-precise-compiler-invocation", "false"))

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftNSClassBaseClass(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -17,6 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftDedupMacros(TestBase):
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     # NOTE: rdar://44201206 - This test may sporadically segfault. It's likely

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
@@ -20,6 +20,7 @@ class TestSwiftClangImporterCustomAlignment(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -18,6 +18,7 @@ import os
 import shutil
 
 class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -7,6 +7,7 @@ class TestSwiftClangImporterExplicitNoImplicit(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
     
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
@@ -7,6 +7,7 @@ class TestSwiftExprImport(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test error handling if the expression evaluator
            encounters a Clang import failure.

--- a/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/TestSwiftClangImporterExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/TestSwiftClangImporterExtraInhabitants.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClangImporterExtraInhabitants(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     # Don't run ClangImporter tests if Clangimporter is disabled.

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
@@ -8,6 +8,7 @@ class TestSwiftFModuleFlags(TestBase):
     @skipIf(macos_version=["<", "14.0"])
     @skipIfDarwinEmbedded
     @swiftTest
+    @skipEmbeddedSwiftOnLinux # Failed to load SwiftCore.so
     @skipIfWindows
     def test(self):
         """Test that -fmodule flags get stripped out"""

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
@@ -9,6 +9,7 @@ class TestSwiftHardMacroConflict(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -22,6 +22,7 @@ class TestSwiftHeadermapConflict(TestBase):
         bugnumber="rdar://60396797",
         setting=("symbols.use-swift-clangimporter", "false"),
     )
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -18,6 +18,7 @@ import os
 import shutil
 
 class TestSwiftIncludeConflict(TestBase):
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/missing_pch/TestSwiftMissingPCH.py
+++ b/lldb/test/API/lang/swift/clangimporter/missing_pch/TestSwiftMissingPCH.py
@@ -11,6 +11,7 @@ class TestSwiftMissingVFSOverlay(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/nserror/TestNSError.py
+++ b/lldb/test/API/lang/swift/clangimporter/nserror/TestNSError.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class SwiftNSErrorTest(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_nserror(self):

--- a/lldb/test/API/lang/swift/clangimporter/nsinteger_nsenum/TestSwiftNSIntegerNSEnum.py
+++ b/lldb/test/API/lang/swift/clangimporter/nsinteger_nsenum/TestSwiftNSIntegerNSEnum.py
@@ -21,12 +21,14 @@ class TestSwiftNSIntegerNSEnum(lldbtest.TestBase):
         check(frame.FindVariable('e1'), 'eCase1')
         check(frame.FindVariable('e2'), 'eCase2')
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_reflection(self):
         self.expect("setting set symbols.swift-enable-ast-context false")
         self.do_test(use_summary=True)
 
+    @skipEmbeddedSwift
     # Don't run a clangimporter test without ClangImporter.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objc-interop/TestSwiftObjCInterop.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc-interop/TestSwiftObjCInterop.py
@@ -12,4 +12,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipUnlessObjCInterop])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+        swiftTest,skipUnlessObjCInterop])

--- a/lldb/test/API/lang/swift/clangimporter/objc/dynamic-swift-type/TestSwiftObjCDynamicType.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc/dynamic-swift-type/TestSwiftObjCDynamicType.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessFoundation
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_baseclass/TestSwiftObjCBaseClassMemberLookup.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_baseclass/TestSwiftObjCBaseClassMemberLookup.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCBaseClassMemberLookup(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_inherited_ivars/TestSwiftAtObjCIvars.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_inherited_ivars/TestSwiftAtObjCIvars.py
@@ -26,6 +26,7 @@ class TestSwiftAtObjCIvars(TestBase):
         lldbutil.check_variable(self, x, False, value='12')
         lldbutil.check_variable(self, y, False, '"12"')
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_at_objc_ivars(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/TestSwiftObjCOptionalDict.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/TestSwiftObjCOptionalDict.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCOptionalDict(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCProtocol(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol_fields/TestSwiftObjCProtocolFields.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol_fields/TestSwiftObjCProtocolFields.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCBaseClassMemberLookup(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -22,6 +22,7 @@ import re
 import shutil
 
 class TestObjCIVarDiscovery(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
     @swiftTest
@@ -30,6 +31,7 @@ class TestObjCIVarDiscovery(TestBase):
         shutil.rmtree(self.getBuildArtifact("aTestFramework.framework/Versions/A/aTestFramework.dSYM"))
         self.do_test(False)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -18,6 +18,7 @@ import os
 import shutil
 
 class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -21,6 +21,7 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
+++ b/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClangImporterProtocolComposition(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -17,6 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftRemoteASTImport(TestBase):
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -18,6 +18,7 @@ import os
 import shutil
 
 class TestSwiftRewriteClangPaths(TestBase):
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
@@ -26,6 +27,7 @@ class TestSwiftRewriteClangPaths(TestBase):
     def testWithRemap(self):
         self.dotest(True)
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -17,6 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftSubmoduleImport(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173245705
     def test(self):

--- a/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
+++ b/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClashingABIName(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test(self):
@@ -22,6 +23,7 @@ class TestSwiftClashingABIName(TestBase):
 
         self.expect('expr --bind-generic-types true -- generic3',
                     substrs=['a.Generic2<a.Generic<a.One>>', 't2 =', 't =', 'j = 98'])
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_in_self(self):

--- a/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
+++ b/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftClassBaseClass(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173245096
     def test(self):

--- a/lldb/test/API/lang/swift/class_empty/TestSwiftClassEmpty.py
+++ b/lldb/test/API/lang/swift/class_empty/TestSwiftClassEmpty.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/class_error/TestClassError.py
+++ b/lldb/test/API/lang/swift/class_error/TestClassError.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/class_static/TestSwiftClassStatic.py
+++ b/lldb/test/API/lang/swift/class_static/TestSwiftClassStatic.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
+++ b/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
@@ -15,6 +15,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestClosureShortcuts(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -51,6 +51,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         target.BreakpointDelete(bkpt.GetID())
         return (target, process, thread)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_simple_closure(self):
         self.build()
@@ -59,6 +60,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_not_captured_error(self, thread.frames[0], "arg", "func_1(arg:)")
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_nested_closure(self):
         self.build()
@@ -83,6 +85,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
+    @skipEmbeddedSwift
     @swiftTest
     # Async variable inspection on Linux/Windows are still problematic.
     @skipIf(oslist=["windows", "linux"])
@@ -106,6 +109,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
+    @skipEmbeddedSwift
     @swiftTest
     # Async variable inspection on Linux/Windows are still problematic.
     @skipIf(oslist=["windows", "linux"])
@@ -118,6 +122,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
             self, thread.frames[0], "x", "task_inside_non_async_function()"
         )
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_ctor_class_closure(self):
         self.build()
@@ -175,6 +180,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_ctor_struct_closure(self):
         self.build()
@@ -232,6 +238,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_ctor_enum_closure(self):
         self.build()

--- a/lldb/test/API/lang/swift/command_memory_find/TestSwiftCommandMemoryFind.py
+++ b/lldb/test/API/lang/swift/command_memory_find/TestSwiftCommandMemoryFind.py
@@ -18,6 +18,7 @@ class TestSwiftCommandMemoryFind(TestBase):
         self.expect(f'memory find -e "{expr}" {hex(addr)} {hex(addr + 8)}',
                     substrs=["data found at location"])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173244841
     def test(self):

--- a/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
+++ b/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_scalar_types(self):
         self.build()

--- a/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -19,6 +19,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftConditionalBreakpoint(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnLinux # Linker failure with arc4random_buf
+    @skipEmbeddedSwiftOnWindows
     def test_swift_conditional_breakpoint(self):
         """Tests that we can set a conditional breakpoint in Swift code"""
         self.build()

--- a/lldb/test/API/lang/swift/constrained_existential/TestSwiftConstrainedExistential.py
+++ b/lldb/test/API/lang/swift/constrained_existential/TestSwiftConstrainedExistential.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftConstrainedExistential(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test constrained existential types"""

--- a/lldb/test/API/lang/swift/constrained_existential_metatype/TestSwiftConstrainedExistentialMetatypeFix.py
+++ b/lldb/test/API/lang/swift/constrained_existential_metatype/TestSwiftConstrainedExistentialMetatypeFix.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftConstrainedExistentialMetatypeFix(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/convention_c_function_pointer/TestSwiftConventionCFunctionPointer.py
+++ b/lldb/test/API/lang/swift/convention_c_function_pointer/TestSwiftConventionCFunctionPointer.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftConventionCFunctionPointer(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
+++ b/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
@@ -20,6 +20,7 @@ import os
 import os.path
 
 class TestSwiftCrossModuleExtension(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_cross_module_extension(self):

--- a/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
@@ -7,6 +7,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftBackwardInteropExpressions(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_func_step_in(self):

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass.py
@@ -32,60 +32,70 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_method_step_in_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_in(thread, 'testMethod', 'SwiftClass.swiftMethod')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_method_step_over_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_over(thread, 'testMethod')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_init_step_in_class(self):
         thread = self.setup('Break here for constructor - class')
         self.check_step_in(thread, 'testConstructor', 'SwiftClass.init')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_init_step_over_class(self):
         thread = self.setup('Break here for constructor - class')
         self.check_step_over(thread, 'testConstructor')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_static_method_step_in_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_in(thread, 'testStaticMethod', 'SwiftClass.swiftStaticMethod')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_static_method_step_over_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_over(thread, 'testStaticMethod')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_getter_step_in_class(self):
         thread = self.setup('Break here for getter - class')
         self.check_step_in(thread, 'testGetter', 'SwiftClass.swiftProperty.getter')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_getter_step_over_class(self):
         thread = self.setup('Break here for getter - class')
         self.check_step_over(thread, 'testGetter')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_setter_step_in_class(self):
         thread = self.setup('Break here for setter - class')
         self.check_step_in(thread, 'testSetter', 'SwiftClass.swiftProperty.setter')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_setter_step_over_class(self):
@@ -93,12 +103,14 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
         self.check_step_over(thread, 'testSetter')
 
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_overriden_step_in_class(self):
         thread = self.setup('Break here for overridden - class')
         self.check_step_in(thread, 'testOverridenMethod', 'SwiftSubclass.overrideableMethod')
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_overriden_step_over_class(self):

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingFunc.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingFunc.py
@@ -33,12 +33,14 @@ class TestSwiftBackwardInteropSteppingFunc(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_func_step_in(self):
         thread = self.setup("Break here for func")
         self.check_step_in(thread, "testFunc", "swiftFunc")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_func_step_over(self):

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct.py
@@ -33,60 +33,70 @@ class TestSwiftBackwardInteropSteppingStruct(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_method_step_in_struct(self):
         thread = self.setup("Break here for method - struct")
         self.check_step_in(thread, "testMethod", "SwiftStruct.swiftMethod")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_method_step_over_struct(self):
         thread = self.setup("Break here for method - struct")
         self.check_step_over(thread, "testMethod")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_init_step_in_struct(self):
         thread = self.setup("Break here for constructor - struct")
         self.check_step_in(thread, "testConstructor", "SwiftStruct.init")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_init_step_over_struct(self):
         thread = self.setup("Break here for constructor - struct")
         self.check_step_over(thread, "testConstructor")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_static_method_step_in_struct(self):
         thread = self.setup("Break here for static method - struct")
         self.check_step_in(thread, "testStaticMethod", "SwiftStruct.swiftStaticMethod")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_static_method_step_over_struct(self):
         thread = self.setup("Break here for static method - struct")
         self.check_step_over(thread, "testStaticMethod")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_getter_step_in_struct(self):
         thread = self.setup("Break here for getter - struct")
         self.check_step_in(thread, "testGetter", "SwiftStruct.swiftProperty.getter")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_getter_step_over_struct(self):
         thread = self.setup("Break here for getter - struct")
         self.check_step_over(thread, "testGetter")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_setter_step_in_struct(self):
         thread = self.setup("Break here for setter - struct")
         self.check_step_in(thread, "testSetter", "SwiftStruct.swiftProperty.setter")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_setter_step_over_struct(self):

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftForwardInteropCxxClassAsExistential(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftForwardInteropCxxClass(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_class(self):

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftForwardInteropCxxLangOpt(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_class(self):

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping.py
@@ -114,6 +114,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn('testContructor', name)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_step_into_extension(self):

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly.py
@@ -114,6 +114,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn('testContructor', name)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_step_into_extension(self):

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
@@ -12,6 +12,7 @@ class TestSwiftForwardInteropSTLTypes(TestBase):
     @skipIf(
         setting=("symbols.use-swift-clangimporter", "false")
     )  # rdar://106438227 (TestSTLTypes fails when clang importer is disabled)
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
+++ b/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
@@ -23,6 +23,7 @@ import shutil
 
 class TestSwiftDebugPrefixMap(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_debug_prefix_map(self):
         self.do_test()
 

--- a/lldb/test/API/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
+++ b/lldb/test/API/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -22,6 +22,7 @@ import os
 class TestSwiftDeploymentTarget(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
@@ -33,6 +34,7 @@ class TestSwiftDeploymentTarget(TestBase):
                                           lldb.SBFileSpec('main.swift'))
         self.expect("expression f", substrs=['i = 23'])
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
@@ -46,6 +48,7 @@ class TestSwiftDeploymentTarget(TestBase):
         lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect("expression self", substrs=['i = 23'])
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
@@ -66,6 +69,7 @@ class TestSwiftDeploymentTarget(TestBase):
 #       CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::SetTriple({{.*}}apple-macosx11.0.0
 #       CHECK-NOT: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RegisterSectionModules("a.out"){{.*}} AST Data blobs
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin  # This test uses macOS triples explicitly.
     @skipIfDarwinEmbedded
     @skipIf(macos_version=["<", "11.1"])

--- a/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
+++ b/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
@@ -30,6 +30,7 @@ class TestSwiftDeserializationFailure(TestBase):
         # FIXME: this is formatted incorrectly.
         self.expect("fr var -d no-dynamic t", substrs=["(T)"]) #, "world"])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows'])
     @skipIf(debug_info=no_match(["dwarf"]))
@@ -39,6 +40,7 @@ class TestSwiftDeserializationFailure(TestBase):
         target, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'main')
         self.run_tests(target, process)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows'])
     @skipIf(debug_info=no_match(["dwarf"]))

--- a/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
+++ b/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
+++ b/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftDifferentABIName(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
+++ b/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
@@ -40,6 +40,7 @@ class TestSwiftDifferentClangFlags(TestBase):
     @skipIf(
         debug_info=decorators.no_match("dsym"),
         bugnumber="This test requires a stripped binary and a dSYM")
+    @skipEmbeddedSwift
     def test_swift_different_clang_flags(self):
         """Test that we use the right compiler flags when debugging"""
         self.build()

--- a/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -72,6 +72,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         self.filecheck_log(log, __file__, "--check-prefix=CHECK-TYPEINFO")
         # CHECK-TYPEINFO: [LLDBTypeInfoProvider] Looking up debug type info for So4CMYKV
 
+    @skipEmbeddedSwift
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
     @swiftTest
     @skipIfWindows

--- a/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/TestSwiftDWARFImporterMemberTypes.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/TestSwiftDWARFImporterMemberTypes.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test looking up a Clang typedef type that isn't directly
         referenced by debug info in the Swift object file.

--- a/lldb/test/API/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -34,6 +34,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
         self.assertTrue(os.path.isdir(include))
         shutil.rmtree(include)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):
@@ -60,6 +61,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
         #self.expect("target var -d run proto", substrs=["(ProtoImpl)", "proto"])
         #self.expect("target var -O proto", substrs=["<ProtoImpl"])
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_expr(self):
@@ -81,6 +83,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
                                                 "private_ivar", "42"])
 
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_eager_member_completion(self):

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/TestSwiftDWARFImporterFromDylib.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/TestSwiftDWARFImporterFromDylib.py
@@ -8,6 +8,7 @@ class TestSwiftDWARFImporterFromDylib(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     # This test needs a working Remote Mirrors implementation.
     @skipIf(oslist=['linux', 'windows'])

--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -23,6 +23,7 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
         self.assertTrue(os.path.isdir(include))
         shutil.rmtree(include)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
+++ b/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
@@ -30,6 +30,7 @@ class TestSwiftDynamicSelf(lldbtest.TestBase):
         lldbutil.check_variable(self, member_v, False, value=v_val)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_dynamic_self(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
+++ b/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftDynamicValueTest(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_dynamic_value(self):
         """Tests that dynamic values work correctly for Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/TestSwiftEmbeddedAsyncStreamContinuation.py
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/TestSwiftEmbeddedAsyncStreamContinuation.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedAsyncStreamContinuation(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         """Test frame variable on an AsyncStream continuation in embedded Swift."""
         self.build()

--- a/lldb/test/API/lang/swift/embedded/builtin_types/TestSwiftEmbeddedBuiltinTypes.py
+++ b/lldb/test/API/lang/swift/embedded/builtin_types/TestSwiftEmbeddedBuiltinTypes.py
@@ -11,6 +11,7 @@ class TestSwiftEmbeddedBuiltinTypes(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test_without_ast(self):
         self.build()
         self.runCmd("setting set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/embedded/class_type_resolution/TestSwiftEmbeddedClassTypeResolution.py
+++ b/lldb/test/API/lang/swift/embedded/class_type_resolution/TestSwiftEmbeddedClassTypeResolution.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedClassTypeResolution(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("setting set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/embedded/closure_types/TestSwiftEmbeddedClosureTypes.py
+++ b/lldb/test/API/lang/swift/embedded/closure_types/TestSwiftEmbeddedClosureTypes.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedClosureTypes(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("setting set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/embedded/dictionary_formatting/TestSwiftEmbeddedDictionaryFormatting.py
+++ b/lldb/test/API/lang/swift/embedded/dictionary_formatting/TestSwiftEmbeddedDictionaryFormatting.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedDictionaryFormatting(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         """Test Dictionary data formatter children in embedded Swift."""
         self.build()

--- a/lldb/test/API/lang/swift/embedded/empty_array/TestSwiftEmbeddedEmptyArray.py
+++ b/lldb/test/API/lang/swift/embedded/empty_array/TestSwiftEmbeddedEmptyArray.py
@@ -7,10 +7,11 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedEmptyArray(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         """Test empty array formatting in embedded Swift."""
         self.build()
-        # Disable the ast context so we don't pass the test by silently falling 
+        # Disable the ast context so we don't pass the test by silently falling
         # back to the ast context implementation.
         self.runCmd("setting set symbols.swift-enable-ast-context false")
 

--- a/lldb/test/API/lang/swift/embedded/enum_typealias_payload/TestSwiftEmbeddedEnumTypealiasPayload.py
+++ b/lldb/test/API/lang/swift/embedded/enum_typealias_payload/TestSwiftEmbeddedEnumTypealiasPayload.py
@@ -11,6 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedEnumTypealiasPayload(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         """Test enums with typealiased payload types."""
         self.build()

--- a/lldb/test/API/lang/swift/embedded/existential_associated_type/TestSwiftEmbeddedExistentialAssociatedType.py
+++ b/lldb/test/API/lang/swift/embedded/existential_associated_type/TestSwiftEmbeddedExistentialAssociatedType.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedExistentialAssociatedType(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("setting set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/embedded/existential_type_resolution/TestSwiftEmbeddedExistentialTypeResolution.py
+++ b/lldb/test/API/lang/swift/embedded/existential_type_resolution/TestSwiftEmbeddedExistentialTypeResolution.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedExistentialTypeResolution(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("setting set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/embedded/expr/TestSwiftEmbeddedExpression.py
+++ b/lldb/test/API/lang/swift/embedded/expr/TestSwiftEmbeddedExpression.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedExpression(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -4,15 +4,17 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftEmbeddedFrameVariable(TestBase):
- 
+
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
         self.implementation(True)
 
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test_without_ast(self):
         """Run the test turning off instantion of  Swift AST contexts in order to ensure that all type information comes from DWARF"""
         self.build()
@@ -35,7 +37,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         alias1 = frame.FindVariable("alias1")
         field = alias1.GetChildMemberWithName("t")
         lldbutil.check_variable(self, field, False, value='1')
- 
+
         alias2 = frame.FindVariable("alias2")
         a3 = alias2.GetChildMemberWithName("a3")
         lldbutil.check_variable(self, a3.GetChildAtIndex(0), False, value='3')
@@ -63,7 +65,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         lldbutil.check_variable(self, q2t.GetChildAtIndex(0), False, value='12')
         lldbutil.check_variable(self, q2t.GetChildAtIndex(1), False, value='13')
 
-        
+
         array = frame.FindVariable("array")
         lldbutil.check_variable(self, array, False, num_children=4)
         for i in range(4):
@@ -128,14 +130,14 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         fullMultipayloadEnum2 = frame.FindVariable("fullMultipayloadEnum2")
         two = fullMultipayloadEnum2.GetChildMemberWithName("two")
         lldbutil.check_variable(self, two, False, value="9.5")
-        
+
         bigFullMultipayloadEnum1 = frame.FindVariable("bigFullMultipayloadEnum1")
         one = bigFullMultipayloadEnum1.GetChildMemberWithName("one")
         first = one.GetChildAtIndex(0)
         second = one.GetChildAtIndex(1)
         lldbutil.check_variable(self, first, False, value="209")
         lldbutil.check_variable(self, second, False, value="315")
-        
+
         bigFullMultipayloadEnum2 = frame.FindVariable("bigFullMultipayloadEnum2")
         two = bigFullMultipayloadEnum2.GetChildMemberWithName("two")
         first = two.GetChildAtIndex(0)

--- a/lldb/test/API/lang/swift/embedded/generic_class_inheritance/TestSwiftEmbeddedGenericClassInheritance.py
+++ b/lldb/test/API/lang/swift/embedded/generic_class_inheritance/TestSwiftEmbeddedGenericClassInheritance.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedGenericClassInheritance(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test_generic_derived(self):
         self.build()
         self.runCmd("setting set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/embedded/generic_class_protocol_constraint/TestSwiftEmbeddedGenericClassProtocolConstraint.py
+++ b/lldb/test/API/lang/swift/embedded/generic_class_protocol_constraint/TestSwiftEmbeddedGenericClassProtocolConstraint.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedGenericClassProtocolConstraint(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("setting set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/embedded/multi_payload_enum/TestSwiftEmbeddedMultiPayloadEnum.py
+++ b/lldb/test/API/lang/swift/embedded/multi_payload_enum/TestSwiftEmbeddedMultiPayloadEnum.py
@@ -11,6 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedMultiPayloadEnum(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test_multi_payload_enum(self):
         """Test that multi-payload enums display the correct case."""
         self.build()
@@ -37,6 +38,7 @@ class TestSwiftEmbeddedMultiPayloadEnum(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test_same_size_payloads(self):
         """Test enums where cases have same-sized payloads."""
         self.build()
@@ -58,6 +60,7 @@ class TestSwiftEmbeddedMultiPayloadEnum(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test_mixed_payload_enum(self):
         """Test enums mixing no-payload and various payload cases."""
         self.build()
@@ -89,6 +92,7 @@ class TestSwiftEmbeddedMultiPayloadEnum(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test_struct_payload_enum(self):
         """Test enums with struct payloads of different sizes."""
         self.build()

--- a/lldb/test/API/lang/swift/embedded/nested_frame_variable/TestSwiftEmbeddedNestedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/nested_frame_variable/TestSwiftEmbeddedNestedFrameVariable.py
@@ -7,12 +7,14 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedNestedFrameVariable(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
         self.implementation()
 
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test_without_ast(self):
         """Run the test turning off instantion of  Swift AST contexts in order to ensure that all type information comes from DWARF"""
         self.build()

--- a/lldb/test/API/lang/swift/embedded/raw_value_enum/TestSwiftEmbeddedRawValueEnum.py
+++ b/lldb/test/API/lang/swift/embedded/raw_value_enum/TestSwiftEmbeddedRawValueEnum.py
@@ -11,6 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedRawValueEnum(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         """Test that raw value enums display correctly in embedded Swift."""
         self.build()

--- a/lldb/test/API/lang/swift/embedded/set/TestSwiftEmbeddedSet.py
+++ b/lldb/test/API/lang/swift/embedded/set/TestSwiftEmbeddedSet.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEmbeddedSet(TestBase):
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         """Test Set data formatter in embedded Swift."""
         self.build()
@@ -28,6 +29,6 @@ class TestSwiftEmbeddedSet(TestBase):
             child = s.GetChildAtIndex(i)
             elements.add(int(child.GetValue()))
         self.assertEqual(elements, {1, 2, 3, 4, 5})
-        
+
         emptySet = frame.FindVariable("emptySet")
         lldbutil.check_variable(self, emptySet, False, summary="0 values")

--- a/lldb/test/API/lang/swift/embedded/typealias/TestSwiftEmbeddedTypealias.py
+++ b/lldb/test/API/lang/swift/embedded/typealias/TestSwiftEmbeddedTypealias.py
@@ -8,6 +8,7 @@ class TestSwiftEmbeddedTypealias(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("setting set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/embedded/unsafe_raw_buffer_pointer/TestSwiftEmbeddedUnsafeRawBufferPointer.py
+++ b/lldb/test/API/lang/swift/embedded/unsafe_raw_buffer_pointer/TestSwiftEmbeddedUnsafeRawBufferPointer.py
@@ -8,6 +8,7 @@ class TestSwiftEmbeddedUnsafeRawBufferPointer(TestBase):
     @skipIf(bugnumber="rdar://170883698")
     @skipUnlessDarwin
     @swiftTest
+    @skipUnlessEmbeddedSwift
     def test(self):
         """Test UnsafeRawBufferPointer formatter in embedded Swift."""
         self.build()

--- a/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
+++ b/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftEnableTesting(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
+++ b/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
@@ -8,6 +8,7 @@ class TestSwiftAnyType(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_any_type(self):
         self.build()

--- a/lldb/test/API/lang/swift/enum_associated/TestEnumAssociated.py
+++ b/lldb/test/API/lang/swift/enum_associated/TestEnumAssociated.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
+++ b/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureAll(oslist=["linux"], bugnumber="rdar://83444822")
     def test(self):

--- a/lldb/test/API/lang/swift/enum_tagged/TestEnumTagged.py
+++ b/lldb/test/API/lang/swift/enum_tagged/TestEnumTagged.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/enums/decoding_error/TestSwiftDecodingErrorEnum.py
+++ b/lldb/test/API/lang/swift/enums/decoding_error/TestSwiftDecodingErrorEnum.py
@@ -6,6 +6,7 @@ import os
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test_swift_decoding_error(self):

--- a/lldb/test/API/lang/swift/enums/extension/TestSwiftEnumExtension.py
+++ b/lldb/test/API/lang/swift/enums/extension/TestSwiftEnumExtension.py
@@ -6,6 +6,8 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @skipEmbeddedSwiftOnLinux # Linker failure with arc4random_buf
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test indirect enums"""
         self.build()

--- a/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
+++ b/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test indirect enums"""

--- a/lldb/test/API/lang/swift/enums/single_case_indirect/TestSwiftSingleCaseIndirectEnum.py
+++ b/lldb/test/API/lang/swift/enums/single_case_indirect/TestSwiftSingleCaseIndirectEnum.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftSingleCaseIndirectEnum(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test single-case indirect enum projection"""

--- a/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftErrorHandlingMissingTypes(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'true'))
     def test(self):

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
@@ -33,6 +33,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         # CHECK-NOT: secret
         # CHECK: Import 
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching.py
@@ -22,6 +22,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         self.expect("expression s", substrs=['i = 23'])
         self.expect("expression m", substrs=['j = 42'])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/explicit_modules/caching/TestSwiftExplicitModuleCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/caching/TestSwiftExplicitModuleCaching.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExplicitModuleCaching(TestBase):
 
+    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))

--- a/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/TestSwiftExplicitModulesChainedBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/TestSwiftExplicitModulesChainedBridgingHeader.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftExplicitModulesChainedBridgingHeader(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin # uses a framework, doesn't link with gold
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_missing_explicit_modules(self):
@@ -31,6 +32,7 @@ class TestCase(lldbtest.TestBase):
         # CHECK: Nonexistent explicit module file
         # CHECK: Explicit modules : false (downgraded
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_sanity(self):
@@ -59,6 +61,7 @@ class TestCase(lldbtest.TestBase):
         # CHECK-SANITY: Turning off implicit modules
         # CHECK-SANITY: Turning on implicit modules
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_setting(self):

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExplicitModulePrivateTypeGeneric(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test(self):
@@ -21,6 +22,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Discovered main module {{.*}}a.swiftmodule
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Module import remark: loaded module 'a'; source: '{{.*}}a.swiftmodule', loaded: '{{.*}}a.swiftmodule'
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_disable_esml(self):
@@ -40,6 +42,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         # DISABLED: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Module import remark: loaded module 'a'; source: 'a', loaded: 'a'
 
         
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/expression/access_control/TestSwiftExpressionAccessControl.py
+++ b/lldb/test/API/lang/swift/expression/access_control/TestSwiftExpressionAccessControl.py
@@ -8,6 +8,7 @@ import os
 class TestSwiftExpressionAccessControl(TestBase):
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_expression_access_control(self):
         """Make sure expressions ignore access control"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
+++ b/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
@@ -6,6 +6,7 @@ import os
 
 
 class TestSwiftExpressionActor(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_static_func(self):
         self.build()
@@ -15,6 +16,7 @@ class TestSwiftExpressionActor(TestBase):
 
         self.expect("expr self", substrs=["A.Type"])
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_func(self):
         self.build()

--- a/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
+++ b/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
@@ -9,6 +9,7 @@ class TestSwiftExprAllocator(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_allocator_self(self):
         """Test expressions involving self in a allocating constructor. In an

--- a/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
+++ b/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -14,24 +14,28 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 class TestClassConstrainedProtocol(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_extension_weak_self(self):
         """Test that we can reconstruct weak self captured in a class constrained protocol."""
         self.build()
         self.do_self_test("Break here for weak self", needs_dynamic=False)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_extension_self (self):
         """Test that we can reconstruct self in method of a class constrained protocol."""
         self.build()
         self.do_self_test("Break here in class protocol", needs_dynamic=False)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_method_weak_self(self):
         """Test that we can reconstruct weak self capture in method of a class conforming to a class constrained protocol."""
         self.build()
         self.do_self_test("Break here for method weak self", needs_dynamic=False)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_method_self(self):
         """Test that we can reconstruct self in method of a class conforming to a class constrained protocol."""

--- a/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
+++ b/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestExpressionsInSwiftMethodsFromObjC(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_expressions_from_objc(self):

--- a/lldb/test/API/lang/swift/expression/classes/open/TestSwiftExpressionOpenClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open/TestSwiftExpressionOpenClass.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestExpressionOpenClass(TestBase):
     NO_DEBUG_INFO_TEST = True
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Tests calling an open function"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestExpressionOpenResilientClass(TestBase):
     NO_DEBUG_INFO_TEST = True
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestExpressionsInSwiftMethodsPureSwift(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_expressions_in_methods(self):
         """Tests that we can run simple Swift expressions correctly"""

--- a/lldb/test/API/lang/swift/expression/empty_self/TestEmptySelf.py
+++ b/lldb/test/API/lang/swift/expression/empty_self/TestEmptySelf.py
@@ -13,4 +13,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -36,6 +36,7 @@ class TestUnitTests(TestBase):
     @expectedFailureAll(
         oslist=["linux"],
         bugnumber="rdar://28180489")
+    @skipEmbeddedSwift
     def test_equality_operators_fileprivate(self):
         """Test that we resolve expression operators correctly"""
         self.build()
@@ -46,6 +47,7 @@ class TestUnitTests(TestBase):
     @expectedFailureAll(
         oslist=["linux"],
         bugnumber="rdar://28180489")
+    @skipEmbeddedSwift
     def test_equality_operators_private(self):
         """Test that we resolve expression operators correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExpressionErrorMissingType(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureWindows
     def test(self):

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -7,6 +7,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_missing_location(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -31,6 +32,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         self.assertIn("no location for 'self' in debug info", all_messages)
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_missing_var(self):
         """Test error reporting in expressions reports
         only diagnostics in user code"""
@@ -85,6 +87,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         check(value)
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_missing_type(self):
         """Test error reporting in expressions reports
         only diagnostics in user code"""
@@ -115,6 +118,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
                     substrs=['self', 'not', 'found'])
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_syntax(self):
         """Test syntax errors are being diagnosed"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
@@ -34,7 +34,7 @@ class TestExpressionErrors(TestBase):
 
         self.checkCanThrow("IThrowObjectOver10", True)
         self.checkCanThrow("ClassError.SomeMethod", False)
- 
+
     def checkCanThrow(self, name, expected):
         sc_list = self.target.FindFunctions(name)
         self.assertEqual(sc_list.GetSize(), 1, "Error looking for %s"%(name))

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -29,6 +29,7 @@ def execute_command(command):
     return exit_status
 
 class TestExclusivitySuppression(TestBase):
+    @skipEmbeddedSwift
     # Test that we can evaluate w.s.i at Breakpoint 1 without triggering
     # a failure due to exclusivity
     @swiftTest
@@ -44,6 +45,7 @@ class TestExclusivitySuppression(TestBase):
 
         lldbutil.check_expression(self, frame, "w.s.i", "8", use_summary=False)
 
+    @skipEmbeddedSwift
     # Test that we properly handle nested expression evaluations by:
     # (1) Breaking at breakpoint 1
     # (2) Running 'expr get()' (which will hit breakpoint 2)

--- a/lldb/test/API/lang/swift/expression/function_definition/TestSwiftFunctionDefinition.py
+++ b/lldb/test/API/lang/swift/expression/function_definition/TestSwiftFunctionDefinition.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFunctionDefinition(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that persistent variables are mutable."""

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -29,12 +29,15 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_generic_expressions(self):
         """Test expressions in generic contexts"""
         self.build()
         self.do_test()
 
+    @skipEmbeddedSwift
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_ivars_in_generic_expressions(self):
         """Test ivar access through expressions in generic contexts"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -17,7 +17,7 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
     @skipIfWindows
     def test_negative(self):
         self.do_test('false')
-        
+
     def do_test(self, flag):
         """Test a .swiftmodule that was compiled with serialized debugging
            options, using a search path to another module it imports. We then

--- a/lldb/test/API/lang/swift/expression/language_version/TestSwiftExpressionLanguageVersion.py
+++ b/lldb/test/API/lang/swift/expression/language_version/TestSwiftExpressionLanguageVersion.py
@@ -7,6 +7,7 @@ class TestSwiftExpressionLanguageVersion(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test changing the Swift language version"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
+++ b/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExprMissingType(lldbtest.TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/expression/mutable_persistent_var/TestSwiftMutablePersistentVar.py
+++ b/lldb/test/API/lang/swift/expression/mutable_persistent_var/TestSwiftMutablePersistentVar.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftMutablePersistentVar(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test that persistent variables are mutable."""
         self.build()

--- a/lldb/test/API/lang/swift/expression/mutating_struct_extension/TestMutatingStructExtension.py
+++ b/lldb/test/API/lang/swift/expression/mutating_struct_extension/TestMutatingStructExtension.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -17,6 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftExpressionObjCContext(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -15,6 +15,7 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestOptionalAmbiguity(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_sample_rename_this(self):
         self.build()
@@ -27,7 +28,7 @@ class TestOptionalAmbiguity(TestBase):
 
     def print_in_closure(self):
         (_, _, thread, _) = lldbutil.run_to_source_breakpoint(self,
-                                "Set a breakpoint here", self.main_source_file) 
+                                "Set a breakpoint here", self.main_source_file)
 
         # Since the failure mode of a name collision is that the expression fails
         # to compile, I just check that here.

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestDefiningOverloadedFunctions(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_simple_overload_expressions(self):
         """Test defining overloaded functions"""

--- a/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
@@ -31,6 +31,7 @@ class TestSwiftExprInProtocolExtension(TestBase):
         self.continue_to_bkpt(self.process, bkpt)
         self.target.BreakpointDelete(bkpt.GetID())
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_protocol_extension(self):
         """Tests that swift expressions in protocol extension functions behave correctly"""

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 
 
 class TestSwiftProtocolExtensionSelf(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that the generic self in a protocol extension works in the expression evaluator.

--- a/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftExpressionScopes(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_expression_scopes(self):
         """Tests that swift expressions resolve scoped variables correctly"""

--- a/lldb/test/API/lang/swift/expression/self/TestSwiftSelf.py
+++ b/lldb/test/API/lang/swift/expression/self/TestSwiftSelf.py
@@ -13,4 +13,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
@@ -21,6 +21,7 @@ import sys
 
 
 class TestSwiftSimpleExpressions(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_simple_swift_expressions(self):
         """Tests that we can run simple Swift expressions correctly"""

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftExpressionsInClassFunctions(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_expressions_in_class_functions(self):
         """Test expressions in class func contexts"""

--- a/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
@@ -23,6 +23,7 @@ class TestSwiftSubmoduleImport(TestBase):
     # Have to find some submodule that is present on both Darwin & Linux for this
     # test to run on both systems...
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_submodule_import(self):

--- a/lldb/test/API/lang/swift/expression/typealias/TestSwiftExpressionTypeAlias.py
+++ b/lldb/test/API/lang/swift/expression/typealias/TestSwiftExpressionTypeAlias.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExpressionTypeAlias(lldbtest.TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftWeakGenericSelf(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Confirms that expression evaluation works with a generic class

--- a/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
@@ -12,12 +12,13 @@
 #
 import lldb
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test.decorators import *	
+from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
 
 class TestSwiftGenericExtension(TestBase):
+     @skipEmbeddedSwift
      @swiftTest
      def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestExternalProviderExtraInhabitants(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
+++ b/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
@@ -29,6 +29,7 @@ class TestFilePrivate(TestBase):
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that we find the right file-local private decls using the discriminator"""

--- a/lldb/test/API/lang/swift/first_expr_module_load/TestSwiftFirstExprModuleLoad.py
+++ b/lldb/test/API/lang/swift/first_expr_module_load/TestSwiftFirstExprModuleLoad.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFirstExprModuleLoad(lldbtest.TestBase):
 
+    @skipEmbeddedSwift
     @skipIf(oslist='windows')
     @swiftTest
     @skipUnlessFoundation

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftFixIts(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_fixits(self):
         """Test applying fixits to expressions"""

--- a/lldb/test/API/lang/swift/foundation/TestSwiftFoundation.py
+++ b/lldb/test/API/lang/swift/foundation/TestSwiftFoundation.py
@@ -12,4 +12,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipUnlessFoundation])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+        swiftTest,skipUnlessFoundation])

--- a/lldb/test/API/lang/swift/foundation_value_types/cfstringref/TestSwiftFoundationTypeCFStringRef.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/cfstringref/TestSwiftFoundationTypeCFStringRef.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFoundationTypeCFStringRef(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
@@ -15,7 +15,7 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[
+    decorators=[skipEmbeddedSwift,
         swiftTest,
         skipUnlessFoundation,
         skipIf(oslist=["windows"]),

--- a/lldb/test/API/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
@@ -13,4 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])
+                          decorators=[skipEmbeddedSwift,
+        swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])

--- a/lldb/test/API/lang/swift/foundation_value_types/decimal/TestSwiftFoundationTypeDecimal.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/decimal/TestSwiftFoundationTypeDecimal.py
@@ -2,5 +2,6 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])
+                          decorators=[skipEmbeddedSwift,
+        swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])
 ])

--- a/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftFoundationValueTypeGlobal(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
@@ -13,4 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipIf(oslist=['windows', 'linux'])])
+                          decorators=[skipEmbeddedSwift,
+        swiftTest,skipIf(oslist=['windows', 'linux'])])

--- a/lldb/test/API/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
@@ -23,6 +23,7 @@ class TestCase(TestBase):
         bugnumber="rdar://60396797",
         setting=("symbols.use-swift-clangimporter", "false"),
     )
+    @skipEmbeddedSwift
     def test_measurement(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -30,6 +31,7 @@ class TestCase(TestBase):
         )
         self.expect("expr -- measurement", substrs=["1.25 m"])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_measurement_without_swift_ast_context(self):

--- a/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -22,6 +22,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @expectedFailureAll(archs=["arm64_32"], bugnumber="<rdar://problem/58065423>")
     @skipUnlessFoundation
     @swiftTest

--- a/lldb/test/API/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
@@ -13,4 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])
+                          decorators=[skipEmbeddedSwift,
+        swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])

--- a/lldb/test/API/lang/swift/frame_var_object_fully_realized/TestFullyRealizedFrameVar.py
+++ b/lldb/test/API/lang/swift/frame_var_object_fully_realized/TestFullyRealizedFrameVar.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
+++ b/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFrameworkPaths(lldbtest.TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/generic_arg_in_extension/TestSwiftGenericArgInExtension.py
+++ b/lldb/test/API/lang/swift/generic_arg_in_extension/TestSwiftGenericArgInExtension.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
+++ b/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
+++ b/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class SwiftGenericClassTest(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests that a generic class type can be resolved from the instance metadata alone"""

--- a/lldb/test/API/lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
+++ b/lldb/test/API/lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generic_error/TestGenericError.py
+++ b/lldb/test/API/lang/swift/generic_error/TestGenericError.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
+++ b/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
@@ -17,6 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftGenericExtension(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/generic_extensions_typealias/TestGenericExtensionsTypealias.py
+++ b/lldb/test/API/lang/swift/generic_extensions_typealias/TestGenericExtensionsTypealias.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
+++ b/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftGenericFunction(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test display of generic function names"""

--- a/lldb/test/API/lang/swift/generic_objcclasswrapper/TestGenericObjcClassWrapper.py
+++ b/lldb/test/API/lang/swift/generic_objcclasswrapper/TestGenericObjcClassWrapper.py
@@ -1,4 +1,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+        swiftTest, skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/generic_self/TestSwiftGenericSelf.py
+++ b/lldb/test/API/lang/swift/generic_self/TestSwiftGenericSelf.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generic_struct_with_optional/TestGenericStructWithOptional.py
+++ b/lldb/test/API/lang/swift/generic_struct_with_optional/TestGenericStructWithOptional.py
@@ -1,5 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+        swiftTest,
     skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/generic_tuple/TestSwiftGenericTuple.py
+++ b/lldb/test/API/lang/swift/generic_tuple/TestSwiftGenericTuple.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generic_type_of_nested_archetype/TestSwiftGenericTypeOfNestedArchetype.py
+++ b/lldb/test/API/lang/swift/generic_type_of_nested_archetype/TestSwiftGenericTypeOfNestedArchetype.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
+++ b/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class SwiftDynamicTypeGenericsTest(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_genericresolution_commands(self):
         """Check that we can correctly figure out the dynamic type of generic things"""

--- a/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
+++ b/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftGetValueAsUnsignedAPITest(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_get_value_as_unsigned_sbapi(self):
         """Tests that the SBValue::GetValueAsUnsigned() API works for Swift types"""
         self.build()

--- a/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
+++ b/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftGenericClassInHashedContainerTest(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests that the type of hashed container whose value type is a non-generic class declared inside a generic class can be read from instance metadata"""

--- a/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
+++ b/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
@@ -11,6 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftHashedContainerEnum(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173243316
     def test_any_object_type(self):

--- a/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
+++ b/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftHideRuntimeSupport(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_hide_runtime_support(self):
         """Test that we hide runtime support values"""

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -36,6 +36,7 @@ class TestLibraryIndirect(TestBase):
 
         return info
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_implementation_only_import_library(self):
@@ -70,6 +71,7 @@ class TestLibraryIndirect(TestBase):
         self.expect("expr container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "value = (first = 2, second = 3)"])
         self.expect("expr container.wrapped.value", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_implementation_only_import_library_no_library_module(self):

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -37,6 +37,7 @@ class TestLibraryResilient(TestBase):
 
         return info
 
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureAll(oslist=["windows"]) # Requires Remote Mirrors support
     def test_implementation_only_import_library(self):
@@ -57,6 +58,7 @@ class TestLibraryResilient(TestBase):
         self.expect("expr container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
         self.expect("expr container.wrapped", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureAll(oslist=["windows"]) # Requires Remote Mirrors support
     def test_implementation_only_import_library_no_library_module(self):

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -42,6 +42,7 @@ class TestMainExecutable(TestBase):
         setting=("symbols.use-swift-clangimporter", "false"),
     )
     @swiftTest
+    @skipEmbeddedSwift
     @skipIfWindows
     def test_implementation_only_import_main_executable(self):
         """Test `@_implementationOnly import` in the main executable
@@ -67,6 +68,7 @@ class TestMainExecutable(TestBase):
         setting=("symbols.use-swift-clangimporter", "false"),
     )
     @swiftTest
+    @skipEmbeddedSwift
     @skipIfWindows
     @skipIfLinux # rdar://problem/67348391
     def test_implementation_only_import_main_executable_no_library_module(self):
@@ -99,6 +101,7 @@ class TestMainExecutable(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
 
     @swiftTest
+    @skipEmbeddedSwift
     @skipIfWindows
     @expectedFailureAll(oslist=["windows"])
     def test_implementation_only_import_main_executable_resilient(self):
@@ -121,6 +124,7 @@ class TestMainExecutable(TestBase):
         self.expect("expr TwoInts(4, 5)", substrs=["(SomeLibrary.TwoInts)", "= (first = 4, second = 5)"])
 
     @swiftTest
+    @skipEmbeddedSwift
     @skipIfWindows
     @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
     def test_implementation_only_import_main_executable_resilient_no_library_module(self):

--- a/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftCGImportedTypes(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_cg_imported_types(self):

--- a/lldb/test/API/lang/swift/inline_array/Makefile
+++ b/lldb/test/API/lang/swift/inline_array/Makefile
@@ -1,4 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFT_EMBEDDED_MODE := 1
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/inline_array/TestSwiftInlineArray.py
+++ b/lldb/test/API/lang/swift/inline_array/TestSwiftInlineArray.py
@@ -6,9 +6,10 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftInlineArray(lldbtest.TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
-    
+
     @swiftTest
     @skipIfWindows
+    @skipUnlessEmbeddedSwift
     def test(self):
         """Test the inline array synthetic child provider and summary"""
         self.build()

--- a/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
+++ b/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
@@ -23,6 +23,7 @@ class TestSwiftInstancePointerSetSP(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_instancepointerset_sp(self):
         """Test that we correctly track instance pointers in ValueObjectPrinter"""

--- a/lldb/test/API/lang/swift/late_dylib/TestSwiftLateDylib.py
+++ b/lldb/test/API/lang/swift/late_dylib/TestSwiftLateDylib.py
@@ -3,6 +3,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateDylib(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded 

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/TestSwiftLateDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/TestSwiftLateDylibClangDeps.py
@@ -3,6 +3,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateDylibClangDeps(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded 

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftLateDylib(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
@@ -3,6 +3,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateSwiftDylibClangDeps(TestBase):
+    @skipEmbeddedSwift
     @skipIf(macos_version=["<", "14.0"])
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/late_symbols/TestSwiftLateSymbols.py
+++ b/lldb/test/API/lang/swift/late_symbols/TestSwiftLateSymbols.py
@@ -6,6 +6,7 @@ import shutil
 import os
 
 class TestSwiftLateSymbols(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -10,6 +10,7 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
     # FIXME: Without the ClangImporter, transitive module dependencies can't be

--- a/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
+++ b/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftLetIntSupport(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_let_int(self):
         """Test that a 'let' Int is formatted properly"""
         self.build()

--- a/lldb/test/API/lang/swift/local_closure_types/TestSwiftLocalClosureTypes.py
+++ b/lldb/test/API/lang/swift/local_closure_types/TestSwiftLocalClosureTypes.py
@@ -17,6 +17,7 @@ lldbinline.MakeInlineTest(
     globals(),
     decorators=[
         swiftTest,
+        skipEmbeddedSwiftOnLinux,
         skipIf(oslist=["macosx"], bugnumber="rdar://26051759"),
         skipIfWindows # rdar://173245096
     ],

--- a/lldb/test/API/lang/swift/local_types/TestSwiftLocalTypes.py
+++ b/lldb/test/API/lang/swift/local_types/TestSwiftLocalTypes.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -26,6 +26,7 @@ class TestSwiftMacro(lldbtest.TestBase):
             'settings set target.experimental.swift-plugin-server-for-path %s=%s'
             % (self.getBuildDir(), swift_plugin_server))
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     # At the time of writing swift/test/Macros/macro_expand.swift is also disabled.
@@ -90,6 +91,7 @@ class TestSwiftMacro(lldbtest.TestBase):
         b = target.BreakpointCreateByName("stringify")
         self.assertGreaterEqual(b.GetNumLocations(), 1)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     # At the time of writing swift/test/Macros/macro_expand.swift is also disabled.

--- a/lldb/test/API/lang/swift/marker_protocol_existential/TestMarkerProtocolExistential.py
+++ b/lldb/test/API/lang/swift/marker_protocol_existential/TestMarkerProtocolExistential.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestMarkerProtocolExistential(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_marker_only(self):
         self.build()
@@ -17,6 +18,7 @@ class TestMarkerProtocolExistential(lldbtest.TestBase):
         x = s.GetChildMemberWithName("x")
         lldbutil.check_variable(self, x, value="42")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_marker_composition(self):
         self.build()
@@ -28,6 +30,7 @@ class TestMarkerProtocolExistential(lldbtest.TestBase):
         a = t.GetChildMemberWithName("a")
         lldbutil.check_variable(self, a, value="10")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_two_markers(self):
         self.build()
@@ -40,6 +43,7 @@ class TestMarkerProtocolExistential(lldbtest.TestBase):
         b = u.GetChildMemberWithName("b")
         lldbutil.check_variable(self, b, value="20")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_any_and_marker(self):
         self.build()
@@ -52,6 +56,7 @@ class TestMarkerProtocolExistential(lldbtest.TestBase):
         x = s.GetChildMemberWithName("x")
         lldbutil.check_variable(self, x, value="42")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_any_marker_and_non_marker(self):
         self.build()

--- a/lldb/test/API/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
+++ b/lldb/test/API/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/meta/TestSwiftMeta.py
+++ b/lldb/test/API/lang/swift/meta/TestSwiftMeta.py
@@ -24,6 +24,7 @@ class TestSwiftMeta(lldbtest.TestBase):
     def test_swiftDecorator(self):
         self.assertTrue(self.getDebugInfo() != "gmodules")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_swiftBuild(self):
         self.build()

--- a/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
+++ b/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
@@ -40,6 +40,7 @@ class TestSwiftMetadataCache(TestBase):
         return False
             
         
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_metadata_cache(self):
         """Test the swift metadata cache."""

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftMetatype(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_metatype(self):
         """Test the formatting of Swift metatypes"""

--- a/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
+++ b/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
@@ -14,6 +14,7 @@ class TestSwiftMissingSDK(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows'])
     @skipIfDarwinEmbedded # swift crash inspecting swift stdlib with little other swift loaded <rdar://problem/55079456> 

--- a/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
+++ b/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftMixAnyObjectType(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_any_object_type(self):

--- a/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
+++ b/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
@@ -9,6 +9,7 @@ class TestSwiftModuleImport(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -26,6 +26,7 @@ class TestSwiftModuleSearchPaths(TestBase):
 
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_module_search_paths(self):
         """
         Tests that we can import modules located using

--- a/lldb/test/API/lang/swift/multi_optionals/TestMultiOptionals.py
+++ b/lldb/test/API/lang/swift/multi_optionals/TestMultiOptionals.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/multibases/TestSwiftMultipleBases.py
+++ b/lldb/test/API/lang/swift/multibases/TestSwiftMultipleBases.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
+++ b/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
@@ -9,6 +9,7 @@ import os
 
 
 class TestMultilangFormatterCategories(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_multilang_formatter_categories(self):

--- a/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftMultipayloadEnum(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_multipayload_enum(self):
         """Test that LLDB understands generic enums with more than one payload type"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
+++ b/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
@@ -38,6 +38,7 @@ class TestSwiftNestedArray(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_nested_array(self):
         """Test Arrays of Arrays in Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_c_enums/TestSwiftNestedCEnums.py
+++ b/lldb/test/API/lang/swift/nested_c_enums/TestSwiftNestedCEnums.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/nested_generic/TestSwiftNestedGeneric.py
+++ b/lldb/test/API/lang/swift/nested_generic/TestSwiftNestedGeneric.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftNestedGeneric(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test the inline array synthetic child provider and summary"""

--- a/lldb/test/API/lang/swift/nested_generic_class/TestSwiftNestedGenericClass.py
+++ b/lldb/test/API/lang/swift/nested_generic_class/TestSwiftNestedGenericClass.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftNestedGenericClass(TestBase):
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Tests that a generic class type nested inside another generic class can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_marker_protocol_existential/TestNestedMarkerProtocolExistential.py
+++ b/lldb/test/API/lang/swift/nested_marker_protocol_existential/TestNestedMarkerProtocolExistential.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestNestedMarkerProtocolExistential(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/no_runtime/TestSwiftNoRuntime.py
+++ b/lldb/test/API/lang/swift/no_runtime/TestSwiftNoRuntime.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftNoRuntime(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test running a Swift expression in a C program"""

--- a/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
+++ b/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
@@ -15,5 +15,6 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[swiftTest, skipUnlessDarwin, skipIf(macos_version=["=", "15.0"])],
+    decorators=[skipEmbeddedSwift,
+        swiftTest, skipUnlessDarwin, skipIf(macos_version=["=", "15.0"])],
 )

--- a/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
+++ b/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/objc_obj_field/TestSwiftObjCObjField.py
+++ b/lldb/test/API/lang/swift/objc_obj_field/TestSwiftObjCObjField.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test(self):

--- a/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
+++ b/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftObjcProtocol(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
+++ b/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftObservation(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that types with private discriminators read from the file cache work"""

--- a/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftOneCaseEnum(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_one_case_enum(self):
         """Test that an enum with only one case does not crash LLDB"""

--- a/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
+++ b/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/opaque_return/TestBoundOpaqueArchetype.py
+++ b/lldb/test/API/lang/swift/opaque_return/TestBoundOpaqueArchetype.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestBoundOpaqueArchetype(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests that a type bound to an opaque archetype can be resolved correctly"""         

--- a/lldb/test/API/lang/swift/opaque_return_frame_var/TestSwiftGlobalOpaque.py
+++ b/lldb/test/API/lang/swift/opaque_return_frame_var/TestSwiftGlobalOpaque.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftGlobalOpaque(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests that a type bound to an opaque archetype can be resolved correctly"""         

--- a/lldb/test/API/lang/swift/opaque_return_resilient/TestSwiftOpaqueReturnResilient.py
+++ b/lldb/test/API/lang/swift/opaque_return_resilient/TestSwiftOpaqueReturnResilient.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOpaqueReturnResilient(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     @skipIfWindows
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/opaque_return_resilient_collection/TestSwiftOpaqueReturnResilientCollection.py
+++ b/lldb/test/API/lang/swift/opaque_return_resilient_collection/TestSwiftOpaqueReturnResilientCollection.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOpaqueReturnResilientCollection(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     @skipIfWindows
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/opaque_return_types/TestOpaqueReturnTypes.py
+++ b/lldb/test/API/lang/swift/opaque_return_types/TestOpaqueReturnTypes.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[
+    decorators=[skipEmbeddedSwift,
         swiftTest,
         skipIf(macos_version=["<", "10.15"]),
     ],

--- a/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
+++ b/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOpaque(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test opaque types in parameter positions"""         

--- a/lldb/test/API/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
+++ b/lldb/test/API/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
@@ -9,6 +9,7 @@ class TestSwiftOptimizedBoundGenericEnum(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test the bound generic enum types in "optimized" code."""

--- a/lldb/test/API/lang/swift/optional_cstruct/TestSwiftOptionalCStruct.py
+++ b/lldb/test/API/lang/swift/optional_cstruct/TestSwiftOptionalCStruct.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOptionalCStruct(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/optional_error_handling/TestSwiftOptionalErrorHandling.py
+++ b/lldb/test/API/lang/swift/optional_error_handling/TestSwiftOptionalErrorHandling.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftOptionalErrorHandling(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureWindows
     def test(self):

--- a/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
+++ b/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
@@ -18,6 +18,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestResilientObjectInOptional(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_optional_of_resilient(self):

--- a/lldb/test/API/lang/swift/optional_url/TestOptionalURL.py
+++ b/lldb/test/API/lang/swift/optional_url/TestOptionalURL.py
@@ -1,4 +1,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessFoundation, skipIf(oslist=['windows'])])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+        swiftTest, skipUnlessFoundation, skipIf(oslist=['windows'])])

--- a/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
+++ b/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
@@ -13,4 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin])
+                          decorators=[skipEmbeddedSwift,
+        swiftTest,skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/orig_defined_payload/TestSwiftOriginallyDefinedInPayload.py
+++ b/lldb/test/API/lang/swift/orig_defined_payload/TestSwiftOriginallyDefinedInPayload.py
@@ -6,6 +6,7 @@ import os
 
 
 class TestSwiftOriginallyDefinedInPayload(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
+++ b/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     def test(self):
         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 
@@ -35,11 +36,12 @@ class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
                 "t = (i = 50)",
             ],
         )
-    
+
     @swiftTest
+    @skipEmbeddedSwift
     def test_expr(self):
         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
-    
+
         self.build()
         filespec = lldb.SBFileSpec("main.swift")
         target, process, thread, breakpoint1 = lldbutil.run_to_source_breakpoint(
@@ -63,8 +65,9 @@ class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
                 "t = (i = 50)",
             ],
         )
-    
+
     @swiftTest
+    @skipEmbeddedSwift
     def test_expr_from_generic(self):
          """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 

--- a/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
+++ b/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
@@ -9,6 +9,7 @@ class TestSwiftOtherArchDylib(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftInterfaceDSYM(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))
     def test_dsym_swiftinterface(self):
@@ -79,6 +80,7 @@ class TestSwiftInterfaceDSYM(TestBase):
         self.assertEqual(len(a_modules), 1)
 
     @swiftTest
+    @skipEmbeddedSwift
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))
     def test_sanity_negative(self):
@@ -114,6 +116,7 @@ class TestSwiftInterfaceDSYM(TestBase):
         self.expect("expression x", error=1)
 
     @swiftTest
+    @skipEmbeddedSwift
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))
     def test_sanity_positive(self):

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -26,6 +26,7 @@ import os.path
 
 
 class TestSwiftInterfaceNoDebugInfo(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_swift_interface(self):
@@ -33,6 +34,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
         self.build()
         self.do_test()
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_swift_interface_fallback(self):
@@ -45,6 +47,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
             open(self.getBuildArtifact(module), 'w').close()
         self.do_test()
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipUnlessPlatform(["macosx"])

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -26,6 +26,7 @@ import os.path
 
 
 class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_swift_interface(self):
@@ -33,6 +34,7 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
         self.build()
         self.do_test()
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_swift_interface_fallback(self):

--- a/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/enum/TestSwiftPartiallyGenericFuncEnum.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/enum/TestSwiftPartiallyGenericFuncEnum.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/struct/TestSwiftPartiallyGenericFuncStruct.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/struct/TestSwiftPartiallyGenericFuncStruct.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
+++ b/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
@@ -36,6 +36,7 @@ class TestNonREPLPlayground(TestBase):
     @skipIf(
         debug_info=decorators.no_match("dsym"),
         bugnumber="This test only builds one way")
+    @skipEmbeddedSwift
     def test_playgrounds(self):
         """Test that playgrounds work"""
         self.build()

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -62,6 +62,7 @@ class TestSwiftPlaygrounds(TestBase):
             triple = '{}-apple-macosx{}'.format(machine, version)
         return triple
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
@@ -71,6 +72,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.launch(True)
         self.do_basic_test(True)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
@@ -80,6 +82,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.launch(False)
         self.do_basic_test(False)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
@@ -90,6 +93,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.launch(True)
         self.do_concurrency_test()
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
+++ b/lldb/test/API/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
+++ b/lldb/test/API/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
@@ -13,4 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])
+                          decorators=[skipEmbeddedSwift,
+        swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])

--- a/lldb/test/API/lang/swift/po/objc/TestSwiftPOObjC.py
+++ b/lldb/test/API/lang/swift/po/objc/TestSwiftPOObjC.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPOObjC(TestBase):
+    @skipEmbeddedSwift
     #NO_DEBUG_INFO_TESTCASE = True
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -16,6 +16,7 @@ class TestCase(TestBase):
         self.filecheck_log(self.log, __file__, f"-check-prefix=CHECK-{key}")
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_int(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -26,6 +27,7 @@ class TestCase(TestBase):
         # CHECK-INT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SiD")
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_string(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -35,6 +37,7 @@ class TestCase(TestBase):
         self._filecheck("STRING")
         # CHECK-STRING: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SSD")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_struct(self):
         self.build()
@@ -45,6 +48,7 @@ class TestCase(TestBase):
         self._filecheck("STRUCT")
         # CHECK-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a6StructVD")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_class(self):
         self.build()
@@ -55,6 +59,7 @@ class TestCase(TestBase):
         self._filecheck("CLASS")
         # CHECK-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a5ClassCD")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_enum(self):
         self.build()
@@ -65,6 +70,7 @@ class TestCase(TestBase):
         self._filecheck("ENUM")
         # CHECK-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a4EnumOD")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_generic_struct(self):
         self.build()
@@ -75,6 +81,7 @@ class TestCase(TestBase):
         self._filecheck("GEN-STRUCT")
         # CHECK-GEN-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a13GenericStructVySSGD")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_generic_class(self):
         self.build()
@@ -85,6 +92,7 @@ class TestCase(TestBase):
         self._filecheck("GEN-CLASS")
         # CHECK-GEN-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a12GenericClassCySSGD")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_generic_enum(self):
         self.build()
@@ -96,6 +104,7 @@ class TestCase(TestBase):
         # CHECK-GEN-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a11GenericEnumOySSGD")
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_described_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -106,6 +115,7 @@ class TestCase(TestBase):
         # CHECK-DESC-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a15DescribedStructVD")
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_described_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -116,6 +126,7 @@ class TestCase(TestBase):
         # CHECK-DESC-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a14DescribedClassCD")
 
     @swiftTest
+    @skipEmbeddedSwift
     def test_described_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
+++ b/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
+++ b/lldb/test/API/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/po/ref_types/TestSwiftPORefTypes.py
+++ b/lldb/test/API/lang/swift/po/ref_types/TestSwiftPORefTypes.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
+++ b/lldb/test/API/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
@@ -14,8 +14,8 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__,
                           globals(),
-                          decorators=[
-                              swiftTest,
+                          decorators=[skipEmbeddedSwift,
+        swiftTest,
                               skipIf(oslist=['windows']),
                               expectedFailureAll(oslist=["linux"],
                                                  bugnumber="rdar://83444822")

--- a/lldb/test/API/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
+++ b/lldb/test/API/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
@@ -13,4 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipIf(oslist=['windows'])])
+                          decorators=[skipEmbeddedSwift,
+        swiftTest,skipIf(oslist=['windows'])])

--- a/lldb/test/API/lang/swift/po/val_types/TestSwiftPOValTypes.py
+++ b/lldb/test/API/lang/swift/po/val_types/TestSwiftPOValTypes.py
@@ -17,6 +17,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftPOValueTypes(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_value_types(self):
         """Test 'po' on a variety of value types with and without custom descriptions."""
@@ -38,6 +39,7 @@ class TestSwiftPOValueTypes(TestBase):
         self.expect("po (dm as Any, cm as Any,48 as Any)", substrs=['12', '24', '36', '48'])
         self.expect("po patatino", substrs=['foo'])
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_ignore_bkpts_in_po(self):
         """Run a po expression with a breakpoint in the debugDescription, make sure we don't hit it."""

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftTypeLookup(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""

--- a/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
+++ b/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
@@ -27,6 +27,7 @@ class TestSwiftPrivateDeclName(TestBase):
         self.b_source = "b.swift"
         self.b_source_spec = lldb.SBFileSpec(self.b_source)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_private_decl_name(self):
         """Test that we correctly find private decls"""

--- a/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
+++ b/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
@@ -9,6 +9,7 @@ class TestSwiftPrivateDiscriminator(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     # FIXME: The only reason this doesn't work on Linux is because the
     # dylib hasn't been loaded when run_to_source_breakpoint wants to

--- a/lldb/test/API/lang/swift/private_generic_self/TestSwiftPrivateGenericSelf.py
+++ b/lldb/test/API/lang/swift/private_generic_self/TestSwiftPrivateGenericSelf.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -8,6 +8,7 @@ class TestSwiftPrivateGenericType(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_private_generic_type(self):

--- a/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
+++ b/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPrivateImport(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_private_import(self):

--- a/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
+++ b/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPrivateMember(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/private_nested_generic_class/TestSwiftPrivateNestedGenericClass.py
+++ b/lldb/test/API/lang/swift/private_nested_generic_class/TestSwiftPrivateNestedGenericClass.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class SwiftPrivateNestedGenericClassTest(TestBase):
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Tests that a private generic class type nested inside another generic class can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/private_self/TestSwiftPrivateSelf.py
+++ b/lldb/test/API/lang/swift/private_self/TestSwiftPrivateSelf.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest]
+    __file__, globals(), decorators=[skipEmbeddedSwift, swiftTest]
 )

--- a/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
+++ b/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftPrivateTypeAlias(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173243316
     def test_swift_private_typealias(self):

--- a/lldb/test/API/lang/swift/private_var/TestSwiftPrivateVar.py
+++ b/lldb/test/API/lang/swift/private_var/TestSwiftPrivateVar.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
+++ b/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftProtocolCompositionExpr(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that expression evaluation can call functions in protocol composition existentials"""

--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestDefaultProtocolExtensionNoSelfReference(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_protocol_default_extension_no_self_reference(self):
         """
         Test that we can resolve "self" even if there are no references to it in a dynamic context

--- a/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
+++ b/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[
+    decorators=[skipEmbeddedSwift,
         swiftTest,
         skipUnlessDarwin,
         expectedFailureAll(

--- a/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
+++ b/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/protocol_optional/TestSwiftProtocolOptional.py
+++ b/lldb/test/API/lang/swift/protocol_optional/TestSwiftProtocolOptional.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/protocols/class_protocol/TestSwiftClassConstrainedProtocolArgument.py
+++ b/lldb/test/API/lang/swift/protocols/class_protocol/TestSwiftClassConstrainedProtocolArgument.py
@@ -7,5 +7,5 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
     __file__, globals(),
-            decorators=[
-            swiftTest,skipUnlessDarwin])
+            decorators=[skipEmbeddedSwift,
+        swiftTest,skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/protocols/stepping_through_witness/TestSwiftSteppingThroughWitness.py
+++ b/lldb/test/API/lang/swift/protocols/stepping_through_witness/TestSwiftSteppingThroughWitness.py
@@ -14,6 +14,7 @@ class TestSwiftSteppingThroughWitness(TestBase):
             "settings set target.process.thread.step-avoid-libraries libswift_Concurrency.dylib"
         )
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_step_in_and_out(self):
         """Test that stepping in and out of protocol methods work"""
@@ -43,6 +44,7 @@ class TestSwiftSteppingThroughWitness(TestBase):
         frame0 = thread.frames[0]
         self.assertIn("doMath", frame0.GetFunctionName())
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_step_over(self):
         """Test that stepping over protocol methods work"""

--- a/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftRangeType(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_range_type(self):
         """Test the Swift.Range<T> type"""
         self.build()

--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftReferenceStorageTypes(TestBase):
+    @skipEmbeddedSwift
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
     def test_swift_reference_storage_types(self):

--- a/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
+++ b/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
@@ -9,6 +9,7 @@ class TestSwiftReflectionLoading(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
+++ b/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
@@ -9,6 +9,7 @@ class TestSwiftReflectionOnly(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -24,6 +24,7 @@ class TestSwiftRegex(TestBase):
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_frame_var(self):
@@ -48,6 +49,7 @@ class TestSwiftRegex(TestBase):
         self.expect('expr -O -- dslRegex',
                     substrs=['Regex<Substring>'])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_frame_var_desc(self):
@@ -60,6 +62,7 @@ class TestSwiftRegex(TestBase):
         self.expect('vo dslRegex',
                     substrs=['Regex<Substring>'])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_expr(self):
@@ -72,6 +75,7 @@ class TestSwiftRegex(TestBase):
         self.expect('expr dslRegex',
                     substrs=['(_StringProcessing.Regex<Substring>) $R1 = {'])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_in_exp(self):

--- a/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
@@ -22,6 +22,7 @@ def execute_command(command):
 
 
 class TestSwiftResilience(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     # Because we rename the .swiftmodule files after building the
@@ -33,6 +34,7 @@ class TestSwiftResilience(TestBase):
         self.build()
         self.doTestWithFlavor("a", "a")
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
@@ -41,6 +43,7 @@ class TestSwiftResilience(TestBase):
         self.build()
         self.doTestWithFlavor("a", "b")
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
@@ -49,6 +52,7 @@ class TestSwiftResilience(TestBase):
         self.build()
         self.doTestWithFlavor("b", "a")
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
+++ b/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
@@ -6,11 +6,13 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftResilienceOtherModule(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_with_debug_info(self):
         self.impl('break here with debug info')
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_without_debug_info(self):

--- a/lldb/test/API/lang/swift/resilience_private_field/TestSwiftResiliencePrivateField.py
+++ b/lldb/test/API/lang/swift/resilience_private_field/TestSwiftResiliencePrivateField.py
@@ -8,6 +8,7 @@ class TestSwiftResiliencePrivateField(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/resilience_private_method/TestSwiftResiliencePrivateMethod.py
+++ b/lldb/test/API/lang/swift/resilience_private_method/TestSwiftResiliencePrivateMethod.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftResiliencePrivateMethod(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/resilience_superclass/TestSwiftResilienceSuperclass.py
+++ b/lldb/test/API/lang/swift/resilience_superclass/TestSwiftResilienceSuperclass.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftResilienceSuperclass(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/TestSwiftResilienceSuperclassMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/TestSwiftResilienceSuperclassMod.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftResilienceSuperclassMod(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftResilienceSuperclassOtherMod(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftResilienceSwiftInterface(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/runtime_failure_recognizer/TestSwiftRuntimeFailureRecognizer.py
+++ b/lldb/test/API/lang/swift/runtime_failure_recognizer/TestSwiftRuntimeFailureRecognizer.py
@@ -23,6 +23,7 @@ class TestSwiftRuntimeRecognizer(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_runtime_recognizer(self):
         """Test Swift Runtime Failure Recognizer"""
         self.build()

--- a/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/TestSwiftRuntimeInstrumentationRecognizer.py
+++ b/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/TestSwiftRuntimeInstrumentationRecognizer.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftRuntimeInstrumentationRecognizer(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureWindows
     def test(self):

--- a/lldb/test/API/lang/swift/span/TestSwiftSpan.py
+++ b/lldb/test/API/lang/swift/span/TestSwiftSpan.py
@@ -6,6 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -23,6 +23,7 @@ class TestSwiftSplitDebug(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_split_debug_info(self):
         """Test split debug info"""

--- a/lldb/test/API/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
+++ b/lldb/test/API/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
@@ -32,6 +32,7 @@ class SwiftStaticLinkingMacOSTestCase(TestBase):
         self.expect("expr self", patterns=patterns,
                     substrs=substrs)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_variables_print_from_both_swift_modules(self):

--- a/lldb/test/API/lang/swift/stdlib/ContiguousArray/TestContiguousArray.py
+++ b/lldb/test/API/lang/swift/stdlib/ContiguousArray/TestContiguousArray.py
@@ -13,6 +13,7 @@ class TestContiguousArray(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_frame_contiguous_array(self):
         """Test that contiguous array prints correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/stdlib_marker_protocols/TestStdlibMarkerProtocols.py
+++ b/lldb/test/API/lang/swift/stdlib_marker_protocols/TestStdlibMarkerProtocols.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestStdlibMarkerProtocols(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
+++ b/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjcProtocol(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/step_into_override/TestStepIntoOverride.py
+++ b/lldb/test/API/lang/swift/step_into_override/TestStepIntoOverride.py
@@ -8,6 +8,7 @@ import platform
 class TestStepIntoOverride(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_stepping(self):
         self.build()

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -9,12 +9,14 @@ class TestStepThroughAllocatingInit(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_stepping_api(self):
         """Test that step in using the Python API steps through thunk."""
         self.build()
         self.do_test(True)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_stepping_cli(self):
         """Same test with the cli - it goes a slightly different path than
            the API."""

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -24,6 +24,7 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipEmbeddedSwift
     @skipIf(oslist=["linux"], archs=no_match("x86_64"))
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""

--- a/lldb/test/API/lang/swift/string/TestSwiftString.py
+++ b/lldb/test/API/lang/swift/string/TestSwiftString.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftTuple(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test the String formatter under adverse conditions"""
         self.build()

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -21,6 +21,7 @@ import shutil
 
 
 class TestSwiftStructChangeRerun(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_struct_change_rerun(self):
         """Test that we display self correctly for an inline-initialized struct"""

--- a/lldb/test/API/lang/swift/substituted_typealias/TestSwiftSubstitutedTypeAlias.py
+++ b/lldb/test/API/lang/swift/substituted_typealias/TestSwiftSubstitutedTypeAlias.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/swift_callback/TestSwiftCallback.py
+++ b/lldb/test/API/lang/swift/swift_callback/TestSwiftCallback.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
+++ b/lldb/test/API/lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
+++ b/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
@@ -21,6 +21,7 @@ import os.path
 import time
 
 class TestSwiftVersion(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_cross_module_extension(self):

--- a/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
+++ b/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftieFormatting(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swiftie_formatting(self):

--- a/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
+++ b/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 @skipIfDarwinEmbedded
 class TestCase(TestBase):
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_body(self):
@@ -17,6 +18,7 @@ class TestCase(TestBase):
         )
         self._do_test("self._count", 41, is_graph_update=True)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_appear(self):
@@ -28,6 +30,7 @@ class TestCase(TestBase):
         )
         self._do_test("self._count", 41, is_graph_update=False)
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_change(self):

--- a/lldb/test/API/lang/swift/symbolic_extended_existential/TestSwiftSymbolicExtendedExistential.py
+++ b/lldb/test/API/lang/swift/symbolic_extended_existential/TestSwiftSymbolicExtendedExistential.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftSymbolicExtendedExistential(lldbtest.TestBase):
 
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test symbolic extended existentials"""

--- a/lldb/test/API/lang/swift/system/TestSwiftSystemFilePath.py
+++ b/lldb/test/API/lang/swift/system/TestSwiftSystemFilePath.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test import lldbutil
 
 class TestSwiftSystemFilePath(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test(self):

--- a/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -8,6 +8,7 @@ class TestSwiftSystemFramework(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
     def test_system_framework(self):

--- a/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
+++ b/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
@@ -7,6 +7,7 @@ class TestSwiftTaggedPointer(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     # This test depends on NSObject, so it is not available on non-Darwin
     # platforms.

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftTuple(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()

--- a/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
+++ b/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class SwiftTypeMetadataTest(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_type_metadata(self):
         """Test that LLDB can effectively use the type metadata to reconstruct dynamic types for Swift"""

--- a/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
+++ b/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftTypeAliasOtherModule(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureWindows
     def test_frame_variable(self):
@@ -18,6 +19,7 @@ class TestSwiftTypeAliasOtherModule(TestBase):
         self.expect("continue")
         self.expect("frame variable -- payload", substrs=["Bool", "true"])
 
+    @skipEmbeddedSwift
     @swiftTest
     @expectedFailureWindows
     def test_expression(self):

--- a/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
+++ b/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftTypeAliasRecurtsive(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test that type aliases of type aliases can be resolved"""
         self.build()

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
+++ b/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
@@ -9,6 +9,7 @@ class TestSwiftCUnion(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_c_unions(self):
         self.build()

--- a/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
+++ b/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
@@ -28,6 +28,7 @@ class TestSwiftUnknownReference(lldbtest.TestBase):
         lldbutil.check_variable(self, m_string, summary='"world"')
 
     
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test_unknown_objc_ref(self):

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -33,6 +33,7 @@ class TestSwiftUnknownSelf(lldbtest.TestBase):
                     substrs=["hello"])
 
 
+    @skipEmbeddedSwift
     @skipIf(bugnumber="SR-10216", archs=['ppc64le'])
     @swiftTest
     @skipUnlessFoundation

--- a/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
+++ b/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
@@ -9,6 +9,7 @@ import os
 
 
 class TestSwiftActorTypes(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_class_types(self):
         """Test swift Actor types"""

--- a/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
+++ b/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
@@ -24,6 +24,7 @@ class TestSwiftArrayType(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_array(self):
         """Check formatting for Swift.Array<T>"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
+++ b/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
@@ -21,6 +21,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftBool(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_bool(self):
         """Test that we can inspect various Swift bools"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -23,6 +23,7 @@ import os
 
 
 class TestSwiftBridgedStringVariables(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_bridged_string_variables(self):

--- a/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestBulkyEnumVariables(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_bulky_enum_variables(self):
         """Tests that large-size Enum variables display correctly"""

--- a/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
+++ b/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftCoreGraphicsTypes(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_swift_coregraphics_types(self):

--- a/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
+++ b/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftClassTypes(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_class_types(self):
         """Test swift Class types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/closure_types/TestSwiftClosureTypes.py
+++ b/lldb/test/API/lang/swift/variables/closure_types/TestSwiftClosureTypes.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClosureTypes(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
@@ -27,6 +27,7 @@ class TestSwiftConsumeOperatorType(TestBase):
     # Skip on aarch64 linux: rdar://91005071
     @skipIf(archs=['aarch64'], oslist=['linux'])
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_consume_operator(self):
         """Check that we properly show variables at various points of the CFG while
         stepping with the consume operator.

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -24,6 +24,7 @@ def stderr_print(line):
     sys.stderr.write(line + "\n")
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while

--- a/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestDictionaryNSObjectAnyObject(TestBase):
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_dictionary_nsobject_any_object(self):

--- a/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -83,6 +83,7 @@ class TestSwiftStdlibDictionary(TestBase):
                 found, ("found a not expected child for '%s':'%s'" %
                         (key_str, value_str)))
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173243316
     # @skipIfLinux  # bugs.swift.org/SR-844

--- a/lldb/test/API/lang/swift/variables/enums/TestSwiftEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/enums/TestSwiftEnumVariables.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestEnumVariables(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_enum_variables(self):
         """Tests that Enum variables display correctly"""

--- a/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
+++ b/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
@@ -15,6 +15,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftErrorType(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         """Test handling of Swift Error types"""

--- a/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
+++ b/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
@@ -26,6 +26,7 @@ class TestSwiftGenericEnumTypes(TestBase):
         var.SetPreferSyntheticValue(True)
         return var
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_generic_enum_types(self):
         """Test that we handle reasonably generically-typed enums"""

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
+++ b/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
@@ -26,6 +26,7 @@ class TestSwiftGenericTupleLabels(lldbtest.TestBase):
     def setUp(self):
         lldbtest.TestBase.setUp(self)
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_generic_tuple_labels(self):
         """Test that LLDB can reconstruct tuple labels from metadata"""

--- a/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
+++ b/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftGenericTypes(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_generic_types(self):
         """Test support for generic types"""

--- a/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftGlobals(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_globals(self):
         """Check that we can examine module globals in the expression parser"""

--- a/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -20,12 +20,14 @@ import os
 
 
 class TestIndirectEnumVariables(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_indirect_cases_variables(self):
         """Tests that indirect Enum variables display correctly when cases are indirect"""
         self.build()
         self.do_test("indirect case break here")
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_indirect_enum_variables(self):
         """Tests that indirect Enum variables display correctly when enum is indirect"""

--- a/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
+++ b/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
@@ -18,6 +18,7 @@ import os
 
 
 class TestInOutVariables(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173243316
     def test_in_out_variables(self):

--- a/lldb/test/API/lang/swift/variables/let/TestSwiftLetConstants.py
+++ b/lldb/test/API/lang/swift/variables/let/TestSwiftLetConstants.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLetConstants(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_let_constants(self):
         """Test that let constants aren't writeable"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
+++ b/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftObjCImportedTypes(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_swift_objc_imported_types(self):

--- a/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -20,6 +20,7 @@ import os
 
 
 class TestSwiftObjCOptionalType(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_swift_objc_optional_type(self):

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftOptionalType(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_optional_type(self):
         """Check formatting for T? and T!"""
         self.do_check_consistency()

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftProtocolTypes(TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_protocol_types(self):
         """Test support for protocol types"""

--- a/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
+++ b/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
@@ -22,6 +22,7 @@ import os
 class TestSwiftStdlibSet(TestBase):
     @swiftTest
     @skipIfWindows # rdar://173243316
+    @skipEmbeddedSwiftOnLinux # Linker failure with arc4random_buf
     def test_swift_stdlib_set(self):
         """Tests that we properly vend synthetic children for Swift.Set"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
@@ -24,6 +24,7 @@ import os
 
 class TestSwiftStaticStringVariables(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_static_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
@@ -24,6 +24,7 @@ import os
 
 class TestSwiftStringVariables(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -21,6 +21,7 @@ import platform
 
 class TestSwiftTypes(TestBase):
     @swiftTest
+    @skipEmbeddedSwift
     @skipIfWindows
     def test_swift_types(self):
         """Test that we can inspect basic Swift types"""

--- a/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
+++ b/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftTupleTypes(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_tuple_types(self):
         """Test support for tuple types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
+++ b/lldb/test/API/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
@@ -2,8 +2,7 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[
-        swiftTest,
-        skipIfWindows # rdar://173243316
-    ]  
+    __file__,
+    globals(),
+    decorators=[skipEmbeddedSwift, swiftTest, skipIfWindows],  # rdar://173243316
 )

--- a/lldb/test/API/lang/swift/variables/unsafe/TestSwiftUnsafeTypes.py
+++ b/lldb/test/API/lang/swift/variables/unsafe/TestSwiftUnsafeTypes.py
@@ -15,6 +15,7 @@ class TestSwiftUnsafeTypes(TestBase):
         self.assertEqual(child.GetSummary(), 'nil')
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test formatters for unsafe types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
+++ b/lldb/test/API/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
@@ -22,6 +22,7 @@ import os
 class TestSwiftValueOfOptionalType(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
 
+    @skipEmbeddedSwift
     @swiftTest
     def test_swift_value_optional_type(self):
         """Check that trying to read an optional's numeric value doesn't crash LLDB"""

--- a/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
+++ b/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftVariadicGenerics(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIfAsan # rdar://152465885 Address Sanitizer assert doing `expr --bind-generic-types=false -- 0`

--- a/lldb/test/API/lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py
+++ b/lldb/test/API/lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py
@@ -52,6 +52,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         )
         self.assertEqual(breakpoint.GetNumLocations(), 1, breakpoint)
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173245044
     @skipIf(oslist=["linux"], archs=no_match("x86_64")) # rdar://170532470
@@ -69,6 +70,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         thread.StepOver()
         self.hit_correct_line(thread, "last main line")
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://173245044
     def test_step_in_and_out_callsite(self):

--- a/lldb/test/API/lang/swift/zero_size_generic_self/TestSwiftZeroSizeGenericSelf.py
+++ b/lldb/test/API/lang/swift/zero_size_generic_self/TestSwiftZeroSizeGenericSelf.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
+++ b/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
@@ -12,6 +12,7 @@ class TestSBValueUpdates(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.skipEmbeddedSwift
     def test_update_and_format_with_type_change(self):
         """Test that an SBValue can update and format itself as its type
         changes"""

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -31,6 +31,7 @@ class TestSwiftREPLExceptions(TestBase):
         self.main_source_file = lldb.SBFileSpec("main.swift")
         self.do_repl_mode_test()
 
+    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_repl_exceptions(self):


### PR DESCRIPTION
This adds a embedded Swift test variant that automatically re-runs test in embedded Swift mode unless
a test explicitly disables this behaviour. It also adds the required `skipIfEmbeddedSwift` to disable any tests
that currently do not work in embedded Swift. This patch does not yet remove any potentially redundant embedded Swift tests.

### How many tests have a passing embedded Swift variant?

About 33% (200) of the 584 Swift tests (1 test = 1 `test_*` method) pass with embedded Swift. It's hard to automatically classify the remaining failures but they range from LLDB crashing, to linker failures, to unavailable language features in embedded.

 I skipped everything without an explicit root cause attached for most tests. So for now a skip decorator that does not have a root-cause attached should be considered a potential bug.

### By how much does the test suite runtime increase?

On my M4 Pro machine with 14 logical cores I get the following test timing increases:

* When running all tests total testing time increases from 13:54 -> 14:45 (+6%)
* When running only Swift tests the total test time increases from 7:49 to 8:56 (+16%)

It should be noted that we could now also remove several `embedded/` tests so the actual test overhead of this could be lower than listed above. If we (optimistically) removed all potentially redundant embedded Swift tests we would save about 15 seconds of testing time. The numbers above change roughly to +4%/+10% test suite runtime overhead.