### PR TITLE
[lldb] Handle ObjC blocks in dynamic-type resolution and DumpTypeValue

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1204,6 +1204,18 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
       break;
     }
 
+    // If this is a function type ref and a reference type info this is an objc
+    // block. Blocks have no children.
+    if (const auto *func_tr =
+            llvm::dyn_cast_or_null<swift::reflection::FunctionTypeRef>(tr)) {
+      assert(func_tr->getFlags().getConvention() ==
+                 swift::FunctionMetadataConvention::Block &&
+             "Unexpected convention for reference function typeref!");
+      if (count_only)
+        return 0;
+      return success;
+    }
+
     bool found_start = false;
     using namespace swift::Demangle;
     Demangler dem;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3556,6 +3556,7 @@ bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type) {
                     node->getKind() == Node::Kind::ThinFunctionType ||
                     node->getKind() == Node::Kind::NoEscapeFunctionType ||
                     node->getKind() == Node::Kind::CFunctionPointer ||
+                    node->getKind() == Node::Kind::ObjCBlock ||
                     node->getKind() == Node::Kind::ImplFunctionType);
   };
   VALIDATE_AND_RETURN(impl, IsFunctionType, type, g_no_exe_ctx,
@@ -5466,6 +5467,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::FunctionType:
     case Node::Kind::NoEscapeFunctionType:
     case Node::Kind::CFunctionPointer:
+    case Node::Kind::ObjCBlock:
     case Node::Kind::ImplFunctionType: {
       // A few formats, we might need to modify our size and count for
       // depending on how we are trying to display the value.

--- a/lldb/test/API/lang/swift/objc_block/Makefile
+++ b/lldb/test/API/lang/swift/objc_block/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc_block/TestSwiftObjCBlock.py
+++ b/lldb/test/API/lang/swift/objc_block/TestSwiftObjCBlock.py
@@ -1,0 +1,32 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftObjCBlock(TestBase):
+    @skipUnlessDarwin
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = self.frame()
+
+        def describe(value):
+            stream = lldb.SBStream()
+            value.GetDescription(stream)
+            return stream.GetData()
+
+        void_container = frame.FindVariable("voidContainer")
+        self.assertTrue(void_container.IsValid(), "voidContainer not found in frame")
+        void_any = void_container.GetChildMemberWithName("any")
+        self.assertIn("(@convention(block) () -> ())", describe(void_any))
+
+        int_container = frame.FindVariable("intContainer")
+        self.assertTrue(int_container.IsValid(), "intContainer not found in frame")
+        int_any = int_container.GetChildMemberWithName("any")
+        self.assertIn("(@convention(block) (Int) -> Int)", describe(int_any))

--- a/lldb/test/API/lang/swift/objc_block/main.swift
+++ b/lldb/test/API/lang/swift/objc_block/main.swift
@@ -1,0 +1,12 @@
+class Container {
+    var any: Any
+    init(_ any: Any) { self.any = any }
+}
+
+func f() {
+    let voidContainer = Container({} as @convention(block) () -> Void)
+    let intContainer = Container({ $0 + 1 } as @convention(block) (Int) -> Int)
+    print("break here")
+}
+
+f()


### PR DESCRIPTION
Treat @convention(block) closures as having no children in SwiftRuntimeTypeVisitor, and recognize ObjCBlock as a function-type kind in TypeSystemSwiftTypeRef.

Assisted-by: claude

rdar://177433083