### PR TITLE
[lldb/test] Skip SwiftUI formatters test on Darwin embedded platforms…

### DIFF
--- a/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
+++ b/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 @skipIf(archs=["x86_64"], bugnumber="rdar://174750739")
+@skipIfDarwinEmbedded
 class TestCase(TestBase):
 
     @skipUnlessDarwin


### PR DESCRIPTION
… (#12825)

The test uses NSHostingView to synchronously trigger SwiftUI's view graph evaluation. On iOS, this requires UIHostingController with a full UIWindow hierarchy and run loop, and @State introspection returns different values due to how SwiftUI manages state storage on UIKit. Skip the test on embedded platforms until we can properly support SwiftUI formatter testing on iOS.

rdar://175376913


(cherry picked from commit 4f1f1346466bc666f4ba55326c3fb8bcdada0fa1)