### PR TITLE
[lldb] Update filecheck_log to use direct input (NFC-ish) (#193618)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2673,14 +2673,16 @@ FileCheck output:
             filecheck_options,
         )
 
-    def filecheck_log(
-        self, log_file, check_file, filecheck_options="", expect_cmd_failure=False
-    ):
+    def filecheck_log(self, log_file, check_file, filecheck_options=None):
+        input_option = f"-input-file={log_file}"
+        if filecheck_options:
+            filecheck_options = [filecheck_options, input_option]
+        else:
+            filecheck_options = input_option
         return self.filecheck(
-            f"platform shell -h -- cat {log_file}",
+            "script None",
             check_file,
             filecheck_options,
-            expect_cmd_failure,
         )
 
     def expect(


### PR DESCRIPTION
Pass log files as direct input to `FileCheck` via its `-input-file`
option.

I had a failing test case where the log file contains the string being
checked for, and yet `FileCheck` failed. While debugging, I noticed the
output from running `platform shell -h -- cat ...` was somehow
truncated. I have not debugged why. As soon as I saw the issue, I
figured it was best to skip all the intermediaries, and pass the log
file straight to `FileCheck`.

(cherry picked from commit 819aabfe1ba19ff85230abad7fb585e4069080bd)

(cherry picked from commit bc4fcde9e3b77e5f6bb1759fa1e4dedf9e321578)