### PR TITLE
[lldb] Add a test for nested type in a cross-module extension

### DIFF
--- a/lldb/test/API/lang/swift/inner_type_in_ext/Makefile
+++ b/lldb/test/API/lang/swift/inner_type_in_ext/Makefile
@@ -1,0 +1,17 @@
+SWIFT_SOURCES := main.swift
+
+all: libModBase.dylib a.out
+
+include Makefile.rules
+LD_EXTRAS = -lModBase -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+libModBase.dylib: ModBase.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=ModBase \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=ModBase \
+		DYLIB_SWIFT_SOURCES:=ModBase.swift \
+		-f $(MAKEFILE_RULES)

--- a/lldb/test/API/lang/swift/inner_type_in_ext/ModBase.swift
+++ b/lldb/test/API/lang/swift/inner_type_in_ext/ModBase.swift
@@ -1,0 +1,1 @@
+public struct Outer {}

--- a/lldb/test/API/lang/swift/inner_type_in_ext/TestSwiftInnerTypeInExt.py
+++ b/lldb/test/API/lang/swift/inner_type_in_ext/TestSwiftInnerTypeInExt.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftInnerTypeInExt(TestBase):
+    @swiftTest
+    # rdar://177460379
+    @skipEmbeddedSwift
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"),
+            extra_images=["ModBase"])
+        frame = thread.GetSelectedFrame()
+        var = frame.FindVariable("variable")
+        self.assertTrue(var.IsValid(), "variable not found in frame")
+        lldbutil.check_variable(self, var, use_dynamic=True, num_children=1)
+        tag = var.GetChildMemberWithName("tag")
+        self.assertTrue(tag.IsValid(), "tag child not found")
+        lldbutil.check_variable(self, tag, value="42")

--- a/lldb/test/API/lang/swift/inner_type_in_ext/main.swift
+++ b/lldb/test/API/lang/swift/inner_type_in_ext/main.swift
@@ -1,0 +1,14 @@
+import ModBase
+
+extension Outer {
+  class Inner<Content> {
+    let tag: Int = 42
+  }
+}
+
+func f<T>(_: T) {
+  let variable = Outer.Inner<T>()
+  print("break here")  // break here
+}
+
+f(1)


### PR DESCRIPTION
Previously TypeSystemSwiftTypeRef could not resolve a type declared in an extension of a type declared in a different module. This was fixed on remote mirrors, this patch adds a test to exercise it.

Assisted-by: Claude