### PR TITLE
[clang][deps] Avoid calling `FileManager::GetUniqueIDMapping()` when possible

### DIFF
--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -497,18 +497,20 @@ void IncludeTreeBuilder::enteredInclude(Preprocessor &PP, FileID FID) {
   if (!StartedEnteringIncludes) {
     StartedEnteringIncludes = true;
 
-    SmallVector<OptionalFileEntryRef> UIDToFE;
-    PP.getFileManager().GetUniqueIDMapping(UIDToFE);
+    if (!PP.getIncludedFiles().empty()) {
+      SmallVector<OptionalFileEntryRef> UIDToFE;
+      PP.getFileManager().GetUniqueIDMapping(UIDToFE);
 
-    // Get the included files (coming from a PCH), and keep track of the
-    // filenames that were recorded in the PCH.
-    for (const FileEntry *FE : PP.getIncludedFiles()) {
-      unsigned UID = FE->getUID();
-      if (UID >= PreIncludedFileNames.size())
-        PreIncludedFileNames.resize(UID + 1);
-      OptionalFileEntryRef FERef = UIDToFE[FE->getUID()];
-      assert(FERef && "No FileEntryRef with given UID");
-      PreIncludedFileNames[UID] = FERef->getName();
+      // Get the included files (coming from a PCH), and keep track of the
+      // filenames that were recorded in the PCH.
+      for (const FileEntry *FE : PP.getIncludedFiles()) {
+        unsigned UID = FE->getUID();
+        if (UID >= PreIncludedFileNames.size())
+          PreIncludedFileNames.resize(UID + 1);
+        OptionalFileEntryRef FERef = UIDToFE[FE->getUID()];
+        assert(FERef && "No FileEntryRef with given UID");
+        PreIncludedFileNames[UID] = FERef->getName();
+      }
     }
   }
 


### PR DESCRIPTION
This function can be fairly expensive, especially in by-module-name scans that share single `CompilerInstance` that has seen lots of files.