### PR TITLE
[lldb][windows] skip test_runInTerminal

### DIFF
--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -105,6 +105,7 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
                 return file.readline()
 
     @skipIfLinux # FIXME: doesn't seem to work on Ubuntu 16.04.
+    @skipIfWindows # rdar://177419646
     @skipIfAsan
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
     def test_runInTerminal(self):


### PR DESCRIPTION
This test is flaky on Windows. Skip it until it's fixed.