### PR TITLE
[🍒][-Wunsafe-buffer-usage] Move warning-only analysis back to function-based (#198006)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -533,6 +533,22 @@ related warnings within the method body.
       - Name: myUnsafeFunction
         UnsafeBufferUsage: true
 
+- When using ``-Wunsafe-buffer-usage`` without
+  ``-fsafe-buffer-usage-suggestions``, warnings are now emitted only
+  once per source file. Pre-compiled code (such as PCH or module
+  headers) is no longer repeatedly analyzed, as it is analyzed during
+  its initial compilation. (Traditionally included headers are still
+  analyzed within each translation unit that includes them).  This
+  behavior matches most of other ``-W`` diagnostics.
+
+  When ``-fsafe-buffer-usage-suggestions`` is enabled, the behavior
+  remains the same as before: pre-compiled code is deserialized and
+  analyzed alongside the translation unit that uses it, because fix-it
+  suggestion analysis requires full visibility of the translation
+  unit.
+
+
+
 Improvements to Clang's diagnostics
 -----------------------------------
 - Added ``-Wlifetime-safety`` to enable lifetime safety analysis,

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3715,7 +3715,8 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
       // Perform unsafe buffer usage analysis:
       if (shouldRunUnsafeBufferUsageAnalysis(S, Node->getBeginLoc())) {
         clang::checkUnsafeBufferUsage(Node, R,
-                                      /*EmitSuggestion =*/true);
+                                      /*EmitSuggestion =*/true,
+                                      S.getLangOpts().BoundsSafetyAttributes);
       }
 
       // More analysis ...
@@ -4034,7 +4035,8 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
     // Perform unsafe buffer usage analysis:
     if (shouldRunUnsafeBufferUsageAnalysis(S, D->getBeginLoc())) {
       clang::checkUnsafeBufferUsage(
-          D, R, /*UnsafeBufferUsageShouldEmitSuggestions=*/false);
+          D, R, /*UnsafeBufferUsageShouldEmitSuggestions=*/false,
+          S.getLangOpts().BoundsSafetyAttributes);
     }
   }
 }

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3663,8 +3663,34 @@ LifetimeSafetyTUAnalysis(Sema &S, TranslationUnitDecl *TU,
   }
 }
 
