### PR TITLE
Add support for CASConfigs.json in .dSYM bundles 

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -1156,11 +1156,13 @@ protected:
 #endif
 
   // BEGIN CAS
-  /// CAS configuration associated with this module, if any.
-  std::optional<llvm::cas::CASConfiguration> m_cas_config;
-  /// Many modules may share the same CAS instance.
-  std::shared_ptr<llvm::cas::ObjectStore> m_cas_object_store;
-  std::shared_ptr<llvm::cas::ActionCache> m_cas_action_cache;
+
+  /// All CAS configurations (+instances) associated with this
+  /// module. An empty optional means uninitialized, an empty vector
+  /// means that this module has no CAS associated with it.
+  std::optional<std::vector<ModuleList::CAS>> m_cas;
+  mutable std::mutex m_cas_init_mutex;
+
   // END CAS
 
   /// A set of hashes of all warnings and errors, to avoid reporting them

--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -568,18 +568,26 @@ public:
                   llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                   bool *did_create_ptr, bool always_create = false);
 
-  // START CAS
-
+  // BEGIN CAS
   struct CAS {
     llvm::cas::CASConfiguration configuration;
     std::shared_ptr<llvm::cas::ObjectStore> object_store;
     std::shared_ptr<llvm::cas::ActionCache> action_cache;
   };
-  /// Search for a CAS configuration file near this module. This
-  /// operation does a lot of file system stat calls.
-  static llvm::Expected<CAS> GetOrCreateCAS(const lldb::ModuleSP &module_sp);
+  /// Find an initialize every CAS associated with \c module_sp.
+  static void ConfigureCASStorage(const lldb::ModuleSP &module_sp);
 
-  /// Check if a string is a CASID.
+  /// Return a list of all CAS associated with \c module_sp.
+  static llvm::ArrayRef<CAS> GetCASStorage(const lldb::ModuleSP &module_sp);
+
+  /// Return the first CAS associated with \c module_sp whose
+  /// ObjectStore resolves \c cas_id. Returns an error if no CAS
+  /// resolves the id.
+  static llvm::Expected<CAS> GetCASForID(const lldb::ModuleSP &module_sp,
+                                         llvm::StringRef cas_id);
+
+  /// Check if a \c id is a CASID for any of the CAS associated with
+  /// \c module_id.
   static bool IsCASID(const lldb::ModuleSP &module_sp, llvm::StringRef id);
 
   /// Gets the shared module from CAS. It works the same as `GetSharedModule`
@@ -662,6 +670,15 @@ private:
   static bool LoadScriptingResourceInTargetForModule(Module &module,
                                                      Target &target,
                                                      Status &error);
+
+  /// Try to load the module referenced by \c cas_id from one of the
+  /// CAS instances near \c nearby. Returns an empty ModuleSpec if no
+  /// CAS could resolve the id.
+  // BEGIN CAS
+  static llvm::Expected<ModuleSpec> LoadModuleFromCAS(
+      llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
+      const lldb::ModuleSP &nearby, const UUID &uuid, const ArchSpec &arch);
+  // END CAS
 
 public:
   typedef LockingAdaptedIterable<std::recursive_mutex, collection>

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -44,6 +44,7 @@
 #include "llvm/CAS/CASConfiguration.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -1647,203 +1648,326 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
   return error;
 }
 
