### PR TITLE
[BoundsSafety][NFC] Cherry-pick upstream PR to introduce LateParsedTypeAttribute

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -190,6 +190,12 @@ public:
 /// FIXME: Perhaps we should change the name of LateParsedDeclaration to
 /// LateParsedTokens.
 struct LateParsedAttribute : public LateParsedDeclaration {
+
+  enum class Kind {
+    Declaration,
+    Type,
+  };
+
   Parser *Self;
   CachedTokens Toks;
   IdentifierInfo &AttrName;
@@ -199,15 +205,48 @@ struct LateParsedAttribute : public LateParsedDeclaration {
   // TO_UPSTREAM(BoundsSafety)
   unsigned NestedTypeLevel;
 
+private:
+  Kind K;
+
+protected:
+  explicit LateParsedAttribute(Parser *P, IdentifierInfo &Name,
+                               SourceLocation Loc, Kind K, unsigned Level = 0)
+      : Self(P), AttrName(Name), AttrNameLoc(Loc), NestedTypeLevel(Level), K(K) {}
+
+public:
   explicit LateParsedAttribute(Parser *P, IdentifierInfo &Name,
                                SourceLocation Loc, unsigned Level = 0)
-    : Self(P), AttrName(Name), AttrNameLoc(Loc), NestedTypeLevel(Level) {}
+    : LateParsedAttribute(P, Name, Loc, Kind::Declaration, Level) {}
 
   void ParseLexedAttributes() override;
 
-  void addDecl(Decl *D) {
-    assert(D && "cannot add null decl!");
-    Decls.push_back(D);
+  void addDecl(Decl *D) { Decls.push_back(D); }
+
+  Kind getKind() const { return K; }
+
+  static bool classof(const LateParsedAttribute *LA) { return true; }
+};
+
+/// A late-parsed attribute that will be applied as a type attribute.
+/// Unlike LateParsedAttribute (which applies to declarations via
+/// ActOnFinishDelayedAttribute), this stores cached tokens that are
+/// parsed during type construction when the placeholder LateParsedAttrType
+/// is replaced with a concrete type (e.g., CountAttributedType).
+struct LateParsedTypeAttribute : public LateParsedAttribute {
+
+  explicit LateParsedTypeAttribute(Parser *P, IdentifierInfo &Name,
+                                   SourceLocation Loc)
+      : LateParsedAttribute(P, Name, Loc, Kind::Type) {}
+
+  void ParseLexedAttributes() override;
+
+  /// Parse this late-parsed type attribute and store results in OutAttrs.
+  /// This method can be called from Sema during type transformation to
+  /// parse the cached tokens and produce the final attribute.
+  void ParseInto(ParsedAttributes &OutAttrs);
+
+  static bool classof(const LateParsedAttribute *LA) {
+    return LA->getKind() == Kind::Type;
   }
 };
 
@@ -1172,6 +1211,7 @@ private:
 
 private:
   friend struct LateParsedAttribute;
+  friend struct LateParsedTypeAttribute;
 
   struct ParsingClass;
 
@@ -1484,7 +1524,9 @@ private:
                                 const char *&PrevSpec, unsigned &DiagID,
                                 bool &isInvalid);
 
-  void ParseLexedCAttributeList(LateParsedAttrList &LA, bool EnterScope,
+  void ParseLexedCAttributeList(LateParsedAttrList &LA,
+                                // TO_UPSTREAM(BoundsSafety)
+                                bool EnterScope,
                                 ParsedAttributes *OutAttrs = nullptr);
 
   /// Finish parsing an attribute for which parsing was delayed.
@@ -1499,6 +1541,24 @@ private:
   // TO_UPSTREAM(BoundsSafety) OFF
   void ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
                             ParsedAttributes *OutAttrs = nullptr);
+
+  void ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
+                               // TO_UPSTREAM(BoundsSafety)
+                               bool EnterScope,
+                               ParsedAttributes &OutAttrs);
+
+  /// Parse cached tokens for a late-parsed attribute and return the parsed
+  /// attributes. Shared implementation used by both ParseLexedCAttribute and
+  /// ParseLexedTypeAttribute.
+  ParsedAttributes ParseLexedCAttributeTokens(LateParsedAttribute &LA,
+                                              // TO_UPSTREAM(BoundsSafety)
+                                              bool EnterScope);
+
+  /// Helper function to move LateParsedTypeAttribute pointers from one list
+  /// to another. Filters type attributes from \p From and appends them to \p
+  /// To.
+  static void TakeTypeAttrsAppendingFrom(LateParsedAttrList &To,
+                                         LateParsedAttrList &From);
 
   void ParseLexedPragmas(ParsingClass &Class);
   void ParseLexedPragma(LateParsedPragma &LP);

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -51,6 +51,7 @@ namespace clang {
   class OverflowBehaviorType;
   struct TemplateIdAnnotation;
   struct LateParsedAttribute;
+  struct LateParsedTypeAttribute;
 
   /// Represents a C++ nested-name-specifier or a global scope specifier.
   ///
@@ -1254,20 +1255,25 @@ typedef SmallVector<Token, 4> CachedTokens;
 class LateParsedAttrList : public SmallVector<LateParsedAttribute *, 2> {
 public:
   LateParsedAttrList(bool PSoon = false,
-                     bool LateAttrParseExperimentalExtOnly = false)
+                     bool LateAttrParseExperimentalExtOnly = false,
+                     bool LateAttrParseTypeAttrOnly = false)
       : ParseSoon(PSoon),
-        LateAttrParseExperimentalExtOnly(LateAttrParseExperimentalExtOnly) {}
+        LateAttrParseExperimentalExtOnly(LateAttrParseExperimentalExtOnly),
+        LateAttrParseTypeAttrOnly(LateAttrParseTypeAttrOnly) {}
 
-  bool parseSoon() { return ParseSoon; }
+  bool parseSoon() const { return ParseSoon; }
   /// returns true iff the attribute to be parsed should only be late parsed
   /// if it is annotated with `LateAttrParseExperimentalExt`
-  bool lateAttrParseExperimentalExtOnly() {
+  bool lateAttrParseExperimentalExtOnly() const {
     return LateAttrParseExperimentalExtOnly;
   }
+
+  bool lateAttrParseTypeAttrOnly() const { return LateAttrParseTypeAttrOnly; }
 
 private:
   bool ParseSoon; // Are we planning to parse these shortly after creation?
   bool LateAttrParseExperimentalExtOnly;
+  bool LateAttrParseTypeAttrOnly;
 };
 
 /// One instance of this struct is used for each type in a

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -320,6 +320,8 @@ void LateParsedAttribute::ParseLexedAttributes() {
   Self->ParseLexedAttribute(*this, true, false);
 }
 
+void LateParsedTypeAttribute::ParseLexedAttributes() {}
+
 void Parser::LateParsedPragma::ParseLexedPragmas() {
   Self->ParseLexedPragma(*this);
 }

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -5045,7 +5045,9 @@ void Parser::ParseStructDeclaration(
 
 // TODO: All callers of this function should be moved to
 // `Parser::ParseLexedAttributeList`.
-void Parser::ParseLexedCAttributeList(LateParsedAttrList &LAs, bool EnterScope,
+void Parser::ParseLexedCAttributeList(LateParsedAttrList &LAs,
+                                      // TO_UPSTREAM(BoundsSafety)
+                                      bool EnterScope,
                                       ParsedAttributes *OutAttrs) {
   assert(LAs.parseSoon() &&
          "Attribute list should be marked for immediate parsing.");
@@ -5056,8 +5058,9 @@ void Parser::ParseLexedCAttributeList(LateParsedAttrList &LAs, bool EnterScope,
   LAs.clear();
 }
 
-void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
-                                  ParsedAttributes *OutAttrs) {
+ParsedAttributes Parser::ParseLexedCAttributeTokens(LateParsedAttribute &LA,
+                                                    // TO_UPSTREAM(BoundsSafety)
+                                                    bool EnterScope) {
   // Create a fake EOF so that attribute parsing won't go off the end of the
   // attribute.
   Token AttrEnd;
@@ -5075,9 +5078,6 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
   // Drop the current token and bring the first cached one. It's the same token
   // as when we entered this function.
   ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
-
-  // TODO: Use `EnterScope`
-  (void)EnterScope;
 
   ParsedAttributes Attrs(AttrFactory);
 
@@ -5113,6 +5113,7 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
     /* TO_UPSTREAM(BoundsSafety) OFF */
   }
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
   if (LA.MacroII) {
     const auto &SM = PP.getSourceManager();
     CharSourceRange ExpansionRange = SM.getExpansionRange(LA.AttrNameLoc);
@@ -5120,8 +5121,7 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
       Attrs[i].setMacroIdentifier(LA.MacroII, ExpansionRange.getBegin(),
                                   SM.isInSystemMacro(LA.AttrNameLoc));
   }
-  for (auto *D : LA.Decls)
-    Actions.ActOnFinishDelayedAttribute(getCurScope(), D, Attrs);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 
   // Due to a parsing error, we either went over the cached tokens or
   // there are still cached tokens left, so we skip the leftover tokens.
@@ -5132,9 +5132,46 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
   if (Tok.is(tok::eof) && Tok.getEofData() == AttrEnd.getEofData())
     ConsumeAnyToken();
 
-  if (OutAttrs) {
+  return Attrs;
+}
+
+void Parser::ParseLexedCAttribute(LateParsedAttribute &LA,
+                                  // TO_UPSTREAM(BoundsSafety)
+                                  bool EnterScope,
+                                  ParsedAttributes *OutAttrs) {
+  ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA, EnterScope);
+
+  for (Decl *D : LA.Decls)
+    Actions.ActOnFinishDelayedAttribute(getCurScope(), D, Attrs);
+
+  if (OutAttrs)
     OutAttrs->takeAllAppendingFrom(Attrs);
-  }
+}
+
+void Parser::ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
+                                     // TO_UPSTREAM(BoundsSafety)
+                                     bool EnterScope,
+                                     ParsedAttributes &OutAttrs) {
+  ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA, EnterScope);
+  OutAttrs.takeAllAppendingFrom(Attrs);
+}
+
+void LateParsedTypeAttribute::ParseInto(ParsedAttributes &OutAttrs) {
+  // Delegate to the Parser that created this attribute
+  Self->ParseLexedTypeAttribute(*this, /*EnterScope*/false, OutAttrs);
+}
+
+void Parser::TakeTypeAttrsAppendingFrom(LateParsedAttrList &To,
+                                        LateParsedAttrList &From) {
+  LateParsedAttrList::iterator It =
+      llvm::remove_if(From, [&](LateParsedAttribute *LA) {
+        if (isa<LateParsedTypeAttribute>(LA)) {
+          To.push_back(LA);
+          return true;
+        }
+        return false;
+      });
+  From.erase(It, From.end());
 }
 
 void Parser::ParseStructUnionBody(SourceLocation RecordLoc,


### PR DESCRIPTION
Cherry-pick squashed commit of https://github.com/llvm/llvm-project/pull/192799 and resolves conflicts.