### PR TITLE
Ensure the ASTWriter can query TMO information for calls

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1576,7 +1576,9 @@ public:
   StringRef getTypeSummaryDescription(TypedMemorySummary Summary) const;
 
   std::optional<InferredTypeInfo>
-  getInferredInfoForCall(const CallExpr *Call) const;
+  tryGetInferredInfoForCall(const CallExpr *Call) const;
+  InferredTypeInfo getInferredInfoForCall(const CallExpr *Call) const;
+
   InferredTypeInfo inferTypedMemoryType(const CallExpr *Call,
                                         const Expr &SizeArg,
                                         const CastExpr *ContainingCast) const;

--- a/clang/include/clang/AST/TypedMemoryInference.h
+++ b/clang/include/clang/AST/TypedMemoryInference.h
@@ -252,7 +252,7 @@ public:
   StringRef getTypeSummaryDescription(TypedMemorySummary Summary);
   void setInferredInfoForCall(const CallExpr *Call, InferredTypeInfo Info);
   std::optional<InferredTypeInfo>
-  getInferredInfoForCall(const ASTContext &Ctx, const CallExpr *Call) const;
+  lookupInferredInfoForCall(const ASTContext &Ctx, const CallExpr *Call) const;
   InferredTypeInfo inferType(const ASTContext &Ctx, const CallExpr *Call,
                              const Expr &SizeArg,
                              const CastExpr *ContainingCastExpr);

--- a/clang/lib/AST/TypedMemoryInference.cpp
+++ b/clang/lib/AST/TypedMemoryInference.cpp
@@ -286,8 +286,8 @@ void TypedMemoryInference::setInferredInfoForCall(const CallExpr *Call,
 }
 
 std::optional<InferredTypeInfo>
