### PR TITLE
[clang][TMO] Ensure the ASTWriter can query TMO information for calls

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1576,7 +1576,10 @@ public:
   StringRef getTypeSummaryDescription(TypedMemorySummary Summary) const;
 
   std::optional<InferredTypeInfo>
+  tryGetInferredInfoForCall(const CallExpr *Call) const;
+  std::optional<InferredTypeInfo>
   getInferredInfoForCall(const CallExpr *Call) const;
+
   InferredTypeInfo inferTypedMemoryType(const CallExpr *Call,
                                         const Expr &SizeArg,
                                         const CastExpr *ContainingCast) const;

--- a/clang/include/clang/AST/TypedMemoryInference.h
+++ b/clang/include/clang/AST/TypedMemoryInference.h
@@ -252,7 +252,8 @@ public:
   StringRef getTypeSummaryDescription(TypedMemorySummary Summary);
   void setInferredInfoForCall(const CallExpr *Call, InferredTypeInfo Info);
   std::optional<InferredTypeInfo>
-  getInferredInfoForCall(const ASTContext &Ctx, const CallExpr *Call) const;
+  lookupInferredInfoForCall(const ASTContext &Ctx, const CallExpr *Call,
+                            bool AllowNonTMOCalls) const;
   InferredTypeInfo inferType(const ASTContext &Ctx, const CallExpr *Call,
                              const Expr &SizeArg,
                              const CastExpr *ContainingCastExpr);

--- a/clang/lib/AST/TypedMemoryInference.cpp
+++ b/clang/lib/AST/TypedMemoryInference.cpp
@@ -285,9 +285,8 @@ void TypedMemoryInference::setInferredInfoForCall(const CallExpr *Call,
   assert(Inserted);
 }
 
