### PR TITLE
[Cherry-pick into next] [LLDB] Fix expression evaluation for constants

### DIFF
--- a/lldb/test/API/lang/swift/expression/constant/Makefile
+++ b/lldb/test/API/lang/swift/expression/constant/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/constant/TestSwiftExpressionConstantMaterialization.py
+++ b/lldb/test/API/lang/swift/expression/constant/TestSwiftExpressionConstantMaterialization.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftExpressionConstantMaterialization(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    # In embedded Swift the Swift compiler emits the DW_AT_byte_size
+    # for Optional as 0, which is incorrect.
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        """Test constants can be materialized"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("expression null", substrs=["nil"])
+        # A materialization failure can have ripple effects on unrelated expressions.
+        self.expect("expression i", substrs=["23"])

--- a/lldb/test/API/lang/swift/expression/constant/main.swift
+++ b/lldb/test/API/lang/swift/expression/constant/main.swift
@@ -1,0 +1,9 @@
+class C {}
+
+func withConstant() {
+  let null : C? = nil
+  let i = 23
+  print("break here")
+}
+
+withConstant()


### PR DESCRIPTION
```
commit f3d8173c5811fe122079f75b23e8de673efb123c
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri May 15 17:50:31 2026 -0700

    [LLDB] Fix expression evaluation for constants
    
    Variables with constant values and nontrivial types were not working
    in the expression evaluator because the size of the type wasn't
    statically known. They caused a materialization failure. However, the
    Swift compiler emits the size of a boxed value's box in the debug
    info, which is sufficient to support constant values.
    
    Assisted-by: claude
    
    rdar://174665103
```
