### PR TITLE
Stack of patches to improve Swift expression diagnostics

### DIFF
--- a/lldb/include/lldb/Expression/LLVMUserExpression.h
+++ b/lldb/include/lldb/Expression/LLVMUserExpression.h
@@ -78,9 +78,6 @@ protected:
             lldb::UserExpressionSP &shared_ptr_to_me,
             lldb::ExpressionVariableSP &result) override;
 
-  virtual void ScanContext(ExecutionContext &exe_ctx,
-                           lldb_private::Status &err) = 0;
-
   bool PrepareToExecuteJITExpression(DiagnosticManager &diagnostic_manager,
                                      ExecutionContext &exe_ctx,
                                      lldb::addr_t &struct_address);

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -55,11 +55,13 @@
 namespace lldb_private {
 
 class ClangModulesDeclVendor;
+// BEGIN SWIFT
 class SwiftPersistentExpressionState;
 class SharedMutex;
 class TypeSystemSwiftTypeRefForExpressions;
 typedef std::shared_ptr<TypeSystemSwiftTypeRefForExpressions>
     TypeSystemSwiftTypeRefForExpressionsSP;
+// END SWIFT
 
 
 OptionEnumValues GetDynamicValueTypes();
@@ -189,6 +191,7 @@ public:
 
   FileSpecList GetClangModuleSearchPaths();
 
+  // BEGIN SWIFT  
   FileSpecList GetSwiftFrameworkSearchPaths();
 
   FileSpecList GetSwiftModuleSearchPaths();
@@ -234,6 +237,7 @@ public:
   bool GetUseAllCompilerFlags() const;
 
   void SetUseAllCompilerFlags(bool b);
+  // END SWIFT  
 
   ImportStdModule GetImportStdModule() const;
 
@@ -521,19 +525,14 @@ public:
 
   void SetREPLEnabled(bool b) { m_repl = b; }
 
+  // BEGIN SWIFT
   bool GetPlaygroundTransformEnabled() const { return m_playground; }
 
   void SetPlaygroundTransformEnabled(bool b) {
     m_playground = b;
   }
 
-  lldb::BindGenericTypes GetBindGenericTypes() const {
-    return m_bind_generic_types;
-  }
-
-  void SetBindGenericTypes(lldb::BindGenericTypes b) {
-    m_bind_generic_types = b;
-  }
+  lldb::BindGenericTypes GetSwiftBindGenericTypes() const;
 
   bool GetPlaygroundTransformHighPerformance() const {
     return m_playground_transforms_hp;
@@ -542,6 +541,7 @@ public:
   void SetPlaygroundTransformHighPerformance(bool b) {
     m_playground_transforms_hp = b;
   }
+  // END SWIFT
 
   void SetCancelCallback(lldb::ExpressionCancelCallback callback, void *baton) {
     m_cancel_callback_baton = baton;
@@ -648,8 +648,6 @@ private:
   /// True if the executed code should be treated as utility code that is only
   /// used by LLDB internally.
   bool m_running_utility_expression = false;
-
-  lldb::BindGenericTypes m_bind_generic_types = lldb::eBindAuto;
 
   lldb::DynamicValueType m_use_dynamic = lldb::eNoDynamicValues;
   Timeout<std::micro> m_timeout = default_timeout;

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -259,7 +259,9 @@ CommandObjectExpression::CommandOptions::GetEvaluateExpressionOptions(
     options.SetTimeout(std::nullopt);
 
   // BEGIN SWIFT
-  options.SetBindGenericTypes(bind_generic_types);
+  if (bind_generic_types != eBindAuto)
+    llvm::cantFail(options.SetBooleanLanguageOption(
+        "swift-bind-generic-types", bind_generic_types == eBind));
   // END SWIFT
   return options;
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -91,7 +91,8 @@ ClangUserExpression::ClangUserExpression(
 
 ClangUserExpression::~ClangUserExpression() = default;
 
-void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
+void ClangUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
+                                      ExecutionContext &exe_ctx) {
   Log *log = GetLog(LLDBLog::Expressions);
 
   LLDB_LOGF(log, "ClangUserExpression::ScanContext()");
@@ -159,12 +160,12 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
         lldb::VariableListSP variable_list_sp(
             function_block->GetBlockVariableList(true));
 
-        const char *thisErrorString = "Stopped in a C++ method, but 'this' "
-                                      "isn't available; pretending we are in a "
-                                      "generic context";
+        const char *msg = "Stopped in a C++ method, but 'this' isn't "
+                          "available; pretending we are in a generic context";
 
         if (!variable_list_sp) {
-          err = Status::FromErrorString(thisErrorString);
+          diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                           eDiagnosticOriginLLDB);
           return;
         }
 
@@ -173,7 +174,8 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
         if (!this_var_sp || !this_var_sp->IsInScope(frame) ||
             !this_var_sp->LocationIsValidForFrame(frame)) {
-          err = Status::FromErrorString(thisErrorString);
+          diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                           eDiagnosticOriginLLDB);
           return;
         }
       }
@@ -189,12 +191,12 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
         lldb::VariableListSP variable_list_sp(
             function_block->GetBlockVariableList(true));
 
-        const char *selfErrorString = "Stopped in an Objective-C method, but "
-                                      "'self' isn't available; pretending we "
-                                      "are in a generic context";
+        const char *msg = "Stopped in an Objective-C method, but 'self' isn't "
+                          "available; pretending we are in a generic context";
 
         if (!variable_list_sp) {
-          err = Status::FromErrorString(selfErrorString);
+          diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                           eDiagnosticOriginLLDB);
           return;
         }
 
@@ -203,7 +205,8 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
         if (!self_variable_sp || !self_variable_sp->IsInScope(frame) ||
             !self_variable_sp->LocationIsValidForFrame(frame)) {
-          err = Status::FromErrorString(selfErrorString);
+          diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                           eDiagnosticOriginLLDB);
           return;
         }
       }