-/// Load the module referenced by \c cas_id from a CAS located
-/// near \c nearby.
-static llvm::Expected<ModuleSpec>
-loadModuleFromCAS(llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
-                  const lldb::ModuleSP &nearby, const UUID &uuid,
-                  const ArchSpec &arch) {
-  llvm::Expected<ModuleList::CAS> maybe_cas =
-      ModuleList::GetOrCreateCAS(nearby);
-  if (!maybe_cas) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Modules), maybe_cas.takeError(),
-                   "Failed to load module '{1}' at '{2}' from CAS: {0}",
-                   name_for_diagnostics, cas_id);
+/// Try to load the module referenced by \c cas_id from one of the
+/// CAS instances near \c nearby. Returns an empty ModuleSpec if no
+/// CAS could resolve the id.
+llvm::Expected<ModuleSpec> ModuleList::LoadModuleFromCAS(
+    llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
+    const ModuleSP &nearby, const UUID &uuid, const ArchSpec &arch) {
+  ConfigureCASStorage(nearby);
+  if (!nearby) {
+    LLDB_LOG(GetLog(LLDBLog::Modules),
+             "Failed to load module '{0}' at '{1}' from CAS: no module",
+             name_for_diagnostics, cas_id);
     return ModuleSpec();
   }
-
-  auto cas = std::move(maybe_cas->object_store);
-  if (!cas) {
+  assert(nearby->m_cas && "ConfigureCASStorage should have populated m_cas");
+  if (nearby->m_cas->empty()) {
     LLDB_LOG(GetLog(LLDBLog::Modules),
-             "Failed to load '{0}' at '{1}' from CAS: CAS is not available",
+             "Failed to load module '{0}' at '{1}' from CAS: no CAS "
+             "associated with module",
              name_for_diagnostics, cas_id);
     return ModuleSpec();
   }
 
-  auto id = cas->parseID(cas_id);
-  if (!id) {
-    // This function is also called for file paths that do not exist.
-    // An invalid CAS ID is not an error we need to surface to a user.
-    llvm::Error remaining = llvm::handleErrors(
-        id.takeError(),
-        [&](std::unique_ptr<llvm::StringError> SE) -> llvm::Error {
-          if (SE->convertToErrorCode() == std::errc::invalid_argument) {
-            LLDB_LOGV(GetLog(LLDBLog::Modules),
-                      "'{0}' is not a CAS id: {1}", cas_id, SE->getMessage());
-            return llvm::Error::success();
-          }
-          return llvm::Error(std::move(SE));
-        });
-    if (remaining)
-      return std::move(remaining);
-    return ModuleSpec();
+  // Try each CAS in turn; return on the first successful resolve.
+  llvm::Error errors = llvm::Error::success();
+  for (const auto &entry : *nearby->m_cas) {
+    const auto &cas = entry.object_store;
+    if (!cas)
+      continue;
+    auto id = cas->parseID(cas_id);
+    if (!id) {
+      // Not a valid CASID for this CAS; keep the error and try the next.
+      errors = joinErrors(std::move(errors), id.takeError());
+      continue;
+    }
+    auto module_proxy = cas->getProxy(*id);
+    if (!module_proxy) {
+      // Valid CASID but the object isn't here; keep the error and
+      // try the next CAS.
+      errors = joinErrors(std::move(errors), module_proxy.takeError());
+      continue;
+    }
+    auto file_buffer =
+        std::make_shared<DataBufferLLVM>(module_proxy->getMemoryBuffer());
+    FileSpec cas_spec;
+    cas_spec.SetDirectory(ConstString(entry.configuration.CASPath));
+    cas_spec.SetFilename(ConstString(cas_id));
+    DataExtractorSP extractor_sp = std::make_shared<DataExtractor>(file_buffer);
+    ModuleSpec loaded(cas_spec, uuid, extractor_sp);
+    loaded.GetArchitecture() = arch;
+    LLDB_LOG(GetLog(LLDBLog::Modules),
+             "loading module using CASID '{0}' from CAS at {1}", cas_id,
+             entry.configuration.CASPath);
+    consumeError(std::move(errors));
+    return loaded;
   }
 
-  auto module_proxy = cas->getProxy(*id);
-  if (!module_proxy)
-    return module_proxy.takeError();
-
-  auto file_buffer =
-      std::make_shared<DataBufferLLVM>(module_proxy->getMemoryBuffer());
-
-  // Swap out the module_spec with the one loaded via CAS.
-  FileSpec cas_spec;
-  cas_spec.SetDirectory(ConstString(maybe_cas->configuration.CASPath));
-  cas_spec.SetFilename(ConstString(cas_id));
-  DataExtractorSP extractor_sp = std::make_shared<DataExtractor>(file_buffer);
-  ModuleSpec loaded(cas_spec, uuid, extractor_sp);
-  loaded.GetArchitecture() = arch;
-
-  LLDB_LOG(GetLog(LLDBLog::Modules), "loading module using CASID '{0}'",
-           cas_id);
-  return loaded;
+  // This function is also called for file paths that do not exist.
+  // An invalid CAS ID is not an error we need to surface to a user.
+  bool not_a_cas_id = false;
+  llvm::Error remaining = llvm::handleErrors(
+      std::move(errors),
+      [&](std::unique_ptr<llvm::StringError> SE) -> llvm::Error {
+        if (SE->convertToErrorCode() == std::errc::invalid_argument) {
+          not_a_cas_id = true;
+          return llvm::Error::success();
+        }
+        return llvm::Error(std::move(SE));
+      });
+  if (remaining)
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Modules), std::move(remaining),
+                   "Unexpected error loading module '{1}' at '{2}' from "
+                   "CAS: {0}",
+                   name_for_diagnostics, cas_id);
+  if (not_a_cas_id)
+    LLDB_LOGV(GetLog(LLDBLog::Modules), "'{0}' is not a CAS id", cas_id);
+  return ModuleSpec();
 }
 
