### PR TITLE
[lldb][NFC] Return unique_ptr from ObjCLanguageRuntime::{GetMetaclass,GetClassDescriptor}

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -608,7 +608,8 @@ bool ClassDescriptorV2::Describe(
   }
 
   if (class_method_func) {
-    AppleObjCRuntime::ClassDescriptorSP metaclass(GetMetaclass());
+    std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor> metaclass =
+        GetMetaclass();
 
     // We don't care about the metaclass's superclass, or its class methods.
     // Its instance methods are our class methods.
@@ -682,20 +683,21 @@ ObjCLanguageRuntime::ClassDescriptorSP ClassDescriptorV2::GetSuperclass() {
       objc_class->m_superclass);
 }
 
-ObjCLanguageRuntime::ClassDescriptorSP ClassDescriptorV2::GetMetaclass() const {
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
+ClassDescriptorV2::GetMetaclass() const {
   lldb_private::Process *process = m_runtime.GetProcess();
 
   if (!process)
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   std::unique_ptr<objc_class_t> objc_class;
 
   if (!Read_objc_class(process, objc_class))
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   lldb::addr_t candidate_isa = m_runtime.GetPointerISA(objc_class->m_isa);
 
-  return ObjCLanguageRuntime::ClassDescriptorSP(
+  return std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>(
       new ClassDescriptorV2(m_runtime, candidate_isa, nullptr));
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
@@ -29,7 +29,8 @@ public:
 
   ObjCLanguageRuntime::ClassDescriptorSP GetSuperclass() override;
 
-  ObjCLanguageRuntime::ClassDescriptorSP GetMetaclass() const override;
+  std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
+  GetMetaclass() const override;
 
   bool IsValid() override {
     return true; // any Objective-C v2 runtime class descriptor we vend is valid
@@ -331,8 +332,9 @@ public:
     return ObjCLanguageRuntime::ClassDescriptorSP();
   }
 
-  ObjCLanguageRuntime::ClassDescriptorSP GetMetaclass() const override {
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+  std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
+  GetMetaclass() const override {
+    return nullptr;
   }
 
   bool IsValid() override { return m_valid; }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -259,9 +259,9 @@ AppleObjCRuntimeV1::ClassDescriptorV1::GetSuperclass() {
       new AppleObjCRuntimeV1::ClassDescriptorV1(m_parent_isa, process_sp));
 }
 
-AppleObjCRuntime::ClassDescriptorSP
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
 AppleObjCRuntimeV1::ClassDescriptorV1::GetMetaclass() const {
-  return ClassDescriptorSP();
+  return nullptr;
 }
 
 bool AppleObjCRuntimeV1::ClassDescriptorV1::Describe(

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.h
@@ -53,7 +53,8 @@ public:
 
     ClassDescriptorSP GetSuperclass() override;
 
-    ClassDescriptorSP GetMetaclass() const override;
+    std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
+    GetMetaclass() const override;
 
     bool IsValid() override { return m_valid; }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3091,16 +3091,16 @@ bool AppleObjCRuntimeV2::TaggedPointerVendorLegacy::IsPossibleTaggedPointer(
   return (ptr & 1);
 }
 
-ObjCLanguageRuntime::ClassDescriptorSP
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
 AppleObjCRuntimeV2::TaggedPointerVendorLegacy::GetClassDescriptor(
     lldb::addr_t ptr) {
   if (!IsPossibleTaggedPointer(ptr))
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   uint32_t foundation_version = m_runtime.GetFoundationVersion();
 
   if (foundation_version == LLDB_INVALID_MODULE_VERSION)
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   uint64_t class_bits = (ptr & 0xE) >> 1;
   ConstString name;
@@ -3129,7 +3129,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorLegacy::GetClassDescriptor(
       name = g_NSDate;
       break;
     default:
-      return ObjCLanguageRuntime::ClassDescriptorSP();
+      return nullptr;
     }
   } else {
     switch (class_bits) {
@@ -3146,12 +3146,12 @@ AppleObjCRuntimeV2::TaggedPointerVendorLegacy::GetClassDescriptor(
       name = g_NSDateTS;
       break;
     default:
-      return ObjCLanguageRuntime::ClassDescriptorSP();
+      return nullptr;
     }
   }
 
   lldb::addr_t unobfuscated = ptr ^ m_runtime.GetTaggedPointerObfuscator();
-  return ClassDescriptorSP(new ClassDescriptorV2Tagged(name, unobfuscated));
+  return std::make_unique<ClassDescriptorV2Tagged>(name, unobfuscated);
 }
 
 AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::
@@ -3178,14 +3178,14 @@ bool AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::
   return (ptr & m_objc_debug_taggedpointer_mask) != 0;
 }
 
-ObjCLanguageRuntime::ClassDescriptorSP
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
 AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(
     lldb::addr_t ptr) {
   ClassDescriptorSP actual_class_descriptor_sp;
   uint64_t unobfuscated = (ptr) ^ m_runtime.GetTaggedPointerObfuscator();
 
   if (!IsPossibleTaggedPointer(unobfuscated))
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   uintptr_t slot = (ptr >> m_objc_debug_taggedpointer_slot_shift) &
                    m_objc_debug_taggedpointer_slot_mask;
@@ -3212,7 +3212,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(
       }
     }
     if (!actual_class_descriptor_sp)
-      return ObjCLanguageRuntime::ClassDescriptorSP();
+      return nullptr;
     m_cache[slot] = actual_class_descriptor_sp;
   }
 
@@ -3222,8 +3222,8 @@ AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(
   int64_t data_payload_signed =
       ((int64_t)(unobfuscated << m_objc_debug_taggedpointer_payload_lshift) >>
        m_objc_debug_taggedpointer_payload_rshift);
-  return ClassDescriptorSP(new ClassDescriptorV2Tagged(
-      actual_class_descriptor_sp, data_payload, data_payload_signed));
+  return std::make_unique<ClassDescriptorV2Tagged>(
+      actual_class_descriptor_sp, data_payload, data_payload_signed);
 }
 
 AppleObjCRuntimeV2::TaggedPointerVendorExtended::TaggedPointerVendorExtended(
@@ -3271,14 +3271,14 @@ bool AppleObjCRuntimeV2::TaggedPointerVendorExtended::
           m_objc_debug_taggedpointer_ext_mask);
 }
 
-ObjCLanguageRuntime::ClassDescriptorSP
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
 AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
     lldb::addr_t ptr) {
   ClassDescriptorSP actual_class_descriptor_sp;
   uint64_t unobfuscated = (ptr) ^ m_runtime.GetTaggedPointerObfuscator();
 
   if (!IsPossibleTaggedPointer(unobfuscated))
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   if (!IsPossibleExtendedTaggedPointer(unobfuscated))
     return this->TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(ptr);
@@ -3301,7 +3301,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
     actual_class_descriptor_sp =
         m_runtime.GetClassDescriptorFromISA((ObjCISA)slot_data);
     if (!actual_class_descriptor_sp)
-      return ObjCLanguageRuntime::ClassDescriptorSP();
+      return nullptr;
     m_ext_cache[slot] = actual_class_descriptor_sp;
   }
 
