### PR TITLE
[lldb][windows] fix @main detection in test builds

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -213,8 +213,15 @@ ifeq "$(USESWIFTDRIVER)" "1"
 ifeq "$(DYLIB_NAME)" ""
 MODULENAME?=$(shell basename $(EXE) .out)
 # Compile with -parse-as-library when main.swift contains "@main".
+# $(file ...) requires GNU Make 4.0+, unavailable on macOS (ships with 3.81).
+ifeq "$(OS)" "Windows_NT"
+ifneq "$(findstring @main,$(file <$(VPATH)/main.swift))" ""
+PARSE_AS_LIBRARY = -parse-as-library
+endif
+else
 ifneq "$(shell grep -w '@main' $(VPATH)/main.swift 2>/dev/null)" ""
 PARSE_AS_LIBRARY = -parse-as-library
+endif
 endif
 else
 EXE = $(DYLIB_FILENAME)

--- a/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
+++ b/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftArrayUninitialized(lldbtest.TestBase):
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test(self):
         """Test unitialized global arrays"""
         self.build()

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -7,7 +7,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -8,7 +8,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_top_level_task(self):
         """Test Task synthetic child provider for top-level Task."""
         self.build()
@@ -35,7 +34,6 @@ class TestCase(TestBase):
         )
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     @skipIfLinux
     def test_current_task(self):
         """Test Task synthetic child for UnsafeCurrentTask (from an async let)."""

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -8,7 +8,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
@@ -8,7 +8,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -7,7 +7,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test(self):
         """Test summary formatter for TaskPriority."""
         self.build()

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -8,7 +8,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_print_task_group(self):
         """Print a TaskGroup and verify its children."""
         self.build()
@@ -18,7 +17,6 @@ class TestCase(TestBase):
         self.do_test_print()
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_print_throwing_task_group(self):
         """Print a ThrowingTaskGroup and verify its children."""
         self.build()
@@ -62,7 +60,6 @@ class TestCase(TestBase):
         )
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_api_task_group(self):
         """Verify a TaskGroup contains its expected children."""
         self.build()
@@ -72,7 +69,6 @@ class TestCase(TestBase):
         self.do_test_api(process)
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_api_throwing_task_group(self):
         """Verify a ThrowingTaskGroup contains its expected children."""
         self.build()

--- a/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
+++ b/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_scalar_types(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
@@ -36,7 +35,6 @@ class TestCase(TestBase):
             )
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     @expectedFailureAll
     def test_generic_types(self):
         self.build()

--- a/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
+++ b/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -16,7 +16,6 @@ class TestCase(TestBase):
         self.filecheck_log(self.log, __file__, f"-check-prefix=CHECK-{key}")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_int(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -27,7 +26,6 @@ class TestCase(TestBase):
         # CHECK-INT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SiD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_string(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -38,7 +36,6 @@ class TestCase(TestBase):
         # CHECK-STRING: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SSD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -49,7 +46,6 @@ class TestCase(TestBase):
         # CHECK-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a6StructVD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -60,7 +56,6 @@ class TestCase(TestBase):
         # CHECK-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a5ClassCD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -71,7 +66,6 @@ class TestCase(TestBase):
         # CHECK-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a4EnumOD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_generic_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -82,7 +76,6 @@ class TestCase(TestBase):
         # CHECK-GEN-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a13GenericStructVySSGD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_generic_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -93,7 +86,6 @@ class TestCase(TestBase):
         # CHECK-GEN-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a12GenericClassCySSGD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_generic_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -104,7 +96,6 @@ class TestCase(TestBase):
         # CHECK-GEN-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a11GenericEnumOySSGD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_described_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -115,7 +106,6 @@ class TestCase(TestBase):
         # CHECK-DESC-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a15DescribedStructVD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_described_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -126,7 +116,6 @@ class TestCase(TestBase):
         # CHECK-DESC-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a14DescribedClassCD")
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_described_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/span/TestSwiftSpan.py
+++ b/lldb/test/API/lang/swift/span/TestSwiftSpan.py
@@ -7,7 +7,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -25,7 +25,6 @@ def stderr_print(line):
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while
         stepping with the consume operator.


### PR DESCRIPTION
This patch uses `$(file) + $(findstring)` instead of `$(shell grep ...)` so the check works regardless of the host shell. On Windows, backslashes in `VPATH` can confuse sh-based $(shell) invocations. make's `$(file)` handles the path natively without spawning a shell.

rdar://176009590