### PR TITLE
[cherry-pick] 3 commits

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -183,13 +183,6 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
     return {};
 
   auto &triple = m_process.GetTarget().GetArchitecture().GetTriple();
-  // On Linux, there seems to be a bug where we can't reliably look for symbols by address,
-  // since these symbols have an actual size and can overlap.
-  // This could be an LLDB bug or a compiler bug.
-  // rdar://166344740
-  if (triple.isOSLinux())
-    return {};
-
   std::optional<Address> maybeAddr = remoteAddressToLLDBAddress(address);
   // This is not an assert, but should never happen.
   if (!maybeAddr)

--- a/lldb/test/API/lang/swift/constrained_existential_metatype/Makefile
+++ b/lldb/test/API/lang/swift/constrained_existential_metatype/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/constrained_existential_metatype/TestSwiftConstrainedExistentialMetatypeFix.py
+++ b/lldb/test/API/lang/swift/constrained_existential_metatype/TestSwiftConstrainedExistentialMetatypeFix.py
@@ -1,0 +1,44 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftConstrainedExistentialMetatypeFix(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+
+        types_log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -v -f "%s"' % types_log)
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.GetSelectedFrame()
+        var = frame.FindVariable("variable")
+        self.assertTrue(var.IsValid(), "variable not found in frame")
+        static = var.GetStaticValue()
+        self.assertTrue(
+            static.GetError().Success(),
+            "static existential-metatype value must lower without error",
+        )
+        lldbutil.check_variable(
+            self,
+            static,
+            typename="@thick any a.MyProto<Self.T == Swift.Int>.Type",
+            num_children=0,
+        )
+        lldbutil.check_variable(
+            self,
+            var,
+            use_dynamic=True,
+            typename="a.MyImpl.Type",
+            summary="a.MyImpl",
+        )
+
+        with open(types_log) as f:
+            log = f.read()
+        self.assertNotIn("invalid existential metatype", log)
+        self.assertNotIn("Couldn't compute size of type", log)

--- a/lldb/test/API/lang/swift/constrained_existential_metatype/main.swift
+++ b/lldb/test/API/lang/swift/constrained_existential_metatype/main.swift
@@ -1,0 +1,22 @@
+public protocol MyProto<T> {
+    associatedtype T
+}
+
+public struct MyImpl: MyProto {
+    public typealias T = Int
+}
+
+public func myAnyType(
+    _ x: any MyProto<Int>
+) -> any MyProto<Int>.Type {
+    return type(of: x)
+}
+
+func f() {
+    let c: any MyProto<Int> = MyImpl()
+    let variable = myAnyType(c)
+    print("break here")
+    _ = variable
+}
+
+f()

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
@@ -16,12 +16,6 @@ class TestSwiftExplicitModulePrivateTypeGeneric(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift"),
             extra_images=["Dylib"])
-        log = self.getBuildArtifact("types.log")
-        self.expect('log enable lldb types symbols -f "%s"' % log)
-        self.expect("expr -d run -- s", error=True)
-        # FIXME: Expression shouldn't depend on all local variables.
-        self.expect("expression 1+1", error=True)
-        self.filecheck_log(log, __file__)
-        # CHECK: Turning off implicit modules
-        # CHECK: ReconstructType
-        # CHECK: Turning on implicit modules
+        self.expect("v s", substrs=["t = (value = 42)"])
+        self.expect("expr -d run -- s", substrs=["t = (value = 42)"])
+        self.expect("expression 1+1", substrs=["(Int)", "= 2"])

--- a/lldb/test/API/lang/swift/opaque_return_resilient/Makefile
+++ b/lldb/test/API/lang/swift/opaque_return_resilient/Makefile
@@ -1,0 +1,16 @@
+SWIFT_SOURCES := main.swift
+
+SWIFTFLAGS_EXTRAS := -I.
+
+LD_EXTRAS = -L. -Xlinker -rpath -Xlinker $(BUILDDIR) -lOpaqueLib
+
+all: dylib $(EXE)
+.PHONY: dylib
+
+include Makefile.rules
+
+dylib: lib.swift
+	"$(MAKE)" -f $(MAKEFILE_RULES) \
+		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=OpaqueLib \
+		DYLIB_SWIFT_SOURCES="lib.swift" \
+		SWIFTFLAGS_EXTRAS="-enable-library-evolution"

--- a/lldb/test/API/lang/swift/opaque_return_resilient/TestSwiftOpaqueReturnResilient.py
+++ b/lldb/test/API/lang/swift/opaque_return_resilient/TestSwiftOpaqueReturnResilient.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftOpaqueReturnResilient(TestBase):
+    @swiftTest
+    @skipIfWindows
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"),
+            extra_images=['OpaqueLib'])
+
+        frame = thread.GetSelectedFrame()
+        variable = frame.FindVariable("variable").GetDynamicValue(
+            lldb.eDynamicCanRunTarget)
+        self.assertTrue(variable.IsValid(), "variable should be valid")
+        self.assertIn("Creator", variable.GetTypeName())
+
+        name = variable.GetChildMemberWithName("name")
+        self.assertTrue(name.IsValid(), "name child should be valid")
+        self.assertEqual(name.GetSummary(), '"alpha"')