+static bool shouldRunUnsafeBufferUsageAnalysis(const Sema &S,
+                                               SourceLocation Loc) {
+  const DiagnosticsEngine &Diags = S.getDiagnostics();
+  return !Diags.isIgnored(diag::warn_unsafe_buffer_operation, Loc) ||
+         !Diags.isIgnored(diag::warn_unsafe_buffer_variable, Loc) ||
+         !Diags.isIgnored(diag::warn_unsafe_buffer_usage_in_container, Loc) ||
+         (!Diags.isIgnored(diag::warn_unsafe_buffer_libc_call, Loc) &&
+          S.getLangOpts().CPlusPlus);
+}
+
+/// \return true iff fix-its should be emitted along with -Wunsafe-buffer-usage
+/// warnings
+static bool shouldEmitUnsafeBufferUsageSuggestions(const Sema &S) {
+  return S.getLangOpts().CPlusPlus20 && S.getDiagnostics()
+                                            .getDiagnosticOptions()
+                                            .ShowSafeBufferUsageSuggestions;
+}
+
+/// \return true iff an extra note that encourages users to turn on fix-its
+/// should be emitted along with -Wunsafe-buffer-usage warnings
+static bool shouldSuggestUnsafeBufferUsageSuggestions(const Sema &S) {
+  return S.getLangOpts().CPlusPlus20 && !S.getDiagnostics()
+                                             .getDiagnosticOptions()
+                                             .ShowSafeBufferUsageSuggestions;
+}
+
 void clang::sema::AnalysisBasedWarnings::IssueWarnings(
-     TranslationUnitDecl *TU) {
+    TranslationUnitDecl *TU) {
   if (!TU)
     return; // This is unexpected, give up quietly.
 
@@ -3674,50 +3700,33 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
     // exit if having uncompilable errors or ignoring all warnings:
     return;
 
-  DiagnosticOptions &DiagOpts = Diags.getDiagnosticOptions();
+  // When the '-fsafe-buffer-usage-suggestions' option is enabled,
+  // the '-Wunsafe-buffer-usage' analysis is performed at the end of the
+  // translation unit. Otherwise, the analysis is more efficiently performed at
+  // the end of each Decl during parsing.
+  if (shouldEmitUnsafeBufferUsageSuggestions(S)) {
+    UnsafeBufferUsageReporter R(S, /*SuggestSuggestions=*/false);
 
-  // UnsafeBufferUsage analysis settings.
-  bool UnsafeBufferUsageCanEmitSuggestions = S.getLangOpts().CPlusPlus20;
-  bool UnsafeBufferUsageShouldEmitSuggestions =  // Should != Can.
-      UnsafeBufferUsageCanEmitSuggestions &&
-      DiagOpts.ShowSafeBufferUsageSuggestions;
-  bool UnsafeBufferUsageShouldSuggestSuggestions =
-      UnsafeBufferUsageCanEmitSuggestions &&
-      !DiagOpts.ShowSafeBufferUsageSuggestions;
-  bool BoundsSafetyAttributedEnabled = S.getLangOpts().BoundsSafetyAttributes;
-  UnsafeBufferUsageReporter R(S, UnsafeBufferUsageShouldSuggestSuggestions);
+    // The Callback function that performs analyses:
+    auto CallAnalyzers = [&](const Decl *Node) -> void {
+      if (Node->hasAttr<UnsafeBufferUsageAttr>())
+        return;
 
-  // The Callback function that performs analyses:
-  auto CallAnalyzers = [&](const Decl *Node) -> void {
-    if (Node->hasAttr<UnsafeBufferUsageAttr>())
-      return;
+      // Perform unsafe buffer usage analysis:
+      if (shouldRunUnsafeBufferUsageAnalysis(S, Node->getBeginLoc())) {
+        clang::checkUnsafeBufferUsage(Node, R,
+                                      /*EmitSuggestion =*/true);
+      }
 
-    // Perform unsafe buffer usage analysis:
-    if (!Diags.isIgnored(diag::warn_unsafe_buffer_operation,
-                         Node->getBeginLoc()) ||
-        !Diags.isIgnored(diag::warn_unsafe_buffer_variable,
-                         Node->getBeginLoc()) ||
-        !Diags.isIgnored(diag::warn_unsafe_buffer_usage_in_container,
-                         Node->getBeginLoc()) ||
-        !Diags.isIgnored(diag::warn_unsafe_buffer_libc_call,
-                         Node->getBeginLoc())) {
-      clang::checkUnsafeBufferUsage(Node, R,
-                                    UnsafeBufferUsageShouldEmitSuggestions,
-                                    BoundsSafetyAttributedEnabled);
+      // More analysis ...
+    };
+    // Emit per-function analysis-based warnings that require the whole-TU
+    // reasoning. Check if any of them is enabled at all before scanning the
+    // AST:
+    if (shouldRunUnsafeBufferUsageAnalysis(S, SourceLocation())) {
+      CallableVisitor(CallAnalyzers, TU->getOwningModule())
+          .TraverseTranslationUnitDecl(TU);
     }
-
-    // More analysis ...
-  };
-  // Emit per-function analysis-based warnings that require the whole-TU
-  // reasoning. Check if any of them is enabled at all before scanning the AST:
-  if (!Diags.isIgnored(diag::warn_unsafe_buffer_operation, SourceLocation()) ||
-      !Diags.isIgnored(diag::warn_unsafe_buffer_variable, SourceLocation()) ||
-      !Diags.isIgnored(diag::warn_unsafe_buffer_usage_in_container,
-                       SourceLocation()) ||
-      (!Diags.isIgnored(diag::warn_unsafe_buffer_libc_call, SourceLocation()) &&
-       S.getLangOpts().CPlusPlus /* only warn about libc calls in C++ */)) {
-    CallableVisitor(CallAnalyzers, TU->getOwningModule())
-        .TraverseTranslationUnitDecl(TU);
   }
 
   if (S.getLangOpts().EnableLifetimeSafety && S.getLangOpts().CPlusPlus &&
@@ -4009,6 +4018,23 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
                                          cfg->getNumBlockIDs());
     } else {
       ++NumFunctionsWithBadCFGs;
+    }
+  }
+
+  // If the '-fsafe-buffer-usage-suggestions' option is not specified or C++20
+  // is not available, '-Wunsafe-buffer-usage' warnings are analyzed at the end
+  // of each Decl. This is because only '-fsafe-buffer-usage-suggestions'
+  // requires visibility of the whole translation unit, hence the cumbersome
+  // post-TU analysis, which deserializes and scans pre-compiled ASTs.
+  if (!shouldEmitUnsafeBufferUsageSuggestions(S) &&
+      !D->hasAttr<UnsafeBufferUsageAttr>()) {
+    UnsafeBufferUsageReporter R(S,
+                                shouldSuggestUnsafeBufferUsageSuggestions(S));
+
+    // Perform unsafe buffer usage analysis:
+    if (shouldRunUnsafeBufferUsageAnalysis(S, D->getBeginLoc())) {
+      clang::checkUnsafeBufferUsage(
+          D, R, /*UnsafeBufferUsageShouldEmitSuggestions=*/false);
     }
   }
 }

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3718,8 +3718,6 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
                                       /*EmitSuggestion =*/true,
                                       S.getLangOpts().BoundsSafetyAttributes);
       }
