### PR TITLE
[lldb] define modulemaps

### DIFF
--- a/lldb/cmake/modules/LLDB-framework.modulemap
+++ b/lldb/cmake/modules/LLDB-framework.modulemap
@@ -1,0 +1,5 @@
+framework module LLDB {
+  umbrella header "LLDB.h"
+  export *
+  module * { export * }
+}

--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -68,6 +68,25 @@ if(NOT APPLE_EMBEDDED)
   )
 endif()
 
+# Copy the module map so LLDB.framework can be imported as a Clang module.
+add_custom_command(TARGET liblldb POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E make_directory
+          $<TARGET_FILE_DIR:liblldb>/Modules
+  COMMAND ${CMAKE_COMMAND} -E copy
+          ${LLDB_SOURCE_DIR}/cmake/modules/LLDB-framework.modulemap
+          $<TARGET_FILE_DIR:liblldb>/Modules/module.modulemap
+  COMMENT "LLDB.framework: copy module map"
+)
+
+if(NOT APPLE_EMBEDDED)
+  add_custom_command(TARGET liblldb POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+            Versions/Current/Modules
+            ${LLDB_FRAMEWORK_ABSOLUTE_BUILD_DIR}/LLDB.framework/Modules
+    COMMENT "LLDB.framework: create Modules symlink"
+  )
+endif()
+
 find_program(unifdef_EXECUTABLE unifdef)
 
 # Wrap output in a target, so lldb-framework can depend on it.

--- a/lldb/test/API/api/framework_modulemaps/TestFrameworkModulemaps.py
+++ b/lldb/test/API/api/framework_modulemaps/TestFrameworkModulemaps.py
@@ -1,0 +1,131 @@
+"""Verify the Clang modulemaps shipped with LLDB.framework and the staged
+LLDBRPC framework headers let clients `@import LLDB;` / `@import LLDBRPC;`
+(and the Swift equivalents when building with C++ interop)."""
+
+import os
+import shutil
+import subprocess
+
+import lldb
+from lldbsuite.test import configuration
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import TestBase
+
+
+@skipUnlessDarwin
+class FrameworkModulemapsTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def _sdk_path(self):
+        return subprocess.check_output(
+            ["xcrun", "--show-sdk-path"], text=True
+        ).strip()
+
+    def _rpc_parked_headers_dir(self):
+        return os.path.join(
+            configuration.lldb_obj_root, "tools", "lldb-rpc", "ParkedHeaders"
+        )
+
+    def _stage_rpc_framework(self, dest):
+        parked = self._rpc_parked_headers_dir()
+        fw = os.path.join(dest, "LLDBRPC.framework")
+        headers = os.path.join(fw, "Headers")
+        modules = os.path.join(fw, "Modules")
+        os.makedirs(headers)
+        os.makedirs(modules)
+        for name in os.listdir(os.path.join(parked, "Headers")):
+            shutil.copy(os.path.join(parked, "Headers", name), headers)
+        shutil.copy(
+            os.path.join(parked, "Modules", "module.modulemap"), modules
+        )
+        return fw
+
+    def _compile_objcxx_import(self, module_name, framework_parent_dir):
+        src = self.getBuildArtifact("import_%s.mm" % module_name.lower())
+        obj = self.getBuildArtifact("import_%s.o" % module_name.lower())
+        cache = self.getBuildArtifact("modules-cache-%s" % module_name.lower())
+        os.makedirs(cache, exist_ok=True)
+        with open(src, "w") as f:
+            f.write("@import %s;\n" % module_name)
+        subprocess.check_call(
+            [
+                "xcrun",
+                "clang++",
+                "-x",
+                "objective-c++",
+                "-std=c++17",
+                "-isysroot",
+                self._sdk_path(),
+                "-fmodules",
+                "-fcxx-modules",
+                "-fmodules-cache-path=" + cache,
+                "-F",
+                framework_parent_dir,
+                "-c",
+                src,
+                "-o",
+                obj,
+            ]
+        )
+        self.assertTrue(os.path.isfile(obj))
+
+    def _compile_swift_import(self, module_name, framework_parent_dir):
+        swiftc = configuration.swiftCompiler
+        if not swiftc or not os.path.isfile(swiftc):
+            try:
+                swiftc = subprocess.check_output(
+                    ["xcrun", "-f", "swiftc"], text=True
+                ).strip()
+            except subprocess.CalledProcessError:
+                self.skipTest("swiftc not available")
+        src = self.getBuildArtifact("import_%s.swift" % module_name.lower())
+        cache = self.getBuildArtifact(
+            "swift-modules-cache-%s" % module_name.lower()
+        )
+        os.makedirs(cache, exist_ok=True)
+        with open(src, "w") as f:
+            f.write("import %s\n" % module_name)
+        subprocess.check_call(
+            [
+                swiftc,
+                "-typecheck",
+                "-cxx-interoperability-mode=default",
+                "-sdk",
+                self._sdk_path(),
+                "-module-cache-path",
+                cache,
+                "-F",
+                framework_parent_dir,
+                src,
+            ]
+        )
+
+    def _require_framework(self):
+        if not self.darwinWithFramework:
+            self.skipTest("LLDB.framework not available")
+
+    def _require_rpc(self):
+        if not os.path.isfile(
+            os.path.join(
+                self._rpc_parked_headers_dir(), "Modules", "module.modulemap"
+            )
+        ):
+            self.skipTest("LLDBRPC framework headers not built")
+
+    def test_lldb_framework_objc_import(self):
+        self._require_framework()
+        self._compile_objcxx_import("LLDB", self.framework_dir)
+
+    def test_lldbrpc_framework_objc_import(self):
+        self._require_rpc()
+        fw = self._stage_rpc_framework(self.getBuildDir())
+        self._compile_objcxx_import("LLDBRPC", os.path.dirname(fw))
+
+    def test_lldb_framework_swift_import(self):
+        self._require_framework()
+        self._compile_swift_import("LLDB", self.framework_dir)
+
+    def test_lldbrpc_framework_swift_import(self):
+        self._require_rpc()
+        fw = self._stage_rpc_framework(self.getBuildDir())
+        self._compile_swift_import("LLDBRPC", os.path.dirname(fw))

