### PR TITLE
[lldb] Disable delayed breakpoints

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -394,7 +394,7 @@ let Definition = "process" in {
              "threads are suspended during single-stepping operations.">;
   def UseDelayedBreakpoints
       : Property<"use-delayed-breakpoints", "Boolean">,
-        DefaultTrue,
+        DefaultFalse,
         Desc<"Specify whether updating breakpoints may be delayed until the "
              "process is about to resume.">;
 }

--- a/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/TestDelayedBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/TestDelayedBreakpoint.py
@@ -9,6 +9,7 @@ import os
 class TestDelayedBreakpoint(TestBase):
     def test(self):
         self.build()
+        self.runCmd("settings set target.process.use-delayed-breakpoints true")
         logfile = os.path.join(self.getBuildDir(), "log.txt")
         self.runCmd(f"log enable -f {logfile} gdb-remote packets")
 
@@ -45,6 +46,7 @@ class TestDelayedBreakpoint(TestBase):
 
     def test_eager_breakpoints(self):
         self.build()
+        self.runCmd("settings set target.process.use-delayed-breakpoints true")
         logfile = os.path.join(self.getBuildDir(), "log.txt")
         self.runCmd(f"log enable -f {logfile} gdb-remote packets")
 


### PR DESCRIPTION
An issue was found whereby setting breakpoints while the process is runnign does not work.