-static llvm::cas::CASConfiguration
-FindCASConfiguration(const ModuleSP &module_sp) {
+/// Parse a CASConfigs.json blob (a JSON array of CAS configuration
+/// objects). A top-level parse failure returns an error; malformed
+/// individual entries are logged and skipped.
+static llvm::Expected<std::vector<llvm::cas::CASConfiguration>>
+ParseCASConfigsJSON(llvm::StringRef content) {
+  auto parsed = llvm::json::parse(content);
+  if (!parsed)
+    return parsed.takeError();
+  auto *arr = parsed->getAsArray();
+  if (!arr)
+    return llvm::createStringError(
+        "CASConfigs.json: expected top-level JSON array");
+  std::vector<llvm::cas::CASConfiguration> configs;
+  for (auto &entry : *arr) {
+    std::string serialized;
+    llvm::raw_string_ostream os(serialized);
+    os << entry;
+    auto cfg = llvm::cas::CASConfiguration::createFromConfig(serialized);
+    if (!cfg) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
+                     cfg.takeError(),
+                     "CASConfigs.json: skipping malformed entry: {0}");
+      continue;
+    }
+    configs.push_back(std::move(*cfg));
+  }
+  return configs;
+}
+
+/// Locate <dSYM>/Contents/Resources/CASConfigs.json for this module's
+/// associated dSYM (if any). Returns "" if no such file exists.
+static std::string FindDSYMCASConfigsPath(const ModuleSP &module_sp) {
+  SymbolFile *sf = module_sp->GetSymbolFile();
+  if (!sf)
+    return {};
+  ObjectFile *sym_obj = sf->GetObjectFile();
+  if (!sym_obj || sym_obj->GetType() != ObjectFile::eTypeDebugInfo)
+    return {};
+
+  // dSYM layout: <name>.dSYM/Contents/Resources/DWARF/<binary>.
+  // Walk up two levels from the binary to land on Contents/Resources.
+  FileSpec path = sym_obj->GetFileSpec();
+  path.RemoveLastPathComponent(); // strip <binary>  -> .../Resources/DWARF
+  path.RemoveLastPathComponent(); // strip DWARF     -> .../Resources
+  path.AppendPathComponent("CASConfigs.json");
+  if (!FileSystem::Instance().Exists(path))
+    return {};
+  return path.GetPath();
+}
+
+/// Find all CAS configurations associated with \c module_sp. The search
+/// order is:
+///   1. ModuleListProperties override (CASOnDiskPath, etc.).
+///   2. The aggregated CASConfigs.json inside the associated dSYM.
+///   3. A .cas-config file next to the binary or its object files.
+///   4. DerivedData/CompilationCache.noindex/builtin fallback.
+static std::vector<llvm::cas::CASConfiguration>
+FindCASConfigurations(const ModuleSP &module_sp) {
+  // 1. Properties override (single config).
+  const auto &props = ModuleList::GetGlobalModuleListProperties();
+  std::string props_path = props.GetCASOnDiskPath().GetPath();
+  if (!props_path.empty())
+    return {{props_path, props.GetCASPluginPath().GetPath(),
+             props.GetCASPluginOptions()}};
+
+  // 2. Aggregated CAS configurations from the dSYM bundle.
+  if (std::string cfg_path = FindDSYMCASConfigsPath(module_sp);
+      !cfg_path.empty()) {
+    auto buf = llvm::MemoryBuffer::getFile(cfg_path);
+    if (buf) {
+      auto configs = ParseCASConfigsJSON((*buf)->getBuffer());
+      if (configs) {
+        LLDB_LOG(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
+                 "Loaded {0} CAS configuration(s) from {1}", configs->size(),
+                 cfg_path);
+        return std::move(*configs);
+      }
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
+                     configs.takeError(), "Failed to parse {1}: {0}", cfg_path);
+    }
+  }
+
+  // 3. .cas-config near the binary / object files (single config).
   auto get_dir = [](FileSpec path) {
     path.ClearFilename();
     return path;
   };
-
-  // Look near the binary / dSYM.
+  if (auto cfg = GetCASConfiguration(module_sp->GetFileSpec()))
+    return {cfg};
   std::set<FileSpec> unique_paths;
