### PR TITLE
[lldb] Fall back to FindProcesses in webinspector-wasm GetProcessInfo

### DIFF
--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.cpp
@@ -171,7 +171,21 @@ bool PlatformWebInspectorWasm::GetProcessInfo(lldb::pid_t pid,
                    "EnsureConnected failed: {0}");
     return false;
   }
-  return PlatformWasm::GetProcessInfo(pid, proc_info);
+  if (PlatformWasm::GetProcessInfo(pid, proc_info))
+    return true;
+  // The webinspector-wasm gdb-server only implements bulk process
+  // enumeration, not per-pid lookup. Fall back to FindProcesses when the
+  // per-pid query returns nothing.
+  ProcessInstanceInfoMatch match;
+  ProcessInstanceInfoList all;
+  PlatformWasm::FindProcesses(match, all);
+  for (const ProcessInstanceInfo &info : all) {
+    if (info.GetProcessID() == pid) {
+      proc_info = info;
+      return true;
+    }
+  }
+  return false;
 }
 
 lldb::ProcessSP


### PR DESCRIPTION
The webinspector-wasm platform server implements bulk process enumeration but not per-pid lookup, so PlatformWasm::GetProcessInfo returns false for every pid. SBTarget::Attach treats that as "no such process" and bails out before reaching Target::Attach, breaking attach-by-pid from SB-API callers including lldb-dap. (The CLI's `process attach` invokes Target::Attach directly and isn't affected.)

When the per-pid query returns nothing, fall back to the bulk FindProcesses query and locate the matching pid in its result.

(cherry picked from commit 45c1f5e9f76a19e24b25817c77028ab8af59c900)