### PR TITLE
[lldb][windows] skip TestSwiftErrorBreakpoint

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 
+@skipIfWindows
 class TestSwiftErrorBreakpoint(TestBase):
     @decorators.skipIfLinux  # <rdar://problem/30909618>
     @swiftTest
@@ -40,14 +41,12 @@ class TestSwiftErrorBreakpoint(TestBase):
         self.do_tests("a.EnumError")
 
     @swiftTest
-    @skipIfWindows
     def test_swift_error_bogus_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests_in_mode("NoSuchErrorHere", mode="untyped", should_stop=False)
 
     @swiftTest
-    @skipIfWindows
     @expectedFailureAll(bugnumber="rdar://148033473")
     def test_swift_typed_error_bogus_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""


### PR DESCRIPTION
TestSwiftErrorBreakpoint is flaky on Windows. Skip it for now.

rdar://177610235