### PR TITLE
[lldb] Don't read live memory for assembly inst emulation (#197601)

### DIFF
--- a/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
@@ -41,10 +41,9 @@ bool UnwindAssemblyInstEmulation::GetNonCallSiteUnwindPlanFromAssembly(
   ProcessSP process_sp(thread.GetProcess());
   if (process_sp) {
     Status error;
-    const bool force_live_memory = true;
     if (process_sp->GetTarget().ReadMemory(
             range.GetBaseAddress(), function_text.data(), range.GetByteSize(),
-            error, force_live_memory) != range.GetByteSize()) {
+            error) != range.GetByteSize()) {
       return false;
     }
   }


### PR DESCRIPTION
In 2021, Augusto changed the Target::ReadMemory API from taking a `prefer_file_cache` argument to taking a `force_live_memory` argument, with opposite meanings - where we used to pass true, the callers now needed to pass false. The default argument was false, so many callers omitted the argument altogether after the change.

One of the edits to
UnwindAssemblyInstEmulation::GetNonCallSiteUnwindPlanFromAssembly unintentionally swapped the intended behavior -- this method which reads the bytes of a function's instructions for emulation should get the bytes from the local binary, if possible, else read from live memory. But it was changed to force reading from live memory unconditionally. This leads to an extra memory read for every function we see for the first time in a single `lldb` process run (the UnwindTable they are added to is part of the Module, and kept in the global Module cache).

It's not a major perf regression, but these are extra memory reads that we don't need to be doing.

I audited all the other changes in the 2021 PR and this was the only mistake like this.

rdar://177026608
(cherry picked from commit f0ad8ee185bc3e78f908c9fc6673489dd6ab03c1)