### PR TITLE
[clang][deps] Reimplement .d generation

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
@@ -33,12 +33,10 @@ public:
       DependencyScanningService &Service, StringRef WorkingDirectory,
       DependencyConsumer &Consumer, DependencyActionController &Controller,
       llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS,
-      bool DiagGenerationAsCompilation,
       std::optional<StringRef> ModuleName = std::nullopt,
       raw_ostream *VerboseOS = nullptr)
       : Service(Service), WorkingDirectory(WorkingDirectory),
         Consumer(Consumer), Controller(Controller), DepFS(std::move(DepFS)),
-        DiagGenerationAsCompilation(DiagGenerationAsCompilation),
         VerboseOS(VerboseOS) {}
   bool runInvocation(std::string Executable,
                      std::shared_ptr<CompilerInvocation> Invocation,
@@ -54,7 +52,6 @@ private:
   DependencyConsumer &Consumer;
   DependencyActionController &Controller;
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
-  bool DiagGenerationAsCompilation;
   std::optional<StringRef> ModuleName;
   std::optional<CompilerInstance> ScanInstanceStorage;
   std::shared_ptr<ModuleDepCollector> MDC;
@@ -102,8 +99,7 @@ void canonicalizeDefines(PreprocessorOptions &PPOpts);
 std::shared_ptr<CompilerInvocation>
 createScanCompilerInvocation(const CompilerInvocation &Invocation,
                              const DependencyScanningService &Service,
-                             DependencyActionController &Controller,
-                             bool DiagGenerationAsCompilation);
+                             DependencyActionController &Controller);
 
 /// Creates dependency output options to be reported to the dependency consumer,
 /// deducing missing information if necessary.

--- a/clang/include/clang/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningService.h
@@ -118,6 +118,10 @@ struct DependencyScanningServiceOptions {
   bool FlushModuleCache = true;
   /// Whether the caching VFS should cache missing filesystem entries.
   bool CacheNegativeStats = shouldCacheNegativeStatsDefault();
+  /// Whether the scanner should mimic the behavior of the compilation itself.
+  /// This enables generation of dependency files, and emission of full
+  /// diagnostics.
+  bool AsCompilation = false;
 };
 
 /// The dependency scanning service contains shared configuration and state that

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -188,7 +188,7 @@ public:
       std::shared_ptr<CompilerInvocation> Invocation,
       StringRef WorkingDirectory, DependencyConsumer &Consumer,
       DependencyActionController &Controller, DiagnosticConsumer &DiagsConsumer,
-      raw_ostream *VerboseOS, bool DiagGenerationAsCompilation);
+      raw_ostream *VerboseOS);
 
   DependencyScanningService &getService() const { return Service; }
 

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -100,8 +100,7 @@ public:
   Expected<cas::IncludeTreeRoot> getIncludeTreeFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
       clang::dependencies::LookupModuleOutputCallback LookupModuleOutput,
