### PR TITLE
[lldb][test] Compile with -parse-as-library for test main.swift sources containing @main (#12838)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -212,6 +212,10 @@ ifeq "$(USESWIFTDRIVER)" "1"
 #----------------------------------------------------------------------
 ifeq "$(DYLIB_NAME)" ""
 MODULENAME?=$(shell basename $(EXE) .out)
+# Compile with -parse-as-library when main.swift contains "@main".
+ifneq "$(shell grep -w '@main' $(VPATH)/main.swift 2>/dev/null)" ""
+PARSE_AS_LIBRARY = -parse-as-library
+endif
 else
 EXE = $(DYLIB_FILENAME)
 MODULENAME?=$(DYLIB_NAME)

--- a/lldb/test/API/functionalities/data-formatter/swift/bridged-string/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/swift/bridged-string/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/array_uninitialized/Makefile
+++ b/lldb/test/API/lang/swift/array_uninitialized/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/Makefile
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/async_fnargs/Makefile
+++ b/lldb/test/API/lang/swift/async/async_fnargs/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/continuations/Makefile
+++ b/lldb/test/API/lang/swift/async/continuations/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/expr/Makefile
+++ b/lldb/test/API/lang/swift/async/expr/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/children/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/name/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -disable-availability-checking
+SWIFTFLAGS_EXTRAS := -Xfrontend -disable-availability-checking
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/parent/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/parent/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/frame/language_specific_data/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/language_specific_data/Makefile
@@ -1,4 +1,3 @@
 SWIFT_SOURCES := main.swift
 SWIFT_ENABLE_EXPLICIT_MODULES := YES
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/frame/variable/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/variable/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/queues/Makefile
+++ b/lldb/test/API/lang/swift/async/queues/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step-in/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_out/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_over/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/taskgroups/Makefile
+++ b/lldb/test/API/lang/swift/async/taskgroups/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/info/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/info/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/list/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/list/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/tree/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/tree/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/backtrace_locals/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/backtrace_locals/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/hidden_frames/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/hidden_frames/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_register_pressure/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_register_pressure/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -Xllvm -Xfrontend --emit-dwarf-unwind=always
+SWIFTFLAGS_EXTRAS := -Xfrontend -Xllvm -Xfrontend --emit-dwarf-unwind=always
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/variables/Makefile
+++ b/lldb/test/API/lang/swift/async/variables/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -enable-upcoming-feature -Xfrontend NonisolatedNonsendingByDefault
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-upcoming-feature -Xfrontend NonisolatedNonsendingByDefault
 include Makefile.rules

--- a/lldb/test/API/lang/swift/bridged_url/Makefile
+++ b/lldb/test/API/lang/swift/bridged_url/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/command_memory_read/Makefile
+++ b/lldb/test/API/lang/swift/command_memory_read/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
@@ -1,5 +1,4 @@
 SWIFT_SOURCES := main.swift
 SWIFT_EMBEDDED_CONCURRENCY := 1
-SWIFTFLAGS_EXTRAS := -parse-as-library
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/generic_arguments/Makefile
+++ b/lldb/test/API/lang/swift/generic_arguments/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/Makefile
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/span/Makefile
+++ b/lldb/test/API/lang/swift/span/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -disable-availability-checking
+SWIFTFLAGS_EXTRAS := -Xfrontend -disable-availability-checking
 include Makefile.rules

--- a/lldb/test/API/lang/swift/swiftui_formatters/Makefile
+++ b/lldb/test/API/lang/swift/swiftui_formatters/Makefile
@@ -1,4 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
-
 include Makefile.rules

--- a/lldb/test/API/lang/swift/system/Makefile
+++ b/lldb/test/API/lang/swift/system/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/Makefile
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/Makefile
@@ -1,4 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
 
 include Makefile.rules


### PR DESCRIPTION
Update `Swift.rules` to automatically use the `-parse-as-library` compiler flag when the
following conditions are true: 1. A source file is named main.swift 2. main.swift
contains the `@main` marker
(cherry picked from commit 276feb0acaa7e94fa7548b850fa0426f0144e957)