### PR TITLE
[lldb] Fix --source-regexp-function for Swift static functions

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -1061,6 +1061,11 @@ static bool ParseGlobal(const swift::Demangle::NodePointer &node,
                         swift::Demangle::Node::Kind &kind) {
   for (auto *child : *node) {
     if (child) {
+      // Peel off static node.
+      if (child->getKind() == swift::Demangle::Node::Kind::Static &&
+          child->hasChildren())
+        child = child->getFirstChild();
+
       kind = child->getKind();
       switch (child->getKind()) {
       case swift::Demangle::Node::Kind::Allocator:

--- a/lldb/test/API/lang/swift/break_source_regex_static_function/Makefile
+++ b/lldb/test/API/lang/swift/break_source_regex_static_function/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/break_source_regex_static_function/TestBreakSourceRegexStaticFunction.py
+++ b/lldb/test/API/lang/swift/break_source_regex_static_function/TestBreakSourceRegexStaticFunction.py
@@ -1,0 +1,32 @@
+"""
+Tests source regex breakpoints scoped to Swift static functions (-X option).
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @skipEmbeddedSwiftOnWindows
+    @swiftTest
+    def test_source_regex_with_static_function_filter(self):
+        self.build()
+        target, _, _, _ = lldbutil.run_to_name_breakpoint(self, "main")
+        self.expect("breakpoint set -p 'break here' -X first")
+        bp = target.breakpoint[-1]
+        self.assertTrue(bp.IsEnabled())
+        self.assertEqual(bp.GetNumResolvedLocations(), 1)
+        self.assertIn("Scope.first", str(bp.location[0]))
+
+    @skipEmbeddedSwiftOnWindows
+    @swiftTest
+    def test_source_regex_with_static_function_filter_and_file(self):
+        self.build()
+        target, _, _, _ = lldbutil.run_to_name_breakpoint(self, "main")
+        self.expect("breakpoint set -f main.swift -p 'break here' -X second")
+        bp = target.breakpoint[-1]
+        self.assertTrue(bp.IsEnabled())
+        self.assertEqual(bp.GetNumResolvedLocations(), 1)
+        self.assertIn("Scope.second", str(bp.location[0]))

--- a/lldb/test/API/lang/swift/break_source_regex_static_function/main.swift
+++ b/lldb/test/API/lang/swift/break_source_regex_static_function/main.swift
@@ -1,0 +1,16 @@
+enum Scope {
+    static func first() {
+        _ = "break here"
+    }
+
+    static func second() {
+        _ = "break here"
+    }
+}
+
+@main enum Entry {
+    static func main() {
+        Scope.first()
+        Scope.second()
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 8ff00c8b2f437c4bbe04a33324b9b7900c3be591)
