### PR TITLE
Improve feature availability diagnostics

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4307,6 +4307,8 @@ def note_feature_incompatible1 : Note<
 def note_silence_unguarded_availability_domain : Note<
   "enclose %0 in %select{an @available|a __builtin_available}1 check to silence "
   "this warning">;
+def note_silence_unguarded_availability_domain_decl : Note<
+  "annotate %0 with the '%1' domain availability attribute to silence this error">;
 
 def warn_unguarded_availability_unavailable :
   Warning<"%0 is unavailable">,

--- a/clang/lib/Sema/SemaFeatureAvailability.cpp
+++ b/clang/lib/Sema/SemaFeatureAvailability.cpp
@@ -19,23 +19,41 @@
 #include "clang/Sema/DelayedDiagnostic.h"
 #include "clang/Sema/ScopeInfo.h"
 #include "clang/Sema/Sema.h"
+#include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallSet.h"
 #include <utility>
 
 using namespace clang;
 using namespace sema;
 
-static bool isFeatureUseGuarded(const DomainAvailabilityAttr *AA,
-                                const Decl *ContextDecl, ASTContext &Ctx) {
+static bool isFeatureUseGuardedLocally(const DomainAvailabilityAttr *AA,
+                                       const Decl *ContextDecl) {
   for (auto *Attr : ContextDecl->specific_attrs<DomainAvailabilityAttr>())
     if (AA->getDomain() == Attr->getDomain())
       return AA->getUnavailable() == Attr->getUnavailable();
   return false;
 }
 
+static bool isFeatureUseGuarded(const DomainAvailabilityAttr *AA,
+                                const Decl *ContextDecl) {
+  while (ContextDecl) {
+    if (isFeatureUseGuardedLocally(AA, ContextDecl))
+      return true;
+    ContextDecl = dyn_cast_or_null<Decl>(ContextDecl->getDeclContext());
+  }
+  return false;
+}
+
 static void diagnoseDeclFeatureAvailability(const NamedDecl *D,
                                             SourceLocation Loc,
                                             Decl *ContextDecl, Sema &S) {
+  // For field type uses, the context is the FieldDecl. Walk up to the parent
+  // record so the "annotate" note names the record rather than the field.
+  // ObjCIvarDecl inherits from FieldDecl but its parent is an ObjC container,
+  // not a CXXRecordDecl, so skip it here.
+  if (auto *FD = dyn_cast<FieldDecl>(ContextDecl); FD && !isa<ObjCIvarDecl>(FD))
+    ContextDecl = cast<Decl>(FD->getParent());
+
   for (auto *Attr : D->specific_attrs<DomainAvailabilityAttr>()) {
     std::string FeatureUse = Attr->getDomain().str();
     // Skip checking if the feature is always enabled.
@@ -44,9 +62,13 @@ static void diagnoseDeclFeatureAvailability(const NamedDecl *D,
             FeatureAvailKind::AlwaysAvailable)
       continue;
 
-    if (!isFeatureUseGuarded(Attr, ContextDecl, S.Context))
+    if (!isFeatureUseGuarded(Attr, ContextDecl)) {
       S.Diag(Loc, diag::err_unguarded_feature)
           << D << FeatureUse << Attr->getUnavailable();
+      if (auto *ND = dyn_cast<NamedDecl>(ContextDecl))
+        S.Diag(Loc, diag::note_silence_unguarded_availability_domain_decl)
+            << ND << FeatureUse;
+    }
   }
 }
 
@@ -56,7 +78,6 @@ class DiagnoseUnguardedFeatureAvailability
   typedef RecursiveASTVisitor<DiagnoseUnguardedFeatureAvailability> Base;
 
   Sema &SemaRef;
-  const Decl *D;
 
   struct FeatureAvailInfo {
     StringRef Domain;
@@ -65,15 +86,31 @@ class DiagnoseUnguardedFeatureAvailability
 
   SmallVector<const Stmt *, 16> StmtStack;
   SmallVector<FeatureAvailInfo, 4> FeatureStack;
+  SmallVector<llvm::PointerUnion<const Decl *, const CompoundStmt *>, 4>
+      ContextStack;
+
+  struct ContextStackScope {
+    DiagnoseUnguardedFeatureAvailability *Visitor;
+    ContextStackScope(
+        DiagnoseUnguardedFeatureAvailability *V,
+        llvm::PointerUnion<const Decl *, const CompoundStmt *> Entry,
+        bool Active = true)
+        : Visitor(Active ? V : nullptr) {
+      if (Visitor)
+        Visitor->ContextStack.push_back(Entry);
+    }
+    ~ContextStackScope() {
+      if (Visitor)
+        Visitor->ContextStack.pop_back();
+    }
+  };
 
   bool isFeatureUseGuarded(const DomainAvailabilityAttr *Attr) const;
 
   bool isConditionallyGuardedByFeature() const;
 
 public:
-  DiagnoseUnguardedFeatureAvailability(Sema &SemaRef, const Decl *D,
-                                       Decl *Ctx = nullptr)
-      : SemaRef(SemaRef), D(D) {}
+  DiagnoseUnguardedFeatureAvailability(Sema &SemaRef) : SemaRef(SemaRef) {}
 
   void diagnoseDeclFeatureAvailability(const NamedDecl *D, SourceRange Range);
 
@@ -84,6 +121,11 @@ public:
     bool Result = Base::TraverseStmt(S);
     StmtStack.pop_back();
     return Result;
+  }
+
+  bool TraverseCompoundStmt(CompoundStmt *CS) {
+    ContextStackScope Scope(this, CS);
+    return Base::TraverseCompoundStmt(CS);
   }
 
   bool TraverseIfStmt(IfStmt *If);
@@ -116,11 +158,25 @@ public:
 
   bool VisitTypeLoc(TypeLoc Ty);
 
-  void IssueDiagnostics() {
+  bool TraverseDecl(Decl *D) {
+    if (!D)
+      return true;
+    bool PushContext =
+        isa<RecordDecl>(D) || isa<FunctionDecl>(D) ||
+        (isa<FieldDecl>(D) && cast<FieldDecl>(D)->hasInClassInitializer());
+    ContextStackScope Scope(this, D, PushContext);
+    return Base::TraverseDecl(D);
+  }
+
+  void IssueDiagnostics(const Decl *D) {
+    ContextStackScope Scope(this, D);
+
     if (auto *FD = dyn_cast<FunctionDecl>(D))
       TraverseStmt(FD->getBody());
     else if (auto *OMD = dyn_cast<ObjCMethodDecl>(D))
       TraverseStmt(OMD->getBody());
+    else if (auto *BD = dyn_cast<BlockDecl>(D))
+      TraverseStmt(BD->getBody());
   }
 };
 
@@ -184,7 +240,16 @@ bool DiagnoseUnguardedFeatureAvailability::isFeatureUseGuarded(
   for (auto &Info : FeatureStack)
     if (Info.Domain == Domain && Info.Unavailable == Attr->getUnavailable())
       return true;
-  return ::isFeatureUseGuarded(Attr, D, SemaRef.Context);
+  const Decl *CtxDecl = nullptr;
+  for (const auto &Entry : llvm::reverse(ContextStack))
+    if ((CtxDecl = dyn_cast<const Decl *>(Entry)))
+      if (::isFeatureUseGuardedLocally(Attr, CtxDecl))
+        return true;
+  if (CtxDecl)
+    return ::isFeatureUseGuarded(
+        Attr, dyn_cast_or_null<Decl>(CtxDecl->getDeclContext()));
+
+  return false;
 }
 
 /// Returns true if the given statement can be a body-like child of \p Parent.
@@ -259,6 +324,15 @@ void DiagnoseUnguardedFeatureAvailability::diagnoseDeclFeatureAvailability(
 
   if (Attrs.empty())
     return;
+
+  if (const auto *CtxDecl = dyn_cast<const Decl *>(ContextStack.back())) {
+    if (const auto *FD = dyn_cast<FieldDecl>(CtxDecl))
+      CtxDecl = FD->getParent();
+    for (const auto *A : Attrs)
+      SemaRef.Diag(Loc, diag::note_silence_unguarded_availability_domain_decl)
+          << cast<NamedDecl>(CtxDecl) << A->getDomain();
+    return;
+  }
 
   auto FixitDiag =
       SemaRef.Diag(Range.getBegin(),
@@ -362,9 +436,9 @@ void Sema::handleDelayedFeatureAvailabilityCheck(DelayedDiagnostic &DD,
 }
 
 void Sema::DiagnoseUnguardedFeatureAvailabilityViolations(Decl *D) {
-  assert((D->getAsFunction() || isa<ObjCMethodDecl>(D)) &&
-         "function or ObjC method decl expected");
-  DiagnoseUnguardedFeatureAvailability(*this, D).IssueDiagnostics();
+  assert((D->getAsFunction() || isa<ObjCMethodDecl>(D) || isa<BlockDecl>(D)) &&
+         "function, ObjC method, or block decl expected");
+  DiagnoseUnguardedFeatureAvailability(*this).IssueDiagnostics(D);
 }
 
 void Sema::DiagnoseFeatureAvailabilityOfDecl(NamedDecl *D,
@@ -372,8 +446,8 @@ void Sema::DiagnoseFeatureAvailabilityOfDecl(NamedDecl *D,
   if (!Context.hasFeatureAvailabilityAttr(D))
     return;
 
-  if (FunctionScopeInfo *Context = getCurFunctionAvailabilityContext()) {
-    Context->HasPotentialFeatureAvailabilityViolations = true;
+  if (FunctionScopeInfo *FSI = getCurFunctionAvailabilityContext()) {
+    FSI->HasPotentialFeatureAvailabilityViolations = true;
     return;
   }
 

--- a/clang/test/Sema/feature-availability.c
+++ b/clang/test/Sema/feature-availability.c
@@ -190,14 +190,21 @@ __attribute__((availability(domain:feature1, UNAVAIL), availability(domain:featu
 __attribute__((availability(macosx,introduced=10), availability(domain:feature1, AVAIL))) void func19(void);
 
 int *g12 = &g0; // expected-error {{cannot use 'g0' because feature 'feature1' is unavailable in this context}}
+// expected-note@-1 {{annotate 'g12' with the 'feature1' domain availability attribute to silence this error}}
 int g7 = sizeof(g0); // expected-error {{cannot use 'g0' because feature 'feature1' is unavailable in this context}}
+// expected-note@-1 {{annotate 'g7' with the 'feature1' domain availability attribute to silence this error}}
 __attribute__((availability(domain:feature1, AVAIL))) int g6 = sizeof(g0);
 __attribute__((availability(domain:feature1, UNAVAIL))) int g8 = sizeof(g0); // expected-error {{cannot use 'g0' because feature 'feature1' is unavailable in this context}}
+// expected-note@-1 {{annotate 'g8' with the 'feature1' domain availability attribute to silence this error}}
 __attribute__((availability(domain:feature2, AVAIL))) int g9 = sizeof(g0); // expected-error {{cannot use 'g0' because feature 'feature1' is unavailable in this context}}
+// expected-note@-1 {{annotate 'g9' with the 'feature1' domain availability attribute to silence this error}}
 void (*fp0)(void) = func6; // expected-error {{cannot use 'func6' because feature 'feature1' is unavailable in this context}}
+// expected-note@-1 {{annotate 'fp0' with the 'feature1' domain availability attribute to silence this error}}
 void (* __attribute__((availability(domain:feature1, AVAIL))) fp1)(void) = func6;
 void (* __attribute__((availability(domain:feature1, UNAVAIL))) fp2)(void) = func6; // expected-error {{cannot use 'func6' because feature 'feature1' is unavailable in this context}}
+// expected-note@-1 {{annotate 'fp2' with the 'feature1' domain availability attribute to silence this error}}
 void (* __attribute__((availability(domain:feature2, AVAIL))) fp3)(void) = func6; // expected-error {{cannot use 'func6' because feature 'feature1' is unavailable in this context}}
+// expected-note@-1 {{annotate 'fp3' with the 'feature1' domain availability attribute to silence this error}}
 
 void func6(void);
 __attribute__((availability(domain:feature1, AVAIL))) void func6(void); // expected-note {{is incompatible with __attribute__((availability(domain:feature1, 0)))}}
@@ -212,7 +219,9 @@ __attribute__((availability(domain:feature1, AVAIL))) int g2;// redecl-error {{n
 typedef int INT0 __attribute__((availability(domain:feature2, AVAIL)));
 typedef INT0 INT1 __attribute__((availability(domain:feature2, AVAIL)));
 typedef INT0 INT2 __attribute__((availability(domain:feature2, UNAVAIL))); // expected-error {{cannot use 'INT0' because feature 'feature2' is unavailable in this context}}
+// expected-note@-1 {{annotate 'INT2' with the 'feature2' domain availability attribute to silence this error}}
 typedef INT0 INT3 __attribute__((availability(domain:feature1, AVAIL))); // expected-error {{cannot use 'INT0' because feature 'feature2' is unavailable in this context}}
+// expected-note@-1 {{annotate 'INT3' with the 'feature2' domain availability attribute to silence this error}}
 
 enum __attribute__((availability(domain:feature1, AVAIL))) E {
   EA,
@@ -229,10 +238,24 @@ struct __attribute__((availability(domain:feature1, AVAIL))) S1 {
 
 struct S2 {
   struct S0 s0; // expected-error {{cannot use 'S0' because feature 'feature1' is unavailable in this context}}
+  // expected-note@-1 {{annotate 'S2' with the 'feature1' domain availability attribute to silence this error}}
   int i0 __attribute__((availability(domain:feature1, AVAIL))); // expected-error {{feature attributes cannot be applied to struct members}}
 };
 
+struct __attribute__((availability(domain:feature1, AVAIL))) Outer {
+  struct Inner {
+    // In C, a nested struct's semantic DeclContext is the enclosing
+    // file/block scope, not the outer struct, so the walk up from Inner
+    // does not find Outer's feature attribute. It's unclear whether this
+    // should be diagnosed; -Wunguarded-availability shows the same
+    // behavior for platform availability.
+    struct S0 s0; // expected-error {{cannot use 'S0' because feature 'feature1' is unavailable in this context}}
+    // expected-note@-1 {{annotate 'Inner' with the 'feature1' domain availability attribute to silence this error}}
+  } m;
+};
+
 struct S0 g10; // expected-error {{cannot use 'S0' because feature 'feature1' is unavailable in this context}}
+// expected-note@-1 {{annotate 'g10' with the 'feature1' domain availability attribute to silence this error}}
 __attribute__((availability(domain:feature1, AVAIL))) struct S0 g11;
 
 void test0(void) {
@@ -353,6 +376,7 @@ void test3(void) {
 }
 
 void test4(struct S0 *s0) { // expected-error {{cannot use 'S0' because feature 'feature1' is unavailable in this context}}
+  // expected-note@-1 {{annotate 'test4' with the 'feature1' domain availability attribute to silence this error}}
   g11.i0 = 0; // expected-error {{cannot use 'g11' because feature 'feature1' is unavailable in this context}} expected-error {{cannot use 'i0' because feature 'feature1' is unavailable in this context}}
   // expected-note@-1 {{enclose 'g11' in a __builtin_available}}
   // expected-note@-2 {{enclose 'i0' in a __builtin_available}}

--- a/clang/test/SemaObjC/feature-availability.m
+++ b/clang/test/SemaObjC/feature-availability.m
@@ -28,18 +28,27 @@ struct __attribute__((availability(domain:feature1, AVAIL))) S1 {};
 
 @interface C0 {
   struct S0 ivar0; // expected-error {{cannot use 'S0' because feature 'feature1' is available in this context}}
+                   // expected-note@-1 {{annotate 'ivar0' with the 'feature1' domain availability attribute to silence this error}}
   struct S1 ivar1; // enabled-error {{cannot use 'S1' because feature 'feature1' is unavailable in this context}}
+                   // enabled-note@-1 {{annotate 'ivar1' with the 'feature1' domain availability attribute to silence this error}}
   struct S1 ivar2 __attribute__((availability(domain:feature1, AVAIL)));
   struct S1 ivar3 __attribute__((availability(domain:feature1, UNAVAIL))); // enabled-error {{cannot use 'S1' because feature 'feature1' is unavailable in this context}}
+                                                                           // enabled-note@-1 {{annotate 'ivar3' with the 'feature1' domain availability attribute to silence this error}}
 }
 @property struct S0 prop0; // expected-error {{cannot use 'S0' because feature 'feature1' is available in this context}}
+                           // expected-note@-1 {{annotate 'prop0' with the 'feature1' domain availability attribute to silence this error}}
 @property struct S1 prop1; // enabled-error {{cannot use 'S1' because feature 'feature1' is unavailable in this context}}
+                           // enabled-note@-1 {{annotate 'prop1' with the 'feature1' domain availability attribute to silence this error}}
 @property struct S1 prop2 __attribute__((availability(domain:feature1, AVAIL)));
 @property struct S1 prop3 __attribute__((availability(domain:feature1, UNAVAIL))); // enabled-error {{cannot use 'S1' because feature 'feature1' is unavailable in this context}}
+                                                                                   // enabled-note@-1 {{annotate 'prop3' with the 'feature1' domain availability attribute to silence this error}}
 -(struct S0)m0; // expected-error {{cannot use 'S0' because feature 'feature1' is available in this context}}
+               // expected-note@-1 {{annotate 'm0' with the 'feature1' domain availability attribute to silence this error}}
 -(struct S1)m1; // enabled-error {{cannot use 'S1' because feature 'feature1' is unavailable in this context}}
+               // enabled-note@-1 {{annotate 'm1' with the 'feature1' domain availability attribute to silence this error}}
 -(struct S1)m2 __attribute__((availability(domain:feature1, AVAIL)));
 -(struct S1)m3 __attribute__((availability(domain:feature1, UNAVAIL))); // enabled-error {{cannot use 'S1' because feature 'feature1' is unavailable in this context}}
+                                                                        // enabled-note@-1 {{annotate 'm3' with the 'feature1' domain availability attribute to silence this error}}
 @end
 
 __attribute__((objc_root_class))
@@ -67,11 +76,13 @@ __attribute__((objc_root_class))
 __attribute__((availability(domain:feature1, AVAIL))) // expected-note 2 {{is incompatible with __attribute__((availability(domain:feature1, 0)))}}
 @interface Base0 {
   struct S0 ivar0; // expected-error {{cannot use 'S0' because feature 'feature1' is available in this context}}
+                   // expected-note@-1 {{annotate 'ivar0' with the 'feature1' domain availability attribute to silence this error}}
   struct S1 ivar1;
   struct S1 ivar2 __attribute__((availability(domain:feature1, AVAIL)));
   struct S1 ivar3 __attribute__((availability(domain:feature1, UNAVAIL))); // expected-error {{cannot merge incompatible feature attribute to this decl}} expected-note {{feature attribute __attribute__((availability(domain:feature1, 1)))}}
 }
 @property struct S0 prop0; // expected-error {{cannot use 'S0' because feature 'feature1' is available in this context}}
+                           // expected-note@-1 {{annotate 'prop0' with the 'feature1' domain availability attribute to silence this error}}
 @property struct S1 prop1;
 @property struct S1 prop2 __attribute__((availability(domain:feature1, AVAIL)));
 @property struct S1 prop3 __attribute__((availability(domain:feature1, UNAVAIL))); // expected-error {{cannot merge incompatible feature attribute to this decl}} expected-note {{feature attribute __attribute__((availability(domain:feature1, 1)))}}
@@ -147,6 +158,7 @@ __attribute__((availability(domain:feature1, UNAVAIL))) // expected-note {{featu
 
 @protocol P0
 @property struct S1 *p0; // enabled-error {{cannot use 'S1' because feature 'feature1' is unavailable in this context}}
+                         // enabled-note@-1 {{annotate 'p0' with the 'feature1' domain availability attribute to silence this error}}
 @end
 
 __attribute__((availability(domain:feature1, AVAIL)))
@@ -206,6 +218,7 @@ __attribute__((availability(domain:feature1, UNAVAIL)))
 @end
 
 void foo(id<P1>); // expected-error {{cannot use 'P1' because feature 'feature1' is available in this context}}
+                  // expected-note@-1 {{annotate 'foo' with the 'feature1' domain availability attribute to silence this error}}
 
 @interface Base8
 @property (copy) id x;


### PR DESCRIPTION
- Emit a "annotate <decl> with the feature attribute" note alongside the unguarded-feature error so users can silence it by annotating the enclosing declaration.
- Walk up the DeclContext chain in isFeatureUseGuarded so an outer decl's feature attribute can guard uses in inner scopes (e.g. an inline method of an annotated class in C++). In C, struct tags are file-scoped, so the walk does not climb into outer structs; this matches the behavior of -Wunguarded-availability.
- Track visited contexts via a ContextStack rather than a single outer-decl pointer, so each Decl encountered during traversal can contribute to guard checking.
- Handle BlockDecl in DiagnoseUnguardedFeatureAvailabilityViolations.