### PR TITLE
[Cherry-pick into next] [LLDB] Avoid eagerly importing private companion modules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -25,6 +25,7 @@
 # FRAMEWORK := "Foo"
 # FRAMEWORK_HEADERS := "Foo.h"
 # FRAMEWORK_MODULES := "module.modulemap"
+# FRAMEWORK_PRIVATE_HEADERS := "Foo_Private.h"
 #
 # Also might be of interest:
 # FRAMEWORK_INCLUDES (Darwin only) :=
@@ -624,6 +625,11 @@ ifneq "$(FRAMEWORK_MODULES)" ""
 endif
 ifneq "$(FRAMEWORK_HEADERS)" ""
 	cp -r $(FRAMEWORK_HEADERS) $(FRAMEWORK).framework/Versions/A/Headers
+endif
+ifneq "$(FRAMEWORK_PRIVATE_HEADERS)" ""
+	mkdir -p $(FRAMEWORK).framework/Versions/A/PrivateHeaders
+	cp -r $(FRAMEWORK_PRIVATE_HEADERS) $(FRAMEWORK).framework/Versions/A/PrivateHeaders
+	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/PrivateHeaders PrivateHeaders)
 endif
 	(cd $(FRAMEWORK).framework/Versions; ln -sf A Current)
 	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/Headers Headers)

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -324,6 +324,17 @@ ifneq "$(FRAMEWORK)" ""
 	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Headers)
 	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Modules)
 	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Resources)
+ifneq "$(FRAMEWORK_HEADERS)" ""
+	$(call CP_R,$(FRAMEWORK_HEADERS),$(FRAMEWORK).framework/Versions/A/Headers)
+endif
+ifneq "$(FRAMEWORK_MODULES)" ""
+	$(call CP_R,$(FRAMEWORK_MODULES),$(FRAMEWORK).framework/Versions/A/Modules)
+endif
+ifneq "$(FRAMEWORK_PRIVATE_HEADERS)" ""
+	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/PrivateHeaders)
+	$(call CP_R,$(FRAMEWORK_PRIVATE_HEADERS),$(FRAMEWORK).framework/Versions/A/PrivateHeaders)
+	cd $(FRAMEWORK).framework && $(call LN_SF,Versions/A/PrivateHeaders,PrivateHeaders)
+endif
 ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
 ifneq "$(MODULENAME)" ""
 	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule)

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -10027,6 +10027,30 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
     // If EBM is enabled, disable implicit modules during contextual imports.
     DisableImplicitImportsRAII no_implicit_imports_raii(*this);
 
+    // Skip Clang modules that are private companions of another
+    // module. They will get imported when the other module is
+    // imported; importing the private module first will pull
+    // declarations from the main module into the private module,
+    // causing redeclaration errors.
+    llvm::StringMap<llvm::StringRef> search_paths;
+    for (const SourceModule &module : cu_imports)
+      if (module.path.size())
+        search_paths.insert({module.path.front().GetStringRef(),
+                             module.search_path.GetStringRef()});
+
+    auto is_private_module = [&](const SourceModule &module) {
+      if (module.path.size() != 1 || module.search_path.IsEmpty())
+        return false;
+      llvm::StringRef name = module.path.front().GetStringRef();
+      if (!name.consume_back("_Private"))
+        return false;
+      auto main_module = search_paths.find(name);
+      if (main_module == search_paths.end())
+        return false;
+      // Both modules must come from the same framework bundle.
+      return module.search_path.GetStringRef() == main_module->second;
+    };
+
     // Even though all modules are ostensibly dependencies of the main
     // module, importing the main module will not give access to,
     // e.g., a private import. So we import all modules individually.
@@ -10041,6 +10065,15 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
               .Cases("SwiftShims", "Builtin", "std", true)
               .Default(false))
         continue;
