### PR TITLE
[lldb][swift] Fix segfault when printing Any of non-inline tuple

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3150,7 +3150,8 @@ Value::ValueType SwiftLanguageRuntime::GetValueType(
     // for a protocol object where does the dynamic data live if the target
     // object is a struct? (for a class, it's easy)
     if (static_type_flags.AllSet(eTypeIsSwift | eTypeIsProtocol) &&
-        dynamic_type_flags.AnySet(eTypeIsStructUnion | eTypeIsEnumeration)) {
+        dynamic_type_flags.AnySet(eTypeIsStructUnion | eTypeIsEnumeration |
+                                  eTypeIsTuple)) {
       lldb::addr_t existential_address;
       bool use_local_buffer = false;
 

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -31,3 +31,28 @@ class TestSwiftTuple(TestBase):
 
         self.expect("expression s.tup.0", substrs=['123'])
         self.expect("expression s.tup.1()", substrs=['321'])
+
+        options = lldb.SBExpressionOptions()
+        options.SetFetchDynamicValue(lldb.eDynamicCanRunTarget)
+
+        # A tuple that fits in the 3-word inline buffer of an Any.
+        self.expect_expr("any_inlined_tuple", result_type="(Int, Int)",
+                         result_children=[
+                             ValueCheck(value="1"),
+                             ValueCheck(value="2"),
+                         ],
+                         options=options)
+        # A tuple too large/non-trivial to fit inline; the existential
+        # container points to a heap-boxed payload.
+        self.expect_expr("any_boxed_tuple",
+                         result_type="(String, Int, [Int])",
+                         result_children=[
+                             ValueCheck(summary='"tuple"'),
+                             ValueCheck(value="42"),
+                             ValueCheck(children=[
+                                 ValueCheck(value="1"),
+                                 ValueCheck(value="2"),
+                                 ValueCheck(value="3"),
+                             ]),
+                         ],
+                         options=options)

--- a/lldb/test/API/lang/swift/tuple/main.swift
+++ b/lldb/test/API/lang/swift/tuple/main.swift
@@ -15,6 +15,8 @@ struct HasTuple {
 
 func main() {
   let s = HasTuple()
+  let any_inlined_tuple: Any = (1, 2)
+  let any_boxed_tuple: Any = ("tuple", 42, [1, 2, 3])
   print("break here")
 }
 


### PR DESCRIPTION
When an Any of a tuple cannot store the tuple inline, then LLDB currently tries to read the tuple storage from host memory. This patch adds tuples to the existing path in SwiftLanguageRuntime::GetValueType for checking whether we have inline storage or not.