### PR TITLE
[BoundsSafety][NFC] Extract diagnostics from Construct*Type classes

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -16120,6 +16120,17 @@ public:
 
   QualType BuildDynamicRangePointerType(QualType PointerTy, Expr *StartPtr,
                                         Expr *EndPtr, bool ScopeCheck = false);
+
+  /// Canonicalize a count expression the same way BuildCountAttributedType
+  /// does, without constructing the type. Used for redecl comparison.
+  ExprResult CanonicalizeBoundsCountExpr(Expr *CountExpr, bool CountInBytes,
+                                         bool OrNull, bool ScopeCheck,
+                                         bool IsArray);
+
+  /// Canonicalize a range (end-pointer) expression the same way
+  /// BuildDynamicRangePointerType does, without constructing the type or
+  /// mutating any declarations. Used for redecl comparison.
+  ExprResult CanonicalizeRangeEndPtrExpr(Expr *EndPtr, bool ScopeCheck);
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 
   bool BuiltinIsBaseOf(SourceLocation RhsTLoc, QualType LhsT, QualType RhsT);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6447,22 +6447,8 @@ public:
                                         bool OrNull, bool AllowRedecl) {
     const Type *T = DeclTy.getTypePtr();
 
-    // Desugar and descend.
-    if (const auto *PT = dyn_cast<ParenType>(T))
-      return diagnoseCountAttributedTypeShape(PT->getInnerType(), CountInBytes,
-                                              OrNull, AllowRedecl);
-    if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
-      return diagnoseCountAttributedTypeShape(MQT->desugar(), CountInBytes,
-                                              OrNull, AllowRedecl);
-    // Function prototypes force AllowRedecl=true for the sub-walk.
-    if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
-      return diagnoseCountAttributedTypeShape(FPT->getReturnType(),
-                                              CountInBytes, OrNull,
-                                              /*AllowRedecl=*/true);
-    if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
-      return diagnoseCountAttributedTypeShape(FPT->getReturnType(),
-                                              CountInBytes, OrNull,
-                                              /*AllowRedecl=*/true);
+    // Sugar types with special semantics — must be checked before generic
+    // desugar.
     if (const auto *AT = dyn_cast<AttributedType>(T)) {
       llvm::SaveAndRestore<bool> Local(AutoPtrAttributed);
       if (AT->getAttrKind() == attr::PtrAutoAttr)
@@ -6482,25 +6468,9 @@ public:
                                               OrNull, AllowRedecl);
     }
 
-    // An AtomicType wrapping a pointer: emit the diagnostic but return true so
-    // the visitor still constructs the atomic type. Its shape prevents
-    // `ConstructBoundsSafetyPointerType::VisitAtomicTypeLoc` from re-emitting
-    // the same diagnostic.
-    if (const auto *ATy = dyn_cast<AtomicType>(T)) {
-      if (ATy->getValueType()->isPointerType()) {
-        unsigned DiagIndex = CountInBytes ? 3 : 2;
-        if (OrNull)
-          DiagIndex += 2;
-        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
-            << DiagIndex;
-        return true;
-      }
-      // Atomic of non-pointer falls through to the leaf check below.
-    }
-
     // At Level 0 we either diagnose, or canonicalize and compare for
     // AllowRedecl.
