### PR TITLE
"[DWARFVerifier] Skip DW_TAG_LLVM_annotation in verifyNameIndexCompleteness" and  "[NFC][DebugInfo] Add Annotations parameter to DIBuilder::createStructType"

### DIFF
--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -587,12 +587,15 @@ namespace llvm {
     /// \param NumExtraInhabitants The number of extra inhabitants of the type.
     /// An extra inhabitant is a bit pattern that does not represent a valid
     /// value for instances of a given type. This is used by the Swift language.
+    /// \param Annotations  Attribute annotations, emitted as
+    /// DW_TAG_LLVM_annotation entries.
     LLVM_ABI DICompositeType *createStructType(
         DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
         uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
         DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang = 0,
         DIType *VTableHolder = nullptr, StringRef UniqueIdentifier = "",
-        DIType *Specification = nullptr, uint32_t NumExtraInhabitants = 0);
+        DIType *Specification = nullptr, uint32_t NumExtraInhabitants = 0,
+        DINodeArray Annotations = nullptr);
 
     /// Create debugging information entry for an union.
     /// \param Scope        Scope in which this union is defined.

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1982,6 +1982,9 @@ void DWARFVerifier::verifyNameIndexCompleteness(
   case DW_TAG_member:
     return;
 
+  case DW_TAG_LLVM_annotation:
+    return;
+
   // According to a strict reading of the specification, enumerators should not
   // be indexed (and LLVM currently does not do that). However, this causes
   // problems for the debuggers, so we may need to reconsider this.

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -631,13 +631,13 @@ DICompositeType *DIBuilder::createStructType(
     uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
     DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang,
     DIType *VTableHolder, StringRef UniqueIdentifier, DIType *Specification,
-    uint32_t NumExtraInhabitants) {
+    uint32_t NumExtraInhabitants, DINodeArray Annotations) {
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_structure_type, Name, File, LineNumber,
       getNonCompileUnitScope(Context), DerivedFrom, SizeInBits, AlignInBits, 0,
       Flags, Elements, RunTimeLang, /*EnumKind=*/std::nullopt, VTableHolder,
       nullptr, UniqueIdentifier, nullptr, nullptr, nullptr, nullptr, nullptr,
-      nullptr, Specification, NumExtraInhabitants);
+      Annotations, Specification, NumExtraInhabitants);
   trackIfUnresolved(R);
   if (isa_and_nonnull<DILocalScope>(Context))
     getSubprogramNodesTrackingVector(Context).emplace_back(R);


### PR DESCRIPTION
commit 2af9f9f8b1dc6c0fbfec46e35a3624fa9d5be563 (HEAD -> cp-0427-resolve-marker-protocol, a/cp-0427-resolve-marker-protocol)
Author: Augusto Noronha <anoronha@apple.com>
Date:   Tue Apr 7 14:43:48 2026 -0700

    [DWARFVerifier] Skip DW_TAG_LLVM_annotation in verifyNameIndexCompleteness

    Annotations are not indexed, so we need to skip them on the verifier.

    (cherry picked from commit 12c8efe53b43e4cee787b1f4e8d3b0aa0133f245)

 llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp | 3 +++
 1 file changed, 3 insertions(+)

commit 3d9483ebe9af1733614622ea285da918e4f97398
Author: Augusto Noronha <anoronha@apple.com>
Date:   Wed Mar 18 11:52:54 2026 -0700

    [NFC][DebugInfo] Add Annotations parameter to DIBuilder::createStructType

    DICompositeType already has an "Annotations" ivar. This simply adds a
    way to set it from the "createStructType" function.

    (cherry picked from commit f902012271860b688dc415cab9d7e6bc492a8770)

 llvm/include/llvm/IR/DIBuilder.h | 5 ++++-
 llvm/lib/IR/DIBuilder.cpp        | 4 ++--
 2 files changed, 6 insertions(+), 3 deletions(-)