+
+      if (is_private_module(module)) {
+        LOG_PRINTF(GetLog(LLDBLog::Types),
+                   "Skipping private Clang module %s "
+                   "(primary module %s will automatically imported it)",
+                   module.path.front().AsCString(""),
+                   module.search_path.AsCString(""));
+        continue;
+      }
 
       auto loaded_module = LoadOneModule(module, *this, process_sp,
                                          /*import_dylibs=*/false);

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/Makefile
@@ -1,0 +1,28 @@
+SWIFT_SOURCES = main.swift
+SWIFT_OBJC_INTEROP := 1
+
+all: TestFramework.framework a.out
+
+include Makefile.rules
+
+SWIFTFLAGS_EXTRAS = \
+  -F$(BUILDDIR) -framework TestFramework \
+  -Xlinker -rpath -Xlinker $(BUILDDIR)
+
+TestFramework.framework: TestFramework.swift TestFramework.h \
+                         TestFramework_Private.h \
+                         module.modulemap module.private.modulemap
+	"$(MAKE)" -f $(MAKEFILE_RULES) -C $(BUILDDIR) VPATH=$(VPATH) \
+		MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		DYLIB_NAME=TestFramework \
+		DYLIB_ONLY=YES \
+		DYLIB_SWIFT_SOURCES=TestFramework.swift \
+		SWIFT_OBJC_INTEROP=1 \
+		SWIFT_OBJC_HEADER=TestFramework-Swift.h \
+		FRAMEWORK=TestFramework \
+		FRAMEWORK_HEADERS="$(SRCDIR)/TestFramework.h $(BUILDDIR)/TestFramework-Swift.h" \
+		FRAMEWORK_MODULES="$(SRCDIR)/module.modulemap $(SRCDIR)/module.private.modulemap" \
+		FRAMEWORK_PRIVATE_HEADERS="$(SRCDIR)/TestFramework_Private.h" \
+		DYLIB_INSTALL_NAME="@executable_path/TestFramework.framework/Versions/A/TestFramework"
+	$(call LN_SF,$(BUILDDIR)/TestFramework.framework/TestFramework,$(BUILDDIR)/TestFramework)

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestFramework.h
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestFramework.h
@@ -1,0 +1,2 @@
+#import <Foundation/Foundation.h>
+#import <TestFramework/TestFramework-Swift.h>

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestFramework.swift
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestFramework.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc public class TestObject: NSObject {
+    @objc internal var privateDetail: String {
+        return "private detail: internal implementation info"
+    }
+}

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestFramework_Private.h
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestFramework_Private.h
@@ -1,0 +1,5 @@
+#import <TestFramework/TestFramework.h>
+
+@interface TestObject (Private)
+@property(readonly, copy) NSString *privateDetail;
+@end

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestObjCInternalPropertyRedecl.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestObjCInternalPropertyRedecl.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestObjCInternalPropertyRedecl(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipEmbeddedSwift
+    @skipUnlessDarwin
+    @swiftTest
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    def test(self):
+        """Test that the import of a Clang private companion framework
+           module works in the expression evaluator"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'),
+            extra_images=['TestFramework'])
+
+        self.expect("expression o.privateDetail",
+                    substrs=["private detail: internal implementation info"])

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/main.swift
@@ -1,0 +1,10 @@
+import TestFramework
+// Importing the companion private Clang module is what causes
+// LLDB to see the private @objc property as ambiguous.
+import TestFramework_Private
+
+func main() {
+    let o = TestObject()
+    print(o.privateDetail) // break here
+}
+main()

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/module.modulemap
@@ -1,0 +1,5 @@
+framework module TestFramework {
+  umbrella header "TestFramework.h"
+  export *
+  module * { export * }
+}

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/module.private.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/module.private.modulemap
@@ -1,0 +1,4 @@
+framework module TestFramework_Private {
+  umbrella header "TestFramework_Private.h"
+  export *
+}


### PR DESCRIPTION
```
commit 3eede8f7381f5725aeba66153f5fa66265dfadfd
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri May 22 16:21:14 2026 -0700

    [LLDB] Avoid eagerly importing private companion modules
    
    in the Swift expression evaluator. They will get imported when the
    main module is imported; importing the private module first will pull
    declarations from the main module into the private module, causing
    redeclaration errors.
    
    Assisted-by: claude
    
    rdar://177002320
```
