### PR TITLE
[lldb] Remove recursive IsVariable helper

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -990,13 +990,6 @@ llvm::Error SwiftLanguageRuntime::RunObjectDescriptionExpr(
   return DumpString(*result_or_err, strm);
 }
 
-static bool IsVariable(ValueObject &object) {
-  if (object.IsSynthetic())
-    return IsVariable(*object.GetNonSyntheticValue());
-
-  return bool(object.GetVariable());
-}
-
 static bool IsSwiftResultVariable(ConstString name) {
   if (name) {
     llvm::StringRef name_sr(name.GetStringRef());
@@ -1119,7 +1112,7 @@ llvm::Error SwiftLanguageRuntime::GetObjectDescription(Stream &str,
 
   std::string expr_string;
 
-  if (::IsVariable(object) || ::IsSwiftResultVariable(object.GetName())) {
+  if (object.GetVariable() || ::IsSwiftResultVariable(object.GetName())) {
     // if the object is a Swift variable, it has two properties:
     // a) its name is something we can refer to in expressions for free
     // b) its type may be something we can't actually talk about in expressions


### PR DESCRIPTION
The removed `IsVariable()` helper function could infinitely recurse when called with a ValueObject that reports `IsSynthetic() == true`, but does not also override `GetNonSyntheticValue()`.

The base class implementation of `GetNonSyntheticValue()` essentially returns `this`, so the recursive call `IsVariable(*object.GetNonSyntheticValue())` could, for some objects, be the same as `IsVariable(object)`, and that would result in infinite recursion.

`ValueObjectRecognizerSynthesizedValue` is one such class: it overrides `IsSynthetic()` to return true, but inherits the default `GetNonSyntheticValue()`.

The fix replaces the helper with a direct call to `ValueObject::GetVariable()`. This is correct for `ValueObjectSynthetic`, based on the definitions:

1. `ValueObjectSynthetic ::GetVariable()` returns `m_parent->GetVariable()`
2. `ValueObjectSynthetic::GetNonSyntheticValue()` returns `m_parent`

Thus, `GetNonSyntheticValue()->GetVariable()` is the same as `GetVariable()`.

rdar://177596673