### PR TITLE
Add way to pass setOnlyIfDifferent for generate pcm/pch actions (#12768)

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -861,7 +861,7 @@ public:
   std::unique_ptr<raw_pwrite_stream> createDefaultOutputFile(
       bool Binary = true, StringRef BaseInput = "", StringRef Extension = "",
       bool RemoveFileOnSignal = true, bool CreateMissingDirectories = false,
-      bool ForceUseTemporary = false);
+      bool ForceUseTemporary = false, bool SetOnlyIfDifferent = false);
 
   /// Create a new output file, optionally deriving the output path name, and
   /// add it to the list of tracked output files.
@@ -869,7 +869,8 @@ public:
   /// \return - Null on error.
   std::unique_ptr<raw_pwrite_stream>
   createOutputFile(StringRef OutputPath, bool Binary, bool RemoveFileOnSignal,
-                   bool UseTemporary, bool CreateMissingDirectories = false);
+                   bool UseTemporary, bool CreateMissingDirectories = false,
+                   bool SetOnlyIfDifferent = false);
 
 private:
   /// Prepare the CompilerInstance for executing a frontend action.
@@ -899,7 +900,7 @@ private:
   Expected<std::unique_ptr<raw_pwrite_stream>>
   createOutputFileImpl(StringRef OutputPath, bool Binary,
                        bool RemoveFileOnSignal, bool UseTemporary,
-                       bool CreateMissingDirectories);
+                       bool CreateMissingDirectories, bool SetOnlyIfDifferent);
 
 public:
   std::unique_ptr<raw_pwrite_stream> createNullOutputFile();

--- a/clang/include/clang/Frontend/FrontendActions.h
+++ b/clang/include/clang/Frontend/FrontendActions.h
@@ -96,6 +96,8 @@ protected:
 
   bool shouldEraseOutputFiles() override;
 
+  bool SetOnlyIfDifferent;
+
 public:
   /// Compute the AST consumer arguments that will be used to
   /// create the PCHGenerator instance returned by CreateASTConsumer.
@@ -108,9 +110,12 @@ public:
   /// into. On error, returns null.
   static std::unique_ptr<llvm::raw_pwrite_stream>
   CreateOutputFile(CompilerInstance &CI, StringRef InFile,
-                   std::string &OutputFile);
+                   std::string &OutputFile, bool SetOnlyIfDifferent = false);
 
   bool BeginSourceFileAction(CompilerInstance &CI) override;
