### PR TITLE
[lldb] Fix @objc and @c enums triggering ASTContext fallback

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1632,13 +1632,21 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
   }
 
   if (llvm::dyn_cast_or_null<swift::reflection::BuiltinTypeInfo>(ti)) {
+    Flags type_flags(m_type.GetTypeInfo());
+    // This might be an enum declared with @objc or @c. They cannot carry
+    // a payload so have no children.
+    if (type_flags.AnySet(eTypeIsEnumeration)) {
+      if (count_only)
+        return 0;
+      return success;
+    }
+
     // Clang enums have an artificial rawValue property. We could
     // consider handling them here, but
     // TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex can also
     // handle them and without a Process.
     if (!TypeSystemSwiftTypeRef::IsBuiltinType(m_type) &&
-        !Flags(m_type.GetTypeInfo()).AnySet(eTypeIsMetatype) &&
-        !m_type.IsFunctionType()) {
+        !type_flags.AnySet(eTypeIsMetatype) && !m_type.IsFunctionType()) {
       LLDB_LOG(GetLog(LLDBLog::Types),
                "{0}: unrecognized builtin type info or this is a Clang type "
                "without DWARF debug info",

--- a/lldb/test/API/lang/swift/c_compat_enum/Makefile
+++ b/lldb/test/API/lang/swift/c_compat_enum/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/c_compat_enum/TestSwiftCCompatEnum.py
+++ b/lldb/test/API/lang/swift/c_compat_enum/TestSwiftCCompatEnum.py
@@ -1,0 +1,47 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftCCompatEnum(TestBase):
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        self.build()
+
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+
+        v = thread.GetSelectedFrame().FindVariable("v")
+        self.assertTrue(v.IsValid(), "v not found in frame")
+
+        # We can't actually inspect the enums because of 
+        # rdar://177569037 (lldb can't show cases of an @objc or @c enum)
+        # so we have to resort to reading the logs instead and make 
+        # sure the fallback wasn't triggered.
+        import io
+        with io.open(log, "r", encoding="utf-8") as f:
+            log_contents = f.read()
+
+        def fired_fallback(type_name):
+            for line in log_contents.splitlines():
+                if "had to engage SwiftASTContext fallback" in line and \
+                   type_name in line:
+                    return line
+            return None
+
+        objc_fallback = fired_fallback("TheObjCEnum")
+        self.assertIsNone(
+            objc_fallback,
+            "TypeSystemSwiftTypeRef fell through to AST-context fallback "
+            "for the @objc enum: " + (objc_fallback or ""))
+
+        c_fallback = fired_fallback("TheCEnum")
+        self.assertIsNone(
+            c_fallback,
+            "TypeSystemSwiftTypeRef fell through to AST-context fallback "
+            "for the @c enum: " + (c_fallback or ""))

--- a/lldb/test/API/lang/swift/c_compat_enum/main.swift
+++ b/lldb/test/API/lang/swift/c_compat_enum/main.swift
@@ -1,0 +1,22 @@
+@objc public enum TheObjCEnum: UInt32 {
+  case foo
+  case bar
+}
+
+@c public enum TheCEnum: Int32 {
+  case foo
+  case bar
+}
+
+struct Wrap {
+  let objcValue: TheObjCEnum
+  let cValue: TheCEnum
+}
+
+func entry() {
+  let v = Wrap(objcValue: .foo, cValue: .foo)
+  print("break here")
+  _ = v
+}
+
+entry()


### PR DESCRIPTION
These types don't have field descriptors, so the only thing reflection knows about them are that they are builtin.

Note that this not fix displaying the cases of the enums. I've filed rdar://177569037 (lldb can't show cases of an @objc or @c enum) to track that.

Assisted-by: claude

rdar://177432906