### PR TITLE
[LLDB] Add a progress event to xcrun invocations

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -14,6 +14,7 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Mangled.h"
 #include "lldb/Core/ModuleSpec.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Core/SearchFilter.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Host/FileSystem.h"
@@ -1706,6 +1707,7 @@ std::optional<std::string> Module::RemapSourceFile(llvm::StringRef path) {
 
 void Module::RegisterXcodeSDK(llvm::StringRef sdk_name,
                               llvm::StringRef sysroot) {
+  Progress progress("Looking for Xcode SDK", sdk_name.str());
   auto sdk_path_or_err =
       HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk_name.str()});
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -15,6 +15,7 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/PseudoTerminal.h"
 #include "lldb/Target/Process.h"
@@ -285,6 +286,7 @@ static llvm::StringRef GetXcodeSDKDir(std::string preferred,
                                       std::string secondary) {
   llvm::StringRef sdk;
   auto get_sdk = [&](std::string sdk) -> llvm::StringRef {
+    Progress progress("Looking for Xcode SDK", sdk);
     auto sdk_path_or_err =
         HostInfo::GetSDKRoot(HostInfo::SDKOptions{XcodeSDK(std::move(sdk))});
     if (!sdk_path_or_err) {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
@@ -1133,6 +1134,7 @@ ResolveSDKPathFromDebugInfo(lldb_private::Target *target) {
   if (FileSystem::Instance().Exists(sdk_path)) {
     return sdk_path;
   }
+  Progress progress("Looking for Xcode SDK", merged_sdk.GetString().str());
   auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{merged_sdk});
   if (!path_or_err)
     return llvm::createStringError(
@@ -1508,6 +1510,7 @@ PlatformDarwin::ResolveSDKPathFromDebugInfo(Module &module) {
   if (FileSystem::Instance().Exists(sdk.GetSysroot()))
     return sdk.GetSysroot().GetPath();
 
+  Progress progress("Looking for Xcode SDK", sdk.GetString().str());
   auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!path_or_err)
     return llvm::createStringError(
@@ -1544,6 +1547,7 @@ PlatformDarwin::ResolveSDKPathFromDebugInfo(CompileUnit &unit) {
 
   auto sdk = std::move(*sdk_or_err);
 
+  Progress progress("Looking for Xcode SDK", sdk.GetString().str());
   auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!path_or_err)
     return llvm::createStringError(

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -23,6 +23,7 @@
 #include "lldb/Core/ModuleList.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
@@ -127,8 +128,9 @@ ConstString PlatformMacOSX::GetSDKDirectory(lldb_private::Target &target) {
   }
 
   // Use the default SDK as a fallback.
-  auto sdk_path_or_err =
-      HostInfo::GetSDKRoot(HostInfo::SDKOptions{XcodeSDK::GetAnyMacOS()});
+  XcodeSDK sdk = XcodeSDK::GetAnyMacOS();
+  Progress progress("Looking for Xcode SDK", sdk.GetString().str());
+  auto sdk_path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!sdk_path_or_err) {
     Debugger::ReportError("Error while searching for Xcode SDK: " +
                           toString(sdk_path_or_err.takeError()));

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1259,6 +1259,7 @@ SwiftASTContext::GetPluginServer(llvm::StringRef plugin_library_path) {
 }
 
 static std::string GetPluginServerForSDK(llvm::StringRef sdk_path) {
+  Progress progress("Looking for swift-plugin-server in SDK", sdk_path.str());
   XcodeSDK sdk(std::string(llvm::sys::path::filename(sdk_path)));
   auto server_or_err = HostInfo::FindSDKTool(sdk, "swift-plugin-server");
   if (!server_or_err)
@@ -2309,6 +2310,7 @@ static std::optional<StringRef> GetDSYMBundle(Module &module) {
 }
 
 static std::string GetSDKPath(std::string m_description, XcodeSDK sdk) {
+  Progress progress("Looking for Xcode SDK", sdk.GetString().str());
   auto sdk_path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!sdk_path_or_err) {
     Debugger::ReportError("Error while searching for SDK: " +

--- a/lldb/test/API/functionalities/progress_reporting/clang_modules/TestClangModuleBuildProgress.py
+++ b/lldb/test/API/functionalities/progress_reporting/clang_modules/TestClangModuleBuildProgress.py
@@ -40,7 +40,8 @@ class TestCase(TestBase):
         # Trigger module builds.
         self.expect("expression @import MyModule")
 
-        event = lldbutil.fetch_next_event(self, listener, broadcaster)
-        payload = lldb.SBDebugger.GetProgressFromEvent(event)
-        message = payload[0]
-        self.assertEqual(message, "Building Clang modules")
+        while True:
+            event = lldbutil.fetch_next_event(self, listener, broadcaster)
+            payload = lldb.SBDebugger.GetProgressFromEvent(event)
+            if payload[0] == "Building Clang modules":
+                break


### PR DESCRIPTION
LLDB invokes xcrun to find SDKs on disk. This is usually very fast, but
sometimes (after an Xcode update, or when the searched SDK does not
exist) it can take very long (10s or more). The progress event provides
user feedback to explain the hang.

Previously this functionality was in HostInfo, but it may not depend on
Core, so this patch is instrumenting the call sites instead.

cf: https://github.com/llvm/llvm-project/pull/198931
(cherry picked from commit https://github.com/swiftlang/llvm-project/commit/3873d151c9248fed3da049d793208296413bbcc8)

 Conflicts:
	lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp

Plus:

[LLDB] Add Progress events for SDK searches in Swift plugin.