### PR TITLE
[clang][cas] Use FileError for two path-related errors in IncludeTreeActionController

### DIFF
--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -745,7 +745,7 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
     llvm::ErrorOr<cas::ObjectRef> CASContents =
         FM.getObjectRefForFileContent(PPOpts.ImplicitPCHInclude);
     if (!CASContents)
-      return llvm::errorCodeToError(CASContents.getError());
+      return llvm::createFileError(PPOpts.ImplicitPCHInclude, CASContents.getError());
 
     auto PCHFile = cas::IncludeTree::File::create(DB, "<PCH>", *CASContents);
     if (!PCHFile)
@@ -937,7 +937,7 @@ Expected<cas::ObjectRef> IncludeTreeBuilder::addToFileList(FileManager &FM,
   llvm::ErrorOr<cas::ObjectRef> CASContents =
       FM.getObjectRefForFileContent(Filename);
   if (!CASContents)
-    return llvm::errorCodeToError(CASContents.getError());
+    return llvm::createFileError(Filename, CASContents.getError());
 
   auto addFile = [&](StringRef Filename) -> Expected<cas::ObjectRef> {
     assert(!Filename.empty());


### PR DESCRIPTION
(This adds to https://github.com/llvm/llvm-project/pull/199126)

A future change will update `getObjectRefForFileContent` to use `Expected` and internally form a `FileError`, but for now update the callers, which avoids an API break with swift.