### PR TITLE
[Cherry-pick into next] [LLDB] Shorten cache path

### DIFF
--- a/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
+++ b/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
@@ -16,7 +16,7 @@ class TestSwiftMetadataCache(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
-        cache_dir = self.getBuildArtifact('swift-metadata-cache')
+        cache_dir = self.getBuildArtifact('cache')
         # Set the lldb module cache directory to a directory inside the build
         # artifacts directory so no other tests are interfered with.
         self.runCmd('settings set symbols.swift-metadata-cache-path "%s"' % cache_dir)


### PR DESCRIPTION
```
commit c82f9a5d6a79b8fc0892281d55f5a49a76e032e2
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue May 26 17:22:25 2026 -0700

    [LLDB] Shorten cache path
    
    On Windows the MAX_PATH limit is very short and this test runs against
    its limits. Push out the inevitable a few days by renaming the cache
    path to be shorter.
```
