### PR TITLE
Shorten swift categories

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -272,17 +272,17 @@ def _decorateTest(
         key, val = setting[0], setting[1]
         if key == "symbols.use-swift-clangimporter":
             if _is_setting_disabled(val):
-                swift_module_importer = ["dwarfimporter"]
+                swift_module_importer = ["noclang"]
                 setting = None
             elif _is_setting_enabled(val):
-                swift_module_importer = ["clangimporter"]
+                swift_module_importer = ["clang"]
                 setting = None
         elif key == "symbols.use-swift-dwarfimporter":
             if _is_setting_disabled(val):
-                swift_module_importer = ["clangimporter"]
+                swift_module_importer = ["clang"]
                 setting = None
             elif _is_setting_enabled(val):
-                swift_module_importer = ["dwarfimporter"]
+                swift_module_importer = ["noclang"]
                 setting = None
 
     def fn(**actual_variants):

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -997,28 +997,28 @@ def swiftTest(func):
 
 def skipEmbeddedSwift(func):
     def skip_fn(swift_embedded=None, **kwargs):
-        if swift_embedded == "swift_embedded":
+        if swift_embedded == "swiftembed":
             return "not supported in embedded Swift"
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)
 
 def skipEmbeddedSwiftOnLinux(func):
     def skip_fn(swift_embedded=None, **kwargs):
-        if swift_embedded == "swift_embedded" and lldbplatformutil.getPlatform() == "linux":
+        if swift_embedded == "swiftembed" and lldbplatformutil.getPlatform() == "linux":
             return "not supported in embedded Swift on Linux"
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)
 
 def skipEmbeddedSwiftOnWindows(func):
     def skip_fn(swift_embedded=None, **kwargs):
-        if swift_embedded == "swift_embedded" and lldbplatformutil.getPlatform() == "windows":
+        if swift_embedded == "swiftembed" and lldbplatformutil.getPlatform() == "windows":
             return "not supported in embedded Swift on Windows"
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)
 
 def skipUnlessEmbeddedSwift(func):
     def skip_fn(swift_embedded=None, **kwargs):
-        if swift_embedded != "swift_embedded":
+        if swift_embedded != "swiftembed":
             return "Only supported in embedded Swift"
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1964,7 +1964,7 @@ def _swift_module_importer_setup(test_instance, variant_value):
         test_instance.runCmd("settings set symbols.use-swift-clangimporter true")
 
 def _embedded_swift_setup(test_instance, variant_value):
-    if variant_value == "swift_embedded":
+    if variant_value == "swiftembed":
         test_instance.extra_make_flags["SWIFT_EMBEDDED_MODE"] = "1"
     elif variant_value == "swift":
         test_instance.extra_make_flags["SWIFT_EMBEDDED_MODE"] = "0"

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1822,7 +1822,7 @@ class TestVariant:
     Test variants multiply test methods by different configurations.
     Each variant adds a new dimension to the test matrix, creating copies
     of test methods for each category in the variant. For example, Swift
-    tests are run with both 'clangimporter' and 'dwarfimporter' settings.
+    tests are run with both 'clang' and 'noclang' settings.
 
     When a variant is registered in `_test_variants`, the `LLDBTestCaseFactory`
     metaclass iterates over every `test*` method and, for each method that
@@ -1958,9 +1958,9 @@ def _expand_test_variants(attrname, methods, variant, xfail_fns, skip_fns):
 
 
 def _swift_module_importer_setup(test_instance, variant_value):
-    if variant_value == "dwarfimporter":
+    if variant_value == "noclang":
         test_instance.runCmd("settings set symbols.use-swift-clangimporter false")
-    elif variant_value == "clangimporter":
+    elif variant_value == "clang":
         test_instance.runCmd("settings set symbols.use-swift-clangimporter true")
 
 def _embedded_swift_setup(test_instance, variant_value):
@@ -2069,7 +2069,7 @@ class LLDBTestCaseFactory(type):
                     # NO_DEBUG_INFO_TESTCASE — put method in newattrs for variant expansion
                     newattrs[attrname] = attrvalue
 
-                # Expand test variants (e.g. swift clangimporter/dwarfimporter)
+                # Expand test variants (e.g. swift clang/noclang)
                 for variant in _test_variants:
                     if variant.should_expand(attrvalue):
                         xfail_fns = getattr(attrvalue, "__variant_xfail__", {})
@@ -2200,7 +2200,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
         # And the result object.
         self.res = lldb.SBCommandReturnObject()
 
-        # Apply variant-specific settings (e.g. swift clangimporter/dwarfimporter).
+        # Apply variant-specific settings (e.g. swift clang/noclang).
         for variant in _test_variants:
             variant_value = self.getVariant(variant.name)
             if variant_value is not None:

--- a/lldb/packages/Python/lldbsuite/test/test_categories.py
+++ b/lldb/packages/Python/lldbsuite/test/test_categories.py
@@ -21,8 +21,8 @@ debug_info_categories = {
 }
 
 swift_module_importer_categories = {
-    "clangimporter": True,
-    "dwarfimporter": True,
+    "clang": True,
+    "noclang": True,
 }
 
 embedded_swift_categories = {
@@ -59,8 +59,8 @@ all_categories = {
     "stresstest": "Tests related to stressing lldb limits",
     "swiftmaccatalyst": "Tests which require swift maccatalyst stdlib support",
     "watchpoint": "Watchpoint-related tests",
-    "clangimporter": "Tests run with the Swift ClangImporter",
-    "dwarfimporter": "Tests run with the Swift DWARFImporter",
+    "clang": "Tests run with the Swift ClangImporter+DWARFImporter",
+    "noclang": "Tests run with the Swift DWARFImporter",
     "swift_embedded": "Tests are compiled as embedded Swift",
     "swift": "Tests are compiled as normal Swift",
 }

--- a/lldb/packages/Python/lldbsuite/test/test_categories.py
+++ b/lldb/packages/Python/lldbsuite/test/test_categories.py
@@ -27,7 +27,7 @@ swift_module_importer_categories = {
 
 embedded_swift_categories = {
     "swift": True,
-    "swift_embedded": True,
+    "swiftembed": True,
 }
 
 all_categories = {
@@ -61,7 +61,7 @@ all_categories = {
     "watchpoint": "Watchpoint-related tests",
     "clang": "Tests run with the Swift ClangImporter+DWARFImporter",
     "noclang": "Tests run with the Swift DWARFImporter",
-    "swift_embedded": "Tests are compiled as embedded Swift",
+    "swiftembed": "Tests are compiled as embedded Swift",
     "swift": "Tests are compiled as normal Swift",
 }
 

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -7,7 +7,7 @@ class TestSwiftClangImporterCaching(TestBase):
 
     @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
-    @skipIf(swift_module_importer="dwarfimporter")
+    @skipIf(swift_module_importer="noclang")
     @skipIf(setting=("symbols.swift-precise-compiler-invocation", "false"))
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestCxxForwardInteropNestedClasses(TestBase):
 
-    @skipIf(swift_module_importer="dwarfimporter")
+    @skipIf(swift_module_importer="noclang")
     @swiftTest
     @skipIfWindows
     def test(self):


### PR DESCRIPTION
On Windows the new category permutations result in long path names which can run against the really short maximum path length on the platform. This patch renames some categories for clarity while shortening the names.