@@ -3313,8 +3313,8 @@ AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
                  << m_objc_debug_taggedpointer_ext_payload_lshift) >>
        m_objc_debug_taggedpointer_ext_payload_rshift);
 
-  return ClassDescriptorSP(new ClassDescriptorV2Tagged(
-      actual_class_descriptor_sp, data_payload, data_payload_signed));
+  return std::make_unique<ClassDescriptorV2Tagged>(
+      actual_class_descriptor_sp, data_payload, data_payload_signed);
 }
 
 AppleObjCRuntimeV2::NonPointerISACache::NonPointerISACache(

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
@@ -198,7 +198,7 @@ private:
   public:
     bool IsPossibleTaggedPointer(lldb::addr_t ptr) override;
 
-    ObjCLanguageRuntime::ClassDescriptorSP
+    std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
     GetClassDescriptor(lldb::addr_t ptr) override;
 
   protected:
@@ -231,7 +231,7 @@ private:
   class TaggedPointerVendorExtended
       : public TaggedPointerVendorRuntimeAssisted {
   public:
-    ObjCLanguageRuntime::ClassDescriptorSP
+    std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
     GetClassDescriptor(lldb::addr_t ptr) override;
 
   protected:
@@ -272,7 +272,7 @@ private:
   public:
     bool IsPossibleTaggedPointer(lldb::addr_t ptr) override;
 
-    ObjCLanguageRuntime::ClassDescriptorSP
+    std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
     GetClassDescriptor(lldb::addr_t ptr) override;
 
   protected:

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -63,7 +63,7 @@ public:
 
     virtual ClassDescriptorSP GetSuperclass() = 0;
 
-    virtual ClassDescriptorSP GetMetaclass() const = 0;
+    virtual std::unique_ptr<ClassDescriptor> GetMetaclass() const = 0;
 
     // virtual if any implementation has some other version-specific rules but
     // for the known v1/v2 this is all that needs to be done
@@ -198,7 +198,7 @@ public:
 
     virtual bool IsPossibleTaggedPointer(lldb::addr_t ptr) = 0;
 
-    virtual ObjCLanguageRuntime::ClassDescriptorSP
+    virtual std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
     GetClassDescriptor(lldb::addr_t ptr) = 0;
 
   protected:


### PR DESCRIPTION


GetMetaclass() always creates a fresh ClassDescriptor on the heap and has no caching at the call sites, so shared ownership is unnecessary. Using std::unique_ptr makes the ownership transfer explicit and moves one step toward replacing ClassDescriptorSP with unique_ptr where possible.

All three TaggedPointerVendor::GetClassDescriptor implementations always construct a fresh ClassDescriptorV2Tagged on the heap, and the sole external caller in 'language objc tagged-pointer info' uses the result transiently. The tagged descriptor itself is never stored in any cache (only the underlying actual-class descriptor is), so shared ownership is unnecessary at this layer. Switch the return type to std::unique_ptr<ClassDescriptor>.

The goal is to clarify ownership semantics of these data structures, and to make it explicit (by a conversion from UP->SP) when shared ownership is truly needed. With enough simplifications, the goal is prove we don't need shared ownership.