-
-      // More analysis ...
     };
     // Emit per-function analysis-based warnings that require the whole-TU
     // reasoning. Check if any of them is enabled at all before scanning the

--- a/clang/test/BoundsSafety/Sema/terminated-by-ptr-assign.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-ptr-assign.c
@@ -47,11 +47,11 @@ const char *__null_terminated const_arr_stringlit(int x) {
 const char *__null_terminated const_arr_stringlit_arit(int x) {
   const char const_arr_stringlit[] = "hello";
 
-  const char *__null_terminated p = const_arr_stringlit + 3;         // ok
-  p = const_arr_stringlit + 3;                                       // ok
-  nul(const_arr_stringlit + 3);                                      // ok
-  (void)((const char *__null_terminated)( const_arr_stringlit + 3)); // ok
-  return const_arr_stringlit + 3;                                    // ok
+  const char *__null_terminated p = const_arr_stringlit + 3;         // ubu-warning{{unsafe pointer arithmetic}}
+  p = const_arr_stringlit + 3;                                       // ubu-warning{{unsafe pointer arithmetic}}
+  nul(const_arr_stringlit + 3);                                      // ubu-warning{{unsafe pointer arithmetic}}
+  (void)((const char *__null_terminated)( const_arr_stringlit + 3)); // ubu-warning{{unsafe pointer arithmetic}}
+  return const_arr_stringlit + 3;                                    // ubu-warning{{unsafe pointer arithmetic}}
 }
 
 const char *__null_terminated const_arr_stringlit_arit_end(int x) {
@@ -61,27 +61,27 @@ const char *__null_terminated const_arr_stringlit_arit_end(int x) {
   // bs-error@+3{{initializing 'const char *__single __terminated_by(0)' (aka 'const char *__single') with an expression of incompatible type 'const char *__bidi_indexable' is an unsafe operation}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  const char *__null_terminated p = const_arr_stringlit + 6;
+  const char *__null_terminated p = const_arr_stringlit + 6; // ubu-warning{{unsafe pointer arithmetic}}
   // ubu-warning@+4{{assigning to 'const char * __terminated_by(0)' (aka 'const char *') from incompatible type 'const char *' is an unsafe operation}}
   // bs-error@+3{{assigning to 'const char *__single __terminated_by(0)' (aka 'const char *__single') from incompatible type 'const char *__bidi_indexable' is an unsafe operation}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  p = const_arr_stringlit + 6;
+  p = const_arr_stringlit + 6; // ubu-warning{{unsafe pointer arithmetic}}
   // ubu-warning@+4{{passing 'const char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   // bs-error@+3{{passing 'const char *__bidi_indexable' to parameter of incompatible type 'const char *__single __terminated_by(0)' (aka 'const char *__single') is an unsafe operation}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  nul(const_arr_stringlit + 6);
+  nul(const_arr_stringlit + 6); // ubu-warning{{unsafe pointer arithmetic}}
   // ubu-warning@+4{{casting 'const char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   // bs-error@+3{{casting 'const char *__bidi_indexable' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  (void)((const char *__null_terminated)( const_arr_stringlit + 6));
+  (void)((const char *__null_terminated)( const_arr_stringlit + 6)); // ubu-warning{{unsafe pointer arithmetic}}
   // ubu-warning@+4{{returning 'const char *' from a function with incompatible result type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   // bs-error@+3{{returning 'const char *__bidi_indexable' from a function with incompatible result type 'const char *__single __terminated_by(0)' (aka 'const char *__single') is an unsafe operation}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  return const_arr_stringlit + 6;
+  return const_arr_stringlit + 6; // ubu-warning{{unsafe pointer arithmetic}}
 }
 
 const char *__null_terminated const_arr_stringlit_arit_pastend(int x) {
@@ -91,27 +91,27 @@ const char *__null_terminated const_arr_stringlit_arit_pastend(int x) {
   // bs-error@+3{{initializing 'const char *__single __terminated_by(0)' (aka 'const char *__single') with an expression of incompatible type 'const char *__bidi_indexable' is an unsafe operation}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  const char *__null_terminated p = const_arr_stringlit + 7;
+  const char *__null_terminated p = const_arr_stringlit + 7; // ubu-warning{{unsafe pointer arithmetic}}
   // ubu-warning@+4{{assigning to 'const char * __terminated_by(0)' (aka 'const char *') from incompatible type 'const char *' is an unsafe operation}}
   // bs-error@+3{{assigning to 'const char *__single __terminated_by(0)' (aka 'const char *__single') from incompatible type 'const char *__bidi_indexable' is an unsafe operation}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  p = const_arr_stringlit + 7;
+  p = const_arr_stringlit + 7; // ubu-warning{{unsafe pointer arithmetic}}
   // ubu-warning@+4{{passing 'const char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   // bs-error@+3{{passing 'const char *__bidi_indexable' to parameter of incompatible type 'const char *__single __terminated_by(0)' (aka 'const char *__single') is an unsafe operation}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  nul(const_arr_stringlit + 7);
+  nul(const_arr_stringlit + 7); // ubu-warning{{unsafe pointer arithmetic}}
   // ubu-warning@+4{{casting 'const char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   // bs-error@+3{{casting 'const char *__bidi_indexable' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  (void)((const char *__null_terminated)( const_arr_stringlit + 7));
+  (void)((const char *__null_terminated)( const_arr_stringlit + 7)); // ubu-warning{{unsafe pointer arithmetic}}
   // ubu-warning@+4{{returning 'const char *' from a function with incompatible result type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   // bs-error@+3{{returning 'const char *__bidi_indexable' from a function with incompatible result type 'const char *__single __terminated_by(0)' (aka 'const char *__single') is an unsafe operation}}
   // bs-note@+2{{consider using '__unsafe_null_terminated_from_indexable()' to perform this conversion. Note this performs a linear scan of memory to find the null terminator}}
   // bs-note@+1{{consider using '__unsafe_null_terminated_from_indexable()' with a pointer to the null terminator to perform this conversion. Note this performs the conversion in constant time}}
-  return const_arr_stringlit + 7;
+  return const_arr_stringlit + 7; // ubu-warning{{unsafe pointer arithmetic}}
 }
 
 const char *__null_terminated const_arr_braced(int x) {

--- a/clang/test/Modules/safe_buffers_optout.cpp
+++ b/clang/test/Modules/safe_buffers_optout.cpp
@@ -2,39 +2,37 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -emit-module -fmodule-name=safe_buffers_test_base -x c++ %t/safe_buffers_test.modulemap -std=c++20\
-// RUN:            -o %t/safe_buffers_test_base.pcm -Wunsafe-buffer-usage
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -emit-module -fmodule-name=safe_buffers_test_textual -x c++ %t/safe_buffers_test.modulemap -std=c++20\
-// RUN:            -o %t/safe_buffers_test_textual.pcm -Wunsafe-buffer-usage
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -emit-module -fmodule-name=safe_buffers_test_optout -x c++ %t/safe_buffers_test.modulemap -std=c++20\
-// RUN:            -fmodule-file=%t/safe_buffers_test_base.pcm -fmodule-file=%t/safe_buffers_test_textual.pcm \
-// RUN:            -o %t/safe_buffers_test_optout.pcm -Wunsafe-buffer-usage
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodule-file=%t/safe_buffers_test_optout.pcm -I %t -std=c++20 -Wunsafe-buffer-usage\
-// RUN:            -verify %t/safe_buffers_optout-explicit.cpp
 
-
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -verify -fmodules-cache-path=%t -fmodule-map-file=%t/safe_buffers_test.modulemap -I%t\
-// RUN:            -x c++ -std=c++20 -Wunsafe-buffer-usage %t/safe_buffers_optout-implicit.cpp
-
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -emit-module -fmodule-name=safe_buffers_test_base -x c++\
+// RUN:            %t/safe_buffers_test.modulemap -std=c++20 -o %t/safe_buffers_test_base.pcm -Wunsafe-buffer-usage -verify
 //--- safe_buffers_test.modulemap
 module safe_buffers_test_base {
  header "base.h"
 }
 
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -emit-module -fmodule-name=safe_buffers_test_textual -x c++ \
+// RUN:            %t/safe_buffers_test.modulemap -std=c++20 -o %t/safe_buffers_test_textual.pcm \
+// RUN:            -Wunsafe-buffer-usage
 module safe_buffers_test_textual {
  textual header "textual.h"
 }
 
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -emit-module -fmodule-name=safe_buffers_test_optout -x c++ \
+// RUN:            %t/safe_buffers_test.modulemap -std=c++20 -fmodule-file=%t/safe_buffers_test_base.pcm \
+// RUN:            -fmodule-file=%t/safe_buffers_test_textual.pcm -o %t/safe_buffers_test_optout.pcm -Wunsafe-buffer-usage\
+// RUN:            -verify
 module safe_buffers_test_optout {
   explicit module test_sub1 {  header "test_sub1.h" }
   explicit module test_sub2 {  header "test_sub2.h" }
   use safe_buffers_test_base
 }
 
+
 //--- base.h
 #ifdef __cplusplus
 int base(int *p) {
-  int x = p[5];
+  int x = p[5]; // expected-warning{{unsafe buffer access}}\
+		   expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 #pragma clang unsafe_buffer_usage begin
   int y = p[5];
 #pragma clang unsafe_buffer_usage end
@@ -47,7 +45,8 @@ int base(int *p) {
 
 #ifdef __cplusplus
 int sub1(int *p) {
-  int x = p[5];
+  int x = p[5]; // expected-warning{{unsafe buffer access}}\
+		   expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 #pragma clang unsafe_buffer_usage begin
   int y = p[5];
 #pragma clang unsafe_buffer_usage end
@@ -69,7 +68,8 @@ T sub1_T(T *p) {
 
 #ifdef __cplusplus
 int sub2(int *p) {
-  int x = p[5];
+  int x = p[5]; // expected-warning{{unsafe buffer access}}\
+		   expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 #pragma clang unsafe_buffer_usage begin
   int y = p[5];
 #pragma clang unsafe_buffer_usage end
@@ -86,7 +86,25 @@ int textual(int *p) {
 }
 #endif
 
-//--- safe_buffers_optout-explicit.cpp
+// Specify modules explicitly:
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodule-file=%t/safe_buffers_test_optout.pcm -I %t \
+// RUN:            -std=c++20 -Wunsafe-buffer-usage -verify=main %t/safe_buffers_optout_main.cpp
+
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodule-file=%t/safe_buffers_test_optout.pcm -I %t \
+// RUN:            -std=c++20 -Wunsafe-buffer-usage -verify=main-fixit %t/safe_buffers_optout_main.cpp \
+// RUN:            -fsafe-buffer-usage-suggestions
+
+// Specify modules implicitly:
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -verify=main -fmodules-cache-path=%t \
+// RUN:            -fmodule-map-file=%t/safe_buffers_test.modulemap -I%t\
+// RUN:            -x c++ -std=c++20 -Wunsafe-buffer-usage %t/safe_buffers_optout_main.cpp
+
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -verify=main-fixit -fmodules-cache-path=%t \
+// RUN:            -fmodule-map-file=%t/safe_buffers_test.modulemap -I%t\
+// RUN:            -x c++ -std=c++20 -Wunsafe-buffer-usage %t/safe_buffers_optout_main.cpp \
+// RUN:            -fsafe-buffer-usage-suggestions
+
+//--- safe_buffers_optout_main.cpp
 #include "test_sub1.h"
 #include "test_sub2.h"
 
@@ -95,44 +113,20 @@ int textual(int *p) {
 // `safe_buffers_test_optout`, which uses another top-level module
 // `safe_buffers_test_base`. (So the module dependencies form a DAG.)
 
-// No expected warnings from base.h, test_sub1, or test_sub2 because they are
-// in seperate modules, and the explicit commands that builds them have no
-// `-Wunsafe-buffer-usage`.
-
-int foo(int * p) {
-  int x = p[5]; // expected-warning{{unsafe buffer access}} expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+int foo(int * p) { // main-fixit-warning{{'p' is an unsafe pointer used for buffer access}} \
+                      main-fixit-note{{change type of 'p' to 'std::span' to preserve bounds information}}
+  int x = p[5]; // main-warning{{unsafe buffer access}} \
+		   main-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}} \
+                   main-fixit-note{{used in buffer access here}}
 #pragma clang unsafe_buffer_usage begin
   int y = p[5];
 #pragma clang unsafe_buffer_usage end
   sub1_T(p); // instantiate template
   return sub1(p) + sub2(p);
 }
-
-#pragma clang unsafe_buffer_usage begin
-#include "textual.h"         // This header is textually included (i.e., it is in the same TU as %s), so warnings are suppressed
-#pragma clang unsafe_buffer_usage end
-
-//--- safe_buffers_optout-implicit.cpp
-#include "test_sub1.h"
-#include "test_sub2.h"
-
-// Testing safe buffers opt-out region serialization with modules: this
-// file loads 2 submodules from top-level module
-// `safe_buffers_test_optout`, which uses another top-level module
-// `safe_buffers_test_base`. (So the module dependencies form a DAG.)
-
-// No expected warnings from base.h, test_sub1, or test_sub2 because they are
-// in seperate modules, and the explicit commands that builds them have no
-// `-Wunsafe-buffer-usage`.
-
-int foo(int * p) {
-  int x = p[5]; // expected-warning{{unsafe buffer access}} expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
-#pragma clang unsafe_buffer_usage begin
-  int y = p[5];
-#pragma clang unsafe_buffer_usage end
-  sub1_T(p); // instantiate template
-  return sub1(p) + sub2(p);
-}
+// main-warning@test_sub1.h:15 {{unsafe buffer access}}
+// main-note@test_sub1.h:15 {{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+// main-note@-5{{in instantiation of function template specialization 'sub1_T<int>' requested here}}
 
 #pragma clang unsafe_buffer_usage begin
 #include "textual.h"         // This header is textually included (i.e., it is in the same TU as %s), so warnings are suppressed

--- a/clang/test/PCH/unsafe-buffer-usage-pragma-pch-complex.cpp
+++ b/clang/test/PCH/unsafe-buffer-usage-pragma-pch-complex.cpp
@@ -7,9 +7,15 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 
-// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t/pch_2.h.pch %t/pch_2.h -x c++
-// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -include-pch %t/pch_2.h.pch -emit-pch -o %t/pch_1.h.pch %t/pch_1.h -x c++
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t/pch_2.h.pch %t/pch_2.h -x c++ -Wunsafe-buffer-usage -verify
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -include-pch %t/pch_2.h.pch -emit-pch -o %t/pch_1.h.pch %t/pch_1.h -x c++ -Wunsafe-buffer-usage -verify
 // RUN: %clang_cc1 -Wno-unused-value -std=c++20 -include-pch %t/pch_1.h.pch -verify %t/main.cpp -Wunsafe-buffer-usage
+
+// With '-fsafe-buffer-usage-suggestions':
+
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t/pch_2.h.pch %t/pch_2.h -x c++ -Wunsafe-buffer-usage -verify=with-fixit -fsafe-buffer-usage-suggestions
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -include-pch %t/pch_2.h.pch -emit-pch -o %t/pch_1.h.pch %t/pch_1.h -x c++ -Wunsafe-buffer-usage -verify=with-fixit -fsafe-buffer-usage-suggestions
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -include-pch %t/pch_1.h.pch %t/main.cpp -Wunsafe-buffer-usage -verify=with-fixit -fsafe-buffer-usage-suggestions
 
 
 //--- textual_1.h
@@ -18,6 +24,7 @@ int a(int *s) {
 #pragma clang unsafe_buffer_usage begin
   return s[1];
 #pragma clang unsafe_buffer_usage end
+
 }
 
 //--- textual_2.h
@@ -29,18 +36,21 @@ int b(int *s) {
 }
 
 //--- pch_1.h
-#include "textual_2.h"
-
+#include "textual_2.h" // with-fixit-no-diagnostics
+// expected-warning@textual_2.h:2{{unsafe buffer access}} \
+   expected-note@textual_2.h:2{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 int c(int *s) {
-  s[2];  // <- expected warning here
+  s[2];  // expected-warning{{unsafe buffer access}} \
+	    expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 #pragma clang unsafe_buffer_usage begin
   return s[1];
 #pragma clang unsafe_buffer_usage end
 }
 
 //--- pch_2.h
-int d(int *s) {
-  s[2];  // <- expected warning here
+int d(int *s) { // with-fixit-no-diagnostics
+  s[2];  // expected-warning{{unsafe buffer access}} \
+	    expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 #pragma clang unsafe_buffer_usage begin
   return s[1];
 #pragma clang unsafe_buffer_usage end
@@ -51,12 +61,15 @@ int d(int *s) {
 #include "textual_1.h"
 // expected-warning@textual_1.h:2{{unsafe buffer access}} \
    expected-note@textual_1.h:2{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
-// expected-warning@textual_2.h:2{{unsafe buffer access}} \
-   expected-note@textual_2.h:2{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
-// expected-warning@pch_1.h:4{{unsafe buffer access}} \
-   expected-note@pch_1.h:4{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
-// expected-warning@pch_2.h:2{{unsafe buffer access}} \
-   expected-note@pch_2.h:2{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+
+// with-fixit-warning@textual_1.h:1 {{'s' is an unsafe pointer used for buffer access}}
+// with-fixit-note@textual_1.h:2 {{used in buffer access here}}
+// with-fixit-warning@textual_2.h:1 {{'s' is an unsafe pointer used for buffer access}}
+// with-fixit-note@textual_2.h:2 {{used in buffer access here}}
+// with-fixit-warning@pch_1.h:4 {{'s' is an unsafe pointer used for buffer access}}
+// with-fixit-note@pch_1.h:5 {{used in buffer access here}}
+// with-fixit-warning@pch_2.h:1 {{'s' is an unsafe pointer used for buffer access}}
+// with-fixit-note@pch_2.h:2 {{used in buffer access here}}
 int main() {
   int s[] = {1, 2, 3};
   return a(s) + b(s) + c(s) + d(s);

--- a/clang/test/PCH/unsafe-buffer-usage-pragma-pch-cross-files-2.cpp
+++ b/clang/test/PCH/unsafe-buffer-usage-pragma-pch-cross-files-2.cpp
@@ -2,15 +2,17 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 
-// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t/header.pch %t/header.h -x c++
-// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t/header.pch -verify %t/main.cpp
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t/header.pch %t/header.h -x c++ -verify -Wunsafe-buffer-usage
+// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t/header.pch -verify=with-fixit %t/main.cpp -fsafe-buffer-usage-suggestions
+// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t/header.pch %t/main.cpp -verify
 
 //--- header.h
 int foo(int *p) {
-  return p[5];  // This will be warned
+  return p[5];  // expected-warning{{unsafe buffer access}}\
+		   expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 }
 
-#pragma clang unsafe_buffer_usage begin // The opt-out region spans over two files of one TU
+#pragma clang unsafe_buffer_usage begin // The opt-out region spans over two prefix files of one TU
 #include "header-2.h"
 
 
@@ -21,5 +23,7 @@ int bar(int *p) {
 #pragma clang unsafe_buffer_usage end
 
 //--- main.cpp
-// expected-warning@header.h:2 {{unsafe buffer access}}
-// expected-note@header.h:2 {{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+// with-fixit-warning@header.h:1 {{'p' is an unsafe pointer used for buffer access}}
+// with-fixit-note@header.h:1 {{change type of 'p' to 'std::span' to preserve bounds information}}
+// with-fixit-note@header.h:2 {{used in buffer access here}}
+// expected-no-diagnostics

--- a/clang/test/PCH/unsafe-buffer-usage-pragma-pch-cross-files.cpp
+++ b/clang/test/PCH/unsafe-buffer-usage-pragma-pch-cross-files.cpp
@@ -2,12 +2,15 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 //
-// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t/header.pch %t/header.h -x c++
-// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t/header.pch -verify %t/main.cpp
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t/header.pch %t/header.h -x c++\
+// RUN:            -Wunsafe-buffer-usage -verify
+// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t/header.pch -verify=with-fixit %t/main.cpp -fsafe-buffer-usage-suggestions
+// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t/header.pch %t/main.cpp -verify
 
 //--- header.h
 int foo(int *p) {
-  return p[5];  // This will be warned
+  return p[5];  // expected-warning{{unsafe buffer access}} \
+		   expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 }
 
 #pragma clang unsafe_buffer_usage begin
@@ -25,5 +28,7 @@ int bar(int *p) {
 
 
 //--- main.cpp
-// expected-warning@header.h:2 {{unsafe buffer access}}
-// expected-note@header.h:2 {{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+// with-fixit-warning@header.h:1 {{'p' is an unsafe pointer used for buffer access}}
+// with-fixit-note@header.h:1 {{change type of 'p' to 'std::span' to preserve bounds information}}
+// with-fixit-note@header.h:2 {{used in buffer access here}}
+// expected-no-diagnostics

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-pragma-issue-79379.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-pragma-issue-79379.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -std=c++20 -verify %s
+
+// Test that -Wunsafe-buffer-usage respects #pragma clang diagnostic
+// push/pop, just like other diagnostics such as -Wsign-compare.
+//
+// Previously, -Wunsafe-buffer-usage analysis ran at end-of-TU, which caused
+// a nonlocal effect: the warning only fired if it was enabled at both the
+// point of occurrence AND at the end of the file. With per-Decl analysis,
+// the warning now correctly follows the diagnostic state at each function
+// definition.
+
+// No warning here: -Wunsafe-buffer-usage is not enabled.
+void f1(int *x) { (void)x[1]; }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wunsafe-buffer-usage"
+
+// Warning here: -Wunsafe-buffer-usage is enabled by the pragma above.
+void f2(int *x) { (void)x[1]; } // expected-warning{{unsafe buffer access}} \
+                                    expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+
+#pragma clang diagnostic pop
+
+// No warning here: the pop restored the previous state (disabled).
+void f3(int *x) { (void)x[1]; }

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-pragma-pch.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-pragma-pch.cpp
@@ -3,22 +3,31 @@
 // Test without PCH
 // RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include %s -verify %s
 // Test with PCH
-// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t %s
-// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t -verify %s
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t %s -Wunsafe-buffer-usage -verify
+// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t -verify=pch-main %s
+
+// Test with PCH and -fsafe-buffer-usage-suggestions
+// RUN: %clang_cc1 -Wno-unused-value -std=c++20 -emit-pch -o %t %s -Wunsafe-buffer-usage -verify=fixit \
+// RUN:            -fsafe-buffer-usage-suggestions
+// RUN: %clang_cc1 -Wno-unused-value -Wunsafe-buffer-usage -std=c++20 -include-pch %t -verify=pch-main-fixit %s\
+// RUN:            -fsafe-buffer-usage-suggestions
 
 #ifndef A_H
 #define A_H
 
 int a(int *s) {
-  s[2];  // <- expected warning here
+  s[2]; // expected-warning {{unsafe buffer access}}\
+           expected-note {{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+        // fixit-no-diagnostics
 #pragma clang unsafe_buffer_usage begin
   return s[1];
 #pragma clang unsafe_buffer_usage end
 }
 
 #else
-// expected-warning@-7{{unsafe buffer access}}
-// expected-note@-8{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+// pch-main-no-diagnostics
+// pch-main-fixit-warning@-11{{'s' is an unsafe pointer used for buffer access}}\
+   pch-main-fixit-note@-10{{used in buffer access here}}
 int main() {
   int s[] = {1, 2, 3};
   return a(s);

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-template-instantiation-notes.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-template-instantiation-notes.cpp
@@ -1,0 +1,47 @@
+// Without -fsafe-buffer-usage-suggestions, -Wunsafe-buffer-usage analysis
+// runs per-Decl during parsing, so the template instantiation stack is
+// available and instantiation notes are emitted (rdar://107480207).
+//
+// With -fsafe-buffer-usage-suggestions, the analysis runs at end-of-TU
+// where the instantiation stack is no longer available, so instantiation
+// notes are not yet emitted.
+
+
+// RUN: %clang_cc1 -std=c++20 -Wunsafe-buffer-usage -verify %s
+// RUN: %clang_cc1 -std=c++20 -Wunsafe-buffer-usage -fsafe-buffer-usage-suggestions \
+// RUN:            -verify=with-fixit %s
+
+void use(int);
+
+template<typename T>
+void templateFunction(T *p) { // with-fixit-warning{{'p' is an unsafe pointer used for buffer access}}
+  use(p[5]); // expected-warning{{unsafe buffer access}} \
+                expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}} \
+                with-fixit-note{{used in buffer access here}}
+}
+
+void instantiate(int *p) {
+  templateFunction(p); // expected-note{{in instantiation of function template specialization 'templateFunction<int>' requested here}}
+}
+
+template<typename T>
+T templateReturn(T *p) { // with-fixit-warning{{'p' is an unsafe pointer used for buffer access}}
+  return p[5]; // expected-warning{{unsafe buffer access}} \
+                  expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}} \
+                  with-fixit-note{{used in buffer access here}}
+}
+
+void instantiate2(int *p) {
+  templateReturn(p); // expected-note{{in instantiation of function template specialization 'templateReturn<int>' requested here}}
+}
+
+template<typename T>
+void templateArithmetic(T *p) { // with-fixit-warning{{'p' is an unsafe pointer used for buffer access}}
+  use(*(p + 3)); // expected-warning{{unsafe pointer arithmetic}} \
+                    expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}} \
+                    with-fixit-note{{used in pointer arithmetic here}}
+}
+
+void instantiate3(int *p) {
+  templateArithmetic(p); // expected-note{{in instantiation of function template specialization 'templateArithmetic<int>' requested here}}
+}


### PR DESCRIPTION
Move the warning-only analysis back to the end of parsing each Decl.
The warning-only analysis no longer does any extra AST deserialization.
Pre-compiled code will only be analyzed once during its own compilation.
    
When `-fsafe-buffer-usage-suggestions` is used, the behavior is the
same as before, because it requires visibility of the whole
translation unit.
    
rdar://177185295
    
Also fix rdar://107480207 & rdar://176992568 for the warning-only case.