@@ -232,13 +235,13 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
           lldb::VariableListSP variable_list_sp(
               function_block->GetBlockVariableList(true));
 
-          const char *thisErrorString = "Stopped in a context claiming to "
-                                        "capture a C++ object pointer, but "
-                                        "'this' isn't available; pretending we "
-                                        "are in a generic context";
+          const char *msg = "Stopped in a context claiming to capture a C++ "
+                            "object pointer, but 'this' isn't available; "
+                            "pretending we are in a generic context";
 
           if (!variable_list_sp) {
-            err = Status::FromErrorString(thisErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
@@ -247,7 +250,8 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           if (!this_var_sp || !this_var_sp->IsInScope(frame) ||
               !this_var_sp->LocationIsValidForFrame(frame)) {
-            err = Status::FromErrorString(thisErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
         }
@@ -259,13 +263,13 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
           lldb::VariableListSP variable_list_sp(
               function_block->GetBlockVariableList(true));
 
-          const char *selfErrorString =
-              "Stopped in a context claiming to capture an Objective-C object "
-              "pointer, but 'self' isn't available; pretending we are in a "
-              "generic context";
+          const char *msg = "Stopped in a context claiming to capture an "
+                            "Objective-C object pointer, but 'self' isn't "
+                            "available; pretending we are in a generic context";
 
           if (!variable_list_sp) {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
@@ -274,21 +278,24 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           if (!self_variable_sp || !self_variable_sp->IsInScope(frame) ||
               !self_variable_sp->LocationIsValidForFrame(frame)) {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
           Type *self_type = self_variable_sp->GetType();
 
           if (!self_type) {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
           CompilerType self_clang_type = self_type->GetForwardCompilerType();
 
           if (!self_clang_type) {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
@@ -299,7 +306,8 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
             m_in_objectivec_method = true;
             m_needs_object_ptr = true;
           } else {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
         } else {
@@ -525,7 +533,7 @@ bool ClangUserExpression::PrepareForParsing(
     return false;
 
   Status err;
-  ScanContext(exe_ctx, err);
+  ScanContext(diagnostic_manager, exe_ctx);
 
   if (!err.Success()) {
     diagnostic_manager.PutString(lldb::eSeverityWarning, err.AsCString());

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
@@ -206,8 +206,8 @@ private:
 
   void SetupCppModuleImports(ExecutionContext &exe_ctx);
 
-  void ScanContext(ExecutionContext &exe_ctx,
-                   lldb_private::Status &err) override;
+  void ScanContext(DiagnosticManager &diagnostic_manager,
+                   ExecutionContext &exe_ctx);
 
   bool AddArguments(ExecutionContext &exe_ctx, std::vector<lldb::addr_t> &args,
                     lldb::addr_t struct_address,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1436,7 +1436,7 @@ SwiftExpressionParser::ParseAndImport(
   if (repl || !playground) {
     code_manipulator = std::make_unique<SwiftASTManipulator>(
         m_swift_ast_ctx, *source_file, m_sc, repl,
-        m_options.GetBindGenericTypes());
+        m_options.GetSwiftBindGenericTypes());
 
     if (!playground) {
       code_manipulator->RewriteResult();
@@ -1458,7 +1458,7 @@ SwiftExpressionParser::ParseAndImport(
       if (local_context_is_swift) {
         llvm::Error error = AddRequiredAliases(
             m_sc.block, stack_frame_sp, m_swift_ast_ctx, *code_manipulator,
-            m_options.GetUseDynamic(), m_options.GetBindGenericTypes());
+            m_options.GetUseDynamic(), m_options.GetSwiftBindGenericTypes());
         if (error)
           return error;
       }
@@ -1750,9 +1750,10 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 
   // The result in case parsing the expression fails. If the option is auto
   // expression evaluation should retry by binding the generic types.
-  auto parse_result_failure = m_options.GetBindGenericTypes() == lldb::eBindAuto
-                                  ? ParseResult::retry_bind_generic_params
-                                  : ParseResult::unrecoverable_error;
+  auto parse_result_failure =
+      m_options.GetSwiftBindGenericTypes() == lldb::eBindAuto
+          ? ParseResult::retry_bind_generic_params
+          : ParseResult::unrecoverable_error;
   // Helper function to diagnose errors in m_swift_scratch_context.
   unsigned buffer_id = UINT32_MAX;
   auto DiagnoseSwiftASTContextError = [&]() {
@@ -2181,7 +2182,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 
   if (ThreadSafeASTContext ast_ctx = m_swift_ast_ctx.GetASTContext()) {
     if (!SwiftASTManipulator::ShouldBindGenericTypes(
-            m_options.GetBindGenericTypes()) &&
+            m_options.GetSwiftBindGenericTypes()) &&
         !RedirectCallFromSinkToTrampolineFunction(
             *m_module.get(), *parsed_expr->code_manipulator.get(), **ast_ctx)) {
       diagnostic_manager.Printf(

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -442,7 +442,7 @@ do {
 
     // The expression text is inserted into the body of $__lldb_user_expr_%u.
     if (!SwiftASTManipulator::ShouldBindGenericTypes(
-            options.GetBindGenericTypes())) {
+            options.GetSwiftBindGenericTypes())) {
       // A Swift program can't have types with non-bound generic type parameters
       // inside a non generic function. For example, the following program would
       // not compile as T is not part of foo's signature.
@@ -546,7 +546,7 @@ func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
                             current_counter);
     }
   } else if (!SwiftASTManipulator::ShouldBindGenericTypes(
-                 options.GetBindGenericTypes())) {
+                 options.GetSwiftBindGenericTypes())) {
     auto c = MakeGenericSignaturesAndCalls(local_variables, generic_sig,
                                            needs_object_ptr);
     if (!c) {

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -312,8 +312,10 @@ bool SwiftUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
 
 /// Create a \c VariableInfo record for \c variable if there isn't
 /// already shadowing inner declaration in \c processed_variables.
+/// This function only returns an Error if `self` cannot be reconstructed.
 static llvm::Error AddVariableInfo(
-    lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
+    lldb::VariableSP variable_sp, DiagnosticManager &diagnostic_manager,
+    lldb::StackFrameSP &stack_frame_sp,
     SwiftASTContextForExpressions &ast_context, SwiftLanguageRuntime *runtime,
     llvm::SmallDenseSet<const char *, 8> &processed_variables,
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
@@ -398,19 +400,20 @@ static llvm::Error AddVariableInfo(
   // to get very far making a local out of it, so discard it here.
   Log *log = GetLog(LLDBLog::Types | LLDBLog::Expressions);
   if (could_not_resolve) {
-    if (log)
-      log->Printf("Discarding local %s because we couldn't fully realize it, "
-                  "our best attempt was: %s.",
-                  name_cstr,
-                  target_type.GetDisplayTypeName().AsCString("<unknown>"));
+    std::string msg =
+        llvm::formatv("discarded local '{0}', type '{1}' could not be realized",
+                      name, target_type.GetDisplayTypeName());
+    diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                     eDiagnosticOriginLLDB);
+
     // Not realizing self is a fatal error for an expression and the
     // Swift compiler error alone is not particularly useful.
     if (is_self)
       return llvm::createStringError(
           llvm::inconvertibleErrorCode(),
-          "Discarding local %s because we couldn't fully realize it, "
+          "Discarding self because we couldn't fully realize it, "
           "our best attempt was: %s.",
-          name_cstr, target_type.GetDisplayTypeName().AsCString("<unknown>"));
+          target_type.GetDisplayTypeName().AsCString("<unknown>"));
     return llvm::Error::success();
   }
 
@@ -517,7 +520,8 @@ static void CollectVariablesInScope(SymbolContext &sc,
 
 /// Create a \c VariableInfo record for each visible variable.
 static llvm::Error RegisterAllVariables(
-    SymbolContext &sc, lldb::StackFrameSP &stack_frame_sp,
+    DiagnosticManager &diagnostic_manager, SymbolContext &sc,
+    lldb::StackFrameSP &stack_frame_sp,
     SwiftASTContextForExpressions &ast_context,
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
     lldb::DynamicValueType use_dynamic,
@@ -535,10 +539,10 @@ static llvm::Error RegisterAllVariables(
   // not already shadowed by an inner declaration.
   llvm::SmallDenseSet<const char *, 8> processed_names;
   for (size_t vi = 0, ve = variables.GetSize(); vi != ve; ++vi)
-    if (auto error =
-            AddVariableInfo({variables.GetVariableAtIndex(vi)}, stack_frame_sp,
-                            ast_context, language_runtime, processed_names,
-                            local_variables, use_dynamic, bind_generic_types))
+    if (auto error = AddVariableInfo(
+            {variables.GetVariableAtIndex(vi)}, diagnostic_manager,
+            stack_frame_sp, ast_context, language_runtime, processed_names,
+            local_variables, use_dynamic, bind_generic_types))
       return error;
   return llvm::Error::success();
 }
@@ -656,8 +660,9 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
 
   if (!m_options.GetUseContextFreeSwiftPrintObject()) {
     if (llvm::Error error = RegisterAllVariables(
-            sc, stack_frame, *m_swift_ast_ctx, local_variables,
-            m_options.GetUseDynamic(), m_options.GetSwiftBindGenericTypes())) {
+            diagnostic_manager, sc, stack_frame, *m_swift_ast_ctx,
+            local_variables, m_options.GetUseDynamic(),
+            m_options.GetSwiftBindGenericTypes())) {
       diagnostic_manager.PutString(lldb::eSeverityInfo,
                                    llvm::toString(std::move(error)));
       diagnostic_manager.PutString(

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -349,7 +349,7 @@ static llvm::Error AddVariableInfo(
       should_not_bind_generic_types &&
       (variable_sp->GetType()->GetForwardCompilerType().GetTypeInfo() &
        lldb::eTypeIsPack);
-  bool is_meaningless_without_dynamic_resolution = false;
+  bool could_not_resolve = false;
   // If we're not binding the generic types, we need to set the self type as an
   // opaque pointer type. This is necessary because we don't bind the generic
   // parameters, and we can't have a type with unbound generics in a non-generic
@@ -363,8 +363,10 @@ static llvm::Error AddVariableInfo(
     CompilerType var_type = SwiftExpressionParser::ResolveVariable(
         variable_sp, stack_frame_sp, runtime, use_dynamic, bind_generic_types);
 
-    is_meaningless_without_dynamic_resolution =
-        var_type.IsMeaninglessWithoutDynamicResolution();
+    // IsMeaninglessWithoutDynamicResolution basically only checks if
+    // it is an unspecialized generic type.
+    could_not_resolve = !should_not_bind_generic_types &&
+                        var_type.IsMeaninglessWithoutDynamicResolution();
 
     // ImportType would only return a TypeRef type anyway, so it's
     // faster to leave the type in its original context for faster
@@ -395,7 +397,7 @@ static llvm::Error AddVariableInfo(
   // If we couldn't fully realize the type, then we aren't going
   // to get very far making a local out of it, so discard it here.
   Log *log = GetLog(LLDBLog::Types | LLDBLog::Expressions);
-  if (is_meaningless_without_dynamic_resolution) {
+  if (could_not_resolve) {
     if (log)
       log->Printf("Discarding local %s because we couldn't fully realize it, "
                   "our best attempt was: %s.",

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -182,20 +182,21 @@ findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
   return info;
 }
 
-void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
+bool SwiftUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
+                                      ExecutionContext &exe_ctx) {
   Log *log = GetLog(LLDBLog::Expressions);
   LLDB_LOG(log, "SwiftUserExpression::ScanContext()");
 
   m_target = exe_ctx.GetTargetPtr();
   if (!m_target) {
     LLDB_LOG(log, "  [SUE::SC] Null target");
-    return;
+    return true;
   }
 
   StackFrame *frame = exe_ctx.GetFramePtr();
   if (!frame) {
     LLDB_LOG(log, "  [SUE::SC] Null stack frame");
-    return;
+    return true;
   }
 
   SymbolContext sym_ctx = frame->GetSymbolContext(
@@ -204,21 +205,21 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
   bool frame_is_swift = isSwiftLanguageSymbolContext(*this, sym_ctx);
   if (!frame_is_swift) {
     LLDB_LOG(log, "  [SUE::SC] Frame is not swift-y");
-    return;
+    return true;
   }
 
   if (!m_swift_ast_ctx) {
     LLDB_LOG(log, "  [SUE::SC] NULL Swift AST Context");
-    return;
+    return true;
   }
   if (!m_swift_ast_ctx->GetClangImporter()) {
     LLDB_LOG(log, "  [SUE::SC] Swift AST Context has no Clang importer");
-    return;
+    return true;
   }
 
   if (m_swift_ast_ctx->HasFatalErrors()) {
     LLDB_LOG(log, "  [SUE::SC] Swift AST Context has fatal errors");
-    return;
+    return true;
   }
 
   LLDB_LOG(log, "  [SUE::SC] Compilation unit is swift");
@@ -226,7 +227,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
   Block *innermost_block = sym_ctx.block;
   if (!innermost_block) {
     LLDB_LOG(log, "  [SUE::SC] No block");
-    return;
+    return true;
   }
 
   VariableList variable_list;
@@ -244,27 +245,34 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
   if (variable_list.Empty()) {
     LLDB_LOG(log, "  [SUE::SC] No self variable");
-    return;
+    return true;
   }
 
   assert(variable_list.GetSize() == 1 && variable_list.GetVariableAtIndex(0) &&
          "Unexpected variable list state");
 
   lldb::VariableSP self_var_sp = variable_list.GetVariableAtIndex(0);
+  auto maybe_self_info = findSwiftSelf(*frame, self_var_sp);
+  if (!maybe_self_info) {
+    LLDB_LOG(log, "  [SUE::SC] Could not determine info about 'self'");
+    return true;
+  }
+
   // If we have a self variable, but it has no location at the current PC, then
   // we can't use it.  Set the self var back to empty and we'll just pretend we
   // are in a regular frame, which is really the best we can do.
   if (!self_var_sp->LocationIsValidForFrame(frame)) {
-    LLDB_LOG(log, "  [SUE::SC] `self` variable location not valid for frame");
-    return;
+    Function *function =
+        frame->GetSymbolContext(lldb::eSymbolContextFunction).function;
+    bool optimized = function && function->GetIsOptimized();
+    diagnostic_manager.AddDiagnostic(
+        StringRef(optimized ? "no location for 'self'; possibly optimized out"
+                            : "no location for 'self' in debug info"),
+        lldb::eSeverityError, eDiagnosticOriginLLDB);
+    // This is currently unrecoverable.    
+    return false;
   }
-
-  auto maybe_self_info = findSwiftSelf(*frame, self_var_sp);
-  if (!maybe_self_info) {
-    LLDB_LOG(log, "  [SUE::SC] Could not determine info about `self`");
-    return;
-  }
-
+  
   // Check to see if we are in a class func of a class (or static func of a
   // struct) and adjust our type to point to the instance type.
   SwiftSelfInfo info = *maybe_self_info;
@@ -277,8 +285,12 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
   // Handle weak self.
 
   auto ts = info.type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
-  if (!ts)
-    return;
+  if (!ts) {
+    diagnostic_manager.AddDiagnostic("'self' does not have a Swift type",
+                                     lldb::eSeverityWarning,
+                                     eDiagnosticOriginLLDB);
+    return true;
+  }    
 
   if (auto ownership_kind = ts->GetNonTriviallyManagedReferenceKind(
           info.type.GetOpaqueQualType()))
@@ -295,6 +307,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
   LLDB_LOG(log, "  [SUE::SC] Containing class name: {0}",
            info.type.GetTypeName());
+  return true;  
 }
 
 /// Create a \c VariableInfo record for \c variable if there isn't
@@ -872,12 +885,9 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
       ConstString("Swift"), swift::ImportedModule(&*module_decl_or_err));
   m_result_delegate.RegisterPersistentState(persistent_state);
   m_error_delegate.RegisterPersistentState(persistent_state);
- 
-  ScanContext(exe_ctx, err);
 
-  if (!err.Success())
-    diagnostic_manager.Printf(lldb::eSeverityWarning, "warning: %s\n",
-                              err.AsCString());
+  if (!ScanContext(diagnostic_manager, exe_ctx))
+    return false;
 
   StreamString m_transformed_stream;
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -655,7 +655,7 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
   if (!m_options.GetUseContextFreeSwiftPrintObject()) {
     if (llvm::Error error = RegisterAllVariables(
             sc, stack_frame, *m_swift_ast_ctx, local_variables,
-            m_options.GetUseDynamic(), m_options.GetBindGenericTypes())) {
+            m_options.GetUseDynamic(), m_options.GetSwiftBindGenericTypes())) {
       diagnostic_manager.PutString(lldb::eSeverityInfo,
                                    llvm::toString(std::move(error)));
       diagnostic_manager.PutString(
@@ -676,7 +676,7 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
     }
 
     if (!SwiftASTManipulator::ShouldBindGenericTypes(
-            m_options.GetBindGenericTypes()) &&
+            m_options.GetSwiftBindGenericTypes()) &&
         !CanEvaluateExpressionWithoutBindingGenericParams(
             local_variables, m_generic_signature, *m_swift_ast_ctx, sc.block,
             *stack_frame.get())) {
@@ -924,7 +924,7 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                SwiftExpressionParser::ParseResult::retry_bind_generic_params &&
            parse_result != SwiftExpressionParser::ParseResult::
                                retry_bind_generic_params_not_supported) ||
-          m_options.GetBindGenericTypes() != lldb::eBindAuto)
+          m_options.GetSwiftBindGenericTypes() != lldb::eBindAuto)
         // If we're not retrying, just copy the diagnostics over.
         diagnostic_manager.Consume(std::move(first_try_diagnostic_manager));
     } else {
@@ -958,11 +958,12 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
     case ParseResult::retry_bind_generic_params:
       // Retry running the expression without binding the generic types if
       // BindGenericTypes was in the auto setting, give up otherwise.
-      if (m_options.GetBindGenericTypes() != lldb::eBindAuto) 
+      if (m_options.GetSwiftBindGenericTypes() != lldb::eBindAuto)
         return false;
       // Retry binding generic parameters, this is the only
       // case that will loop.
-      m_options.SetBindGenericTypes(lldb::eBind);
+      llvm::cantFail(
+          m_options.SetBooleanLanguageOption("swift-bind-generic-types", true));
       retry = true;
       break;
     

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -148,8 +148,8 @@ private:
   /// environment.
   //------------------------------------------------------------------
 
-  void ScanContext(ExecutionContext &exe_ctx,
-                   lldb_private::Status &err) override;
+  bool ScanContext(DiagnosticManager &diagnostic_manager,
+                   ExecutionContext &exe_ctx);
 
   bool AddArguments(ExecutionContext &exe_ctx, std::vector<lldb::addr_t> &args,
                     lldb::addr_t struct_address,

--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -338,7 +338,7 @@ public:
     if (!m_num_clang_errors || m_num_swift_errors)
       for (const RawDiagnostic &diagnostic : m_raw_swift_diagnostics)
         diagnostic_manager.AddDiagnostic(std::make_unique<Diagnostic>(
-            eDiagnosticOriginClang, 0, diagnostic.detail));
+            eDiagnosticOriginSwift, 0, diagnostic.detail));
   }
   void AddDiagnostic(std::unique_ptr<Diagnostic> diagnostic) {
     if (diagnostic)

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5803,3 +5803,21 @@ bool EvaluateExpressionOptions::GetCppIgnoreContextQualifiers() const {
   return llvm::cantFail(
       GetBooleanLanguageOption(s_cpp_ignore_context_qualifiers_option));
 }
+
+// BEGIN SWIFT
+// FIXME: this option is Swift plugin specific and should be registered by it,
+// instead of hard-coding it here.
+constexpr llvm::StringLiteral s_swift_bind_generic_types_option =
+    "swift-bind-generic-types";
+
+lldb::BindGenericTypes
+EvaluateExpressionOptions::GetSwiftBindGenericTypes() const {
+  auto value_or_err =
+      GetBooleanLanguageOption(s_swift_bind_generic_types_option);
+  if (!value_or_err) {
+    llvm::consumeError(value_or_err.takeError());
+    return lldb::eBindAuto;
+  }
+  return *value_or_err ? lldb::eBind : lldb::eDontBind;
+}
+// END SWIFT

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -14,10 +14,11 @@ class TestSwiftExpressionErrorReporting(TestBase):
         )
         process.Continue()
         self.ci.HandleCommand(
-            "settings set symbols.testing.inject-variable-location-error true", self.res
+            "settings set testing.inject-variable-location-error true", self.res
         )
         if not self.res.Succeeded():
             # This test needs assertions.
+            self.skipTest("LLDB compiled without assertions")
             return
 
         options = lldb.SBExpressionOptions()
@@ -28,10 +29,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         diags = data.GetValueForKey("errors").GetItemAtIndex(0)
         details = diags.GetValueForKey("details")
         all_messages = [str(detail.GetValueForKey("message")) for detail in details]
-        self.assertIn(
-            'Missing debug information for variable "self": variable not available',
-            all_messages,
-        )
+        self.assertIn("no location for 'self' in debug info", all_messages)
 
     @swiftTest
     def test_missing_var(self):

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -10,9 +10,8 @@ class TestSwiftExpressionErrorReporting(TestBase):
     def test_missing_location(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.swift")
+            self, "breakpoint 1", lldb.SBFileSpec("main.swift")
         )
-        process.Continue()
         self.ci.HandleCommand(
             "settings set testing.inject-variable-location-error true", self.res
         )
@@ -37,7 +36,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         only diagnostics in user code"""
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, 'break here', lldb.SBFileSpec('main.swift'))
+            self, 'breakpoint ', lldb.SBFileSpec('main.swift'))
 
         # This produces two errors:
         #   error: <EXPR>:8:1: initializers may only be declared within a type
@@ -91,7 +90,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         only diagnostics in user code"""
         self.build(dictionary={'HIDE_SWIFTMODULE': 'YES'})
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, 'break here', lldb.SBFileSpec('main.swift'))
+            self, 'breakpoint', lldb.SBFileSpec('main.swift'))
 
         options = lldb.SBExpressionOptions()
         value = self.frame().EvaluateExpression("strct", options)
@@ -114,3 +113,17 @@ class TestSwiftExpressionErrorReporting(TestBase):
         process.Continue()
         self.expect('expression -O -- number', error=True,
                     substrs=['self', 'not', 'found'])
+
+    @swiftTest
+    def test_syntax(self):
+        """Test syntax errors are being diagnosed"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'breakpoint 3', lldb.SBFileSpec('main.swift'))
+
+        options = lldb.SBExpressionOptions()
+        options.SetBooleanLanguageOption("swift-bind-generic-types", False)
+        value = self.frame().EvaluateExpression("t!", options)
+        self.assertIn(
+            "cannot force unwrap value of non-optional type 'T'",
+            str(value.GetError()))

--- a/lldb/test/API/lang/swift/expression/error_reporting/main.swift
+++ b/lldb/test/API/lang/swift/expression/error_reporting/main.swift
@@ -1,7 +1,7 @@
 class State {
   init(x: Int) {
     number = x
-    print("in class") // break here
+    print("breakpoint 1")
   }
 
   var number : Int
@@ -10,8 +10,16 @@ class State {
 struct S { var properties: Bool = true }
 
 func f(_ strct : S) {
-  print("in function") // break here
+  print("breakpoint 2")
 }
 
-f(S())
+class C<T> {
+  func g(_ t : T) {
+    print("breakpoint 3")
+  }
+}
+
+let s = S()
+f(s)
 State(x: 20)
+C<S>().g(s)

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -33,9 +33,9 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
             breakpoints.append(
                 target.BreakpointCreateBySourceRegex(
                     "breakpoint " + str(i), lldb.SBFileSpec('main.swift')))
-            self.assertTrue(
-                breakpoints[i].GetNumLocations() > 0,
-                "Didn't get valid breakpoint for %s" % (str(i)))
+            self.assertGreater(
+                breakpoints[i].GetNumLocations(), 0,
+                "Didn't get valid breakpoint for %d"%i)
 
         # Launch the process, and do not stop at the entry point.
         process = target.LaunchSimple(None, None, os.getcwd())


### PR DESCRIPTION
1. Cherry-pick of https://github.com/llvm/llvm-project/pull/197037
2. Fix all bugs uncovered by the fact that TestSwiftExpressionErrorReporting wasn't actually running
3. Don't discard local generic variables in the generic expression evaluator (rdar://176570358).
   - this is the main driver behind this patch series, the rest are things I uncovered along the way.
   - the effect of this bug is that the dropped variable result in bogus error messages that hide better diagnostics
   - I'm also wondering if this effectively made the generic expression evaluator much less useful in practice
5. In order to test the above, an NFC refactor to move bind-generic-type into the generic LanguageOptions