### PR TITLE
[Cherry-pick into next] [lldb][swift] Add inline test variant

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1037,6 +1037,33 @@ def swiftTest(func):
 
     return skipTestIfFn(is_not_swift_compatible)(func)
 
+def skipEmbeddedSwift(func):
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded == "swift_embedded":
+            return "not supported in embedded Swift"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
+
+def skipEmbeddedSwiftOnLinux(func):
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded == "swift_embedded" and lldbplatformutil.getPlatform() == "linux":
+            return "not supported in embedded Swift on Linux"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
+
+def skipEmbeddedSwiftOnWindows(func):
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded == "swift_embedded" and lldbplatformutil.getPlatform() == "windows":
+            return "not supported in embedded Swift on Windows"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
+
+def skipUnlessEmbeddedSwift(func):
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded != "swift_embedded":
+            return "Only supported in embedded Swift"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
 
 def skipIfHostIncompatibleWithTarget(func):
     """Decorate the item to skip tests when the host and target are incompatible."""

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -279,17 +279,17 @@ def _decorateTest(
         key, val = setting[0], setting[1]
         if key == "symbols.use-swift-clangimporter":
             if _is_setting_disabled(val):
-                swift_module_importer = ["dwarfimporter"]
+                swift_module_importer = ["noclang"]
                 setting = None
             elif _is_setting_enabled(val):
-                swift_module_importer = ["clangimporter"]
+                swift_module_importer = ["clang"]
                 setting = None
         elif key == "symbols.use-swift-dwarfimporter":
             if _is_setting_disabled(val):
-                swift_module_importer = ["clangimporter"]
+                swift_module_importer = ["clang"]
                 setting = None
             elif _is_setting_enabled(val):
-                swift_module_importer = ["dwarfimporter"]
+                swift_module_importer = ["noclang"]
                 setting = None
 
     def fn(**actual_variants):

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1039,28 +1039,28 @@ def swiftTest(func):
 
 def skipEmbeddedSwift(func):
     def skip_fn(swift_embedded=None, **kwargs):
-        if swift_embedded == "swift_embedded":
+        if swift_embedded == "swiftembed":
             return "not supported in embedded Swift"
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)
 
 def skipEmbeddedSwiftOnLinux(func):
     def skip_fn(swift_embedded=None, **kwargs):
-        if swift_embedded == "swift_embedded" and lldbplatformutil.getPlatform() == "linux":
+        if swift_embedded == "swiftembed" and lldbplatformutil.getPlatform() == "linux":
             return "not supported in embedded Swift on Linux"
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)
 
 def skipEmbeddedSwiftOnWindows(func):
     def skip_fn(swift_embedded=None, **kwargs):
-        if swift_embedded == "swift_embedded" and lldbplatformutil.getPlatform() == "windows":
+        if swift_embedded == "swiftembed" and lldbplatformutil.getPlatform() == "windows":
             return "not supported in embedded Swift on Windows"
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)
 
 def skipUnlessEmbeddedSwift(func):
     def skip_fn(swift_embedded=None, **kwargs):
-        if swift_embedded != "swift_embedded":
+        if swift_embedded != "swiftembed":
             return "Only supported in embedded Swift"
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -621,6 +621,8 @@ class Base(unittest.TestCase):
         if not cls.mydir:
             raise Exception("Subclasses must override the 'mydir' attribute.")
 
+        cls.extra_make_flags = {}
+
         # Save old working directory.
         cls.oldcwd = os.getcwd()
 
@@ -1611,6 +1613,8 @@ class Base(unittest.TestCase):
         if command is None:
             raise Exception("Don't know how to build binary")
 
+        command += [f"{k}={v}" for k, v in self.extra_make_flags.items()]
+
         self.runBuildCommand(command)
 
     def runBuildCommand(self, command):
@@ -2016,6 +2020,14 @@ def _swift_module_importer_setup(test_instance, variant_value):
     elif variant_value == "clangimporter":
         test_instance.runCmd("settings set symbols.use-swift-clangimporter true")
 