--- a/lldb/tools/lldb-rpc/LLDBRPC-framework.modulemap
+++ b/lldb/tools/lldb-rpc/LLDBRPC-framework.modulemap
@@ -1,0 +1,5 @@
+framework module LLDBRPC {
+  umbrella header "LLDBRPC.h"
+  export *
+  module * { export * }
+}

--- a/lldb/tools/lldb-rpc/LLDBRPC.h
+++ b/lldb/tools/lldb-rpc/LLDBRPC.h
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDBRPC_H
+#define LLDBRPC_H
+
+#include <LLDBRPC/SBDefines.h>
+#include <LLDBRPC/SBLanguages.h>
+#include <LLDBRPC/lldb-rpc-defines.h>
+#include <LLDBRPC/lldb-rpc-enumerations.h>
+#include <LLDBRPC/lldb-rpc-types.h>
+
+#endif // LLDBRPC_H

--- a/lldb/tools/lldb-rpc/LLDBRPCHeaders.cmake
+++ b/lldb/tools/lldb-rpc/LLDBRPCHeaders.cmake
@@ -93,8 +93,35 @@ foreach(source_header ${public_headers})
   list(APPEND preprocessed_headers ${parked_header})
 endforeach()
 
+# Copy the umbrella header so LLDBRPC.framework can be imported as a Clang module.
+set(lldbrpc_umbrella_header_output
+  ${CMAKE_CURRENT_BINARY_DIR}/ParkedHeaders/Headers/LLDBRPC.h)
+add_custom_command(OUTPUT ${lldbrpc_umbrella_header_output}
+  COMMAND ${CMAKE_COMMAND} -E copy
+          ${CMAKE_CURRENT_SOURCE_DIR}/LLDBRPC.h
+          ${lldbrpc_umbrella_header_output}
+  COMMENT "LLDBRPC: copy umbrella header"
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/LLDBRPC.h
+)
+
+# Copy the module map so LLDBRPC.framework can be imported as a Clang module.
+set(lldbrpc_modulemap_output
+  ${CMAKE_CURRENT_BINARY_DIR}/ParkedHeaders/Modules/module.modulemap)
+add_custom_command(OUTPUT ${lldbrpc_modulemap_output}
+  COMMAND ${CMAKE_COMMAND} -E make_directory
+          ${CMAKE_CURRENT_BINARY_DIR}/ParkedHeaders/Modules
+  COMMAND ${CMAKE_COMMAND} -E copy
+          ${CMAKE_CURRENT_SOURCE_DIR}/LLDBRPC-framework.modulemap
+          ${lldbrpc_modulemap_output}
+  COMMENT "LLDBRPC: copy module map"
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/LLDBRPC-framework.modulemap
+)
+
 # Wrap header preprocessing in a target, so liblldbrpc can depend on.
-add_custom_target(liblldbrpc-headers DEPENDS ${preprocessed_headers})
+add_custom_target(liblldbrpc-headers
+  DEPENDS ${preprocessed_headers}
+          ${lldbrpc_umbrella_header_output}
+          ${lldbrpc_modulemap_output})
 add_dependencies(liblldbrpc-headers copy-aux-rpc-headers liblldb-header-staging)
 set_target_properties(liblldbrpc-headers PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ParkedHeaders


### PR DESCRIPTION
This patch defines modulemaps for `LLDB` and `LLDBRPC`. This allows importing lldb from Swift and objc with `@import LLDB;`.

rdar://163301652