### PR TITLE
[Index] Deserialize Swift access control properties from index records

### DIFF
--- a/clang/lib/Index/IndexDataStoreUtils.cpp
+++ b/clang/lib/Index/IndexDataStoreUtils.cpp
@@ -239,6 +239,40 @@ SymbolPropertySet index::getSymbolProperties(uint64_t Props) {
   if (Props & INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ASYNC)
     SymbolProperties |= (SymbolPropertySet)SymbolProperty::SwiftAsync;
 
+  uint64_t SwiftAccessLevelBits =
+      INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_LESSTHANFILEPRIVATE |
+      INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_FILEPRIVATE |
+      INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_INTERNAL |
+      INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_PACKAGE |
+      INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_SPI |
+      INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_PUBLIC;
+  switch (Props & SwiftAccessLevelBits) {
+  case INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_LESSTHANFILEPRIVATE:
+    SymbolProperties |= (SymbolPropertySet)
+        SymbolProperty::SwiftAccessControlLessThanFilePrivate;
+    break;
+  case INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_FILEPRIVATE:
+    SymbolProperties |=
+        (SymbolPropertySet)SymbolProperty::SwiftAccessControlFilePrivate;
+    break;
+  case INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_INTERNAL:
+    SymbolProperties |=
+        (SymbolPropertySet)SymbolProperty::SwiftAccessControlInternal;
+    break;
+  case INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_PACKAGE:
+    SymbolProperties |=
+        (SymbolPropertySet)SymbolProperty::SwiftAccessControlPackage;
+    break;
+  case INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_SPI:
+    SymbolProperties |=
+        (SymbolPropertySet)SymbolProperty::SwiftAccessControlSPI;
+    break;
+  case INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ACCESSCONTROL_PUBLIC:
+    SymbolProperties |=
+        (SymbolPropertySet)SymbolProperty::SwiftAccessControlPublic;
+    break;
+  }
+
   return SymbolProperties;
 }
 

--- a/clang/lib/Index/IndexSymbol.cpp
+++ b/clang/lib/Index/IndexSymbol.cpp
@@ -589,7 +589,14 @@ StringRef index::getSymbolLanguageString(SymbolLanguage K) {
 
 std::optional<SymbolProperty>
 index::getSwiftAccessLevelFromSymbolPropertySet(SymbolPropertySet Props) {
-  if (uint32_t AccessLevel = Props & (1 << 19 | 1 << 18 | 1 << 17)) {
+  uint32_t AccessLevelBits =
+      (uint32_t)SymbolProperty::SwiftAccessControlLessThanFilePrivate |
+      (uint32_t)SymbolProperty::SwiftAccessControlFilePrivate |
+      (uint32_t)SymbolProperty::SwiftAccessControlInternal |
+      (uint32_t)SymbolProperty::SwiftAccessControlPackage |
+      (uint32_t)SymbolProperty::SwiftAccessControlSPI |
+      (uint32_t)SymbolProperty::SwiftAccessControlPublic;
+  if (uint32_t AccessLevel = Props & AccessLevelBits) {
     return (SymbolProperty)AccessLevel;
   }
   return std::nullopt;


### PR DESCRIPTION
- **Explanation**: https://github.com/swiftlang/llvm-project/pull/11716 added functionality to serialize Swift access levels into the Index Store. However, we were missing logic to deserialize the Swift access control levels from index records serialized to disk. The deserialization logic added in this PR matches what we’re doing in `applyForEachSymbolProperty`.
- **Scope**: Deserialization of index records
- **Issue**: rdar://177051671
- **Risk**: Very low, this is just mapping a few bits over.
- **Testing**: Tested locally from he swift repository, will add a test there as a follow-up PR.
- **Reviewer**: @hamishknight 