### PR TITLE
[lldb][windows] skip TestSwiftExpressionOpenResilientClass.py

### DIFF
--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestExpressionOpenResilientClass(TestBase):
     NO_DEBUG_INFO_TEST = True
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows
     def test(self):
         """Tests calling an open resilient function"""
         self.build()


### PR DESCRIPTION
`TestSwiftExpressionOpenResilientClass.py` is flaky on Windows CI. Skip it for now until it's fixed.