### PR TITLE
[compiler-rt] Fix instrprof-exit-on-signal.c test to support internal lit shell

### DIFF
--- a/compiler-rt/test/profile/instrprof-exit-on-signal.c
+++ b/compiler-rt/test/profile/instrprof-exit-on-signal.c
@@ -1,11 +1,11 @@
 // RUN: %clang_profgen -o %t %s
 //
 // Verify SIGTERM handling.
-// RUN: %run LLVM_PROFILE_FILE="%15x%t.profraw" %t 15
+// RUN: env LLVM_PROFILE_FILE="%15x%t.profraw" %run %t 15
 // RUN: llvm-profdata show %t.profraw | FileCheck %s
 //
 // Verify SIGUSR1 handling.
-// RUN: %run LLVM_PROFILE_FILE="%30x%t.profraw" %t 30
+// RUN: env LLVM_PROFILE_FILE="%30x%t.profraw" %run %t 30
 // RUN: llvm-profdata show %t.profraw | FileCheck %s
 
 #include <stdlib.h>


### PR DESCRIPTION
rdar://176394848