### PR TITLE
🍒[clang][DependencyScanning] Preserve Necessary Preprocessor Callbacks…

### DIFF
--- a/clang/include/clang/Lex/PPCallbacks.h
+++ b/clang/include/clang/Lex/PPCallbacks.h
@@ -473,6 +473,28 @@ public:
   /// \param IfLoc the source location of the \#if/\#ifdef/\#ifndef directive.
   virtual void Endif(SourceLocation Loc, SourceLocation IfLoc) {
   }
+
+  /// Walk owned descendants. For each descendant whose raw pointer satisfies
+  /// `Pred`, release ownership from its owning unique_ptr and append the raw
+  /// pointer to `Released`. Default: leaf — no descendants to walk.
+  virtual void
+  releasePreservedDescendants(llvm::function_ref<bool(PPCallbacks *)> Pred,
+                              SmallVectorImpl<PPCallbacks *> &Released) {}
+
+  /// Walk the subtree rooted at `CB` (recursing into descendants first), then
+  /// check `CB` itself. Any `CB` whose contents satisfy `Pred` has its
+  /// ownership released and the raw pointer appended to `Released`. After this
+  /// returns, `CB` may be safely reset/destroyed without freeing the released
+  /// pointers.
+  static void releaseIfPreserved(std::unique_ptr<PPCallbacks> &CB,
+                                 llvm::function_ref<bool(PPCallbacks *)> Pred,
+                                 SmallVectorImpl<PPCallbacks *> &Released) {
+    if (!CB)
+      return;
+    CB->releasePreservedDescendants(Pred, Released);
+    if (Pred(CB.get()))
+      Released.push_back(CB.release());
+  }
 };
 
 /// Simple wrapper class for chaining callbacks.
@@ -777,6 +799,13 @@ public:
   void Endif(SourceLocation Loc, SourceLocation IfLoc) override {
     First->Endif(Loc, IfLoc);
     Second->Endif(Loc, IfLoc);
+  }
+
+  void releasePreservedDescendants(
+      llvm::function_ref<bool(PPCallbacks *)> Pred,
+      SmallVectorImpl<PPCallbacks *> &Released) override {
+    releaseIfPreserved(First, Pred, Released);
+    releaseIfPreserved(Second, Pred, Released);
   }
 };
 

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -1337,7 +1337,7 @@ public:
                                                 std::move(Callbacks));
     Callbacks = std::move(C);
   }
-  void removePPCallbacks() { Callbacks.reset(); }
+  void removePPCallbacks();
   /// \}
 
   PPCachedActions *getPPCachedActions() const { return CachedActions.get(); }

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -1677,6 +1677,17 @@ void Preprocessor::createPreprocessingRecord() {
   addPPCallbacks(std::unique_ptr<PPCallbacks>(Record));
 }
 
+void Preprocessor::removePPCallbacks() {
+  auto IsPreserved = [&](PPCallbacks *C) {
+    return C == Record || C == DirTracer;
+  };
+  SmallVector<PPCallbacks *, 2> Released;
+  PPCallbacks::releaseIfPreserved(Callbacks, IsPreserved, Released);
+  Callbacks.reset();
+  for (auto *P : Released)
+    addPPCallbacks(std::unique_ptr<PPCallbacks>(P));
+}
+
 const char *Preprocessor::getCheckPoint(FileID FID, const char *Start) const {
   if (auto It = CheckPoints.find(FID); It != CheckPoints.end()) {
     const SmallVector<const char *> &FileCheckPoints = It->second;

--- a/clang/test/ClangScanDeps/modules-by-name-detailed-preprocessing-record.c
+++ b/clang/test/ClangScanDeps/modules-by-name-detailed-preprocessing-record.c
@@ -1,0 +1,41 @@
+// Test that scanning multiple modules by name does not crash due to
+// use-after-free of PreprocessingRecord when removePPCallbacks() is
+// called between scans. The option -detailed-preprocessing-record leads
+// to the creation of a PreprocessingRecord instance.
+// 
+// Without the corresponding fix in the Preprocessor, this test fails with
+// address sanitizer.
+//
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+//--- module.modulemap
+module A {
+  header "A.h"
+}
+module B {
+  header "B.h"
+  use A
+}
+
+//--- A.h
+#define A_VALUE 1
+
+//--- B.h
+#include "A.h"
+int b_val = A_VALUE;
+
+//--- cdb.json.template
+[{
+  "file": "",
+  "directory": "DIR",
+  "command": "clang -fmodules -fmodules-cache-path=DIR/cache -fimplicit-module-maps -IDIR -Xclang -detailed-preprocessing-record -x c"
+}]
+
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full -module-names=A,B > %t/result.json
+// RUN: cat %t/result.json | FileCheck %s
+
+// CHECK:      "modules": [
+// CHECK:          "name": "A"
+// CHECK:          "name": "B"


### PR DESCRIPTION
… during By-name Lookup (#197731)

The by-name lookup logic uses new dependency collector callbacks per lookup. The algorithm used to wipe out all callbacks for each query. This turned out to be perilous. We have two raw pointers in the preprocessor that point to the callbacks, and removing all callbacks per query can lead to use-after-free situations through these dangling pointers. Resetting the dangling pointers to null does not really work either, since there may be dependencies between the callbacks and other data structures. An example of this is the `PreprocessingRecord *Record` callback and the `GlobalPreprocessedEntityMap` in ASTReader. Hence, to fix the use-after-free issue, we preserve the callbacks that the preprocessor may hold a raw pointer to.

This is not intended to indicate how we want to handle this in the long run. We should avoid removing PP callbacks and reset their states across by-name lookups.

rdar://175362366
(cherry picked from commit 4f9a7d09f4760ac9c5745e8bb829366d29ff9687)