-TypedMemoryInference::getInferredInfoForCall(const ASTContext &Ctx,
-                                             const CallExpr *Call) const {
+TypedMemoryInference::lookupInferredInfoForCall(const ASTContext &Ctx,
+                                                const CallExpr *Call) const {
   if (!Ctx.getLangOpts().TypedMemoryOperations)
     return std::nullopt;
   if (Call->getDependence() != ExprDependence::None)
@@ -296,31 +296,6 @@ TypedMemoryInference::getInferredInfoForCall(const ASTContext &Ctx,
   if (auto Found = InferredTMOCallTypes.find(Call);
       Found != InferredTMOCallTypes.end())
     return Found->second;
-
-#ifndef NDEBUG
-  // If we get here something has gone wrong: either we've failed to perform
-  // inference on a call that we should have, or the caller has incorrectly
-  // called us on an inappropriate function. Either case is wrong so we assert
-  // in debug/relassert builds and warn in release.
-  //
-  // We're currently going to be forgiving as we don't want to break builds
-  // with error diagnostics until we're sure this does not actually fire in
-  // practice.
-  DiagnosticsEngine &Diags = Ctx.getDiagnostics();
-  const FunctionDecl *Callee = Call->getDirectCallee();
-  if (!Callee || !Callee->getAttr<TypedMemoryAttr>()) {
-    unsigned DiagID = Diags.getCustomDiagID(
-        DiagnosticsEngine::Warning,
-        "Requesting TMO inference result for non-TMO applicable call %0");
-    Diags.Report(Call->getBeginLoc(), DiagID) << Call << Call->getSourceRange();
-    return std::nullopt;
-  }
-
-  unsigned DiagID =
-      Diags.getCustomDiagID(DiagnosticsEngine::Warning,
-                            "Requesting inference result for %0 but not found");
-  Diags.Report(Call->getBeginLoc(), DiagID) << Call << Call->getSourceRange();
-#endif
 
   return std::nullopt;
 }
@@ -720,8 +695,13 @@ void ASTContext::setInferredInfoForCall(const CallExpr *Call,
 }
 
 std::optional<InferredTypeInfo>
+ASTContext::tryGetInferredInfoForCall(const CallExpr *Call) const {
+  return getTMOInference().lookupInferredInfoForCall(*this, Call);
+}
+
+InferredTypeInfo
 ASTContext::getInferredInfoForCall(const CallExpr *Call) const {
-  return getTMOInference().getInferredInfoForCall(*this, Call);
+  return *getTMOInference().lookupInferredInfoForCall(*this, Call);
 }
 
 InferredTypeInfo

--- a/clang/lib/CodeGen/CGTypedMemory.cpp
+++ b/clang/lib/CodeGen/CGTypedMemory.cpp
@@ -88,11 +88,10 @@ RValue CodeGenFunction::EmitTypedMemoryCall(const CallExpr *E,
   auto *InferredParameter = E->getArg(InferredParamIndex);
 
   TypedMemoryDescriptorBits Descriptor;
-  if (auto InferredInfo = Context.getInferredInfoForCall(E);
-      InferredInfo && InferredInfo->Type) {
-    if (auto PrimaryType = InferredInfo->Type->primaryType()) {
+  if (InferredTypeInfo Info = Context.getInferredInfoForCall(E); Info.Type) {
+    if (auto PrimaryType = Info.Type->primaryType()) {
       auto TypeDescriptor = Context.getTypedMemoryDescriptor(
-          *PrimaryType, OO_None, InferredInfo->InferredCallsiteFlags);
+          *PrimaryType, OO_None, Info.InferredCallsiteFlags);
       Descriptor = TypeDescriptor.asBits();
     }
   } else {

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -1047,8 +1047,9 @@ void ASTStmtWriter::VisitCallExpr(CallExpr *E) {
   CurrentPackingBits.addBit(E->isCoroElideSafe());
   CurrentPackingBits.addBit(E->usesMemberSyntax());
 
+  ASTContext &Ctx = Record.getASTContext();
   std::optional<InferredTypeInfo> TMOInference =
-      Record.getASTContext().getInferredInfoForCall(E);
+      Ctx.tryGetInferredInfoForCall(E);
   CurrentPackingBits.addBit(TMOInference.has_value());
 
   Record.AddSourceLocation(E->getRParenLoc());

--- a/clang/test/Modules/tmo-clang-modules-serialization.cpp
+++ b/clang/test/Modules/tmo-clang-modules-serialization.cpp
@@ -1,0 +1,79 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++17 -x c++ -fmodules \
+// RUN:   -ftyped-memory-operations -Wtyped-memory-inference-failure -Rtmo-remarks \
+// RUN:   -emit-module -fmodule-name=tmoalloc -fmodule-map-file=%t/tmoalloc.modulemap \
+// RUN:   %t/tmoalloc.modulemap -verify=module -o %t/tmoalloc.pcm
+//
+// RUN: %clang_cc1 -std=c++17 -x c++ -fmodules \
+// RUN:   -ftyped-memory-operations -Wtyped-memory-inference-failure -Rtmo-remarks \
+// RUN:   -fmodule-map-file=%t/tmoalloc.modulemap -fmodule-file=tmoalloc=%t/tmoalloc.pcm \
+// RUN:   -fsyntax-only -verify %t/tmo-user.cpp
+
+//--- tmoalloc.modulemap
+module tmoalloc {
+  header "tmoalloc.h"
+}
+
+//--- tmoalloc.h
+
+#ifndef TMOALLOC_H
+#define TMOALLOC_H
+
+void *test_typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *test_malloc(__SIZE_TYPE__ size) __attribute__((typed_memory_operation(test_typed_malloc, 1)));
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+inline S1 *test_inline_tmo_call(int n) {
+  return (S1 *)test_malloc(sizeof(S1) * n);
+  // module-remark@-1 {{passing TMO information for array of type 'S1' to 'test_typed_malloc' (retargeted from 'test_malloc')}}
+  // module-note@-2 {{inferred array of 'S1' from expression 'sizeof(S1) * n'}}
+  // module-note@-3 {{encoding array of 'S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+}
+
+template <class T> T *alloc_t(T, int n) {
+  return (T *)test_malloc(sizeof(T) * n); // #alloc_t
+}
+
+inline int *alloc_int(int n) {
+  return alloc_t(n, n);
+  // module-note@-1 {{in instantiation of function template specialization 'alloc_t<int>' requested here}}
+  // module-remark@#alloc_t {{passing TMO information for array of type 'int' to 'test_typed_malloc' (retargeted from 'test_malloc')}}
+  // module-note@#alloc_t {{inferred array of 'int' from expression 'sizeof(int) * n'}}
+  // module-note@#alloc_t {{encoding array of 'int' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
+}
+
+inline int *alloc_inference_fail(int n) {
+  auto *r = test_malloc(n);
+  // module-warning@-1 {{could not infer allocation type in call to 'test_malloc'}}
+  // module-note@-2 {{unable to infer allocation type from expression 'n'}}
+  return (int *)r;
+}
+
+#endif
+
+//--- tmo-user.cpp
+
+#include "tmoalloc.h"
+
+void test_in_module() {
+  test_inline_tmo_call(10);
+  S1 * s = alloc_t(S1{}, 10);
+  // expected-note@-1 {{in instantiation of function template specialization 'alloc_t<S1>' requested here}}
+  // expected-remark@tmoalloc.h:23 {{passing TMO information for array of type 'S1' to 'test_typed_malloc' (retargeted from 'test_malloc')}}
+  // expected-note@tmoalloc.h:23 {{inferred array of 'S1' from expression 'sizeof(S1) * n'}}
+  // expected-note@tmoalloc.h:23 {{encoding array of 'S1' as 74309947616562710. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 4009135638 }}}
+  alloc_int(10);
+  test_malloc(10);
+  // expected-warning@-1 {{could not infer allocation type in call to 'test_malloc'}}
+  // expected-note@-2 {{unable to infer allocation type from expression '10'}}
+}
+

--- a/clang/test/Modules/tmo-cxx-module-serialization.cppm
+++ b/clang/test/Modules/tmo-cxx-module-serialization.cppm
@@ -1,0 +1,46 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++20 %t/M.cppm -ftyped-memory-operations -fsyntax-only -verify
+
+//--- foo.h
+
+void *test_typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *test_malloc(__SIZE_TYPE__ size) __attribute__((typed_memory_operation(test_typed_malloc, 1)));
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+inline S1 *test_inline_tmo_call(int n) {
+  return (S1 *)test_malloc(sizeof(S1) * n);
+}
+
+template <class T> T *alloc_t(int n) {
+  return (T *)test_malloc(sizeof(T) * n);
+}
+
+inline int *alloc_int(int n) {
+  return alloc_t<int>(n);
+}
+
+
+//--- M.cppm
+// expected-no-diagnostics
+module;
+#include "foo.h"
+export module M;
+export using ::test_inline_tmo_call;
+export using ::alloc_t;
+export using ::alloc_int;
+
+
+export void test_in_module() {
+  test_inline_tmo_call(10);
+  alloc_t<S1>(10);
+  alloc_int(10);
+}

--- a/clang/test/PCH/Inputs/tmo_allocation.h
+++ b/clang/test/PCH/Inputs/tmo_allocation.h
@@ -11,6 +11,15 @@ struct S1 {
   void (*fptr)();
 };
 
+void *non_tmo_function(__SIZE_TYPE__);
+void *in_pch_non_tmo_call() {
+  return non_tmo_function(sizeof(struct S1));
+}
+
+inline void *in_pch_non_tmo_call_inline() {
+  return non_tmo_function(sizeof(struct S1));
+}
+
 void in_pch_function() {
   void *iptr_failed_inference = malloc(1000); // #pch_failed_inference
   // expected-warning@#pch_failed_inference {{could not infer allocation type in call to 'malloc'}}

--- a/clang/test/PCH/Inputs/tmo_allocation_cxx.h
+++ b/clang/test/PCH/Inputs/tmo_allocation_cxx.h
@@ -1,0 +1,84 @@
+
+#define _TYPED(rewrite_target, type_param_pos) __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+extern "C" {
+
+void *typed_malloc(__SIZE_TYPE__ size, unsigned long long);
+void *malloc(__SIZE_TYPE__ size) _TYPED(typed_malloc, 1);
+
+struct S1 {
+  void *p;
+  int i;
+  int j;
+  void (*fptr)();
+};
+
+}
+
+void *non_tmo_function(__SIZE_TYPE__);
+void *in_pch_non_tmo_call() {
+  return non_tmo_function(sizeof(S1));
+}
+
+inline void *in_pch_non_tmo_call_inline() {
+  return non_tmo_function(sizeof(S1));
+}
+
+void in_pch_function() {
+  void *iptr_failed_inference = malloc(1000); // #pch_failed_inference
+  // expected-warning@#pch_failed_inference {{could not infer allocation type in call to 'malloc'}}
+  // expected-note@#pch_failed_inference {{unable to infer allocation type from expression '1000'}}
+  void *iptr1 = malloc(sizeof(int)); // #pch_iptr1
+  // expected-remark@#pch_iptr1 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_iptr1 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#pch_iptr1 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  int *iptr2 = (int *)malloc(sizeof(int)); // #pch_iptr2
+  // expected-remark@#pch_iptr2 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_iptr2 {{inferred 'int' from expression 'sizeof(int)'}}
+  // expected-note@#pch_iptr2 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  int *iptr3 = (int *)malloc(100); // #pch_iptr3
+  // expected-remark@#pch_iptr3 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_iptr3 {{inferred 'int' from cast of result from call to '(int *)malloc(100)'}}
+  // expected-note@#pch_iptr3 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+  void *s1ptr1 = malloc(sizeof(S1)); // #pch_s1ptr1
+  // expected-remark@#pch_s1ptr1 {{passing TMO information for type 'S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_s1ptr1 {{inferred 'S1' from expression 'sizeof(S1)'}}
+  // expected-note@#pch_s1ptr1 {{encoding 'S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  S1 *s1ptr2 = (S1 *)malloc(sizeof(S1)); // #pch_s1ptr2
+  // expected-remark@#pch_s1ptr2 {{passing TMO information for type 'S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_s1ptr2 {{inferred 'S1' from expression 'sizeof(S1)'}}
+  // expected-note@#pch_s1ptr2 {{encoding 'S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+  S1 *s1ptr3 = (S1 *)malloc(100); // #pch_s1ptr3
+  // expected-remark@#pch_s1ptr3 {{passing TMO information for type 'S1' to 'typed_malloc' (retargeted from 'malloc')}}
+  // expected-note@#pch_s1ptr3 {{inferred 'S1' from cast of result from call to '(S1 *)malloc(100)'}}
+  // expected-note@#pch_s1ptr3 {{encoding 'S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
+}
+
+template <class T> void in_pch_template_function() {
+  void *tptr_failed_inference = malloc(1000); // #template_failed_inference
+  void *tptr1 = malloc(sizeof(T)); // #tptr1
+  T *tptr2 = (T *)malloc(sizeof(T)); // #tptr2
+  T *tptr3 = (T *)malloc(100); // #tptr3
+  T *tptr4 = static_cast<T *>(malloc(100)); // #tptr4
+  T *tptr5 = reinterpret_cast<T *>(malloc(100)); // #tptr5
+}
+
+template void in_pch_template_function<float>(); //#float_instantiation
+// expected-note@#float_instantiation {{in instantiation of function template specialization 'in_pch_template_function<float>' requested here}}
+// expected-warning@#template_failed_inference {{could not infer allocation type in call to 'malloc'}}
+// expected-note@#template_failed_inference {{unable to infer allocation type from expression '1000'}}
+// expected-remark@#tptr1 {{passing TMO information for type 'float' to 'typed_malloc' (retargeted from 'malloc')}}
+// expected-note@#tptr1 {{inferred 'float' from expression 'sizeof(float)'}}
+// expected-note@#tptr1 {{encoding 'float' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+// expected-remark@#tptr2 {{passing TMO information for type 'float' to 'typed_malloc' (retargeted from 'malloc')}}
+// expected-note@#tptr2 {{inferred 'float' from expression 'sizeof(float)'}}
+// expected-note@#tptr2 {{encoding 'float' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+// expected-remark@#tptr3 {{passing TMO information for type 'float' to 'typed_malloc' (retargeted from 'malloc')}}
+// expected-note@#tptr3 {{inferred 'float' from cast of result from call to '(float *)malloc(100)'}}
+// expected-note@#tptr3 {{encoding 'float' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+// expected-remark@#tptr4 {{passing TMO information for type 'float' to 'typed_malloc' (retargeted from 'malloc')}}
+// expected-note@#tptr4 {{inferred 'float' from cast of result from call to 'static_cast<float *>(malloc(100))'}}
+// expected-note@#tptr4 {{encoding 'float' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
+// expected-remark@#tptr5 {{passing TMO information for type 'float' to 'typed_malloc' (retargeted from 'malloc')}}
+// expected-note@#tptr5 {{inferred 'float' from cast of result from call to 'reinterpret_cast<float *>(malloc(100))'}}
+// expected-note@#tptr5 {{encoding 'float' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}

--- a/clang/test/PCH/tmo-with-pch.cpp
+++ b/clang/test/PCH/tmo-with-pch.cpp
@@ -1,27 +1,25 @@
 // Test this without pch.
-// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include %S/Inputs/tmo_allocation.h -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -Wtyped-memory-inference-failure  -verify -fsyntax-only \
-// RUN:                                           -std=c23 -include %S/Inputs/tmo_allocation.h -o - %s
+// RUN: %clang_cc1 -x c++ -ftyped-memory-operations -std=c++26 -include %S/Inputs/tmo_allocation_cxx.h -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -x c++ -ftyped-memory-operations -Wtyped-memory-inference-failure -Rtmo-remarks -verify -fsyntax-only \
+// RUN:                                             -std=c++26 -include %S/Inputs/tmo_allocation_cxx.h -o - %s
 
 // Test with pch.
-// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
-// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -x c++ -ftyped-memory-operations -Wtyped-memory-inference-failure -std=c++26 -emit-pch -o %t %S/Inputs/tmo_allocation_cxx.h
+// RUN: %clang_cc1 -x c++ -ftyped-memory-operations -Wtyped-memory-inference-failure -std=c++26 -include-pch %t -emit-llvm -o - %s | FileCheck %s
 
 // Test with pch and remarks.
-// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
-// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang_cc1 -x c -ftyped-memory-operations -Rtmo-remarks -Wtyped-memory-inference-failure -verify -fsyntax-only \
-// RUN:                                                         -std=c23 -include-pch %t %s
+// RUN: %clang_cc1 -x c++ -ftyped-memory-operations -Wtyped-memory-inference-failure -Rtmo-remarks -std=c++26 -emit-pch -o %t %S/Inputs/tmo_allocation_cxx.h
+// RUN: %clang_cc1 -x c++ -ftyped-memory-operations -Wtyped-memory-inference-failure -Rtmo-remarks -std=c++26 -include-pch %t -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -x c++ -ftyped-memory-operations -Wtyped-memory-inference-failure -Rtmo-remarks -verify -fsyntax-only \
+// RUN:                                                         -std=c++26 -include-pch %t %s
 
-// RUN: %clang_cc1 -x c -ftyped-memory-operations -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
-// RUN: not %clang_cc1 -x c -std=c23 -include-pch %t %s 2>&1 | FileCheck --check-prefix=PCH_HAS_TMO %s
-// PCH_HAS_TMO: Typed Memory Operations Callsite Rewriting was enabled in precompiled file
-// RUN: %clang_cc1 -x c -std=c23 -emit-pch -o %t %S/Inputs/tmo_allocation.h
-// RUN: not %clang_cc1 -x c -ftyped-memory-operations -std=c23 -include-pch %t %s 2>&1 | FileCheck --check-prefix=PCH_NO_TMO %s
-// PCH_NO_TMO: Typed Memory Operations Callsite Rewriting was disabled in precompiled file
+
+// RUN: %clang_cc1 -x c++ -std=c++23 -ftyped-memory-operations -Wtyped-memory-inference-failure -emit-pch -fpch-instantiate-templates -o %t %S/Inputs/tmo_allocation_cxx.h
+// RUN: %clang_cc1 -x c++ -std=c++23 -ftyped-memory-operations -Wtyped-memory-inference-failure -include-pch %t -emit-llvm -o - %s  | FileCheck %s
+
 
 static void call_in_pch_function(void) {
-    in_pch_function();
+  in_pch_function();
 }
 // CHECK-LABEL: in_pch_function
 // CHECK: call ptr @typed_malloc(i64 noundef 1000, i64 noundef [[LOC1_DESC:[0-9]+]])
@@ -32,20 +30,12 @@ static void call_in_pch_function(void) {
 // CHECK: call ptr @typed_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
 // CHECK: call ptr @typed_malloc(i64 noundef 100, i64 noundef [[S1_DESC]])
 
-static void call_in_pch_fam_function(__SIZE_TYPE__ n) {
-    in_pch_fam_function(n);
-}
-// CHECK-LABEL: in_pch_fam_function
-// CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[ELEM_ARRAY_DESC:72058145178419728]])
-// CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[PREFIX_HEADER_HPA_DESC:72058694934233616]])
-// CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[PREFIX_HEADER_HPA_DESC]])
-// CHECK: call ptr @typed_malloc(i64 noundef 28, i64 noundef [[S1_DESC]])
-// CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[ELEM_INDETERMINATE_DESC:72057595422605840]])
+// CHECK-LABEL: in_pch_template_function
+// CHECK: call ptr @typed_malloc(i64 noundef 1000, i64 noundef [[LOC2_DESC:[0-9]+]])
 
 // CHECK-LABEL: out_of_pch_function
 void out_of_pch_function() {
-  __SIZE_TYPE__ n;
-  int *iptr1 = malloc(sizeof(int)); // #iptr1
+  void *iptr1 = malloc(sizeof(int)); // #iptr1
   // CHECK: call ptr @typed_malloc(i64 noundef 4, i64 noundef [[GENERICDATA32_DESC:72057870300512784]])
   // expected-remark@#iptr1 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
   // expected-note@#iptr1 {{inferred 'int' from expression 'sizeof(int)'}}
@@ -60,7 +50,7 @@ void out_of_pch_function() {
   // expected-remark@#iptr3 {{passing TMO information for type 'int' to 'typed_malloc' (retargeted from 'malloc')}}
   // expected-note@#iptr3 {{inferred 'int' from cast of result from call to '(int *)malloc(10)'}}
   // expected-note@#iptr3 {{encoding 'int' as 72057870300512784. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1384677904 }}}
-  struct S1 *s1ptr1 = malloc(sizeof(struct S1)); // #s1ptr1
+  void *s1ptr1 = malloc(sizeof(struct S1)); // #s1ptr1
   // CHECK: call ptr @typed_malloc(i64 noundef 24, i64 noundef [[S1_DESC]])
   // expected-remark@#s1ptr1 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
   // expected-note@#s1ptr1 {{inferred 'struct S1' from expression 'sizeof(struct S1)'}}
@@ -75,24 +65,12 @@ void out_of_pch_function() {
   // expected-remark@#s1ptr3 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
   // expected-note@#s1ptr3 {{inferred 'struct S1' from cast of result from call to '(struct S1 *)malloc(100)'}}
   // expected-note@#s1ptr3 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
-  void *tuple1 = malloc(sizeof(struct S1) + sizeof(struct Elem)); // #tuple1
-  // CHECK: call ptr @typed_malloc(i64 noundef 28, i64 noundef [[S1_DESC]])
-  // expected-remark@#tuple1 {{passing TMO information for type 'struct S1' to 'typed_malloc' (retargeted from 'malloc')}}
-  // expected-note@#tuple1 {{inferred tuple of ('struct S1', 'struct Elem') from expression 'sizeof(struct S1) + sizeof(struct Elem)'}}
-  // expected-note@#tuple1 {{encoding 'struct S1' as 74309672738655766. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 4009135638 }}}
-  void *unknown1 = malloc(sizeof(struct Elem) + n); // #unknown1
-  // CHECK: call ptr @typed_malloc({{.*}}, i64 noundef [[ELEM_INDETERMINATE_DESC]])
-  // expected-remark@#unknown1 {{passing TMO information for type 'struct Elem' to 'typed_malloc' (retargeted from 'malloc')}}
-  // expected-note@#unknown1 {{inferred indeterminate set of {'struct Elem'} from expression 'sizeof(struct Elem) + n'}}
-  // expected-note@#unknown1 {{encoding 'struct Elem' as 72057595422605840. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ ] }, "TypeHash": 1384677904 }}}
 }
 
 // CHECK: !{!"type-descriptor", !"[[LOC1_DESC]]", !"[[LOC1_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
 // CHECK: !{!"type-descriptor", !"[[GENERICDATA32_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
 // CHECK: !{!"type-descriptor", !"[[S1_DESC]]", !"4009135638", !"\22LayoutSemantics\22: [ \22AnonymousPointer\22, \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22FixedSize\22 ]"}
-// CHECK: !{!"type-descriptor", !"[[ELEM_ARRAY_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22Array\22 ]"}
-// CHECK: !{!"type-descriptor", !"[[PREFIX_HEADER_HPA_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ \22HeaderPrefixedArray\22 ]"}
-// CHECK: !{!"type-descriptor", !"[[ELEM_INDETERMINATE_DESC]]", !"1384677904", !"\22LayoutSemantics\22: [ \22GenericData\22 ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
+// CHECK: !{!"type-descriptor", !"[[LOC2_DESC]]", !"[[LOC2_DESC]]", !"\22LayoutSemantics\22: [ ], \22TypeFlags\22: [ ], \22TypeKind\22: \22KindC\22, \22CallsiteFlags\22: [ ]"}
 
 // non-tmo-tests
 


### PR DESCRIPTION
To detect state errors, debug build we issue a warning if a TMO query is made when it shouldn't be. But this query is actually legitimate during serialization, as it's used to determine whether the call node is actually a TMO call. The alternative would be duplicating the "is this call subject to a TMO rewrite" logic.

The result is that when assertions are enabled and tmo is being used while building a module header. This PR makes it so we can distinguish valid serialization calls from those calls where this is actually an error.

While this is only triggered when serializing trees for modules, this PR also introduces tests for the PCH paths as well, on the presumption that it's possible that future PCH changes may serialize more information, and so could hit this path.