### PR TITLE
[lldb] Use private stop for breakpoint-delaying decision

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1772,7 +1772,7 @@ llvm::Error Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
                                                  BreakpointAction action,
                                                  bool forbid_delay) {
   // Breakpoints immediately affect running processes, so do not delay them.
-  forbid_delay |= IsRunning();
+  forbid_delay |= StateIsRunningState(GetPrivateState());
 
   if (forbid_delay)
     if (llvm::Error E = FlushDelayedBreakpoints())


### PR DESCRIPTION
Using the public stop is correct but too conservative: breakpoints changed during private stops are very likely to happen while the process has a public "running" state but a private "stopped" state.

rdar://178062860