+
+  GeneratePCHAction(bool SetOnlyIfDifferent = false)
+    : SetOnlyIfDifferent(SetOnlyIfDifferent) {}
 };
 
 class GenerateModuleAction : public ASTFrontendAction {
@@ -162,6 +167,12 @@ private:
 
   std::unique_ptr<raw_pwrite_stream>
   CreateOutputFile(CompilerInstance &CI, StringRef InFile) override;
+
+  bool SetOnlyIfDifferent;
+
+public:
+  GenerateModuleFromModuleMapAction(bool SetOnlyIfDifferent = false)
+    : SetOnlyIfDifferent(SetOnlyIfDifferent) {}
 };
 
 /// Generates full BMI (which contains full information to generate the object

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -921,7 +921,7 @@ void CompilerInstance::clearOutputFiles(bool EraseFiles) {
 
 std::unique_ptr<raw_pwrite_stream> CompilerInstance::createDefaultOutputFile(
     bool Binary, StringRef InFile, StringRef Extension, bool RemoveFileOnSignal,
-    bool CreateMissingDirectories, bool ForceUseTemporary) {
+    bool CreateMissingDirectories, bool ForceUseTemporary, bool SetOnlyIfDifferent) {
   StringRef OutputPath = getFrontendOpts().OutputFile;
   std::optional<SmallString<128>> PathStorage;
   if (OutputPath.empty()) {
@@ -936,7 +936,7 @@ std::unique_ptr<raw_pwrite_stream> CompilerInstance::createDefaultOutputFile(
 
   return createOutputFile(OutputPath, Binary, RemoveFileOnSignal,
                           getFrontendOpts().UseTemporary || ForceUseTemporary,
-                          CreateMissingDirectories);
+                          CreateMissingDirectories, SetOnlyIfDifferent);
 }
 
 std::unique_ptr<raw_pwrite_stream> CompilerInstance::createNullOutputFile() {
@@ -1006,10 +1006,11 @@ llvm::cas::ActionCache &CompilerInstance::getOrCreateActionCache() {
 std::unique_ptr<raw_pwrite_stream>
 CompilerInstance::createOutputFile(StringRef OutputPath, bool Binary,
                                    bool RemoveFileOnSignal, bool UseTemporary,
-                                   bool CreateMissingDirectories) {
+                                   bool CreateMissingDirectories,
+                                   bool SetOnlyIfDifferent) {
   Expected<std::unique_ptr<raw_pwrite_stream>> OS =
       createOutputFileImpl(OutputPath, Binary, RemoveFileOnSignal, UseTemporary,
-                           CreateMissingDirectories);
+                           CreateMissingDirectories, SetOnlyIfDifferent);
   if (OS)
     return std::move(*OS);
   getDiagnostics().Report(diag::err_fe_unable_to_open_output)
@@ -1102,7 +1103,8 @@ Expected<std::unique_ptr<llvm::raw_pwrite_stream>>
 CompilerInstance::createOutputFileImpl(StringRef OutputPath, bool Binary,
                                        bool RemoveFileOnSignal,
                                        bool UseTemporary,
-                                       bool CreateMissingDirectories) {
+                                       bool CreateMissingDirectories,
+                                       bool SetOnlyIfDifferent) {
   assert((!CreateMissingDirectories || UseTemporary) &&
          "CreateMissingDirectories is only allowed when using temporary files");
 
@@ -1125,7 +1127,8 @@ CompilerInstance::createOutputFileImpl(StringRef OutputPath, bool Binary,
           .setTextWithCRLF(!Binary)
           .setDiscardOnSignal(RemoveFileOnSignal)
           .setAtomicWrite(UseTemporary)
-          .setImplyCreateDirectories(UseTemporary && CreateMissingDirectories));
+          .setImplyCreateDirectories(UseTemporary && CreateMissingDirectories)
+          .setOnlyIfDifferent(SetOnlyIfDifferent));
   if (!O)
     return O.takeError();
 

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -128,7 +128,7 @@ GeneratePCHAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
 
   std::string OutputFile;
   std::unique_ptr<raw_pwrite_stream> OS =
-      CreateOutputFile(CI, InFile, /*ref*/ OutputFile);
+      CreateOutputFile(CI, InFile, /*ref*/ OutputFile, SetOnlyIfDifferent);
   if (!OS)
     return nullptr;
 
@@ -162,10 +162,13 @@ bool GeneratePCHAction::ComputeASTConsumerArguments(CompilerInstance &CI,
 
 std::unique_ptr<llvm::raw_pwrite_stream>
 GeneratePCHAction::CreateOutputFile(CompilerInstance &CI, StringRef InFile,
-                                    std::string &OutputFile) {
+                                    std::string &OutputFile,
+                                    bool SetOnlyIfDifferent) {
   // Because this is exposed via libclang we must disable RemoveFileOnSignal.
   std::unique_ptr<raw_pwrite_stream> OS = CI.createDefaultOutputFile(
-      /*Binary=*/true, InFile, /*Extension=*/"", /*RemoveFileOnSignal=*/false);
+      /*Binary=*/true, InFile, /*Extension=*/"", /*RemoveFileOnSignal=*/false,
+      /*CreateMissingDirectories=*/false, /*ForceUseTemporary=*/false,
+      SetOnlyIfDifferent);
   if (!OS)
     return nullptr;
 
@@ -258,7 +261,8 @@ GenerateModuleFromModuleMapAction::CreateOutputFile(CompilerInstance &CI,
   return CI.createDefaultOutputFile(/*Binary=*/true, InFile, /*Extension=*/"",
                                     /*RemoveFileOnSignal=*/false,
                                     /*CreateMissingDirectories=*/true,
-                                    /*ForceUseTemporary=*/true);
+                                    /*ForceUseTemporary=*/true,
+                                    /*SetOnlyIfDifferent=*/SetOnlyIfDifferent);
 }
 
 bool GenerateModuleInterfaceAction::PrepareToExecuteAction(


### PR DESCRIPTION
(cherry picked from commit d65fcdad333e4103999d7dbb7d4ad2252938f768)