+def _embedded_swift_setup(test_instance, variant_value):
+    if variant_value == "swift_embedded":
+        test_instance.extra_make_flags["SWIFT_EMBEDDED_MODE"] = "1"
+    elif variant_value == "swift":
+        test_instance.extra_make_flags["SWIFT_EMBEDDED_MODE"] = "0"
+    else:
+        assert False, f"Unknown variant: {variant_value}"
+
 
 _test_variants = [
     TestVariant(
@@ -2023,6 +2035,13 @@ _test_variants = [
         values=test_categories.swift_module_importer_categories,
         predicate=lambda m: getattr(m, "__swift_test__", False),
         setup_fn=_swift_module_importer_setup,
+        attrs_to_preserve=("debug_info",),
+    ),
+    TestVariant(
+        name="swift_embedded",
+        values=test_categories.embedded_swift_categories,
+        predicate=lambda m: getattr(m, "__swift_test__", False),
+        setup_fn=_embedded_swift_setup,
         attrs_to_preserve=("debug_info",),
     ),
 ]

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2021,7 +2021,7 @@ def _swift_module_importer_setup(test_instance, variant_value):
         test_instance.runCmd("settings set symbols.use-swift-clangimporter true")
 
 def _embedded_swift_setup(test_instance, variant_value):
-    if variant_value == "swift_embedded":
+    if variant_value == "swiftembed":
         test_instance.extra_make_flags["SWIFT_EMBEDDED_MODE"] = "1"
     elif variant_value == "swift":
         test_instance.extra_make_flags["SWIFT_EMBEDDED_MODE"] = "0"

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1879,7 +1879,7 @@ class TestVariant:
     Test variants multiply test methods by different configurations.
     Each variant adds a new dimension to the test matrix, creating copies
     of test methods for each category in the variant. For example, Swift
-    tests are run with both 'clangimporter' and 'dwarfimporter' settings.
+    tests are run with both 'clang' and 'noclang' settings.
 
     When a variant is registered in `_test_variants`, the `LLDBTestCaseFactory`
     metaclass iterates over every `test*` method and, for each method that
@@ -2015,9 +2015,9 @@ def _expand_test_variants(attrname, methods, variant, xfail_fns, skip_fns):
 
 
 def _swift_module_importer_setup(test_instance, variant_value):
-    if variant_value == "dwarfimporter":
+    if variant_value == "noclang":
         test_instance.runCmd("settings set symbols.use-swift-clangimporter false")
-    elif variant_value == "clangimporter":
+    elif variant_value == "clang":
         test_instance.runCmd("settings set symbols.use-swift-clangimporter true")
 
 def _embedded_swift_setup(test_instance, variant_value):
@@ -2126,7 +2126,7 @@ class LLDBTestCaseFactory(type):
                     # NO_DEBUG_INFO_TESTCASE — put method in newattrs for variant expansion
                     newattrs[attrname] = attrvalue
 
-                # Expand test variants (e.g. swift clangimporter/dwarfimporter)
+                # Expand test variants (e.g. swift clang/noclang)
                 for variant in _test_variants:
                     if variant.should_expand(attrvalue):
                         xfail_fns = getattr(attrvalue, "__variant_xfail__", {})
@@ -2261,7 +2261,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
         # And the result object.
         self.res = lldb.SBCommandReturnObject()
 
-        # Apply variant-specific settings (e.g. swift clangimporter/dwarfimporter).
+        # Apply variant-specific settings (e.g. swift clang/noclang).
         for variant in _test_variants:
             variant_value = self.getVariant(variant.name)
             if variant_value is not None:

--- a/lldb/packages/Python/lldbsuite/test/test_categories.py
+++ b/lldb/packages/Python/lldbsuite/test/test_categories.py
@@ -21,8 +21,8 @@ debug_info_categories = {
 }
 
 swift_module_importer_categories = {
-    "clangimporter": True,
-    "dwarfimporter": True,
+    "clang": True,
+    "noclang": True,
 }
 
 embedded_swift_categories = {
@@ -59,8 +59,8 @@ all_categories = {
     "stresstest": "Tests related to stressing lldb limits",
     "swiftmaccatalyst": "Tests which require swift maccatalyst stdlib support",
     "watchpoint": "Watchpoint-related tests",
-    "clangimporter": "Tests run with the Swift ClangImporter",
-    "dwarfimporter": "Tests run with the Swift DWARFImporter",
+    "clang": "Tests run with the Swift ClangImporter+DWARFImporter",
+    "noclang": "Tests run with the Swift DWARFImporter",
     "swift_embedded": "Tests are compiled as embedded Swift",
     "swift": "Tests are compiled as normal Swift",
 }

--- a/lldb/packages/Python/lldbsuite/test/test_categories.py
+++ b/lldb/packages/Python/lldbsuite/test/test_categories.py
@@ -27,7 +27,7 @@ swift_module_importer_categories = {
 
 embedded_swift_categories = {
     "swift": True,
-    "swift_embedded": True,
+    "swiftembed": True,
 }
 
 all_categories = {
@@ -61,7 +61,7 @@ all_categories = {
     "watchpoint": "Watchpoint-related tests",
     "clang": "Tests run with the Swift ClangImporter+DWARFImporter",
     "noclang": "Tests run with the Swift DWARFImporter",
-    "swift_embedded": "Tests are compiled as embedded Swift",
+    "swiftembed": "Tests are compiled as embedded Swift",
     "swift": "Tests are compiled as normal Swift",
 }
 

--- a/lldb/packages/Python/lldbsuite/test/test_categories.py
+++ b/lldb/packages/Python/lldbsuite/test/test_categories.py
@@ -25,6 +25,11 @@ swift_module_importer_categories = {
     "dwarfimporter": True,
 }
 
+embedded_swift_categories = {
+    "swift": True,
+    "swift_embedded": True,
+}
+
 all_categories = {
     "basic_process": "Basic process execution sniff tests.",
     "cmdline": "Tests related to the LLDB command-line interface",
@@ -56,6 +61,8 @@ all_categories = {
     "watchpoint": "Watchpoint-related tests",
     "clangimporter": "Tests run with the Swift ClangImporter",
     "dwarfimporter": "Tests run with the Swift DWARFImporter",
+    "swift_embedded": "Tests are compiled as embedded Swift",
+    "swift": "Tests are compiled as normal Swift",
 }
 
 

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftClangImporterCaching(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
-    @skipIf(swift_module_importer="dwarfimporter")
+    @skipIf(swift_module_importer="noclang")
     @skipIf(setting=("symbols.swift-precise-compiler-invocation", "false"))
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestCxxForwardInteropNestedClasses(TestBase):
 
-    @skipIf(swift_module_importer="dwarfimporter")
+    @skipIf(swift_module_importer="noclang")
     @swiftTest
     @skipIfWindows
     def test(self):


### PR DESCRIPTION
```
commit ffffe040ecbd63aa9bc03687dfad89d854f393f3
Author: Raphael Isemann <rise@apple.com>
Date:   Tue Mar 31 08:06:29 2026 +0100

    [lldb][swift] Add inline test variant
    
    This adds a Swift test variant that run each Swift test with the test
    target compiled as embedded Swift.

commit 8b96abc7ed8f897aa82cf3e200577dae0e9253b9
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri May 22 13:21:42 2026 -0700

    [LLDB] Rename clangimporter/dwarfimporter test categories
    
    to the more accurate (and shorter) clang | noclang categories.

commit 83b9daaaa1967d316dd4c3c8b39e8d4f56e7cc66
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri May 22 13:29:49 2026 -0700

    [LLDB] Rename swift_embedded to the shorter swiftembed
```
