### PR TITLE
[lldb] Fix wrong buffer size when fetching Objective-C classes

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2258,7 +2258,7 @@ AppleObjCRuntimeV2::DynamicClassInfoExtractor::UpdateISAToDescriptorMap(
 
   if (class_buffer_addr != LLDB_INVALID_ADDRESS) {
     arguments.GetValueAtIndex(index++)->GetScalar() = class_buffer_addr;
-    arguments.GetValueAtIndex(index++)->GetScalar() = class_buffer_byte_size;
+    arguments.GetValueAtIndex(index++)->GetScalar() = class_buffer_len;
   }
 
   // Only dump the runtime classes from the expression evaluation if the log is


### PR DESCRIPTION
Jim spotted that we currently pass the buffer length in *bytes*, when actually this API takes the buffer length in number of elements. This causes that the Objective-C runtime write more memory that we allocated for it. This can cause that the function calling expression crashes and leaves the Objective-C runtime mutex locked.

(cherry picked from commit 8ca967fe37ae2c7d86594ce87d5ea946628cd81e)

rdar://173261750