-      DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-      bool DiagGenerationAsCompilation);
+      DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS);
 
   /// Given a Clang driver command-line for a translation unit, gather the
   /// modular dependencies and return the information needed for explicit build.

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -526,10 +526,10 @@ void dependencies::initializeScanCompilerInstance(
 std::shared_ptr<CompilerInvocation> dependencies::createScanCompilerInvocation(
     const CompilerInvocation &Invocation,
     const DependencyScanningService &Service,
-    DependencyActionController &Controller, bool DiagGenerationAsCompilation) {
+    DependencyActionController &Controller) {
   auto ScanInvocation = std::make_shared<CompilerInvocation>(Invocation);
 
-  if (!DiagGenerationAsCompilation)
+  if (!Service.getOpts().AsCompilation)
     sanitizeDiagOpts(ScanInvocation->getDiagnosticOpts());
 
   ScanInvocation->getPreprocessorOpts().AllowPCHWithDifferentModulesCachePath =
@@ -631,6 +631,14 @@ dependencies::initializeScanInstanceDependencyCollector(
     CompilerInvocation &Inv, DependencyActionController &Controller,
     PrebuiltModulesAttrsMap PrebuiltModulesASTMap,
     SmallVector<StringRef> &StableDirs) {
+  // FIXME: Find a way to implement this via a DependencyConsumer.
+  if (Service.getOpts().AsCompilation && !DepOutputOpts->OutputFile.empty()) {
+    auto DFG = std::make_shared<ReversePrefixMappingDependencyFileGenerator>(
+        *DepOutputOpts);
+    DFG->initialize(ScanInstance.getInvocation());
+    ScanInstance.addDependencyCollector(std::move(DFG));
+  }
+
   auto MDC = std::make_shared<ModuleDepCollector>(
       Service, std::move(DepOutputOpts), ScanInstance, Consumer, Controller,
       Inv, std::move(PrebuiltModulesASTMap), StableDirs);
@@ -858,8 +866,8 @@ bool DependencyScanningAction::runInvocation(
   Scanned = true;
 
   // Create a compiler instance to handle the actual work.
-  auto ScanInvocation = createScanCompilerInvocation(
-      *OriginalInvocation, Service, Controller, DiagGenerationAsCompilation);
+  auto ScanInvocation =
+      createScanCompilerInvocation(*OriginalInvocation, Service, Controller);
 
   // Quickly discovers and compiles modules for the real scan below.
   std::optional<AsyncModuleCompiles> AsyncCompiles;

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -86,8 +86,7 @@ bool DependencyScanningWorker::computeDependencies(
   }
 
   DependencyScanningAction Action(Service, WorkingDirectory, DepConsumer,
-                                  Controller, DepFS,
-                                  /*DiagGenerationAsCompilation=*/false);
+                                  Controller, DepFS);
 
   const bool Success = llvm::all_of(CommandLines, [&](const auto &Cmd) {
     if (StringRef(Cmd[1]) != "-cc1") {
@@ -113,8 +112,7 @@ bool DependencyScanningWorker::computeDependencies(
 void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef WorkingDirectory,
     DependencyConsumer &DepsConsumer, DependencyActionController &Controller,
-    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-    bool DiagGenerationAsCompilation) {
+    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS) {
   DepFS->setCurrentWorkingDirectory(WorkingDirectory);
 
   // Adjust the invocation.
@@ -137,11 +135,8 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
     DepFile = Path.str().str();
   }
 
-  // FIXME: EmitDependencyFile should only be set when it's for a real
-  // compilation.
   DependencyScanningAction Action(Service, WorkingDirectory, DepsConsumer,
                                   Controller, DepFS,
-                                  DiagGenerationAsCompilation,
                                   /*ModuleName=*/std::nullopt, VerboseOS);
 
   // Ignore result; we're just collecting dependencies.

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -296,14 +296,13 @@ Expected<cas::IncludeTreeRoot>
 DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
     LookupModuleOutputCallback LookupModuleOutput,
-    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-    bool DiagGenerationAsCompilation) {
+    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS) {
   GetIncludeTree Consumer(*getCAS());
   auto Controller = createIncludeTreeActionController(LookupModuleOutput,
                                                       getCASOpts(), *getCAS());
-  Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
-      VerboseOS, DiagGenerationAsCompilation);
+  Worker.computeDependenciesFromCompilerInvocation(std::move(Invocation), CWD,
+                                                   Consumer, *Controller,
+                                                   DiagsConsumer, VerboseOS);
   return Consumer.getIncludeTree();
 }
 
@@ -605,15 +604,22 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
   // failed, but warnings are ignored and deferred for the main compilation.
   ScanInvocation->getDiagnosticOpts().IgnoreWarnings = true;
 
-  LookupModuleOutputCallback Lookup;
+  // Make the output file path absolute relative to WorkingDirectory.
+  std::string &DepFile = ScanInvocation->getDependencyOutputOpts().OutputFile;
+  if (!DepFile.empty() && !llvm::sys::path::is_absolute(DepFile)) {
+    // FIXME: On Windows, WorkingDirectory is insufficient for making an
+    // absolute path if OutputFile has a root name.
+    llvm::SmallString<128> Path = StringRef(DepFile);
+    llvm::sys::path::make_absolute(WorkingDirectory, Path);
+    DepFile = Path.str().str();
+  }
 
   std::optional<llvm::cas::CASID> Root;
   if (Error E =
           Tool.getIncludeTreeFromCompilerInvocation(
                   std::move(ScanInvocation), WorkingDirectory,
-                  /*LookupModuleOutput=*/nullptr, DiagsConsumer, VerboseOS,
-                  /*DiagGenerationAsCompilation=*/true)
-                    .moveInto(Root))
+                  /*LookupModuleOutput=*/nullptr, DiagsConsumer, VerboseOS)
+              .moveInto(Root))
     return std::move(E);
 
   // Turn off dependency outputs. Should have already been emitted.
@@ -661,8 +667,7 @@ bool CompilerInstanceWithContext::initialize(
       makeInProcessModuleCache(Worker.Service.getModuleCacheEntries());
   CIPtr = std::make_unique<CompilerInstance>(
       createScanCompilerInvocation(*OriginalInvocation, Worker.Service,
-                                   Controller,
-                                   /*DiagGenerationAsCompilation=*/false),
+                                   Controller),
       Worker.PCHContainerOps, std::move(ModCache));
   auto &CI = *CIPtr;
 

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -555,6 +555,7 @@ scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
         DB, llvm::vfs::createPhysicalFileSystem());
   };
   Opts.Compilation = dependencies::IncludeTreeCompilation{CASOpts, DB, Cache};
+  Opts.AsCompilation = true;
   dependencies::DependencyScanningService Service(std::move(Opts));
   tooling::DependencyScanningTool Tool(Service);
 
@@ -1005,6 +1006,7 @@ int ScanServer::listen() {
         CAS, llvm::vfs::createPhysicalFileSystem());
   };
   Opts.Compilation = dependencies::IncludeTreeCompilation{CASOpts, CAS, Cache};
+  Opts.AsCompilation = true;
   dependencies::DependencyScanningService Service(std::move(Opts));
 
   std::atomic<int> NumRunning(0);


### PR DESCRIPTION
This removes the `DiagGenerationAsCompilation` function argument and introduces a service option `AsCompilation`. This minimizes the upstream diff, and also reimplements the dependency file generation that was dropped when merging recent upstream changes.