-  llvm::cas::CASConfiguration cas_config =
-      GetCASConfiguration(module_sp->GetFileSpec());
-
-  if (!cas_config) {
-    // Look near the object files.
-    if (SymbolFile *sf = module_sp->GetSymbolFile()) {
-      sf->GetDebugInfoModules().ForEach([&](const ModuleSP &m) {
-        if (m)
-          unique_paths.insert(get_dir(m->GetFileSpec()));
-        return IterationAction::Continue;
-      });
-      for (auto &path : unique_paths)
-        if ((cas_config = GetCASConfiguration(path)))
-          break;
-    }
+  if (SymbolFile *sf = module_sp->GetSymbolFile()) {
+    sf->GetDebugInfoModules().ForEach([&](const ModuleSP &m) {
+      if (m)
+        unique_paths.insert(get_dir(m->GetFileSpec()));
+      return IterationAction::Continue;
+    });
+    for (auto &path : unique_paths)
+      if (auto cfg = GetCASConfiguration(path))
+        return {cfg};
   }
-  // TODO: Remove this block once the build system consistently
+
+  // 4. TODO: Remove this block once the build system consistently
   // generates .cas-config files.
-  if (!cas_config) {
-    unique_paths.insert(get_dir(module_sp->GetFileSpec()));
-    for (auto &path : unique_paths) {
-      llvm::StringRef parent = path.GetDirectory().GetStringRef();
-      while (!parent.empty() &&
-             llvm::sys::path::filename(parent) != "DerivedData")
-        parent = llvm::sys::path::parent_path(parent);
-      if (parent.empty())
-        continue;
-      llvm::SmallString<256> cas_path(parent);
-      llvm::sys::path::append(cas_path, "CompilationCache.noindex", "builtin");
-      FileSpec fs = FileSpec(cas_path);
-      ModuleList::GetGlobalModuleListProperties().SetCASOnDiskPath(fs);
-      cas_config = GetCASConfiguration(fs);
-      if (cas_config)
-        break;
-    }
-  }    
-  return cas_config;
+  unique_paths.insert(get_dir(module_sp->GetFileSpec()));
+  for (auto &path : unique_paths) {
+    llvm::StringRef parent = path.GetDirectory().GetStringRef();
+    while (!parent.empty() &&
+           llvm::sys::path::filename(parent) != "DerivedData")
+      parent = llvm::sys::path::parent_path(parent);
+    if (parent.empty())
+      continue;
+    llvm::SmallString<256> cas_path(parent);
+    llvm::sys::path::append(cas_path, "CompilationCache.noindex", "builtin");
+    FileSpec fs = FileSpec(cas_path);
+    ModuleList::GetGlobalModuleListProperties().SetCASOnDiskPath(fs);
+    if (auto cfg = GetCASConfiguration(fs))
+      return {cfg};
+  }
+  return {};
 }
 
-llvm::Expected<ModuleList::CAS>
-ModuleList::GetOrCreateCAS(const ModuleSP &module_sp) {
-  if (!module_sp)
-    return llvm::createStringError("no lldb::Module available");
-
-  // Already initialized?
-  std::optional<llvm::cas::CASConfiguration> &cas_config =
-      module_sp->m_cas_config;
-  if (cas_config) {
-    if (!*cas_config)
-      return llvm::createStringError("no CAS associated with module (cached)");
-    if (!module_sp->m_cas_object_store)
-      return llvm::createStringError(
-          "CAS config created, but CAS not available (cached)");
-  }
-
-  cas_config = FindCASConfiguration(module_sp);
-  if (!*cas_config)
-    return llvm::createStringError("no CAS associated with module");
-
-  // Look in the cache.
-  auto &shared_module_list = GetSharedModuleListInfo();
-  std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
+/// Look up cas_config in the shared CAS cache, or instantiate it and
+/// insert. Returns a CAS triple with null instances if instantiation
+/// failed.
+///
+/// \pre Caller must hold \c shared_module_list.shared_lock — the
+///      function mutates \c shared_module_list.module_list.m_cas_cache.
+static ModuleList::CAS
+FindOrCreateInSharedCache(const llvm::cas::CASConfiguration &cas_config,
+                          SharedModuleListInfo &shared_module_list) {
   auto &cas_cache = shared_module_list.module_list.m_cas_cache;
-  {
-    auto weak_cached = cas_cache.find(*cas_config);
-    if (weak_cached != cas_cache.end()) {
-      if (!weak_cached->second)
-        return llvm::createStringError(
-            "CAS config created, but CAS not available (cached)");
-      auto cached_object_store_sp = weak_cached->second->object_store.lock();
-      auto cached_action_cache_sp = weak_cached->second->action_cache.lock();
-      if (cached_object_store_sp && cached_action_cache_sp) {
-        module_sp->m_cas_object_store = cached_object_store_sp;
-        module_sp->m_cas_action_cache = cached_action_cache_sp;
-        return ModuleList::CAS{*cas_config, cached_object_store_sp,
-                               cached_action_cache_sp};
-      } else {
-        cas_cache.erase(*cas_config);
-        LLDB_LOG(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
-                 "CAS at {0} was garbage-collected", cas_config->CASPath);
-      }
+  auto weak_cached = cas_cache.find(cas_config);
+  if (weak_cached != cas_cache.end()) {
+    if (weak_cached->second) {
+      auto os = weak_cached->second->object_store.lock();
+      auto ac = weak_cached->second->action_cache.lock();
+      if (os && ac)
+        return {cas_config, std::move(os), std::move(ac)};
+      cas_cache.erase(cas_config);
+      LLDB_LOG(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
+               "CAS at {0} was garbage-collected", cas_config.CASPath);
+    } else {
+      return {cas_config, nullptr, nullptr};
     }
   }
-
-  // Create the CAS.
-  auto cas = cas_config->createDatabases();
-  if (!cas) {
-    cas_cache.insert({*cas_config, {}});
-    return cas.takeError();
+  auto created = cas_config.createDatabases();
+  if (!created) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
+                   created.takeError(), "Failed to initialize CAS at {1}: {0}",
+                   cas_config.CASPath);
+    cas_cache.insert({cas_config, {}});
+    return {cas_config, nullptr, nullptr};
   }
-
   LLDB_LOG(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
-           "Initialized CAS at {0}", cas_config->CASPath);
-
-  // Cache the CAS.
-  module_sp->m_cas_object_store = cas->first;
-  module_sp->m_cas_action_cache = cas->second;
+           "Initialized CAS at {0}", cas_config.CASPath);
   cas_cache.insert(
-      {*cas_config, SharedModuleList::CAS(cas->first, cas->second)});
+      {cas_config, SharedModuleList::CAS(created->first, created->second)});
+  return {cas_config, created->first, created->second};
+}
 
