### PR TITLE
[clang][deps] Create appropriate action controller

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -150,11 +150,11 @@ public:
       clang::dependencies::DependencyScanningWorker &Worker,
       clang::dependencies::LookupModuleOutputCallback LookupModuleOutput);
 
-private:
   std::unique_ptr<clang::dependencies::DependencyActionController>
   createActionController(
       clang::dependencies::LookupModuleOutputCallback LookupModuleOutput);
 
+private:
   dependencies::DependencyScanningWorker Worker;
 
   friend class CompilerInstanceWithContext;

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -559,11 +559,13 @@ llvm::Expected<TranslationUnitDeps>
 CompilerInstanceWithContext::computeDependenciesByNameOrError(
     StringRef ModuleName, const llvm::DenseSet<ModuleID> &AlreadySeen,
     DependencyActionController &Controller) {
+  // FIXME: Make IncludeTreeActionController re-entrant and avoid cloning here.
+  auto ControllerClone = Controller.clone();
   FullDependencyConsumer Consumer(AlreadySeen);
   // We need to clear the DiagnosticOutput so that each by-name lookup
   // has a clean diagnostics buffer.
   DiagPrinterWithOS->DiagnosticOutput.clear();
-  if (computeDependencies(ModuleName, Consumer, Controller))
+  if (computeDependencies(ModuleName, Consumer, *ControllerClone))
     return Consumer.takeTranslationUnitDeps();
   return makeErrorFromDiagnosticsOS(*DiagPrinterWithOS);
 }

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1265,18 +1265,18 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
         SmallVector<StringRef> Names;
         ModuleNameRef.split(Names, ',');
 
-        CallbackActionController Controller(LookupOutput);
+        auto Controller = WorkerTool.createActionController(LookupOutput);
 
         if (Names.size() == 1) {
           auto MaybeModuleDepsGraph = WorkerTool.getModuleDependencies(
               Names[0], Input->CommandLine, CWD, AlreadySeenModules,
-              Controller);
+              *Controller);
           if (handleModuleResult(Names[0], MaybeModuleDepsGraph, *FD,
                                  LocalIndex, DependencyOS, Errs))
             HadErrors = true;
         } else {
           auto CIWithCtx = CompilerInstanceWithContext::initializeOrError(
-              WorkerTool, CWD, Input->CommandLine, Controller);
+              WorkerTool, CWD, Input->CommandLine, *Controller);
           if (llvm::Error Err = CIWithCtx.takeError()) {
             handleErrorWithInfoString(
                 "Compiler instance with context setup error", std::move(Err),
@@ -1288,7 +1288,7 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
           for (auto N : Names) {
             auto MaybeModuleDepsGraph =
                 CIWithCtx->computeDependenciesByNameOrError(
-                    N, AlreadySeenModules, Controller);
+                    N, AlreadySeenModules, *Controller);
             if (handleModuleResult(N, MaybeModuleDepsGraph, *FD, LocalIndex,
                                    DependencyOS, Errs)) {
               HadErrors = true;

--- a/llvm/lib/Support/PrefixMappingFileSystem.cpp
+++ b/llvm/lib/Support/PrefixMappingFileSystem.cpp
@@ -94,18 +94,6 @@ public:
     PREFIX_MAP_PATH(Path, MappedPath)
     return ProxyFileSystem::isLocal(MappedPath, Result);
   }
-
-protected:
-  void printImpl(raw_ostream &OS, PrintType Type,
-                 unsigned IndentLevel) const override {
-    printIndent(OS, IndentLevel);
-    OS << "PrefixMappingFileSystem\n";
-    if (Type == PrintType::Summary)
-      return;
-    getUnderlyingFS().print(
-        OS, Type == PrintType::Contents ? PrintType::Summary : Type,
-        IndentLevel + 1);
-  }
 };
 
 } // namespace

--- a/llvm/lib/Support/PrefixMappingFileSystem.cpp
+++ b/llvm/lib/Support/PrefixMappingFileSystem.cpp
@@ -94,6 +94,18 @@ public:
     PREFIX_MAP_PATH(Path, MappedPath)
     return ProxyFileSystem::isLocal(MappedPath, Result);
   }
+
+protected:
+  void printImpl(raw_ostream &OS, PrintType Type,
+                 unsigned IndentLevel) const override {
+    printIndent(OS, IndentLevel);
+    OS << "PrefixMappingFileSystem\n";
+    if (Type == PrintType::Summary)
+      return;
+    getUnderlyingFS().print(
+        OS, Type == PrintType::Contents ? PrintType::Summary : Type,
+        IndentLevel + 1);
+  }
 };
 
 } // namespace


### PR DESCRIPTION
Upstream doesn't (yet) have `DependencyScanningTool::createActionController()`, so the new instantiation wasn't working with include-tree, making "ClangScanDeps/modules-include-tree-by-mod-name.c" fail.

rdar://176956531