### PR TITLE
[lldb] Add portable alternative to grep in Swift.rules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -213,7 +213,7 @@ ifeq "$(USESWIFTDRIVER)" "1"
 ifeq "$(DYLIB_NAME)" ""
 MODULENAME?=$(shell basename $(EXE) .out)
 # Compile with -parse-as-library when main.swift contains "@main".
-ifneq "$(shell grep -w '@main' $(VPATH)/main.swift 2>/dev/null)" ""
+ifneq "$(findstring @main,$(file < $(VPATH)/main.swift))" ""
 PARSE_AS_LIBRARY = -parse-as-library
 endif
 else

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -214,7 +214,7 @@ ifeq "$(DYLIB_NAME)" ""
 MODULENAME?=$(shell basename $(EXE) .out)
 # Compile with -parse-as-library when main.swift contains "@main".
 ifneq "$(wildcard $(VPATH)/main.swift)" ""
-ifneq "$(shell git grep --no-index -w '@main' $(VPATH)/main.swift)" ""
+ifneq "$(shell git -C $(VPATH) grep --no-index -w '@main' main.swift)" ""
 PARSE_AS_LIBRARY = -parse-as-library
 endif
 endif

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -213,12 +213,8 @@ ifeq "$(USESWIFTDRIVER)" "1"
 ifeq "$(DYLIB_NAME)" ""
 MODULENAME?=$(shell basename $(EXE) .out)
 # Compile with -parse-as-library when main.swift contains "@main".
-ifneq ($(findstring cmd.exe,$(SHELL)),)
-ifneq "$(findstring @main,$(file < $(VPATH)/main.swift))" ""
-PARSE_AS_LIBRARY = -parse-as-library
-endif
-else
-ifneq "$(shell grep -w '@main' $(VPATH)/main.swift 2>/dev/null)" ""
+ifneq "$(wildcard $(VPATH)/main.swift)" ""
+ifneq "$(shell git grep --no-index -w '@main' $(VPATH)/main.swift)" ""
 PARSE_AS_LIBRARY = -parse-as-library
 endif
 endif

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -213,8 +213,14 @@ ifeq "$(USESWIFTDRIVER)" "1"
 ifeq "$(DYLIB_NAME)" ""
 MODULENAME?=$(shell basename $(EXE) .out)
 # Compile with -parse-as-library when main.swift contains "@main".
+ifneq ($(findstring cmd.exe,$(SHELL)),)
 ifneq "$(findstring @main,$(file < $(VPATH)/main.swift))" ""
 PARSE_AS_LIBRARY = -parse-as-library
+endif
+else
+ifneq "$(shell grep -w '@main' $(VPATH)/main.swift 2>/dev/null)" ""
+PARSE_AS_LIBRARY = -parse-as-library
+endif
 endif
 else
 EXE = $(DYLIB_FILENAME)


### PR DESCRIPTION
Replaces a newly introduced `grep` usage (#12838) in Swift.rules with `git grep`. Regular `grep` is not installed is not available on windows CI.