### PR TITLE
[lldb][windows] fix TestSwiftImportSearchPaths.py

### DIFF
--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -28,10 +28,11 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
                     + 'target.experimental.swift-discover-implicit-search-paths '
                     + flag)
         indirect_name = self.platformContext.getFullLibName("Indirect").split(".")[0]
-        indirect = f"hidden/{indirect_name}"
+        indirect_lib = f"hidden/{indirect_name}"
+
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'),
-            extra_images=['Direct', self.getBuildArtifact(indirect)])
+            extra_images=['Direct', indirect_lib])
 
         types_log = self.getBuildArtifact("types.log")
         self.expect("log enable lldb types -f " + types_log)


### PR DESCRIPTION
Construct the indirect library path with the platform's shlib prefix/extension so it matches the actual on-disk filename on all platforms (on Windows the library is named `Indirect.dll`, without the `lib` prefix used on macOS/Linux).