### PR TITLE
[lldb] Fix type info provider not finding objc types with no debug info

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -308,6 +308,7 @@ public:
     llvm::raw_string_ostream(wrapped) << "$s" << mangledName << 'D';
     swift::Demangle::Demangler dem;
     auto *node = dem.demangleSymbol(wrapped);
+    bool is_objc_name = false;
     if (!node) {
       // Try `mangledName` as plain ObjC class name. Ex: NSObject, NSView, etc.
       // Since this looking up an ObjC type, the default mangling falvor should
@@ -322,6 +323,7 @@ public:
         return nullptr;
       }
       wrapped = maybeMangled.result();
+      is_objc_name = true;
       LLDB_LOG(GetLog(LLDBLog::Types),
                "[LLDBTypeInfoProvider] using mangled ObjC class name: {0}",
                wrapped);
@@ -346,9 +348,32 @@ public:
     auto ts = swift_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
     if (!ts)
       return nullptr;
-    bool is_imported = true;
     CompilerType clang_type =
         m_runtime.LookupAnonymousClangType(mangled.AsCString(nullptr));
+    // If this is an objc type consult the ObjC runtime first, as it should be
+    // cheaper than looking for the type in the module and work when the ObjC is
+    // compiled without debug info.
+    if (!clang_type && is_objc_name) {
+      if (auto *process = &m_runtime.GetProcess())
+        if (auto *objc_runtime = SwiftLanguageRuntime::GetObjCRuntime(*process))
+          if (DeclVendor *decl_vendor = objc_runtime->GetDeclVendor()) {
+            auto types = decl_vendor->FindTypes(ConstString(mangledName), 1);
+            if (!types.empty()) {
+              clang_type = types[0];
+              LLDB_LOGV(GetLog(LLDBLog::Types),
+                        "[LLDBTypeInfoProvider] using ObjC runtime decl vendor "
+                        "type for {0}",
+                        mangledName);
+            } else {
+              LLDB_LOG(
+                  GetLog(LLDBLog::Types),
+                  "[LLDBTypeInfoProvider] ObjC runtime failed to find type {0}",
+                  mangledName);
+            }
+          }
+    }
+
+    bool is_imported = true;
     if (!clang_type)
       is_imported =
           ts->IsImportedType(swift_type.GetOpaqueQualType(), &clang_type);

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/Makefile
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/Makefile
@@ -1,0 +1,25 @@
+SWIFT_SOURCES := main.swift
+
+all: libMyObjCBase.dylib libMyLib.dylib a.out
+
+include Makefile.rules
+
+LD_EXTRAS = -lMyLib -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR) -I$(SRCDIR) -Xcc -fmodule-map-file=$(SRCDIR)/module.modulemap
+
+libMyObjCBase.dylib: $(SRCDIR)/MyObjCBase.m $(SRCDIR)/MyObjCBase.h
+	$(CC) -isysroot "$(SDKROOT)" -g0 -c $(SRCDIR)/MyObjCBase.m \
+		-o $(BUILDDIR)/MyObjCBase.o
+	$(CC) -isysroot "$(SDKROOT)" -dynamiclib -lobjc \
+		$(BUILDDIR)/MyObjCBase.o \
+		-o $(BUILDDIR)/libMyObjCBase.dylib
+
+libMyLib.dylib: $(SRCDIR)/MyLib.swift libMyObjCBase.dylib
+	"$(MAKE)" -f $(MAKEFILE_RULES) \
+		VPATH=$(SRCDIR) \
+		MAKE_DSYM=NO \
+		DEBUG_INFO_FLAG= SWIFT_DEBUG_INFO_FLAG= \
+		DYLIB_ONLY=YES DYLIB_NAME=MyLib \
+		DYLIB_SWIFT_SOURCES=MyLib.swift \
+		SWIFTFLAGS_EXTRAS="-I$(SRCDIR) -Xcc -fmodule-map-file=$(SRCDIR)/module.modulemap" \
+		LD_EXTRAS="-lMyObjCBase -L$(BUILDDIR)"

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/MyLib.swift
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/MyLib.swift
@@ -1,0 +1,5 @@
+import MyObjCBase
+
+public class MyDerived: MyObjCBase {
+  public var tag: Int = 42
+}

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/MyObjCBase.h
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/MyObjCBase.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+@interface MyObjCBase : NSObject
+@end

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/MyObjCBase.m
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/MyObjCBase.m
@@ -1,0 +1,4 @@
+#import "MyObjCBase.h"
+
+@implementation MyObjCBase
+@end

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/TestSwiftObjCSuperClassNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/TestSwiftObjCSuperClassNoDebugInfo.py
@@ -1,0 +1,29 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftObjCSuperClassNoDebugInfo(TestBase):
+    @swiftTest
+    @skipUnlessDarwin
+    @skipEmbeddedSwift
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"),
+            extra_images=["MyLib", "MyObjCBase"])
+
+        frame = thread.GetSelectedFrame()
+        var = frame.FindVariable("variable")
+        self.assertTrue(var.IsValid(), "variable not found in frame")
+        lldbutil.check_variable(
+            self, var, use_dynamic=True,
+            typename="MyLib.MyDerived",
+            num_children=2,
+        )
+
+        dynamic = var.GetDynamicValue(lldb.eDynamicCanRunTarget)
+        tag = dynamic.GetChildMemberWithName("tag")
+        lldbutil.check_variable(self, tag, value="42")

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/main.swift
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/main.swift
@@ -1,0 +1,8 @@
+import MyLib
+
+func f() {
+  let variable: AnyObject = MyDerived()
+  print("break here \(variable)")
+}
+
+f()

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/module.modulemap
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/module.modulemap
@@ -1,0 +1,4 @@
+module MyObjCBase {
+  header "MyObjCBase.h"
+  export *
+}


### PR DESCRIPTION
LLDBTypeInfoProvider would fails to find the clang type if it was an objc type defined in a module without debug info, OR if the objc module was not imported into the current context.

rdar://176586415