### PR TITLE
lldb: shorten path for windows limit

### DIFF
--- a/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
+++ b/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
@@ -16,7 +16,7 @@ class TestSwiftMetadataCache(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
-        cache_dir = self.getBuildArtifact('swift-metadata-cache')
+        cache_dir = self.getBuildArtifact('$')
         # Set the lldb module cache directory to a directory inside the build
         # artifacts directory so no other tests are interfered with.
         self.runCmd('settings set symbols.swift-metadata-cache-path "%s"' % cache_dir)


### PR DESCRIPTION
The current name pushes us over 256 characters. Trim the cache path to `$` which is used often as a shorthand for cache.