### PR TITLE
[lldb][repl] fix incorrect number of trailing ~ in single character diagnostic range

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -149,8 +149,14 @@ public:
       }
       return;
     }
-    // FXIME: This is a heuristic.
-    uint16_t len = info.Ranges.size() ? info.Ranges.front().getByteLength() : 0;
+
+    uint16_t len = 0;
+    for (const auto &R : info.Ranges) {
+      if (R.getStart() == source_loc) {
+        len = R.getByteLength();
+        break;
+      }
+    }
     bool in_user_input = false;
     bool hidden = false;
     [&]() {

--- a/lldb/test/Shell/SwiftREPL/DiagnosticCaret.test
+++ b/lldb/test/Shell/SwiftREPL/DiagnosticCaret.test
@@ -1,0 +1,12 @@
+// Test that the caret for a single-character operator is correctly underlined.
+
+// REQUIRES: swift
+// XFAIL: system-windows
+
+// RUN: env LANG=C %lldb --repl 2>&1 < %s | FileCheck %s
+
+let foo = 1
+foo!
+
+// CHECK: {{^[ ]+\^$}}
+// CHECK-NEXT: {{^[ ]+}}error: cannot force unwrap value of non-optional type 'Int'


### PR DESCRIPTION
Only use the range length if the range starts at the diagnostic location.

## Before

```
Welcome to Apple Swift version 6.3 (swiftlang-6.3.0.123.5 clang-2100.0.123.102).
Type :help for assistance.
  1> let foo = 1
foo: Int = 1
  2> foo!
        ˄˜˜˜
        ╰─ error: cannot force unwrap value of non-optional type 'Int'
```

## After

```
Welcome to Swift version 6.4-dev (LLVM 2298a8046ef037a, Swift cfe03154e6e8158).
Type :help for assistance.
  1> let foo = 1
foo: Int = 1
  2> foo!
        ˄
        ╰─ error: cannot force unwrap value of non-optional type 'Int'
```

rdar://176913198