-  return ModuleList::CAS{*cas_config, cas->first, cas->second};
+void ModuleList::ConfigureCASStorage(const ModuleSP &module_sp) {
+  if (!module_sp)
+    return;
+  std::lock_guard<std::mutex> module_lock(module_sp->m_cas_init_mutex);
+  std::optional<std::vector<ModuleList::CAS>> &module_cas = module_sp->m_cas;
+  if (module_cas)
+    return; // Already initialized.
+  std::vector<llvm::cas::CASConfiguration> found =
+      FindCASConfigurations(module_sp);
+  auto &entries = module_cas.emplace();
+  if (found.empty())
+    return;
+  auto &shared_module_list = GetSharedModuleListInfo();
+  std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
+  entries.reserve(found.size());
+  for (auto &cfg : found)
+    entries.push_back(FindOrCreateInSharedCache(cfg, shared_module_list));
+}
+
+llvm::ArrayRef<ModuleList::CAS>
+ModuleList::GetCASStorage(const ModuleSP &module_sp) {
+  ConfigureCASStorage(module_sp);
+  if (!module_sp)
+    return {};
+  assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
+  return *module_sp->m_cas;
 }
 
 bool ModuleList::IsCASID(const ModuleSP &module_sp,
                          llvm::StringRef id) {
-  auto cas = GetOrCreateCAS(module_sp);
-  if (!cas) {
-    consumeError(cas.takeError());
+  ConfigureCASStorage(module_sp);
+  if (!module_sp)
     return false;
-  }
-
-  auto ref = cas->object_store->parseID(id);
-  if (!ref) {
+  assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
+  for (const auto &entry : *module_sp->m_cas) {
+    if (!entry.object_store)
+      continue;
+    auto ref = entry.object_store->parseID(id);
+    if (ref)
+      return true;
     consumeError(ref.takeError());
-    return false;
   }
-  return true;
+  return false;
 }
 
+llvm::Expected<ModuleList::CAS>
+ModuleList::GetCASForID(const ModuleSP &module_sp, llvm::StringRef cas_id) {
+  ConfigureCASStorage(module_sp);
+  if (!module_sp)
+    return llvm::createStringError("no lldb::Module available");
+  assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
+  if (module_sp->m_cas->empty())
+    return llvm::createStringError("no CAS associated with module");
+  llvm::Error errors = llvm::Error::success();
+  for (const auto &entry : *module_sp->m_cas) {
+    if (!entry.object_store)
+      continue;
+    auto id = entry.object_store->parseID(cas_id);
+    if (!id) {
+      consumeError(id.takeError());
+      continue;
+    }
+    auto proxy = entry.object_store->getProxy(*id);
+    if (!proxy) {
+      errors = joinErrors(std::move(errors), proxy.takeError());
+      continue;
+    }
+    consumeError(std::move(errors));
+    return entry;
+  }
+  if (errors)
+    return std::move(errors);
+  return llvm::createStringError(
+      "no CAS associated with module resolves CASID '" + cas_id + "'");
+}
 
 llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
     llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
     const lldb::ModuleSP &nearby, ModuleSpec &module_spec,
     lldb::ModuleSP &module_sp) {
   auto loaded =
-      loadModuleFromCAS(cas_id, name_for_diagnostics, nearby,
+      LoadModuleFromCAS(cas_id, name_for_diagnostics, nearby,
                         module_spec.GetUUID(), module_spec.GetArchitecture());
   if (!loaded)
     return loaded.takeError();
@@ -1859,9 +1983,8 @@ llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
 
   if (status.Success()) {
     if (module_sp) {
-      module_sp->m_cas_config = nearby->m_cas_config;
-      module_sp->m_cas_object_store = nearby->m_cas_object_store;
-      module_sp->m_cas_action_cache = nearby->m_cas_action_cache;
+      std::lock_guard<std::mutex> dest_lock(module_sp->m_cas_init_mutex);
+      module_sp->m_cas = nearby->m_cas;
     }
     return true;
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -917,23 +917,34 @@ static std::string GetClangModulesCacheProperty() {
   return std::string(path);
 }
 
-void SwiftASTContext::ConfigureCASStorage(const SymbolContext &sc) {
-  llvm::Expected<ModuleList::CAS> cas =
-      ModuleList::GetOrCreateCAS(sc.module_sp);
-  if (!cas) {
-    HEALTH_LOG_PRINTF("Did not create CAS: %s",
-                      toString(cas.takeError()).c_str());
+void SwiftASTContext::ConfigureDefaultCASStorage(const ModuleSP &module_sp) {
+  llvm::ArrayRef<ModuleList::CAS> all_cas =
+      ModuleList::GetCASStorage(module_sp);
+  if (all_cas.empty()) {
+    HEALTH_LOG_PRINTF("Did not create CAS: no CAS associated with module");
     return;
   }
-  SetCASStorage(std::move(cas->object_store), std::move(cas->action_cache));
+  // Pick the first instantiated entry as the default.
+  for (const auto &entry : all_cas) {
+    if (entry.object_store) {
+      InitializeCASOptions(entry);
+      LOG_PRINTF(GetLog(LLDBLog::Types), "Bound default CAS at path: %s",
+                 entry.configuration.CASPath.c_str());
+      return;
+    }
+  }
+  HEALTH_LOG_PRINTF(
+      "Did not create CAS: config(s) found, but no CAS available");
+}
+
+void SwiftASTContext::InitializeCASOptions(ModuleList::CAS cas) {
+  m_cas = std::move(cas.object_store);
+  m_action_cache = std::move(cas.action_cache);
   swift::CASOptions &cas_options = GetCASOptions();
-  cas_options.Config.CASPath = cas->configuration.CASPath;
-  cas_options.Config.PluginPath = cas->configuration.PluginPath;
-  cas_options.Config.PluginOptions = cas->configuration.PluginOptions;
+  cas_options.Config.CASPath = std::move(cas.configuration.CASPath);
+  cas_options.Config.PluginPath = std::move(cas.configuration.PluginPath);
+  cas_options.Config.PluginOptions = std::move(cas.configuration.PluginOptions);
   m_cas_initialized = true;
-  LOG_PRINTF(GetLog(LLDBLog::Types),
-             "Setup CAS from module list properties with CAS path: %s",
-             cas->configuration.CASPath.c_str());
 }
 
 SwiftASTContext::ScopedDiagnostics::ScopedDiagnostics(
@@ -2716,7 +2727,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 
   SymbolContext sc;
   module.CalculateSymbolContext(&sc);
-  swift_ast_sp->ConfigureCASStorage(sc);
+  swift_ast_sp->ConfigureDefaultCASStorage(sc.module_sp);
 
   // The serialized triple is the triple of the last binary
   // __swiftast section that was processed. Instead of relying on
@@ -2972,6 +2983,18 @@ bool SwiftASTContext::DiscoverExplicitMainModule(const SymbolContext &sc,
   const SourceModule &module = cu_imports.front();
   std::unique_ptr<llvm::MemoryBuffer> buffer;
   std::optional<std::string> moduleCacheKey;
+  // If a dSYM aggregates multiple CAS, pick the one that actually
+  // resolves this module's CASID — not just the first-instantiated
+  // entry ConfigureDefaultCASStorage picked.
+  if (auto matched = ModuleList::GetCASForID(
+          sc.module_sp, module.search_path.GetStringRef())) {
+    InitializeCASOptions(*matched);
+    LOG_PRINTF(GetLog(LLDBLog::Types),
+               "Re-bound CAS to match main module CASID: %s",
+               matched->configuration.CASPath.c_str());
+  } else {
+    consumeError(matched.takeError());
+  }
   if (auto E = GetModuleContentsFromCAS(module.search_path).moveInto(buffer)) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Types), std::move(E),
                    "Could not open {1}: {0}", module.search_path);
@@ -3422,7 +3445,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     }
   }
 
-  swift_ast_sp->ConfigureCASStorage(sc);
+  // DiscoverExplicitMainModule may replace this with a more specific one.  
+  swift_ast_sp->ConfigureDefaultCASStorage(sc.module_sp);
 
   std::string resource_dir = HostInfo::GetSwiftResourceDir(
       triple, swift_ast_sp->GetPlatformSDKPath());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -327,12 +327,6 @@ public:
     m_platform_sdk_path = path.str();
   }
 
-  void SetCASStorage(std::shared_ptr<llvm::cas::ObjectStore> cas,
-                     std::shared_ptr<llvm::cas::ActionCache> action_cache) {
-    m_cas = std::move(cas);
-    m_action_cache = std::move(action_cache);
-  }
-
   /// \return the ExtraArgs of the ClangImporterOptions.
   const std::vector<std::string> &GetClangArguments();
 
@@ -913,9 +907,14 @@ public:
   swift::Mangle::ManglingFlavor GetManglingFlavor();
 
 protected:
-  /// This function implements various heuristics to find a CAS
-  /// configuration file.
-  void ConfigureCASStorage(const SymbolContext &sc);
+  /// Pick the default (position-based primary) CAS associated with
+  /// \c module_sp and bind it to this AST context.
+  void ConfigureDefaultCASStorage(const lldb::ModuleSP &module_sp);
+  /// Bind this AST context's CAS storage and CASOptions to \c cas.
+  /// Shared between ConfigureDefaultCASStorage and the precision bind
+  /// that DiscoverExplicitMainModule performs once it has the main
+  /// module's CASID.
+  void InitializeCASOptions(ModuleList::CAS cas);
   /// Extract the bridging PCH from debug info an set the ClangImporter option.
   void ConfigureBridgingHeader(const SymbolContext &sc);
 

--- a/lldb/test/API/lang/swift/explicit_modules/no-caching/TestSwiftExplicitModuleNoCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/no-caching/TestSwiftExplicitModuleNoCaching.py
@@ -20,6 +20,6 @@ class TestSwiftExplicitModuleNoCaching(TestBase):
         self.expect('log enable lldb types symbols -f "%s"' % log)
         self.expect("expression 1+1")
         self.filecheck_log(log, __file__)
-        # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ConfigureCASStorage() -- Setup CAS {{.*}}cas
+        # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ConfigureDefaultCASStorage() -- Bound default CAS at path
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- Explicit module map entries
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     Swift

--- a/lldb/test/Shell/Swift/caching.test
+++ b/lldb/test/Shell/Swift/caching.test
@@ -16,7 +16,7 @@
 # RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s --check-prefix=CAS-FALLBACK --check-prefix=CHECK
 
 # CAS-FALLBACK:  cannot be loaded from CAS using key:
-# CAS-LOAD:      ConfigureCASStorage() -- Setup CAS from module list properties with CAS path
+# CAS-LOAD:      ConfigureDefaultCASStorage() -- Bound default CAS at path
 # CHECK:         LogConfiguration() --   Extra clang arguments
 # CHECK-COUNT-1: LogConfiguration() --     -triple
 # CAS-LOAD:      LogConfiguration() --     -fmodule-file-cache-key

--- a/llvm/test/tools/dsymutil/AArch64/cas-config.test
+++ b/llvm/test/tools/dsymutil/AArch64/cas-config.test
@@ -1,0 +1,36 @@
+# Verify that dsymutil collects .cas-config files in parent paths of
+# each debug map object and aggregates their contents into
+# Contents/Resources/CASConfigs.json inside the output dSYM bundle.
+
+# RUN: rm -rf %t.dir && mkdir -p %t.dir/sub
+# RUN: cp %p/../Inputs/DWARF5/1.o %t.dir/sub/1.o
+# RUN: echo '{"CASPath": "test-cas1"}' > %t.dir/sub/.cas-config
+# RUN: echo '{"CASPath": "test-cas2"}' > %t.dir/.cas-config
+
+# RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map \
+# RUN:   -oso-prepend-path=%t.dir/sub -o %t.dir/classic.dSYM
+# RUN: cat %t.dir/classic.dSYM/Contents/Resources/CASConfigs.json | FileCheck %s
+
+# RUN: rm -rf %t.dir/parallel.dSYM
+# RUN: dsymutil --linker parallel -y %p/dummy-debug-map-arm64.map \
+# RUN:   -oso-prepend-path=%t.dir/sub -o %t.dir/parallel.dSYM
+# RUN: cat %t.dir/parallel.dSYM/Contents/Resources/CASConfigs.json | FileCheck %s
+
+# CHECK: [
+# CHECK:   {"CASPath": "test-cas1"}
+# CHECK:   {"CASPath": "test-cas2"}
+# CHECK: ]
+
+# Without a .cas-config file present, no CASConfigs.json should be produced.
+
+# RUN: rm -rf %t.empty_classic && mkdir -p %t.empty_classic
+# RUN: cp %p/../Inputs/DWARF5/1.o %t.empty_classic/1.o
+# RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map \
+# RUN:   -oso-prepend-path=%t.empty_classic -o %t.empty_classic/out.dSYM
+# RUN: not ls %t.empty_classic/out.dSYM/Contents/Resources/CASConfigs.json
+
+# RUN: rm -rf %t.empty.parallel && mkdir -p %t.empty.parallel
+# RUN: cp %p/../Inputs/DWARF5/1.o %t.empty.parallel/1.o
+# RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map \
+# RUN:   -oso-prepend-path=%t.empty.parallel -o %t.empty.parallel/out.dSYM
+# RUN: not ls %t.empty.parallel/out.dSYM/Contents/Resources/CASConfigs.json

--- a/llvm/test/tools/dsymutil/AArch64/cas-config.test
+++ b/llvm/test/tools/dsymutil/AArch64/cas-config.test
@@ -16,10 +16,10 @@
 # RUN:   -oso-prepend-path=%t.dir/sub -o %t.dir/parallel.dSYM
 # RUN: cat %t.dir/parallel.dSYM/Contents/Resources/CASConfigs.json | FileCheck %s
 
-# CHECK: [
-# CHECK:   {"CASPath": "test-cas1"}
-# CHECK:   {"CASPath": "test-cas2"}
-# CHECK: ]
+# CHECK:      [
+# CHECK-NEXT:   {"CASPath": "test-cas1"},
+# CHECK-NEXT:   {"CASPath": "test-cas2"}
+# CHECK-NEXT: ]
 
 # Without a .cas-config file present, no CASConfigs.json should be produced.
 

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -901,7 +901,7 @@ bool DwarfLinkerForBinary::linkImpl(
     llvm::StringSet<> VisitedPaths;
     std::string CASConfigs = "[\n";
     raw_string_ostream CASConfigStream(CASConfigs);
-    bool Found = false;
+    bool First = true;
     for (const auto &Obj : Map.objects()) {
       StringRef ObjPath = Obj->getObjectFilename();
       for (StringRef Dir = sys::path::parent_path(ObjPath); !Dir.empty();
@@ -915,12 +915,14 @@ bool DwarfLinkerForBinary::linkImpl(
         if (!BufferOrErr)
           continue;
 
-        CASConfigStream << (*BufferOrErr)->getBuffer() << ",\n";
-        Found = true;
+        if (!First)
+          CASConfigStream << ",\n";
+        First = false;
+        CASConfigStream << (*BufferOrErr)->getBuffer().rtrim('\n');
       }
     }
-    CASConfigStream << "]\n";
-    if (Found) {
+    CASConfigStream << "\n]\n";
+    if (!First) {
       std::error_code EC;
       SmallString<128> CASConfigsPath;
       sys::path::append(CASConfigsPath, *Options.ResourceDir);

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -893,6 +893,54 @@ bool DwarfLinkerForBinary::linkImpl(
         MaxDWARFVersion = std::max(Unit.getVersion(), MaxDWARFVersion);
       };
 
+  if (Options.ResourceDir) {
+    // Collect .cas-config files. The build system might put these
+    // anywhere in the build directory, so dsymutil scans all parent
+    // paths of each object file. Their contents is a JSON dictionary,
+    // so this loop aggregates them in a JSON array.
+    llvm::StringSet<> VisitedPaths;
+    std::string CASConfigs = "[\n";
+    raw_string_ostream CASConfigStream(CASConfigs);
+    bool Found = false;
+    for (const auto &Obj : Map.objects()) {
+      StringRef ObjPath = Obj->getObjectFilename();
+      for (StringRef Dir = sys::path::parent_path(ObjPath); !Dir.empty();
+           Dir = sys::path::parent_path(Dir)) {
+        if (!VisitedPaths.insert(Dir).second)
+          break;
+
+        SmallString<256> CASConfigPath(Dir);
+        sys::path::append(CASConfigPath, ".cas-config");
+        auto BufferOrErr = MemoryBuffer::getFile(CASConfigPath);
+        if (!BufferOrErr)
+          continue;
+
+        CASConfigStream << (*BufferOrErr)->getBuffer() << ",\n";
+        Found = true;
+      }
+    }
+    CASConfigStream << "]\n";
+    if (Found) {
+      std::error_code EC;
+      SmallString<128> CASConfigsPath;
+      sys::path::append(CASConfigsPath, *Options.ResourceDir);
+      EC = sys::fs::create_directories(CASConfigsPath.str(), true,
+                                       sys::fs::perms::all_all);
+      if (EC) {
+        reportWarning("could not create directory '" + CASConfigsPath +
+                      "': " + EC.message());
+      } else {
+        sys::path::append(CASConfigsPath, "CASConfigs.json");
+        raw_fd_ostream OS(CASConfigsPath.str(), EC, sys::fs::OF_Text);
+        if (EC)
+          reportWarning("could not open '" + CASConfigsPath +
+                        "': " + EC.message());
+        else
+          OS << CASConfigs;
+      }
+    }
+  }
+
   llvm::StringSet<> SwiftModules;
   for (const auto &Obj : Map.objects()) {
     // N_AST objects (swiftmodule files) should get dumped directly into the
@@ -907,13 +955,13 @@ bool DwarfLinkerForBinary::linkImpl(
 
       auto ErrorOrMem = MemoryBuffer::getFile(File);
       if (!ErrorOrMem) {
-        reportWarning("Could not open '" + File + "'");
+        reportWarning("could not open '" + File + "'");
         continue;
       }
       auto FromInterfaceOrErr =
           IsBuiltFromSwiftInterface((*ErrorOrMem)->getBuffer());
       if (!FromInterfaceOrErr) {
-        reportWarning("Could not parse binary Swift module: " +
+        reportWarning("could not parse binary Swift module: " +
                           toString(FromInterfaceOrErr.takeError()),
                       Obj->getObjectFilename());
         // Only skip swiftmodules that could be parsed and are


### PR DESCRIPTION
When caching is enabled the Swift compiler might substitute CAS
identifiers for on-disk paths. In order to resolve them the build system
puts a .cas-config file in the build directory. Dsymutil needs to
collect the contents of these files so tools consuming the dSYM (which
do not have access to the original build directory) can resolve these
CAS identifiers, too.