-    if (const auto *CAT = T->getAs<CountAttributedType>()) {
+    if (const auto *CAT = dyn_cast<CountAttributedType>(T)) {
       if (Level == 0) {
         if (!AllowRedecl) {
           S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
@@ -6528,7 +6498,7 @@ public:
                                               OrNull, AllowRedecl);
     }
 
-    if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
+    if (const auto *DRPT = dyn_cast<DynamicRangePointerType>(T)) {
       if (Level == 0) {
         S.Diag(Loc, diag::err_bounds_safety_conflicting_count_range_attributes);
         return false;
@@ -6537,7 +6507,41 @@ public:
                                               OrNull, AllowRedecl);
     }
 
-    // Use getAsArrayType to desugar.
+    // Generic desugar for all other sugar types (ParenType, MacroQualifiedType,
+    // ElaboratedType, TypeOfType, etc.)
+    QualType Desugared = DeclTy.getSingleStepDesugaredType(S.Context);
+    if (Desugared != DeclTy)
+      return diagnoseCountAttributedTypeShape(Desugared, CountInBytes, OrNull,
+                                              AllowRedecl);
+
+    // Non-sugar types below — all sugar is already stripped at this point.
+
+    // Function prototypes force AllowRedecl=true for the sub-walk.
+    if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
+      return diagnoseCountAttributedTypeShape(FPT->getReturnType(),
+                                              CountInBytes, OrNull,
+                                              /*AllowRedecl=*/true);
+    if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
+      return diagnoseCountAttributedTypeShape(FPT->getReturnType(),
+                                              CountInBytes, OrNull,
+                                              /*AllowRedecl=*/true);
+
+    // An AtomicType wrapping a pointer: emit the diagnostic but return true so
+    // the visitor still constructs the atomic type. Its shape prevents
+    // ConstructBoundsSafetyPointerType::VisitAtomicTypeLoc from re-emitting
+    // the same diagnostic.
+    if (const auto *ATy = dyn_cast<AtomicType>(T)) {
+      if (ATy->getValueType()->isPointerType()) {
+        unsigned DiagIndex = CountInBytes ? 3 : 2;
+        if (OrNull)
+          DiagIndex += 2;
+        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
+            << DiagIndex;
+        return true;
+      }
+      // Atomic of non-pointer falls through to the leaf check below.
+    }
+
     if (const auto *AT = S.Context.getAsArrayType(DeclTy)) {
       if (Level == 0) {
         if (AT->hasAttr(attr::ArrayDecayDiscardsCountInParameters))
@@ -6574,7 +6578,7 @@ public:
     // see `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
     // attribute to be used on code that prefers to keep its pointees
     // incomplete until they need to be used.
-    if (const auto *PT = T->getAs<PointerType>()) {
+    if (const auto *PT = dyn_cast<PointerType>(T)) {
       auto FAttr = PT->getPointerAttributes();
       if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
         S.Diag(Loc, diag::err_bounds_safety_conflicting_count_bound_attributes)
@@ -6647,18 +6651,8 @@ public:
   bool diagnoseDynamicRangePointerTypeShape(QualType DeclTy, bool AllowRedecl) {
     const Type *T = DeclTy.getTypePtr();
 
-    // Desugar and descend.
-    if (const auto *PT = dyn_cast<ParenType>(T))
-      return diagnoseDynamicRangePointerTypeShape(PT->getInnerType(),
-                                                  AllowRedecl);
-    if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
-      return diagnoseDynamicRangePointerTypeShape(MQT->desugar(), AllowRedecl);
-    if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
-      return diagnoseDynamicRangePointerTypeShape(FPT->getReturnType(),
-                                                  AllowRedecl);
-    if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
-      return diagnoseDynamicRangePointerTypeShape(FPT->getReturnType(),
-                                                  AllowRedecl);
+    // Sugar types with special semantics — must be checked before generic
+    // desugar.
     if (const auto *AT = dyn_cast<AttributedType>(T)) {
       llvm::SaveAndRestore<bool> Local(AutoPtrAttributed);
       if (AT->getAttrKind() == attr::PtrAutoAttr)
@@ -6677,17 +6671,7 @@ public:
       return diagnoseDynamicRangePointerTypeShape(VTT->desugar(), AllowRedecl);
     }
 
-    // Like the counted_by case, we emit the diagnostic but return true.
-    if (const auto *ATy = dyn_cast<AtomicType>(T)) {
-      if (ATy->getValueType()->isPointerType()) {
-        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
-            << /*ended_by*/ 6;
-        return true;
-      }
-      // Atomic of non-pointer falls through to the leaf check below.
-    }
-
-    if (const auto *CAT = T->getAs<CountAttributedType>()) {
+    if (const auto *CAT = dyn_cast<CountAttributedType>(T)) {
       if (Level == 0) {
         S.Diag(Loc, diag::err_bounds_safety_conflicting_count_range_attributes);
         return false;
@@ -6697,7 +6681,7 @@ public:
 
     // At Level 0 we diagnose outright conflicts, or canonicalize and compare
     // for AllowRedecl.
-    if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
+    if (const auto *DRPT = dyn_cast<DynamicRangePointerType>(T)) {
       if (Level == 0) {
         if (DRPT->getEndPointer() == nullptr)
           return true;
@@ -6706,8 +6690,6 @@ public:
               << /*pointer*/ 1 << /*end*/ 3;
           return false;
         }
-        // Canonicalize new end-pointer expression and compare against existing
-        // one
         ExprResult CanonEnd =
             S.CanonicalizeRangeEndPtrExpr(AttrArg, ScopeCheck);
         if (CanonEnd.isInvalid())
@@ -6725,8 +6707,31 @@ public:
       return diagnoseDynamicRangePointerTypeShape(DRPT->desugar(), AllowRedecl);
     }
 
-    // Nothing to diagnose here for __ended_by.
-    if (const auto *PT = T->getAs<PointerType>()) {
+    // Generic desugar for all other sugar types (ParenType, MacroQualifiedType,
+    // ElaboratedType, TypeOfType, etc.)
+    QualType Desugared = DeclTy.getSingleStepDesugaredType(S.Context);
+    if (Desugared != DeclTy)
+      return diagnoseDynamicRangePointerTypeShape(Desugared, AllowRedecl);
+
+    // Non-sugar types below — all sugar is already stripped at this point.
+    if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
+      return diagnoseDynamicRangePointerTypeShape(FPT->getReturnType(),
+                                                  AllowRedecl);
+    if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
+      return diagnoseDynamicRangePointerTypeShape(FPT->getReturnType(),
+                                                  AllowRedecl);
+
+    // Like the counted_by case, we emit the diagnostic but return true.
+    if (const auto *ATy = dyn_cast<AtomicType>(T)) {
+      if (ATy->getValueType()->isPointerType()) {
+        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
+            << /*ended_by*/ 6;
+        return true;
+      }
+      // Atomic of non-pointer falls through to the leaf check below.
+    }
+
+    if (const auto *PT = dyn_cast<PointerType>(T)) {
       auto FAttr = PT->getPointerAttributes();
       if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
         S.Diag(Loc, diag::err_bounds_safety_conflicting_count_bound_attributes)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6430,60 +6430,6 @@ public:
   bool ScopeCheck;
   bool AutoPtrAttributed = false;
 
-  // Pre-check for base class. Return true if and only if no diagnostics are
-  // emitted here.
-  //
-  // Emits:
-  // - err_bounds_safety_conflicting_count_bound_attributes
-  // - err_bounds_safety_terminated_by_wrong_pointer_type
-  bool diagnoseDynamicBoundTypeShape(QualType DeclTy) {
-    const Type *T = DeclTy.split().Ty;
-
-    // Desugar and descend.
-    if (const auto *PT = dyn_cast<ParenType>(T))
-      return diagnoseDynamicBoundTypeShape(PT->getInnerType());
-    if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
-      return diagnoseDynamicBoundTypeShape(MQT->desugar());
-    if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
-      return diagnoseDynamicBoundTypeShape(FPT->getReturnType());
-    if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
-      return diagnoseDynamicBoundTypeShape(FPT->getReturnType());
-    if (const auto *AT = dyn_cast<AttributedType>(T)) {
-      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed);
-      if (AT->getAttrKind() == attr::PtrAutoAttr)
-        AutoPtrAttributed = true;
-      return diagnoseDynamicBoundTypeShape(AT->getModifiedType());
-    }
-
-    if (const auto *VTT = dyn_cast<ValueTerminatedType>(T)) {
-      // A __terminated_by pointer cannot also carry a count or range attribute
-      // unless the terminator was auto-inferred via __ptrauto (see
-      // VisitValueTerminatedType in the visitor for the drop behavior).
-      if (Level == 0 && !AutoPtrAttributed) {
-        S.Diag(Loc, diag::err_bounds_safety_terminated_by_wrong_pointer_type);
-        return false;
-      }
-      return diagnoseDynamicBoundTypeShape(VTT->desugar());
-    }
-
-    // Use getAs to desugar typedefs, elaborated types, etc.
-    if (const auto *PT = T->getAs<PointerType>()) {
-      auto FAttr = PT->getPointerAttributes();
-      if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
-        S.Diag(Loc, diag::err_bounds_safety_conflicting_count_bound_attributes)
-            << DiagName << (FAttr.hasLowerBound() ? 0 : 1);
-        return false;
-      }
-      if (Level == 0)
-        return true;
-      --Level;
-      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
-      return diagnoseDynamicBoundTypeShape(PT->getPointeeType());
-    }
-
-    return true;
-  }
-
   // Pre-check for counted_by family. Sets CountInBytes = true for pointers
   // whose pointee has unknown size, and AllowRedecl = true when descending
   // into a function-prototype subwalk.
@@ -6525,10 +6471,16 @@ public:
           AT->getModifiedType(), CountInBytes, OrNull, AllowRedecl);
     }
 
-    // Base walker already handled the Level 0 __terminated_by check.
-    if (const auto *VTT = dyn_cast<ValueTerminatedType>(T))
+    // A __terminated_by pointer cannot also carry a count or range attribute
+    // unless the terminator was auto-inferred via __ptrauto.
+    if (const auto *VTT = dyn_cast<ValueTerminatedType>(T)) {
+      if (Level == 0 && !AutoPtrAttributed) {
+        S.Diag(Loc, diag::err_bounds_safety_terminated_by_wrong_pointer_type);
+        return false;
+      }
       return diagnoseCountAttributedTypeShape(VTT->desugar(), CountInBytes,
                                               OrNull, AllowRedecl);
+    }
 
     // An AtomicType wrapping a pointer: emit the diagnostic but return true so
     // the visitor still constructs the atomic type. Its shape prevents
@@ -6624,6 +6576,12 @@ public:
     // attribute to be used on code that prefers to keep its pointees
     // incomplete until they need to be used.
     if (const auto *PT = T->getAs<PointerType>()) {
+      auto FAttr = PT->getPointerAttributes();
+      if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
+        S.Diag(Loc, diag::err_bounds_safety_conflicting_count_bound_attributes)
+            << DiagName << (FAttr.hasLowerBound() ? 0 : 1);
+        return false;
+      }
       if (Level == 0) {
         if (!CountInBytes) {
           QualType PointeeTy = QualType(PT, 0)->getPointeeType();
@@ -6710,9 +6668,15 @@ public:
                                                   AllowRedecl);
     }
 
-    // Base walker already handled the Level 0 __terminated_by check.
-    if (const auto *VTT = dyn_cast<ValueTerminatedType>(T))
+    // A __terminated_by pointer cannot also carry a count or range attribute
+    // unless the terminator was auto-inferred via __ptrauto.
+    if (const auto *VTT = dyn_cast<ValueTerminatedType>(T)) {
+      if (Level == 0 && !AutoPtrAttributed) {
+        S.Diag(Loc, diag::err_bounds_safety_terminated_by_wrong_pointer_type);
+        return false;
+      }
       return diagnoseDynamicRangePointerTypeShape(VTT->desugar(), AllowRedecl);
+    }
 
     // Like the counted_by case, we emit the diagnostic but return true.
     if (const auto *ATy = dyn_cast<AtomicType>(T)) {
@@ -6764,6 +6728,12 @@ public:
 
     // Nothing to diagnose here for __ended_by.
     if (const auto *PT = T->getAs<PointerType>()) {
+      auto FAttr = PT->getPointerAttributes();
+      if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
+        S.Diag(Loc, diag::err_bounds_safety_conflicting_count_bound_attributes)
+            << DiagName << (FAttr.hasLowerBound() ? 0 : 1);
+        return false;
+      }
       if (Level == 0)
         return true;
       --Level;
@@ -7996,14 +7966,6 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
 
     LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc,
                                       Level, AttrArg,  Info.ScopeCheck};
-    if (!DiagCtx.diagnoseDynamicBoundTypeShape(Info.DeclTy))
-      return;
-
-    // Reset Ctx.Level before the second walker call. The base walker decrements
-    // Ctx.Level when it descends through pointers and the range-specific walker
-    // needs to start from the original Level.
-    DiagCtx.Level = Level;
-    DiagCtx.AutoPtrAttributed = false;
     if (!DiagCtx.diagnoseDynamicRangePointerTypeShape(
             Info.DeclTy, /*AllowRedecl=*/OriginatesInAPINotes))
       return;
@@ -8017,8 +7979,6 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
   } else {
     LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc,
                                       Level, AttrArg,  Info.ScopeCheck};
-    if (!DiagCtx.diagnoseDynamicBoundTypeShape(Info.DeclTy))
-      return;
 
     if (!AttrArg->getType()->isIntegralOrEnumerationType()) {
       Diag(Loc, diag::err_attribute_argument_type_for_bounds_safety_count)
@@ -8032,10 +7992,6 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
       DiagCtx.AttrArg = AttrArg;
     }
 
-    // Reset Ctx.Level before the second walker call for the same reasoning as
-    // above.
-    DiagCtx.Level = Level;
-    DiagCtx.AutoPtrAttributed = false;
     if (!DiagCtx.diagnoseCountAttributedTypeShape(
             Info.DeclTy, CountInBytes, OrNull,
             /*AllowRedecl=*/OriginatesInAPINotes))

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6418,6 +6418,377 @@ static void handleXRayLogArgsAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 /* TO_UPSTREAM(BoundsSafety) ON*/
 namespace {
 
+// Shared context used by the flat pre-checkers to track state while walking
+// nested pointer types.
+class LateBoundsAttrDiagContext {
+public:
+  Sema &S;
+  StringRef DiagName;
+  SourceLocation Loc;
+  unsigned Level;
+  bool AutoPtrAttributed = false;
+};
+
+// Pre-check for base class. Return true if and only if no diagnostics are
+// emitted here.
+//
+// Emits:
+// - err_bounds_safety_conflicting_count_bound_attributes
+// - err_bounds_safety_terminated_by_wrong_pointer_type
+static bool diagnoseDynamicBoundTypeShape(LateBoundsAttrDiagContext &Ctx,
+                                          QualType DeclTy) {
+  Sema &S = Ctx.S;
+  const Type *T = DeclTy.split().Ty;
+
+  // Desugar and descend.
+  if (const auto *PT = dyn_cast<ParenType>(T))
+    return diagnoseDynamicBoundTypeShape(Ctx, PT->getInnerType());
+  if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
+    return diagnoseDynamicBoundTypeShape(Ctx, MQT->desugar());
+  if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
+    return diagnoseDynamicBoundTypeShape(Ctx, FPT->getReturnType());
+  if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
+    return diagnoseDynamicBoundTypeShape(Ctx, FPT->getReturnType());
+  if (const auto *AT = dyn_cast<AttributedType>(T)) {
+    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed);
+    if (AT->getAttrKind() == attr::PtrAutoAttr)
+      Ctx.AutoPtrAttributed = true;
+    return diagnoseDynamicBoundTypeShape(Ctx, AT->getModifiedType());
+  }
+
+  if (const auto *VTT = dyn_cast<ValueTerminatedType>(T)) {
+    // A __terminated_by pointer cannot also carry a count or range attribute
+    // unless the terminator was auto-inferred via __ptrauto (see
+    // VisitValueTerminatedType in the visitor for the drop behavior).
+    if (Ctx.Level == 0 && !Ctx.AutoPtrAttributed) {
+      S.Diag(Ctx.Loc, diag::err_bounds_safety_terminated_by_wrong_pointer_type);
+      return false;
+    }
+    return diagnoseDynamicBoundTypeShape(Ctx, VTT->desugar());
+  }
+
+  // Use getAs to desugar typedefs, elaborated types, etc.
+  if (const auto *PT = T->getAs<PointerType>()) {
+    auto FAttr = PT->getPointerAttributes();
+    if (FAttr.hasUpperBound() && !Ctx.AutoPtrAttributed) {
+      S.Diag(Ctx.Loc,
+             diag::err_bounds_safety_conflicting_count_bound_attributes)
+          << Ctx.DiagName << (FAttr.hasLowerBound() ? 0 : 1);
+      return false;
+    }
+    if (Ctx.Level == 0)
+      return true;
+    --Ctx.Level;
+    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed, false);
+    return diagnoseDynamicBoundTypeShape(Ctx, PT->getPointeeType());
+  }
+
+  return true;
+}
+
+// Pre-check for counted_by family. Sets CountIntBytes = true for pointers
+// whose pointee has unknown size, and AllowRedecl = true when descending into
+// a function-prototype subwalk.
+//
+// Emits:
+// - err_attribute_pointers_only
+// - err_bounds_safety_atomic_unsupported_attribute
+// - err_bounds_safety_conflicting_pointer_attributes
+// - err_bounds_safety_conflicting_count_range_attributes
+// - err_bounds_safety_complete_array_with_count
+// - err_bounds_safety_sized_by_array
+// - err_multiple_coupled_decls_in_bounds_safety_dynamic_count
+// - err_bounds_safety_counted_by_without_size
+static bool diagnoseCountAttributedTypeShape(LateBoundsAttrDiagContext &Ctx,
+                                             QualType DeclTy,
+                                             bool &CountInBytes, bool OrNull,
+                                             bool AllowRedecl) {
+  Sema &S = Ctx.S;
+  const Type *T = DeclTy.split().Ty;
+
+  // Desugar and descend.
+  if (const auto *PT = dyn_cast<ParenType>(T))
+    return diagnoseCountAttributedTypeShape(Ctx, PT->getInnerType(),
+                                            CountInBytes, OrNull, AllowRedecl);
+  if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
+    return diagnoseCountAttributedTypeShape(Ctx, MQT->desugar(), CountInBytes,
+                                            OrNull, AllowRedecl);
+  // Function prototypes force AllowRedecl=true for the sub-walk.
+  if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
+    return diagnoseCountAttributedTypeShape(Ctx, FPT->getReturnType(),
+                                            CountInBytes, OrNull,
+                                            /*AllowRedecl=*/true);
+  if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
+    return diagnoseCountAttributedTypeShape(Ctx, FPT->getReturnType(),
+                                            CountInBytes, OrNull,
+                                            /*AllowRedecl=*/true);
+  if (const auto *AT = dyn_cast<AttributedType>(T)) {
+    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed);
+    if (AT->getAttrKind() == attr::PtrAutoAttr)
+      Ctx.AutoPtrAttributed = true;
+    return diagnoseCountAttributedTypeShape(Ctx, AT->getModifiedType(),
+                                            CountInBytes, OrNull, AllowRedecl);
+  }
+
+  // Base walker already handled the Level 0 __terminated_by check.
+  if (const auto *VTT = dyn_cast<ValueTerminatedType>(T))
+    return diagnoseCountAttributedTypeShape(Ctx, VTT->desugar(), CountInBytes,
+                                            OrNull, AllowRedecl);
+
+  // An AtomicType wrapping a pointer: emit the diagnostic but return true so
+  // the visitor still constructs the atomic type. Its shape prevents
+  // `ConstructBoundsSafetyPointerType::VisitAtomicTypeLoc` from re-emitting
+  // the same diagnostic.
+  if (const auto *ATy = dyn_cast<AtomicType>(T)) {
+    if (ATy->getValueType()->isPointerType()) {
+      unsigned DiagIndex = CountInBytes ? 3 : 2;
+      if (OrNull)
+        DiagIndex += 2;
+      S.Diag(Ctx.Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
+          << DiagIndex;
+      return true;
+    }
+    // Atomic of non-pointer falls through to the leaf check below.
+  }
+
+  // At Level 0 we diagnose or pass through to the visitor's Profile compare
+  // (see TODO in DiagnoseConflictingType).
+  if (const auto *CAT = T->getAs<CountAttributedType>()) {
+    if (Ctx.Level == 0) {
+      if (!AllowRedecl) {
+        S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+            << /*pointer*/ CAT->isPointerType() << /*count*/ 2;
+        return false;
+      }
+      return true;
+    }
+    return diagnoseCountAttributedTypeShape(Ctx, CAT->desugar(), CountInBytes,
+                                            OrNull, AllowRedecl);
+  }
+
+  if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
+    if (Ctx.Level == 0) {
+      S.Diag(Ctx.Loc,
+             diag::err_bounds_safety_conflicting_count_range_attributes);
+      return false;
+    }
+    return diagnoseCountAttributedTypeShape(Ctx, DRPT->desugar(), CountInBytes,
+                                            OrNull, AllowRedecl);
+  }
+
+  // Use getAsArrayType to desugar.
+  if (const auto *AT = S.Context.getAsArrayType(DeclTy)) {
+    if (Ctx.Level == 0) {
+      if (AT->hasAttr(attr::ArrayDecayDiscardsCountInParameters))
+        return diagnoseCountAttributedTypeShape(
+            Ctx, S.Context.getArrayDecayedType(QualType(AT, 0)), CountInBytes,
+            OrNull, AllowRedecl);
+      if (isa<IncompleteArrayType>(AT)) {
+        if (CountInBytes) {
+          S.Diag(Ctx.Loc, diag::err_bounds_safety_sized_by_array)
+              << Ctx.DiagName;
+          return false;
+        }
+        return true;
+      }
+      S.Diag(Ctx.Loc, diag::err_bounds_safety_complete_array_with_count);
+      return false;
+    }
+    --Ctx.Level;
+    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed, false);
+    bool InnerOK = diagnoseCountAttributedTypeShape(
+        Ctx, AT->getElementType(), CountInBytes, OrNull, AllowRedecl);
+    if (!InnerOK)
+      return false;
+    // Count attributes on the element of an array type are not supported yet
+    S.Diag(Ctx.Loc,
+           diag::err_multiple_coupled_decls_in_bounds_safety_dynamic_count);
+    return false;
+  }
+
+  // Check the pointee for counted_by-without-size.
+  //
+  // NOTE: We don't error for incomplete types that might be later completed
+  // (e.g. a struct forward declaration). Instead for those
+  // completable-incomplete types we delay checking until the type is used
+  // see `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
+  // attribute to be used on code that prefers to keep its pointees
+  // incomplete until they need to be used.
+  if (const auto *PT = T->getAs<PointerType>()) {
+    if (Ctx.Level == 0) {
+      if (!CountInBytes) {
+        QualType PointeeTy = QualType(PT, 0)->getPointeeType();
+        if (PointeeTy->isAlwaysIncompleteType() ||
+            PointeeTy->isFunctionType() || PointeeTy->isSizelessType() ||
+            PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
+          // Use unspecified pointer attributes for diagnostic purposes.
+          QualType Unsp = S.Context.getBoundsSafetyPointerType(
+              QualType(PT, 0), BoundsSafetyPointerAttributes::unspecified());
+
+          auto PD = S.PDiag(diag::err_bounds_safety_counted_by_without_size);
+          PD << Unsp << Unsp->getPointeeType() << OrNull;
+          // Suggest `__sized_by` if the `__counted_by` macro was used.
+          // We intentionally don't suggest a fixit if the attribute is used
+          // directly (i.e. without the macro) because it is not expected that
+          // users will use it.
+          int SuggestFixIt = 0; // Default don't suggest __sized_by
+          if (Ctx.Loc.isMacroID()) {
+            // FIXME(dliew): Use `AL.MacroII` to get the name. Unfortunately
+            // `AL.MacroII` is not set so we can't simply check the macro name
+            // is what we expect. So instead we have the lexer tell us the
+            // contents of the token and check against that.
+            // rdar://100631458
+            auto MacroName =
+                Lexer::getImmediateMacroName(Ctx.Loc, S.SourceMgr, S.LangOpts);
+            if (MacroName == "__counted_by") {
+              SuggestFixIt = 1; // Emit text to suggest __sized_by
+              auto MacroLoc = S.SourceMgr.getExpansionLoc(Ctx.Loc);
+              PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by");
+            } else if (MacroName == "__counted_by_or_null") {
+              SuggestFixIt = 1; // Emit text to suggest __sized_by_or_null
+              auto MacroLoc = S.SourceMgr.getExpansionLoc(Ctx.Loc);
+              PD << FixItHint::CreateReplacement(MacroLoc,
+                                                 "__sized_by_or_null");
+            }
+          }
+          PD << SuggestFixIt;
+          S.Diag(Ctx.Loc, PD);
+
+          // Recover by assuming a byte count.
+          CountInBytes = true;
+        }
+      }
+      return true;
+    }
+    --Ctx.Level;
+    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed, false);
+    return diagnoseCountAttributedTypeShape(Ctx, PT->getPointeeType(),
+                                            CountInBytes, OrNull, AllowRedecl);
+  }
+
+  // Fallback for pointers_only.
+  S.Diag(Ctx.Loc, diag::err_attribute_pointers_only) << Ctx.DiagName << 0;
+  return false;
+}
+
+// Pre-check for ended-by.
+//
+// Emits:
+// - err_attribute_pointers_only
+// - err_bounds_safety_atomic_unsupported_attribute
+// - err_bounds_safety_conflicting_count_range_attributes
+// - err_bounds_safety_conflicting_pointer_attributes
+static bool diagnoseDynamicRangePointerTypeShape(LateBoundsAttrDiagContext &Ctx,
+                                                 QualType DeclTy,
+                                                 bool AllowRedecl) {
+  Sema &S = Ctx.S;
+  const Type *T = DeclTy.split().Ty;
+
+  // Desugar and descend.
+  if (const auto *PT = dyn_cast<ParenType>(T))
+    return diagnoseDynamicRangePointerTypeShape(Ctx, PT->getInnerType(),
+                                                AllowRedecl);
+  if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
+    return diagnoseDynamicRangePointerTypeShape(Ctx, MQT->desugar(),
+                                                AllowRedecl);
+  if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
+    return diagnoseDynamicRangePointerTypeShape(Ctx, FPT->getReturnType(),
+                                                AllowRedecl);
+  if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
+    return diagnoseDynamicRangePointerTypeShape(Ctx, FPT->getReturnType(),
+                                                AllowRedecl);
+  if (const auto *AT = dyn_cast<AttributedType>(T)) {
+    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed);
+    if (AT->getAttrKind() == attr::PtrAutoAttr)
+      Ctx.AutoPtrAttributed = true;
+    return diagnoseDynamicRangePointerTypeShape(Ctx, AT->getModifiedType(),
+                                                AllowRedecl);
+  }
+
+  // Base walker already handled the Level 0 __terminated_by check.
+  if (const auto *VTT = dyn_cast<ValueTerminatedType>(T))
+    return diagnoseDynamicRangePointerTypeShape(Ctx, VTT->desugar(),
+                                                AllowRedecl);
+
+  // Like the counted_by case, we emit the diagnostic but return true.
+  if (const auto *ATy = dyn_cast<AtomicType>(T)) {
+    if (ATy->getValueType()->isPointerType()) {
+      S.Diag(Ctx.Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
+          << /*ended_by*/ 6;
+      return true;
+    }
+    // Atomic of non-pointer falls through to the leaf check below.
+  }
+
+  if (const auto *CAT = T->getAs<CountAttributedType>()) {
+    if (Ctx.Level == 0) {
+      S.Diag(Ctx.Loc,
+             diag::err_bounds_safety_conflicting_count_range_attributes);
+      return false;
+    }
+    return diagnoseDynamicRangePointerTypeShape(Ctx, CAT->desugar(),
+                                                AllowRedecl);
+  }
+
+  // At Level 0 we diagnose outright conflicts. The AllowRedecl or
+  // no-existing-end-pointer cases pass through to the visitor.
+  if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
+    if (Ctx.Level == 0) {
+      if (AllowRedecl || DRPT->getEndPointer() == nullptr)
+        return true;
+      S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+          << /*pointer*/ 1 << /*end*/ 3;
+      return false;
+    }
+    return diagnoseDynamicRangePointerTypeShape(Ctx, DRPT->desugar(),
+                                                AllowRedecl);
+  }
+
+  // Nothing to diagnose here for __ended_by.
+  if (const auto *PT = T->getAs<PointerType>()) {
+    if (Ctx.Level == 0)
+      return true;
+    --Ctx.Level;
+    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed, false);
+    return diagnoseDynamicRangePointerTypeShape(Ctx, PT->getPointeeType(),
+                                                AllowRedecl);
+  }
+
+  // Fallback for pointers_only.
+  S.Diag(Ctx.Loc, diag::err_attribute_pointers_only) << Ctx.DiagName << 0;
+  return false;
+}
+
+// Post-construction helpers. Return true if a mismatch diagnostic was emitted.
+static bool diagnoseRedeclCountMismatch(Sema &S, SourceLocation Loc,
+                                        bool OldIsPointer,
+                                        const CountAttributedType *OldTy,
+                                        const CountAttributedType *NewTy) {
+  llvm::FoldingSetNodeID NewID, OldID;
+  if (const Expr *NewCnt = NewTy->getCountExpr())
+    NewCnt->Profile(NewID, S.Context, /*Canonical*/ true);
+  if (const Expr *OldCnt = OldTy->getCountExpr())
+    OldCnt->Profile(OldID, S.Context, /*Canonical*/ true);
+  if (NewID == OldID)
+    return false;
+  S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+      << /*pointer*/ OldIsPointer << /*count*/ 2;
+  return true;
+}
+
+static bool diagnoseRedeclEndPtrMismatch(Sema &S, SourceLocation Loc,
+                                         const Expr *OldEndPtr,
+                                         const Expr *NewEndPtr) {
+  llvm::FoldingSetNodeID NewID, OldID;
+  NewEndPtr->Profile(NewID, S.Context, /*Canonical*/ true);
+  OldEndPtr->Profile(OldID, S.Context, /*Canonical*/ true);
+  if (NewID == OldID)
+    return false;
+  S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+      << /*pointer*/ 1 << /*end*/ 3;
+  return true;
+}
+
 template<typename Derived>
 class ConstructDynamicBoundType
     : public TypeVisitor<Derived, QualType> {
@@ -6463,7 +6834,7 @@ public:
   QualType VisitType(const Type *T) {
     if (const auto *PTy = T->getAs<PointerType>())
       return VisitPointerType(PTy);
-    S.Diag(Loc, diag::err_attribute_pointers_only) << DiagName << 0;
+    assert(false && "pre-check should have rejected non-pointer leaf type");
     return QualType();
   }
 
@@ -6498,8 +6869,7 @@ public:
     BoundsSafetyPointerAttributes FAttr = T->getPointerAttributes();
 
     if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
-      S.Diag(Loc, diag::err_bounds_safety_conflicting_count_bound_attributes)
-          << DiagName << (FAttr.hasLowerBound() ? 0 : 1);
+      assert(false && "pre-check should have rejected conflicting count+bound");
       return QualType();
     }
 
@@ -6594,7 +6964,8 @@ public:
 
   QualType VisitValueTerminatedType(const ValueTerminatedType *T) {
     if (Level == 0 && !AutoPtrAttributed) {
-      S.Diag(Loc, diag::err_bounds_safety_terminated_by_wrong_pointer_type);
+      assert(false &&
+             "pre-check should have rejected terminated_by on wrong pointer");
       return QualType();
     }
     QualType NewTy = Visit(T->desugar());
@@ -6620,64 +6991,18 @@ public:
       : ConstructDynamicBoundType(S, Level, DiagName, ArgE, Loc, ScopeCheck,
                                   AllowRedecl),
         CountInBytes(CountInBytes), OrNull(OrNull) {
-    if (!ArgExpr->getType()->isIntegralOrEnumerationType()) {
-      S.Diag(Loc, diag::err_attribute_argument_type_for_bounds_safety_count)
-          << DiagName;
-      // Recover by using the integer literal 0 as the count. If we get to
-      // DefaultLvalueConversion and the count is itself a __counted_by value,
-      // clang will go down a fiery stack overflow.
-      ArgExpr = S.ActOnIntegerConstant(ArgExpr->getBeginLoc(), 0).get();
-    }
+    assert(ArgExpr->getType()->isIntegralOrEnumerationType() &&
+           "pre-check should have rewritten non-integral count to literal 0");
   }
 
   QualType BuildDynamicBoundType(QualType CanonTy) {
-    if (!CountInBytes && CanonTy->isPointerType()) {
-      auto PointeeTy = CanonTy->getPointeeType();
-      // NOTE: We don't error for incomplete types that might be later completed
-      // (e.g. a struct forward declaration). Instead for those
-      // completable-incomplete types we delay checking until the type is used
-      // see `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
-      // attribute to be used on code that prefers to keep its pointees
-      // incomplete until they need to be used.
-      if (PointeeTy->isAlwaysIncompleteType() || PointeeTy->isFunctionType() ||
-          PointeeTy->isSizelessType() ||
-          PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
-        // Use unspecified pointer attributes for diagnostic purposes.
-        QualType Unsp = S.Context.getBoundsSafetyPointerType(
-            CanonTy, BoundsSafetyPointerAttributes::unspecified());
-
-        auto PD = S.PDiag(diag::err_bounds_safety_counted_by_without_size);
-        PD << Unsp << Unsp->getPointeeType() << OrNull;
-        // Suggest `__sized_by` if the`__counted_by` macro was used.
-        // We intentionally don't suggest a fixit if the attribute is used
-        // directly (i.e. without the macro) because it is not expected that
-        // users will use it.
-        int SuggestFixIt = 0; // Default don't suggest __sized_by
-        if (Loc.isMacroID()) {
-          // FIXME(dliew): Use `AL.MacroII` to get the name. Unfortunately
-          // `AL.MacroII` is not set so we can't simply check the macro name is
-          // what we expect. So instead we have the lexer tell us the contents
-          // of the token and check against that.
-          // rdar://100631458
-          auto MacroName =
-              Lexer::getImmediateMacroName(Loc, S.SourceMgr, S.LangOpts);
-          if (MacroName == "__counted_by") {
-            SuggestFixIt = 1; // Emit text to suggest __sized_by
-            auto MacroLoc = S.SourceMgr.getExpansionLoc(Loc);
-            PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by");
-          } else if (MacroName == "__counted_by_or_null") {
-            SuggestFixIt = 1; // Emit text to suggest __sized_by_or_null
-            auto MacroLoc = S.SourceMgr.getExpansionLoc(Loc);
-            PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by_or_null");
-          }
-        }
-        PD << SuggestFixIt;
-        S.Diag(Loc, PD);
-
-        // Recover by assuming a byte count.
-        CountInBytes = true;
-      }
-    }
+    assert((CountInBytes || !CanonTy->isPointerType() ||
+            !(CanonTy->getPointeeType()->isAlwaysIncompleteType() ||
+              CanonTy->getPointeeType()->isFunctionType() ||
+              CanonTy->getPointeeType()->isSizelessType() ||
+              CanonTy->getPointeeType()
+                  ->isStructureTypeWithFlexibleArrayMember())) &&
+           "pre-check should have flipped CountInBytes for bad pointee");
     QualType Ty = S.BuildCountAttributedType(CanonTy, ArgExpr, CountInBytes,
                                              OrNull, ScopeCheck);
     assert(ConstructedType == nullptr);
@@ -6686,27 +7011,21 @@ public:
   }
 
   QualType DiagnoseConflictingType(const CountAttributedType *T) {
-    if (AllowRedecl) {
-      QualType NewTy = BuildDynamicBoundType(T->desugar());
-      const auto *NewDCPTy = NewTy->getAs<CountAttributedType>();
-      // We don't have a way to distinguish if '__counted_by' is conflicting or has been
-      // actually inherited from function declaration. Thus, we are now permitting
-      // redundant '__counted_by' as long as the resulting count expressions are equivalent
-      // and picking up the later one.
-      llvm::FoldingSetNodeID NewID;
-      llvm::FoldingSetNodeID OldID;
-      if (const auto *NewCnt = NewDCPTy->getCountExpr())
-        NewCnt->Profile(NewID, S.Context, /*Canonical*/ true);
-      if (const auto *OldCnt = T->getCountExpr())
-        OldCnt->Profile(OldID, S.Context, /*Canonical*/ true);
-
-      if (NewID == OldID)
-        return NewTy;
-    }
-
-    S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-        << /* pointer */ T->isPointerType() << /* count */ 2;
-    return QualType();
+    assert(AllowRedecl &&
+           "pre-check should have rejected !AllowRedecl count conflict");
+    QualType NewTy = BuildDynamicBoundType(T->desugar());
+    const auto *NewDCPTy = NewTy->getAs<CountAttributedType>();
+    // We don't have a way to distinguish if '__counted_by' is conflicting or
+    // has been actually inherited from function declaration. Thus, we are now
+    // permitting redundant '__counted_by' as long as the resulting count
+    // expressions are equivalent and picking up the later one.
+    //
+    // TODO: this call is still in the visitor because it depends on
+    // BuildDynamicBoundType having already run, which constructs the
+    // attribute's new type.
+    if (diagnoseRedeclCountMismatch(S, Loc, T->isPointerType(), T, NewDCPTy))
+      return QualType();
+    return NewTy;
   }
 
   QualType VisitFunctionProtoType(const FunctionProtoType *FPT) {
@@ -6720,18 +7039,18 @@ public:
   }
 
   QualType DiagnoseConflictingType(const DynamicRangePointerType *T) {
-    S.Diag(Loc, diag::err_bounds_safety_conflicting_count_range_attributes);
+    assert(false &&
+           "pre-check should have rejected count+range attribute conflict");
     return QualType();
   }
 
   QualType VisitArrayType(const ArrayType *T) {
     if (Level == 0) {
-      if (T->hasAttr(attr::ArrayDecayDiscardsCountInParameters)) {
+      if (T->hasAttr(attr::ArrayDecayDiscardsCountInParameters))
         return Visit(S.Context.getArrayDecayedType(QualType(T, 0)));
-      } else {
-        S.Diag(Loc, diag::err_bounds_safety_complete_array_with_count);
-        return QualType();
-      }
+      assert(false &&
+             "pre-check should have rejected Level-0 sized array with count");
+      return QualType();
     }
     return TraverseArrayType(T);
   }
@@ -6743,23 +7062,15 @@ public:
     if (NewElementTy.isNull())
       return QualType();
 
-    if (T->getPointeeType() != NewElementTy) {
-      // Count attributes on the element of an array type are not supported yet
-      S.Diag(Loc,
-             diag::err_multiple_coupled_decls_in_bounds_safety_dynamic_count);
-      return QualType();
-    }
-
+    assert(T->getPointeeType() == NewElementTy &&
+           "pre-check should have rejected count on array element");
     return QualType(T, 0);
   }
 
   QualType VisitIncompleteArrayType(const IncompleteArrayType *T) {
     if (Level == 0) {
-      if (CountInBytes) {
-        S.Diag(Loc, diag::err_bounds_safety_sized_by_array) << DiagName;
-        return QualType();
-      }
-
+      assert(!CountInBytes &&
+             "pre-check should have rejected sized_by on incomplete array");
       return BuildDynamicBoundType(QualType(T, 0));
     }
     return TraverseArrayType(T);
@@ -6768,15 +7079,10 @@ public:
   QualType VisitAtomicType(const AtomicType *T) {
     QualType ValTy = T->getValueType();
     if (ValTy->isPointerType()) {
-      if (!AtomicErrorEmitted) {
-        unsigned DiagIndex = CountInBytes ? 3 : 2;
-        if (OrNull)
-          DiagIndex += 2;
-        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
-            << DiagIndex;
-        AtomicErrorEmitted = true;
-      }
-      // Construct the atomic pointer anyway.
+      AtomicErrorEmitted = true;
+      // Construct the atomic pointer anyway so
+      // `ConstructBoundsSafetyPointerType::VisitAtomicTypeLoc` doesn't emit
+      // the diagnostic again.
       QualType NewValTy = Visit(ValTy);
       return S.Context.getAtomicType(NewValTy);
     }
@@ -6966,14 +7272,10 @@ public:
       assert(EndPtr);
       if (auto OldEndPtr = T->getEndPointer()) {
         assert(AllowRedecl);
-        llvm::FoldingSetNodeID NewID;
-        llvm::FoldingSetNodeID OldID;
-        EndPtr->Profile(NewID, S.Context, /*Canonical*/ true);
-        OldEndPtr->Profile(OldID, S.Context, /*Canonical*/ true);
-
-        if (NewID != OldID) {
-          S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-              << /* pointer */ 1 << /* end */ 3;
+        // TODO: this call is still in the visitor because it depends on the
+        // recursive Visit(T->desugar()) above having already run, which
+        // constructs the attribute's new type.
+        if (diagnoseRedeclEndPtrMismatch(S, Loc, OldEndPtr, EndPtr)) {
           ConstructedType = nullptr;
           return QualType();
         }
@@ -6991,25 +7293,23 @@ public:
   }
 
   QualType DiagnoseConflictingType(const CountAttributedType *T) {
-    S.Diag(Loc, diag::err_bounds_safety_conflicting_count_range_attributes);
+    assert(false &&
+           "pre-check should have rejected count+range attribute conflict");
     return QualType();
   }
 
   QualType DiagnoseConflictingType(const DynamicRangePointerType *T) {
-    S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-        << /* pointer */ 1 << /* end */ 3;
+    assert(false && "pre-check should have rejected conflicting range-pointer");
     return QualType();
   }
 
   QualType VisitAtomicType(const AtomicType *T) {
     QualType ValTy = T->getValueType();
     if (ValTy->isPointerType()) {
-      if (!AtomicErrorEmitted) {
-        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
-            << /*ended_by*/ 6;
-        AtomicErrorEmitted = true;
-      }
-      // Construct the atomic pointer anyway.
+      AtomicErrorEmitted = true;
+      // Construct the atomic pointer anyway so
+      // `ConstructBoundsSafetyPointerType::VisitAtomicTypeLoc` doesn't emit
+      // the diagnostic again.
       QualType NewValTy = Visit(ValTy);
       return S.Context.getAtomicType(NewValTy);
     }
@@ -7722,6 +8022,19 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
       StartPtrInfo = TypeCoupledDeclRefInfo(Info.VD, /*Deref=*/Level != 0);
     }
 
+    LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc, Level};
+    if (!diagnoseDynamicBoundTypeShape(DiagCtx, Info.DeclTy))
+      return;
+
+    // Reset Ctx.Level before the second walker call. The base walker decrements
+    // Ctx.Level when it descends through pointers and the range-specific walker
+    // needs to start from the original Level.
+    DiagCtx.Level = Level;
+    DiagCtx.AutoPtrAttributed = false;
+    if (!diagnoseDynamicRangePointerTypeShape(
+            DiagCtx, Info.DeclTy, /*AllowRedecl=*/OriginatesInAPINotes))
+      return;
+
     auto TypeConstructor = ConstructDynamicRangePointerType(
         *this, Level, DiagName, AttrArg, Loc, OriginatesInAPINotes,
         Info.ScopeCheck, StartPtrInfo);
@@ -7729,6 +8042,28 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     HadAtomicError = TypeConstructor.hadAtomicError();
     ConstructedType = TypeConstructor.getConstructedType();
   } else {
+    LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc, Level};
+    if (!diagnoseDynamicBoundTypeShape(DiagCtx, Info.DeclTy))
+      return;
+
+    if (!AttrArg->getType()->isIntegralOrEnumerationType()) {
+      Diag(Loc, diag::err_attribute_argument_type_for_bounds_safety_count)
+          << DiagName;
+      // Recover by using the integer literal 0 as the count. If we get to
+      // DefaultLvalueConversion and the count is itself a __counted_by value,
+      // clang will go down a fiery stack overflow.
+      AttrArg = ActOnIntegerConstant(AttrArg->getBeginLoc(), 0).get();
+    }
+
+    // Reset Ctx.Level before the second walker call for the same reasoning as
+    // above.
+    DiagCtx.Level = Level;
+    DiagCtx.AutoPtrAttributed = false;
+    if (!diagnoseCountAttributedTypeShape(DiagCtx, Info.DeclTy, CountInBytes,
+                                          OrNull,
+                                          /*AllowRedecl=*/OriginatesInAPINotes))
+      return;
+
     auto TypeConstructor = ConstructCountAttributedType(
         *this, Level, DiagName, AttrArg, Loc, CountInBytes, OrNull,
         OriginatesInAPINotes, Info.ScopeCheck);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6901,12 +6901,16 @@ public:
     return QualType(T, 0);
   }
 
-  QualType DiagnoseConflictingType(const CountAttributedType *T) { return QualType(); }
-  QualType DiagnoseConflictingType(const DynamicRangePointerType *T) { return QualType(); }
+  QualType HandleConflictingBoundsAttr(const CountAttributedType *T) {
+    return QualType();
+  }
+  QualType HandleConflictingBoundsAttr(const DynamicRangePointerType *T) {
+    return QualType();
+  }
 
   QualType VisitCountAttributedType(const CountAttributedType *T) {
     if (Level == 0) {
-      return getDerived()->DiagnoseConflictingType(T);
+      return getDerived()->HandleConflictingBoundsAttr(T);
     }
 
     QualType PointerTy = Visit(T->desugar());
@@ -6923,7 +6927,7 @@ public:
 
   QualType VisitDynamicRangePointerType(const DynamicRangePointerType *T) {
     if (Level == 0) {
-      return getDerived()->DiagnoseConflictingType(T);
+      return getDerived()->HandleConflictingBoundsAttr(T);
     }
 
     QualType PointerTy = Visit(T->desugar());
@@ -7016,7 +7020,7 @@ public:
     return Ty;
   }
 
-  QualType DiagnoseConflictingType(const CountAttributedType *T) {
+  QualType HandleConflictingBoundsAttr(const CountAttributedType *T) {
     assert(AllowRedecl &&
            "pre-check should have rejected !AllowRedecl count conflict");
     // Pre-check already verified the canonical count expressions match.
@@ -7034,7 +7038,7 @@ public:
     return ConstructDynamicBoundType::VisitFunctionNoProtoType(FPT);
   }
 
-  QualType DiagnoseConflictingType(const DynamicRangePointerType *T) {
+  QualType HandleConflictingBoundsAttr(const DynamicRangePointerType *T) {
     assert(false &&
            "pre-check should have rejected count+range attribute conflict");
     return QualType();
@@ -7277,13 +7281,13 @@ public:
     return BaseClass::VisitDynamicRangePointerType(T);
   }
 
-  QualType DiagnoseConflictingType(const CountAttributedType *T) {
+  QualType HandleConflictingBoundsAttr(const CountAttributedType *T) {
     assert(false &&
            "pre-check should have rejected count+range attribute conflict");
     return QualType();
   }
 
-  QualType DiagnoseConflictingType(const DynamicRangePointerType *T) {
+  QualType HandleConflictingBoundsAttr(const DynamicRangePointerType *T) {
     assert(false && "pre-check should have rejected conflicting range-pointer");
     return QualType();
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6426,6 +6426,8 @@ public:
   StringRef DiagName;
   SourceLocation Loc;
   unsigned Level;
+  Expr *AttrArg;
+  bool ScopeCheck;
   bool AutoPtrAttributed = false;
 };
 
@@ -6499,6 +6501,7 @@ static bool diagnoseDynamicBoundTypeShape(LateBoundsAttrDiagContext &Ctx,
 // - err_bounds_safety_sized_by_array
 // - err_multiple_coupled_decls_in_bounds_safety_dynamic_count
 // - err_bounds_safety_counted_by_without_size
+// - err_bounds_safety_conflicting_pointer_attributes
 static bool diagnoseCountAttributedTypeShape(LateBoundsAttrDiagContext &Ctx,
                                              QualType DeclTy,
                                              bool &CountInBytes, bool OrNull,
@@ -6551,11 +6554,27 @@ static bool diagnoseCountAttributedTypeShape(LateBoundsAttrDiagContext &Ctx,
     // Atomic of non-pointer falls through to the leaf check below.
   }
 
-  // At Level 0 we diagnose or pass through to the visitor's Profile compare
-  // (see TODO in DiagnoseConflictingType).
+  // At Level 0 we either diagnose, or canonicalize and compare for
+  // AllowRedecl.
   if (const auto *CAT = T->getAs<CountAttributedType>()) {
     if (Ctx.Level == 0) {
       if (!AllowRedecl) {
+        S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+            << /*pointer*/ CAT->isPointerType() << /*count*/ 2;
+        return false;
+      }
+      // AllowRedecl: canonicalize the new count expression and compare against
+      // the existing one.
+      ExprResult CanonCount = S.CanonicalizeBoundsCountExpr(
+          Ctx.AttrArg, CountInBytes, OrNull, Ctx.ScopeCheck,
+          CAT->desugar()->isArrayType());
+      if (CanonCount.isInvalid())
+        return false;
+      llvm::FoldingSetNodeID NewID, OldID;
+      CanonCount.get()->Profile(NewID, S.Context, /*Canonical=*/true);
+      if (const Expr *OldCnt = CAT->getCountExpr())
+        OldCnt->Profile(OldID, S.Context, /*Canonical=*/true);
+      if (NewID != OldID) {
         S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
             << /*pointer*/ CAT->isPointerType() << /*count*/ 2;
         return false;
@@ -6730,15 +6749,32 @@ static bool diagnoseDynamicRangePointerTypeShape(LateBoundsAttrDiagContext &Ctx,
                                                 AllowRedecl);
   }
 
-  // At Level 0 we diagnose outright conflicts. The AllowRedecl or
-  // no-existing-end-pointer cases pass through to the visitor.
+  // At Level 0 we diagnose outright conflicts, or canonicalize and compare
+  // for AllowRedecl.
   if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
     if (Ctx.Level == 0) {
-      if (AllowRedecl || DRPT->getEndPointer() == nullptr)
+      if (DRPT->getEndPointer() == nullptr)
         return true;
-      S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-          << /*pointer*/ 1 << /*end*/ 3;
-      return false;
+      if (!AllowRedecl) {
+        S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+            << /*pointer*/ 1 << /*end*/ 3;
+        return false;
+      }
+      // Canonicalize new end-pointer expression and compare against existing
+      // one
+      ExprResult CanonEnd =
+          S.CanonicalizeRangeEndPtrExpr(Ctx.AttrArg, Ctx.ScopeCheck);
+      if (CanonEnd.isInvalid())
+        return false;
+      llvm::FoldingSetNodeID NewID, OldID;
+      CanonEnd.get()->Profile(NewID, S.Context, /*Canonical=*/true);
+      DRPT->getEndPointer()->Profile(OldID, S.Context, /*Canonical=*/true);
+      if (NewID != OldID) {
+        S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+            << /*pointer*/ 1 << /*end*/ 3;
+        return false;
+      }
+      return true;
     }
     return diagnoseDynamicRangePointerTypeShape(Ctx, DRPT->desugar(),
                                                 AllowRedecl);
@@ -6757,36 +6793,6 @@ static bool diagnoseDynamicRangePointerTypeShape(LateBoundsAttrDiagContext &Ctx,
   // Fallback for pointers_only.
   S.Diag(Ctx.Loc, diag::err_attribute_pointers_only) << Ctx.DiagName << 0;
   return false;
-}
-
-// Post-construction helpers. Return true if a mismatch diagnostic was emitted.
-static bool diagnoseRedeclCountMismatch(Sema &S, SourceLocation Loc,
-                                        bool OldIsPointer,
-                                        const CountAttributedType *OldTy,
-                                        const CountAttributedType *NewTy) {
-  llvm::FoldingSetNodeID NewID, OldID;
-  if (const Expr *NewCnt = NewTy->getCountExpr())
-    NewCnt->Profile(NewID, S.Context, /*Canonical*/ true);
-  if (const Expr *OldCnt = OldTy->getCountExpr())
-    OldCnt->Profile(OldID, S.Context, /*Canonical*/ true);
-  if (NewID == OldID)
-    return false;
-  S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-      << /*pointer*/ OldIsPointer << /*count*/ 2;
-  return true;
-}
-
-static bool diagnoseRedeclEndPtrMismatch(Sema &S, SourceLocation Loc,
-                                         const Expr *OldEndPtr,
-                                         const Expr *NewEndPtr) {
-  llvm::FoldingSetNodeID NewID, OldID;
-  NewEndPtr->Profile(NewID, S.Context, /*Canonical*/ true);
-  OldEndPtr->Profile(OldID, S.Context, /*Canonical*/ true);
-  if (NewID == OldID)
-    return false;
-  S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-      << /*pointer*/ 1 << /*end*/ 3;
-  return true;
 }
 
 template<typename Derived>
@@ -7013,19 +7019,9 @@ public:
   QualType DiagnoseConflictingType(const CountAttributedType *T) {
     assert(AllowRedecl &&
            "pre-check should have rejected !AllowRedecl count conflict");
-    QualType NewTy = BuildDynamicBoundType(T->desugar());
-    const auto *NewDCPTy = NewTy->getAs<CountAttributedType>();
-    // We don't have a way to distinguish if '__counted_by' is conflicting or
-    // has been actually inherited from function declaration. Thus, we are now
-    // permitting redundant '__counted_by' as long as the resulting count
-    // expressions are equivalent and picking up the later one.
-    //
-    // TODO: this call is still in the visitor because it depends on
-    // BuildDynamicBoundType having already run, which constructs the
-    // attribute's new type.
-    if (diagnoseRedeclCountMismatch(S, Loc, T->isPointerType(), T, NewDCPTy))
-      return QualType();
-    return NewTy;
+    // Pre-check already verified the canonical count expressions match.
+    // Just build the new type.
+    return BuildDynamicBoundType(T->desugar());
   }
 
   QualType VisitFunctionProtoType(const FunctionProtoType *FPT) {
@@ -7270,15 +7266,10 @@ public:
       Expr *EndPtr = DRPT->getEndPointer();
       auto EndPtrDecls = DRPT->getEndPtrDecls();
       assert(EndPtr);
-      if (auto OldEndPtr = T->getEndPointer()) {
+      if (T->getEndPointer()) {
+        // Pre-check already verified the canonical end-pointer expressions
+        // match.
         assert(AllowRedecl);
-        // TODO: this call is still in the visitor because it depends on the
-        // recursive Visit(T->desugar()) above having already run, which
-        // constructs the attribute's new type.
-        if (diagnoseRedeclEndPtrMismatch(S, Loc, OldEndPtr, EndPtr)) {
-          ConstructedType = nullptr;
-          return QualType();
-        }
       }
 
       // ConstructType was already set while visiting the nested PointerType.
@@ -8022,7 +8013,8 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
       StartPtrInfo = TypeCoupledDeclRefInfo(Info.VD, /*Deref=*/Level != 0);
     }
 
-    LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc, Level};
+    LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc,
+                                      Level, AttrArg,  Info.ScopeCheck};
     if (!diagnoseDynamicBoundTypeShape(DiagCtx, Info.DeclTy))
       return;
 
@@ -8042,7 +8034,8 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     HadAtomicError = TypeConstructor.hadAtomicError();
     ConstructedType = TypeConstructor.getConstructedType();
   } else {
-    LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc, Level};
+    LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc,
+                                      Level, AttrArg,  Info.ScopeCheck};
     if (!diagnoseDynamicBoundTypeShape(DiagCtx, Info.DeclTy))
       return;
 
@@ -8053,6 +8046,9 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
       // DefaultLvalueConversion and the count is itself a __counted_by value,
       // clang will go down a fiery stack overflow.
       AttrArg = ActOnIntegerConstant(AttrArg->getBeginLoc(), 0).get();
+
+      // Walker needs to see the rewritten version of AttrArg.
+      DiagCtx.AttrArg = AttrArg;
     }
 
     // Reset Ctx.Level before the second walker call for the same reasoning as

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6429,371 +6429,354 @@ public:
   Expr *AttrArg;
   bool ScopeCheck;
   bool AutoPtrAttributed = false;
-};
 
-// Pre-check for base class. Return true if and only if no diagnostics are
-// emitted here.
-//
-// Emits:
-// - err_bounds_safety_conflicting_count_bound_attributes
-// - err_bounds_safety_terminated_by_wrong_pointer_type
-static bool diagnoseDynamicBoundTypeShape(LateBoundsAttrDiagContext &Ctx,
-                                          QualType DeclTy) {
-  Sema &S = Ctx.S;
-  const Type *T = DeclTy.split().Ty;
+  // Pre-check for base class. Return true if and only if no diagnostics are
+  // emitted here.
+  //
+  // Emits:
+  // - err_bounds_safety_conflicting_count_bound_attributes
+  // - err_bounds_safety_terminated_by_wrong_pointer_type
+  bool diagnoseDynamicBoundTypeShape(QualType DeclTy) {
+    const Type *T = DeclTy.split().Ty;
 
-  // Desugar and descend.
-  if (const auto *PT = dyn_cast<ParenType>(T))
-    return diagnoseDynamicBoundTypeShape(Ctx, PT->getInnerType());
-  if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
-    return diagnoseDynamicBoundTypeShape(Ctx, MQT->desugar());
-  if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
-    return diagnoseDynamicBoundTypeShape(Ctx, FPT->getReturnType());
-  if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
-    return diagnoseDynamicBoundTypeShape(Ctx, FPT->getReturnType());
-  if (const auto *AT = dyn_cast<AttributedType>(T)) {
-    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed);
-    if (AT->getAttrKind() == attr::PtrAutoAttr)
-      Ctx.AutoPtrAttributed = true;
-    return diagnoseDynamicBoundTypeShape(Ctx, AT->getModifiedType());
-  }
-
-  if (const auto *VTT = dyn_cast<ValueTerminatedType>(T)) {
-    // A __terminated_by pointer cannot also carry a count or range attribute
-    // unless the terminator was auto-inferred via __ptrauto (see
-    // VisitValueTerminatedType in the visitor for the drop behavior).
-    if (Ctx.Level == 0 && !Ctx.AutoPtrAttributed) {
-      S.Diag(Ctx.Loc, diag::err_bounds_safety_terminated_by_wrong_pointer_type);
-      return false;
+    // Desugar and descend.
+    if (const auto *PT = dyn_cast<ParenType>(T))
+      return diagnoseDynamicBoundTypeShape(PT->getInnerType());
+    if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
+      return diagnoseDynamicBoundTypeShape(MQT->desugar());
+    if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
+      return diagnoseDynamicBoundTypeShape(FPT->getReturnType());
+    if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
+      return diagnoseDynamicBoundTypeShape(FPT->getReturnType());
+    if (const auto *AT = dyn_cast<AttributedType>(T)) {
+      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed);
+      if (AT->getAttrKind() == attr::PtrAutoAttr)
+        AutoPtrAttributed = true;
+      return diagnoseDynamicBoundTypeShape(AT->getModifiedType());
     }
-    return diagnoseDynamicBoundTypeShape(Ctx, VTT->desugar());
-  }
 
-  // Use getAs to desugar typedefs, elaborated types, etc.
-  if (const auto *PT = T->getAs<PointerType>()) {
-    auto FAttr = PT->getPointerAttributes();
-    if (FAttr.hasUpperBound() && !Ctx.AutoPtrAttributed) {
-      S.Diag(Ctx.Loc,
-             diag::err_bounds_safety_conflicting_count_bound_attributes)
-          << Ctx.DiagName << (FAttr.hasLowerBound() ? 0 : 1);
-      return false;
-    }
-    if (Ctx.Level == 0)
-      return true;
-    --Ctx.Level;
-    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed, false);
-    return diagnoseDynamicBoundTypeShape(Ctx, PT->getPointeeType());
-  }
-
-  return true;
-}
-
-// Pre-check for counted_by family. Sets CountIntBytes = true for pointers
-// whose pointee has unknown size, and AllowRedecl = true when descending into
-// a function-prototype subwalk.
-//
-// Emits:
-// - err_attribute_pointers_only
-// - err_bounds_safety_atomic_unsupported_attribute
-// - err_bounds_safety_conflicting_pointer_attributes
-// - err_bounds_safety_conflicting_count_range_attributes
-// - err_bounds_safety_complete_array_with_count
-// - err_bounds_safety_sized_by_array
-// - err_multiple_coupled_decls_in_bounds_safety_dynamic_count
-// - err_bounds_safety_counted_by_without_size
-// - err_bounds_safety_conflicting_pointer_attributes
-static bool diagnoseCountAttributedTypeShape(LateBoundsAttrDiagContext &Ctx,
-                                             QualType DeclTy,
-                                             bool &CountInBytes, bool OrNull,
-                                             bool AllowRedecl) {
-  Sema &S = Ctx.S;
-  const Type *T = DeclTy.split().Ty;
-
-  // Desugar and descend.
-  if (const auto *PT = dyn_cast<ParenType>(T))
-    return diagnoseCountAttributedTypeShape(Ctx, PT->getInnerType(),
-                                            CountInBytes, OrNull, AllowRedecl);
-  if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
-    return diagnoseCountAttributedTypeShape(Ctx, MQT->desugar(), CountInBytes,
-                                            OrNull, AllowRedecl);
-  // Function prototypes force AllowRedecl=true for the sub-walk.
-  if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
-    return diagnoseCountAttributedTypeShape(Ctx, FPT->getReturnType(),
-                                            CountInBytes, OrNull,
-                                            /*AllowRedecl=*/true);
-  if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
-    return diagnoseCountAttributedTypeShape(Ctx, FPT->getReturnType(),
-                                            CountInBytes, OrNull,
-                                            /*AllowRedecl=*/true);
-  if (const auto *AT = dyn_cast<AttributedType>(T)) {
-    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed);
-    if (AT->getAttrKind() == attr::PtrAutoAttr)
-      Ctx.AutoPtrAttributed = true;
-    return diagnoseCountAttributedTypeShape(Ctx, AT->getModifiedType(),
-                                            CountInBytes, OrNull, AllowRedecl);
-  }
-
-  // Base walker already handled the Level 0 __terminated_by check.
-  if (const auto *VTT = dyn_cast<ValueTerminatedType>(T))
-    return diagnoseCountAttributedTypeShape(Ctx, VTT->desugar(), CountInBytes,
-                                            OrNull, AllowRedecl);
-
-  // An AtomicType wrapping a pointer: emit the diagnostic but return true so
-  // the visitor still constructs the atomic type. Its shape prevents
-  // `ConstructBoundsSafetyPointerType::VisitAtomicTypeLoc` from re-emitting
-  // the same diagnostic.
-  if (const auto *ATy = dyn_cast<AtomicType>(T)) {
-    if (ATy->getValueType()->isPointerType()) {
-      unsigned DiagIndex = CountInBytes ? 3 : 2;
-      if (OrNull)
-        DiagIndex += 2;
-      S.Diag(Ctx.Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
-          << DiagIndex;
-      return true;
-    }
-    // Atomic of non-pointer falls through to the leaf check below.
-  }
-
-  // At Level 0 we either diagnose, or canonicalize and compare for
-  // AllowRedecl.
-  if (const auto *CAT = T->getAs<CountAttributedType>()) {
-    if (Ctx.Level == 0) {
-      if (!AllowRedecl) {
-        S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-            << /*pointer*/ CAT->isPointerType() << /*count*/ 2;
+    if (const auto *VTT = dyn_cast<ValueTerminatedType>(T)) {
+      // A __terminated_by pointer cannot also carry a count or range attribute
+      // unless the terminator was auto-inferred via __ptrauto (see
+      // VisitValueTerminatedType in the visitor for the drop behavior).
+      if (Level == 0 && !AutoPtrAttributed) {
+        S.Diag(Loc, diag::err_bounds_safety_terminated_by_wrong_pointer_type);
         return false;
       }
-      // AllowRedecl: canonicalize the new count expression and compare against
-      // the existing one.
-      ExprResult CanonCount = S.CanonicalizeBoundsCountExpr(
-          Ctx.AttrArg, CountInBytes, OrNull, Ctx.ScopeCheck,
-          CAT->desugar()->isArrayType());
-      if (CanonCount.isInvalid())
-        return false;
-      llvm::FoldingSetNodeID NewID, OldID;
-      CanonCount.get()->Profile(NewID, S.Context, /*Canonical=*/true);
-      if (const Expr *OldCnt = CAT->getCountExpr())
-        OldCnt->Profile(OldID, S.Context, /*Canonical=*/true);
-      if (NewID != OldID) {
-        S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-            << /*pointer*/ CAT->isPointerType() << /*count*/ 2;
+      return diagnoseDynamicBoundTypeShape(VTT->desugar());
+    }
+
+    // Use getAs to desugar typedefs, elaborated types, etc.
+    if (const auto *PT = T->getAs<PointerType>()) {
+      auto FAttr = PT->getPointerAttributes();
+      if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
+        S.Diag(Loc, diag::err_bounds_safety_conflicting_count_bound_attributes)
+            << DiagName << (FAttr.hasLowerBound() ? 0 : 1);
         return false;
       }
-      return true;
+      if (Level == 0)
+        return true;
+      --Level;
+      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
+      return diagnoseDynamicBoundTypeShape(PT->getPointeeType());
     }
-    return diagnoseCountAttributedTypeShape(Ctx, CAT->desugar(), CountInBytes,
-                                            OrNull, AllowRedecl);
+
+    return true;
   }
 
-  if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
-    if (Ctx.Level == 0) {
-      S.Diag(Ctx.Loc,
-             diag::err_bounds_safety_conflicting_count_range_attributes);
-      return false;
-    }
-    return diagnoseCountAttributedTypeShape(Ctx, DRPT->desugar(), CountInBytes,
-                                            OrNull, AllowRedecl);
-  }
+  // Pre-check for counted_by family. Sets CountInBytes = true for pointers
+  // whose pointee has unknown size, and AllowRedecl = true when descending
+  // into a function-prototype subwalk.
+  //
+  // Emits:
+  // - err_attribute_pointers_only
+  // - err_bounds_safety_atomic_unsupported_attribute
+  // - err_bounds_safety_conflicting_pointer_attributes
+  // - err_bounds_safety_conflicting_count_range_attributes
+  // - err_bounds_safety_complete_array_with_count
+  // - err_bounds_safety_sized_by_array
+  // - err_multiple_coupled_decls_in_bounds_safety_dynamic_count
+  // - err_bounds_safety_counted_by_without_size
+  bool diagnoseCountAttributedTypeShape(QualType DeclTy, bool &CountInBytes,
+                                        bool OrNull, bool AllowRedecl) {
+    const Type *T = DeclTy.split().Ty;
 
-  // Use getAsArrayType to desugar.
-  if (const auto *AT = S.Context.getAsArrayType(DeclTy)) {
-    if (Ctx.Level == 0) {
-      if (AT->hasAttr(attr::ArrayDecayDiscardsCountInParameters))
-        return diagnoseCountAttributedTypeShape(
-            Ctx, S.Context.getArrayDecayedType(QualType(AT, 0)), CountInBytes,
-            OrNull, AllowRedecl);
-      if (isa<IncompleteArrayType>(AT)) {
-        if (CountInBytes) {
-          S.Diag(Ctx.Loc, diag::err_bounds_safety_sized_by_array)
-              << Ctx.DiagName;
+    // Desugar and descend.
+    if (const auto *PT = dyn_cast<ParenType>(T))
+      return diagnoseCountAttributedTypeShape(PT->getInnerType(), CountInBytes,
+                                              OrNull, AllowRedecl);
+    if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
+      return diagnoseCountAttributedTypeShape(MQT->desugar(), CountInBytes,
+                                              OrNull, AllowRedecl);
+    // Function prototypes force AllowRedecl=true for the sub-walk.
+    if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
+      return diagnoseCountAttributedTypeShape(FPT->getReturnType(),
+                                              CountInBytes, OrNull,
+                                              /*AllowRedecl=*/true);
+    if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
+      return diagnoseCountAttributedTypeShape(FPT->getReturnType(),
+                                              CountInBytes, OrNull,
+                                              /*AllowRedecl=*/true);
+    if (const auto *AT = dyn_cast<AttributedType>(T)) {
+      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed);
+      if (AT->getAttrKind() == attr::PtrAutoAttr)
+        AutoPtrAttributed = true;
+      return diagnoseCountAttributedTypeShape(
+          AT->getModifiedType(), CountInBytes, OrNull, AllowRedecl);
+    }
+
+    // Base walker already handled the Level 0 __terminated_by check.
+    if (const auto *VTT = dyn_cast<ValueTerminatedType>(T))
+      return diagnoseCountAttributedTypeShape(VTT->desugar(), CountInBytes,
+                                              OrNull, AllowRedecl);
+
+    // An AtomicType wrapping a pointer: emit the diagnostic but return true so
+    // the visitor still constructs the atomic type. Its shape prevents
+    // `ConstructBoundsSafetyPointerType::VisitAtomicTypeLoc` from re-emitting
+    // the same diagnostic.
+    if (const auto *ATy = dyn_cast<AtomicType>(T)) {
+      if (ATy->getValueType()->isPointerType()) {
+        unsigned DiagIndex = CountInBytes ? 3 : 2;
+        if (OrNull)
+          DiagIndex += 2;
+        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
+            << DiagIndex;
+        return true;
+      }
+      // Atomic of non-pointer falls through to the leaf check below.
+    }
+
+    // At Level 0 we either diagnose, or canonicalize and compare for
+    // AllowRedecl.
+    if (const auto *CAT = T->getAs<CountAttributedType>()) {
+      if (Level == 0) {
+        if (!AllowRedecl) {
+          S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+              << /*pointer*/ CAT->isPointerType() << /*count*/ 2;
+          return false;
+        }
+        // AllowRedecl: canonicalize the new count expression and compare
+        // against the existing one.
+        ExprResult CanonCount = S.CanonicalizeBoundsCountExpr(
+            AttrArg, CountInBytes, OrNull, ScopeCheck,
+            CAT->desugar()->isArrayType());
+        if (CanonCount.isInvalid())
+          return false;
+        llvm::FoldingSetNodeID NewID, OldID;
+        CanonCount.get()->Profile(NewID, S.Context, /*Canonical=*/true);
+        if (const Expr *OldCnt = CAT->getCountExpr())
+          OldCnt->Profile(OldID, S.Context, /*Canonical=*/true);
+        if (NewID != OldID) {
+          S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+              << /*pointer*/ CAT->isPointerType() << /*count*/ 2;
           return false;
         }
         return true;
       }
-      S.Diag(Ctx.Loc, diag::err_bounds_safety_complete_array_with_count);
+      return diagnoseCountAttributedTypeShape(CAT->desugar(), CountInBytes,
+                                              OrNull, AllowRedecl);
+    }
+
+    if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
+      if (Level == 0) {
+        S.Diag(Loc, diag::err_bounds_safety_conflicting_count_range_attributes);
+        return false;
+      }
+      return diagnoseCountAttributedTypeShape(DRPT->desugar(), CountInBytes,
+                                              OrNull, AllowRedecl);
+    }
+
+    // Use getAsArrayType to desugar.
+    if (const auto *AT = S.Context.getAsArrayType(DeclTy)) {
+      if (Level == 0) {
+        if (AT->hasAttr(attr::ArrayDecayDiscardsCountInParameters))
+          return diagnoseCountAttributedTypeShape(
+              S.Context.getArrayDecayedType(QualType(AT, 0)), CountInBytes,
+              OrNull, AllowRedecl);
+        if (isa<IncompleteArrayType>(AT)) {
+          if (CountInBytes) {
+            S.Diag(Loc, diag::err_bounds_safety_sized_by_array) << DiagName;
+            return false;
+          }
+          return true;
+        }
+        S.Diag(Loc, diag::err_bounds_safety_complete_array_with_count);
+        return false;
+      }
+      --Level;
+      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
+      bool InnerOK = diagnoseCountAttributedTypeShape(
+          AT->getElementType(), CountInBytes, OrNull, AllowRedecl);
+      if (!InnerOK)
+        return false;
+      // Count attributes on the element of an array type are not supported yet
+      S.Diag(Loc,
+             diag::err_multiple_coupled_decls_in_bounds_safety_dynamic_count);
       return false;
     }
-    --Ctx.Level;
-    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed, false);
-    bool InnerOK = diagnoseCountAttributedTypeShape(
-        Ctx, AT->getElementType(), CountInBytes, OrNull, AllowRedecl);
-    if (!InnerOK)
-      return false;
-    // Count attributes on the element of an array type are not supported yet
-    S.Diag(Ctx.Loc,
-           diag::err_multiple_coupled_decls_in_bounds_safety_dynamic_count);
+
+    // Check the pointee for counted_by-without-size.
+    //
+    // NOTE: We don't error for incomplete types that might be later completed
+    // (e.g. a struct forward declaration). Instead for those
+    // completable-incomplete types we delay checking until the type is used
+    // see `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
+    // attribute to be used on code that prefers to keep its pointees
+    // incomplete until they need to be used.
+    if (const auto *PT = T->getAs<PointerType>()) {
+      if (Level == 0) {
+        if (!CountInBytes) {
+          QualType PointeeTy = QualType(PT, 0)->getPointeeType();
+          if (PointeeTy->isAlwaysIncompleteType() ||
+              PointeeTy->isFunctionType() || PointeeTy->isSizelessType() ||
+              PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
+            // Use unspecified pointer attributes for diagnostic purposes.
+            QualType Unsp = S.Context.getBoundsSafetyPointerType(
+                QualType(PT, 0), BoundsSafetyPointerAttributes::unspecified());
+
+            auto PD = S.PDiag(diag::err_bounds_safety_counted_by_without_size);
+            PD << Unsp << Unsp->getPointeeType() << OrNull;
+            // Suggest `__sized_by` if the `__counted_by` macro was used.
+            // We intentionally don't suggest a fixit if the attribute is used
+            // directly (i.e. without the macro) because it is not expected that
+            // users will use it.
+            int SuggestFixIt = 0; // Default don't suggest __sized_by
+            if (Loc.isMacroID()) {
+              // FIXME(dliew): Use `AL.MacroII` to get the name. Unfortunately
+              // `AL.MacroII` is not set so we can't simply check the macro name
+              // is what we expect. So instead we have the lexer tell us the
+              // contents of the token and check against that.
+              // rdar://100631458
+              auto MacroName =
+                  Lexer::getImmediateMacroName(Loc, S.SourceMgr, S.LangOpts);
+              if (MacroName == "__counted_by") {
+                SuggestFixIt = 1; // Emit text to suggest __sized_by
+                auto MacroLoc = S.SourceMgr.getExpansionLoc(Loc);
+                PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by");
+              } else if (MacroName == "__counted_by_or_null") {
+                SuggestFixIt = 1; // Emit text to suggest __sized_by_or_null
+                auto MacroLoc = S.SourceMgr.getExpansionLoc(Loc);
+                PD << FixItHint::CreateReplacement(MacroLoc,
+                                                   "__sized_by_or_null");
+              }
+            }
+            PD << SuggestFixIt;
+            S.Diag(Loc, PD);
+
+            // Recover by assuming a byte count.
+            CountInBytes = true;
+          }
+        }
+        return true;
+      }
+      --Level;
+      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
+      return diagnoseCountAttributedTypeShape(
+          PT->getPointeeType(), CountInBytes, OrNull, AllowRedecl);
+    }
+
+    // Fallback for pointers_only.
+    S.Diag(Loc, diag::err_attribute_pointers_only) << DiagName << 0;
     return false;
   }
 
-  // Check the pointee for counted_by-without-size.
+  // Pre-check for ended-by.
   //
-  // NOTE: We don't error for incomplete types that might be later completed
-  // (e.g. a struct forward declaration). Instead for those
-  // completable-incomplete types we delay checking until the type is used
-  // see `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
-  // attribute to be used on code that prefers to keep its pointees
-  // incomplete until they need to be used.
-  if (const auto *PT = T->getAs<PointerType>()) {
-    if (Ctx.Level == 0) {
-      if (!CountInBytes) {
-        QualType PointeeTy = QualType(PT, 0)->getPointeeType();
-        if (PointeeTy->isAlwaysIncompleteType() ||
-            PointeeTy->isFunctionType() || PointeeTy->isSizelessType() ||
-            PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
-          // Use unspecified pointer attributes for diagnostic purposes.
-          QualType Unsp = S.Context.getBoundsSafetyPointerType(
-              QualType(PT, 0), BoundsSafetyPointerAttributes::unspecified());
+  // Emits:
+  // - err_attribute_pointers_only
+  // - err_bounds_safety_atomic_unsupported_attribute
+  // - err_bounds_safety_conflicting_count_range_attributes
+  // - err_bounds_safety_conflicting_pointer_attributes
+  bool diagnoseDynamicRangePointerTypeShape(QualType DeclTy, bool AllowRedecl) {
+    const Type *T = DeclTy.split().Ty;
 
-          auto PD = S.PDiag(diag::err_bounds_safety_counted_by_without_size);
-          PD << Unsp << Unsp->getPointeeType() << OrNull;
-          // Suggest `__sized_by` if the `__counted_by` macro was used.
-          // We intentionally don't suggest a fixit if the attribute is used
-          // directly (i.e. without the macro) because it is not expected that
-          // users will use it.
-          int SuggestFixIt = 0; // Default don't suggest __sized_by
-          if (Ctx.Loc.isMacroID()) {
-            // FIXME(dliew): Use `AL.MacroII` to get the name. Unfortunately
-            // `AL.MacroII` is not set so we can't simply check the macro name
-            // is what we expect. So instead we have the lexer tell us the
-            // contents of the token and check against that.
-            // rdar://100631458
-            auto MacroName =
-                Lexer::getImmediateMacroName(Ctx.Loc, S.SourceMgr, S.LangOpts);
-            if (MacroName == "__counted_by") {
-              SuggestFixIt = 1; // Emit text to suggest __sized_by
-              auto MacroLoc = S.SourceMgr.getExpansionLoc(Ctx.Loc);
-              PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by");
-            } else if (MacroName == "__counted_by_or_null") {
-              SuggestFixIt = 1; // Emit text to suggest __sized_by_or_null
-              auto MacroLoc = S.SourceMgr.getExpansionLoc(Ctx.Loc);
-              PD << FixItHint::CreateReplacement(MacroLoc,
-                                                 "__sized_by_or_null");
-            }
-          }
-          PD << SuggestFixIt;
-          S.Diag(Ctx.Loc, PD);
-
-          // Recover by assuming a byte count.
-          CountInBytes = true;
-        }
-      }
-      return true;
+    // Desugar and descend.
+    if (const auto *PT = dyn_cast<ParenType>(T))
+      return diagnoseDynamicRangePointerTypeShape(PT->getInnerType(),
+                                                  AllowRedecl);
+    if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
+      return diagnoseDynamicRangePointerTypeShape(MQT->desugar(), AllowRedecl);
+    if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
+      return diagnoseDynamicRangePointerTypeShape(FPT->getReturnType(),
+                                                  AllowRedecl);
+    if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
+      return diagnoseDynamicRangePointerTypeShape(FPT->getReturnType(),
+                                                  AllowRedecl);
+    if (const auto *AT = dyn_cast<AttributedType>(T)) {
+      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed);
+      if (AT->getAttrKind() == attr::PtrAutoAttr)
+        AutoPtrAttributed = true;
+      return diagnoseDynamicRangePointerTypeShape(AT->getModifiedType(),
+                                                  AllowRedecl);
     }
-    --Ctx.Level;
-    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed, false);
-    return diagnoseCountAttributedTypeShape(Ctx, PT->getPointeeType(),
-                                            CountInBytes, OrNull, AllowRedecl);
-  }
 
-  // Fallback for pointers_only.
-  S.Diag(Ctx.Loc, diag::err_attribute_pointers_only) << Ctx.DiagName << 0;
-  return false;
-}
+    // Base walker already handled the Level 0 __terminated_by check.
+    if (const auto *VTT = dyn_cast<ValueTerminatedType>(T))
+      return diagnoseDynamicRangePointerTypeShape(VTT->desugar(), AllowRedecl);
 
-// Pre-check for ended-by.
-//
-// Emits:
-// - err_attribute_pointers_only
-// - err_bounds_safety_atomic_unsupported_attribute
-// - err_bounds_safety_conflicting_count_range_attributes
-// - err_bounds_safety_conflicting_pointer_attributes
-static bool diagnoseDynamicRangePointerTypeShape(LateBoundsAttrDiagContext &Ctx,
-                                                 QualType DeclTy,
-                                                 bool AllowRedecl) {
-  Sema &S = Ctx.S;
-  const Type *T = DeclTy.split().Ty;
-
-  // Desugar and descend.
-  if (const auto *PT = dyn_cast<ParenType>(T))
-    return diagnoseDynamicRangePointerTypeShape(Ctx, PT->getInnerType(),
-                                                AllowRedecl);
-  if (const auto *MQT = dyn_cast<MacroQualifiedType>(T))
-    return diagnoseDynamicRangePointerTypeShape(Ctx, MQT->desugar(),
-                                                AllowRedecl);
-  if (const auto *FPT = dyn_cast<FunctionProtoType>(T))
-    return diagnoseDynamicRangePointerTypeShape(Ctx, FPT->getReturnType(),
-                                                AllowRedecl);
-  if (const auto *FPT = dyn_cast<FunctionNoProtoType>(T))
-    return diagnoseDynamicRangePointerTypeShape(Ctx, FPT->getReturnType(),
-                                                AllowRedecl);
-  if (const auto *AT = dyn_cast<AttributedType>(T)) {
-    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed);
-    if (AT->getAttrKind() == attr::PtrAutoAttr)
-      Ctx.AutoPtrAttributed = true;
-    return diagnoseDynamicRangePointerTypeShape(Ctx, AT->getModifiedType(),
-                                                AllowRedecl);
-  }
-
-  // Base walker already handled the Level 0 __terminated_by check.
-  if (const auto *VTT = dyn_cast<ValueTerminatedType>(T))
-    return diagnoseDynamicRangePointerTypeShape(Ctx, VTT->desugar(),
-                                                AllowRedecl);
-
-  // Like the counted_by case, we emit the diagnostic but return true.
-  if (const auto *ATy = dyn_cast<AtomicType>(T)) {
-    if (ATy->getValueType()->isPointerType()) {
-      S.Diag(Ctx.Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
-          << /*ended_by*/ 6;
-      return true;
-    }
-    // Atomic of non-pointer falls through to the leaf check below.
-  }
-
-  if (const auto *CAT = T->getAs<CountAttributedType>()) {
-    if (Ctx.Level == 0) {
-      S.Diag(Ctx.Loc,
-             diag::err_bounds_safety_conflicting_count_range_attributes);
-      return false;
-    }
-    return diagnoseDynamicRangePointerTypeShape(Ctx, CAT->desugar(),
-                                                AllowRedecl);
-  }
-
-  // At Level 0 we diagnose outright conflicts, or canonicalize and compare
-  // for AllowRedecl.
-  if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
-    if (Ctx.Level == 0) {
-      if (DRPT->getEndPointer() == nullptr)
+    // Like the counted_by case, we emit the diagnostic but return true.
+    if (const auto *ATy = dyn_cast<AtomicType>(T)) {
+      if (ATy->getValueType()->isPointerType()) {
+        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
+            << /*ended_by*/ 6;
         return true;
-      if (!AllowRedecl) {
-        S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-            << /*pointer*/ 1 << /*end*/ 3;
-        return false;
       }
-      // Canonicalize new end-pointer expression and compare against existing
-      // one
-      ExprResult CanonEnd =
-          S.CanonicalizeRangeEndPtrExpr(Ctx.AttrArg, Ctx.ScopeCheck);
-      if (CanonEnd.isInvalid())
-        return false;
-      llvm::FoldingSetNodeID NewID, OldID;
-      CanonEnd.get()->Profile(NewID, S.Context, /*Canonical=*/true);
-      DRPT->getEndPointer()->Profile(OldID, S.Context, /*Canonical=*/true);
-      if (NewID != OldID) {
-        S.Diag(Ctx.Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
-            << /*pointer*/ 1 << /*end*/ 3;
-        return false;
-      }
-      return true;
+      // Atomic of non-pointer falls through to the leaf check below.
     }
-    return diagnoseDynamicRangePointerTypeShape(Ctx, DRPT->desugar(),
-                                                AllowRedecl);
-  }
 
-  // Nothing to diagnose here for __ended_by.
-  if (const auto *PT = T->getAs<PointerType>()) {
-    if (Ctx.Level == 0)
-      return true;
-    --Ctx.Level;
-    llvm::SaveAndRestore<bool> Local(Ctx.AutoPtrAttributed, false);
-    return diagnoseDynamicRangePointerTypeShape(Ctx, PT->getPointeeType(),
-                                                AllowRedecl);
-  }
+    if (const auto *CAT = T->getAs<CountAttributedType>()) {
+      if (Level == 0) {
+        S.Diag(Loc, diag::err_bounds_safety_conflicting_count_range_attributes);
+        return false;
+      }
+      return diagnoseDynamicRangePointerTypeShape(CAT->desugar(), AllowRedecl);
+    }
 
-  // Fallback for pointers_only.
-  S.Diag(Ctx.Loc, diag::err_attribute_pointers_only) << Ctx.DiagName << 0;
-  return false;
-}
+    // At Level 0 we diagnose outright conflicts, or canonicalize and compare
+    // for AllowRedecl.
+    if (const auto *DRPT = T->getAs<DynamicRangePointerType>()) {
+      if (Level == 0) {
+        if (DRPT->getEndPointer() == nullptr)
+          return true;
+        if (!AllowRedecl) {
+          S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+              << /*pointer*/ 1 << /*end*/ 3;
+          return false;
+        }
+        // Canonicalize new end-pointer expression and compare against existing
+        // one
+        ExprResult CanonEnd =
+            S.CanonicalizeRangeEndPtrExpr(AttrArg, ScopeCheck);
+        if (CanonEnd.isInvalid())
+          return false;
+        llvm::FoldingSetNodeID NewID, OldID;
+        CanonEnd.get()->Profile(NewID, S.Context, /*Canonical=*/true);
+        DRPT->getEndPointer()->Profile(OldID, S.Context, /*Canonical=*/true);
+        if (NewID != OldID) {
+          S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+              << /*pointer*/ 1 << /*end*/ 3;
+          return false;
+        }
+        return true;
+      }
+      return diagnoseDynamicRangePointerTypeShape(DRPT->desugar(), AllowRedecl);
+    }
+
+    // Nothing to diagnose here for __ended_by.
+    if (const auto *PT = T->getAs<PointerType>()) {
+      if (Level == 0)
+        return true;
+      --Level;
+      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
+      return diagnoseDynamicRangePointerTypeShape(PT->getPointeeType(),
+                                                  AllowRedecl);
+    }
+
+    // Fallback for pointers_only.
+    S.Diag(Loc, diag::err_attribute_pointers_only) << DiagName << 0;
+    return false;
+  }
+};
 
 template<typename Derived>
 class ConstructDynamicBoundType
@@ -8013,7 +7996,7 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
 
     LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc,
                                       Level, AttrArg,  Info.ScopeCheck};
-    if (!diagnoseDynamicBoundTypeShape(DiagCtx, Info.DeclTy))
+    if (!DiagCtx.diagnoseDynamicBoundTypeShape(Info.DeclTy))
       return;
 
     // Reset Ctx.Level before the second walker call. The base walker decrements
@@ -8021,8 +8004,8 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     // needs to start from the original Level.
     DiagCtx.Level = Level;
     DiagCtx.AutoPtrAttributed = false;
-    if (!diagnoseDynamicRangePointerTypeShape(
-            DiagCtx, Info.DeclTy, /*AllowRedecl=*/OriginatesInAPINotes))
+    if (!DiagCtx.diagnoseDynamicRangePointerTypeShape(
+            Info.DeclTy, /*AllowRedecl=*/OriginatesInAPINotes))
       return;
 
     auto TypeConstructor = ConstructDynamicRangePointerType(
@@ -8034,7 +8017,7 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
   } else {
     LateBoundsAttrDiagContext DiagCtx{*this, DiagName, Loc,
                                       Level, AttrArg,  Info.ScopeCheck};
-    if (!diagnoseDynamicBoundTypeShape(DiagCtx, Info.DeclTy))
+    if (!DiagCtx.diagnoseDynamicBoundTypeShape(Info.DeclTy))
       return;
 
     if (!AttrArg->getType()->isIntegralOrEnumerationType()) {
@@ -8053,9 +8036,9 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     // above.
     DiagCtx.Level = Level;
     DiagCtx.AutoPtrAttributed = false;
-    if (!diagnoseCountAttributedTypeShape(DiagCtx, Info.DeclTy, CountInBytes,
-                                          OrNull,
-                                          /*AllowRedecl=*/OriginatesInAPINotes))
+    if (!DiagCtx.diagnoseCountAttributedTypeShape(
+            Info.DeclTy, CountInBytes, OrNull,
+            /*AllowRedecl=*/OriginatesInAPINotes))
       return;
 
     auto TypeConstructor = ConstructCountAttributedType(

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7042,11 +7042,9 @@ public:
 
   QualType VisitArrayType(const ArrayType *T) {
     if (Level == 0) {
-      if (T->hasAttr(attr::ArrayDecayDiscardsCountInParameters))
-        return Visit(S.Context.getArrayDecayedType(QualType(T, 0)));
-      assert(false &&
+      assert(T->hasAttr(attr::ArrayDecayDiscardsCountInParameters) &&
              "pre-check should have rejected Level-0 sized array with count");
-      return QualType();
+      return Visit(S.Context.getArrayDecayedType(QualType(T, 0)));
     }
     return TraverseArrayType(T);
   }
@@ -7266,11 +7264,7 @@ public:
       Expr *EndPtr = DRPT->getEndPointer();
       auto EndPtrDecls = DRPT->getEndPtrDecls();
       assert(EndPtr);
-      if (T->getEndPointer()) {
-        // Pre-check already verified the canonical end-pointer expressions
-        // match.
-        assert(AllowRedecl);
-      }
+      assert(!T->getEndPointer() || AllowRedecl);
 
       // ConstructType was already set while visiting the nested PointerType.
       // Reconstruct DRPT by merging started_by and ended_by.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6445,7 +6445,7 @@ public:
   // - err_bounds_safety_counted_by_without_size
   bool diagnoseCountAttributedTypeShape(QualType DeclTy, bool &CountInBytes,
                                         bool OrNull, bool AllowRedecl) {
-    const Type *T = DeclTy.split().Ty;
+    const Type *T = DeclTy.getTypePtr();
 
     // Desugar and descend.
     if (const auto *PT = dyn_cast<ParenType>(T))
@@ -6510,8 +6510,7 @@ public:
         // AllowRedecl: canonicalize the new count expression and compare
         // against the existing one.
         ExprResult CanonCount = S.CanonicalizeBoundsCountExpr(
-            AttrArg, CountInBytes, OrNull, ScopeCheck,
-            CAT->desugar()->isArrayType());
+            AttrArg, CountInBytes, OrNull, ScopeCheck, CAT->isArrayType());
         if (CanonCount.isInvalid())
           return false;
         llvm::FoldingSetNodeID NewID, OldID;
@@ -6545,7 +6544,7 @@ public:
           return diagnoseCountAttributedTypeShape(
               S.Context.getArrayDecayedType(QualType(AT, 0)), CountInBytes,
               OrNull, AllowRedecl);
-        if (isa<IncompleteArrayType>(AT)) {
+        if (AT->isIncompleteArrayType()) {
           if (CountInBytes) {
             S.Diag(Loc, diag::err_bounds_safety_sized_by_array) << DiagName;
             return false;
@@ -6646,7 +6645,7 @@ public:
   // - err_bounds_safety_conflicting_count_range_attributes
   // - err_bounds_safety_conflicting_pointer_attributes
   bool diagnoseDynamicRangePointerTypeShape(QualType DeclTy, bool AllowRedecl) {
-    const Type *T = DeclTy.split().Ty;
+    const Type *T = DeclTy.getTypePtr();
 
     // Desugar and descend.
     if (const auto *PT = dyn_cast<ParenType>(T))
@@ -6977,8 +6976,10 @@ public:
     assert(AllowRedecl &&
            "pre-check should have rejected !AllowRedecl count conflict");
     // Pre-check already verified the canonical count expressions match.
-    // Just build the new type.
-    return BuildDynamicBoundType(T->desugar());
+    QualType NewTy = BuildDynamicBoundType(T->desugar());
+    assert(NewTy->getAs<CountAttributedType>() &&
+           "BuildDynamicBoundType should produce a CountAttributedType");
+    return NewTy;
   }
 
   QualType VisitFunctionProtoType(const FunctionProtoType *FPT) {

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -11449,6 +11449,23 @@ QualType Sema::BuildDynamicRangePointerType(QualType PointerTy, Expr *StartPtr,
 }
 /* TO_UPSTREAM(BoundsSafety) OFF */
 
+ExprResult Sema::CanonicalizeBoundsCountExpr(Expr *CountExpr, bool CountInBytes,
+                                             bool OrNull, bool ScopeCheck,
+                                             bool IsArray) {
+  llvm::SmallVector<TypeCoupledDeclRefInfo, 1> Decls;
+  ExprResult R =
+      CountArgChecker(*this, Decls, CountInBytes, OrNull, ScopeCheck, IsArray)
+          .TransformExpr(CountExpr);
+  if (R.isInvalid())
+    return ExprError();
+  return DefaultLvalueConversion(R.get());
+}
+
+ExprResult Sema::CanonicalizeRangeEndPtrExpr(Expr *EndPtr, bool ScopeCheck) {
+  RangeArgChecker RAC(*this, ScopeCheck);
+  return RAC.TransformExpr(EndPtr);
+}
+
 static void
 BuildTypeCoupledDecls(Expr *E,
                       llvm::SmallVectorImpl<TypeCoupledDeclRefInfo> &Decls) {


### PR DESCRIPTION
Downstream refactor of the CRTP `TypeVisitor` classes, by moving diagnostic checks and emissions into flat pre-check member functions in a new class `LateBoundsAttrDiagContext`:

- `diagnoseCountAttributedTypeShape`
- `diagnoseDynamicRangePointerTypeShape`

Replace diagnostic emissions with asserts in these classes:
- `ConstructDynamicBoundType`
- `ConstructCountAttributedType`
- `ConstructDynamicRangePointerType`

Add `Sema::CanonicalizeBoundsCountExpr` and `Sema::CanonicalizeRangeEndPtrExpr` to make canonicalization of count/end-pointer expressions callable from `SemaDeclAttr.cpp` without constructing types or mutating decls.

Resolves #12765