-std::optional<InferredTypeInfo>
-TypedMemoryInference::getInferredInfoForCall(const ASTContext &Ctx,
-                                             const CallExpr *Call) const {
+std::optional<InferredTypeInfo> TypedMemoryInference::lookupInferredInfoForCall(
+    const ASTContext &Ctx, const CallExpr *Call, bool AllowNonTMOCalls) const {
   if (!Ctx.getLangOpts().TypedMemoryOperations)
     return std::nullopt;
   if (Call->getDependence() != ExprDependence::None)
@@ -296,6 +295,9 @@ TypedMemoryInference::getInferredInfoForCall(const ASTContext &Ctx,
   if (auto Found = InferredTMOCallTypes.find(Call);
       Found != InferredTMOCallTypes.end())
     return Found->second;
+
+  if (AllowNonTMOCalls)
+    return std::nullopt;
 
 #ifndef NDEBUG
   // If we get here something has gone wrong: either we've failed to perform
@@ -720,8 +722,15 @@ void ASTContext::setInferredInfoForCall(const CallExpr *Call,
 }
 
 std::optional<InferredTypeInfo>
+ASTContext::tryGetInferredInfoForCall(const CallExpr *Call) const {
+  return getTMOInference().lookupInferredInfoForCall(*this, Call,
+                                                     /*AllowNonTMOCalls=*/true);
+}
+
+std::optional<InferredTypeInfo>
 ASTContext::getInferredInfoForCall(const CallExpr *Call) const {
-  return getTMOInference().getInferredInfoForCall(*this, Call);
+  return getTMOInference().lookupInferredInfoForCall(
+      *this, Call, /*AllowNonTMOCalls=*/false);
 }
 
 InferredTypeInfo

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -1047,8 +1047,9 @@ void ASTStmtWriter::VisitCallExpr(CallExpr *E) {
   CurrentPackingBits.addBit(E->isCoroElideSafe());
   CurrentPackingBits.addBit(E->usesMemberSyntax());
 
+  ASTContext &Ctx = Record.getASTContext();
   std::optional<InferredTypeInfo> TMOInference =
-      Record.getASTContext().getInferredInfoForCall(E);
+      Ctx.tryGetInferredInfoForCall(E);
   CurrentPackingBits.addBit(TMOInference.has_value());
 
   Record.AddSourceLocation(E->getRParenLoc());

--- a/clang/test/Modules/tmo-clang-modules-serialization.cpp
+++ b/clang/test/Modules/tmo-clang-modules-serialization.cpp
@@ -1,0 +1,79 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++17 -x c++ -fmodules \
+// RUN:   -ftyped-memory-operations -Wtyped-memory-inference-failure -Rtmo-remarks \
+// RUN:   -emit-module -fmodule-name=tmoalloc -fmodule-map-file=%t/tmoalloc.modulemap \
+// RUN:   %t/tmoalloc.modulemap -verify=module -o %t/tmoalloc.pcm
+//
+// RUN: %clang_cc1 -std=c++17 -x c++ -fmodules \
+// RUN:   -ftyped-memory-operations -Wtyped-memory-inference-failure -Rtmo-remarks \
+// RUN:   -fmodule-map-file=%t/tmoalloc.modulemap -fmodule-file=tmoalloc=%t/tmoalloc.pcm \
+// RUN:   -fsyntax-only -verify %t/tmo-user.cpp
+
+//--- tmoalloc.modulemap
+module tmoalloc {
+  header "tmoalloc.h"
+}
+
+//--- tmoalloc.h
+
+#ifndef TMOALLOC_H
+#define TMOALLOC_H
+
+void *test_typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *test_malloc(__SIZE_TYPE__ size) __attribute__((typed_memory_operation(test_typed_malloc, 1)));
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+inline S1 *test_inline_tmo_call(int n) {
+  return (S1 *)test_malloc(sizeof(S1) * n);
+  // module-remark@-1 {{passing TMO information for array of type 'S1' to 'test_typed_malloc' (retargeted from 'test_malloc')}}
+  // module-note@-2 {{inferred array of 'S1' from expression 'sizeof(S1) * n'}}
+  // module-note@-3 {{encoding array of 'S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+}
+
+template <class T> T *alloc_t(T, int n) {
+  return (T *)test_malloc(sizeof(T) * n); // #alloc_t
+}
+
+inline int *alloc_int(int n) {
+  return alloc_t(n, n);
+  // module-note@-1 {{in instantiation of function template specialization 'alloc_t<int>' requested here}}
+  // module-remark@#alloc_t {{passing TMO information for array of type 'int' to 'test_typed_malloc' (retargeted from 'test_malloc')}}
+  // module-note@#alloc_t {{inferred array of 'int' from expression 'sizeof(int) * n'}}
+  // module-note@#alloc_t {{encoding array of 'int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+}
+
+inline int *alloc_inference_fail(int n) {
+  auto *r = test_malloc(n);
+  // module-warning@-1 {{could not infer allocation type in call to 'test_malloc'}}
+  // module-note@-2 {{unable to infer allocation type from expression 'n'}}
+  return (int *)r;
+}
+
+#endif
+
+//--- tmo-user.cpp
+
+#include "tmoalloc.h"
+
+void test_in_module() {
+  test_inline_tmo_call(10);
+  S1 * s = alloc_t(S1{}, 10);
+  // expected-note@-1 {{in instantiation of function template specialization 'alloc_t<S1>' requested here}}
+  // expected-remark@tmoalloc.h:23 {{passing TMO information for array of type 'S1' to 'test_typed_malloc' (retargeted from 'test_malloc')}}
+  // expected-note@tmoalloc.h:23 {{inferred array of 'S1' from expression 'sizeof(S1) * n'}}
+  // expected-note@tmoalloc.h:23 {{encoding array of 'S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+  alloc_int(10);
+  test_malloc(10);
+  // expected-warning@-1 {{could not infer allocation type in call to 'test_malloc'}}
+  // expected-note@-2 {{unable to infer allocation type from expression '10'}}
+}
+

--- a/clang/test/Modules/tmo-cxx-module-serialization.cppm
+++ b/clang/test/Modules/tmo-cxx-module-serialization.cppm
@@ -1,0 +1,46 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++20 %t/M.cppm -ftyped-memory-operations -fsyntax-only -verify
+
+//--- foo.h
+
+void *test_typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *test_malloc(__SIZE_TYPE__ size) __attribute__((typed_memory_operation(test_typed_malloc, 1)));
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+inline S1 *test_inline_tmo_call(int n) {
+  return (S1 *)test_malloc(sizeof(S1) * n);
+}
+
+template <class T> T *alloc_t(int n) {
+  return (T *)test_malloc(sizeof(T) * n);
+}
+
+inline int *alloc_int(int n) {
+  return alloc_t<int>(n);
+}
+
+
+//--- M.cppm
+// expected-no-diagnostics
+module;
+#include "foo.h"
+export module M;
+export using ::test_inline_tmo_call;
+export using ::alloc_t;
+export using ::alloc_int;
+
+
+export void test_in_module() {
+  test_inline_tmo_call(10);
+  alloc_t<S1>(10);
+  alloc_int(10);
+}

--- a/clang/test/PCH/Inputs/tmo_allocation.h
+++ b/clang/test/PCH/Inputs/tmo_allocation.h
@@ -11,6 +11,15 @@ struct S1 {
   void (*fptr)();
 };
 
+void *non_tmo_function(__SIZE_TYPE__);
+void *in_pch_non_tmo_call() {
+  return non_tmo_function(sizeof(struct S1));
+}
+
+inline void *in_pch_non_tmo_call_inline() {
+  return non_tmo_function(sizeof(struct S1));
+}
+
 void in_pch_function() {
   void *iptr_failed_inference = malloc(1000); // #pch_failed_inference
   // expected-warning@#pch_failed_inference {{could not infer allocation type in call to 'malloc'}}

--- a/clang/test/PCH/tmo-with-pch.c
+++ b/clang/test/PCH/tmo-with-pch.c
@@ -19,6 +19,7 @@
 // RUN: %clang_cc1 -x c -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
 // RUN: not %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t %s 2>&1 | FileCheck --check-prefix=PCH_NO_TMO %s
 // PCH_NO_TMO: Typed Memory Operations Callsite Rewriting was disabled in precompiled file
+
 static void call_in_pch_function(void) {
     in_pch_function();
 }
@@ -92,3 +93,10 @@ void out_of_pch_function() {
 // CHECK: !{!"type-descriptor", !"[[ELEM_ARRAY_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
 // CHECK: !{!"type-descriptor", !"[[PREFIX_HEADER_HPA_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22HeaderPrefixedArray\22 ]"}
 // CHECK: !{!"type-descriptor", !"[[ELEM_INDETERMINATE_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+
+// non-tmo-tests
+
+void call_non_tmo_functions() {
+  void *r1 = in_pch_non_tmo_call();
+  void *r2 = in_pch_non_tmo_call_inline();
+}


### PR DESCRIPTION
To detect state errors, debug build we issue a warning if a TMO query is made when it shouldn't be. But this query is actually legitimate during serialization, as the alternative would be duplicating the "is this call subject to a TMO rewrite" logic.

The result is that when assertions are enabled and tmo is being used while building a module header. This PR makes it so we can distinguish valid serialization calls from those calls where this is actually an error.

While this is only triggered when serializing trees for modules, this PR also introduces tests for the PCH paths as well, on the presumption that it's possible that future PCH changes may serialize more information, and so could hit this path.