### PR TITLE
[Cherry-pick into swift/release/6.4.x] [LLDB] Add a progress event to xcrun invocations (#198931)

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/macosx/HostInfoMacOSX.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
@@ -23,6 +24,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/RWMutex.h"
@@ -432,6 +434,12 @@ FileSpec HostInfoMacOSX::GetCurrentCommandLineToolsDirectory() {
 static llvm::Expected<std::string>
 xcrun(const std::string &sdk, llvm::ArrayRef<llvm::StringRef> arguments,
       llvm::StringRef developer_dir = "") {
+  std::string details;
+  llvm::raw_string_ostream os(details);
+  os << "xcrun --sdk " << sdk << llvm::join(arguments, " ")
+     << " (DEVELOPER_DIR=" << developer_dir << ')';
+  Progress progress("Running xcrun", details);
+
   Args args;
   if (!developer_dir.empty()) {
     args.AppendArgument("/usr/bin/env");


### PR DESCRIPTION
```
commit 5c63509f4cc356639d9c4067e0812c2312689363
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed May 20 16:21:01 2026 -0700

    [LLDB] Add a progress event to xcrun invocations (#198931)
    
    LLDB invokes xcrun to find SDKs on disk. This is usually very fast, but
    sometimes (after an Xcode update, or when the searched SDK does not
    exist) it can take very long (10s or more). The progress event provides
    user feedback to explain the hang.
```