--- a/lldb/test/API/lang/swift/opaque_return_resilient/lib.swift
+++ b/lldb/test/API/lang/swift/opaque_return_resilient/lib.swift
@@ -1,0 +1,16 @@
+public protocol Producer {
+    var name: String { get }
+}
+
+public class Creator: Producer {
+    public let name: String
+    public init(name: String) { self.name = name }
+}
+
+open class Manager {
+    public init() {}
+
+    public var producer: some Producer {
+        return Creator(name: "alpha")
+    }
+}

--- a/lldb/test/API/lang/swift/opaque_return_resilient/main.swift
+++ b/lldb/test/API/lang/swift/opaque_return_resilient/main.swift
@@ -1,0 +1,10 @@
+import OpaqueLib
+
+func use() {
+    let manager = Manager()
+    let variable = manager.producer
+    print("break here") // break here
+    _ = variable
+}
+
+use()

--- a/lldb/test/API/lang/swift/opaque_return_resilient_collection/Makefile
+++ b/lldb/test/API/lang/swift/opaque_return_resilient_collection/Makefile
@@ -1,0 +1,16 @@
+SWIFT_SOURCES := main.swift
+
+SWIFTFLAGS_EXTRAS := -I.
+
+LD_EXTRAS = -L. -Xlinker -rpath -Xlinker $(BUILDDIR) -lOpaqueLib
+
+all: dylib $(EXE)
+.PHONY: dylib
+
+include Makefile.rules
+
+dylib: lib.swift
+	"$(MAKE)" -f $(MAKEFILE_RULES) \
+		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=OpaqueLib \
+		DYLIB_SWIFT_SOURCES="lib.swift" \
+		SWIFTFLAGS_EXTRAS="-enable-library-evolution"

--- a/lldb/test/API/lang/swift/opaque_return_resilient_collection/TestSwiftOpaqueReturnResilientCollection.py
+++ b/lldb/test/API/lang/swift/opaque_return_resilient_collection/TestSwiftOpaqueReturnResilientCollection.py
@@ -1,0 +1,29 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftOpaqueReturnResilientCollection(TestBase):
+    @swiftTest
+    @skipIfWindows
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"),
+            extra_images=['OpaqueLib'])
+
+        frame = thread.GetSelectedFrame()
+        manager = frame.FindVariable("manager")
+        items = manager.GetChildMemberWithName("items")
+        self.assertTrue(items.IsValid(), "items should be valid")
+        self.assertIn("Creator", items.GetTypeName())
+
+        first = items.GetChildAtIndex(0)
+        self.assertTrue(first.IsValid(), "items[0] should be valid")
+        self.assertIn("Creator", first.GetTypeName())
+
+        name = first.GetChildMemberWithName("name")
+        self.assertTrue(name.IsValid(), "name child should be valid")
+        self.assertEqual(name.GetSummary(), '"one"')

--- a/lldb/test/API/lang/swift/opaque_return_resilient_collection/lib.swift
+++ b/lldb/test/API/lang/swift/opaque_return_resilient_collection/lib.swift
@@ -1,0 +1,17 @@
+public struct Creator {
+    public let name: String
+    public init(name: String) { self.name = name }
+}
+
+open class Manager {
+    private var items: [Creator] = [
+        Creator(name: "one"),
+        Creator(name: "two"),
+    ]
+
+    public init() {}
+
+    public var creators: some Collection<Creator> {
+        return items
+    }
+}

--- a/lldb/test/API/lang/swift/opaque_return_resilient_collection/main.swift
+++ b/lldb/test/API/lang/swift/opaque_return_resilient_collection/main.swift
@@ -1,0 +1,10 @@
+import OpaqueLib
+
+func use() {
+    let manager = Manager()
+    let variable = manager.creators
+    print("break here") // break here
+    _ = variable
+}
+
+use()


### PR DESCRIPTION
- [lldb] Enable resolvePointerAsSymbol on Linux (cherry picked from commit 8b6ea8ef11291608573a129894c7951c764796c8)
- [lldb] Add/fix tests for resilient opaque types. (cherry picked from commit 80949bd0ee36592832ea4290360325ac56be4352)
- [lldb] Test for existential metatype of constrained existential (cherry picked from commit f758a01b13158861f78759007893d1e4b968f5a3)