### PR TITLE
🍒 [VirtualOutput] Update downstream clang for upstreamed version

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -117,8 +117,8 @@ class CompilerInstance : public ModuleLoader {
   /// The file manager.
   IntrusiveRefCntPtr<FileManager> FileMgr;
 
-  /// The output context.
-  IntrusiveRefCntPtr<llvm::vfs::OutputBackend> TheOutputBackend;
+  /// The output manager.
+  IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputMgr;
 
   /// The source manager.
   IntrusiveRefCntPtr<SourceManager> SourceMgr;
@@ -512,15 +512,20 @@ public:
   /// @{
 
   /// Set the output manager.
-  void setOutputBackend(IntrusiveRefCntPtr<llvm::vfs::OutputBackend> NewOutputs);
+  void
+  setOutputManager(IntrusiveRefCntPtr<llvm::vfs::OutputBackend> NewOutputs);
 
   /// Create an output manager.
-  void createOutputBackend();
+  void createOutputManager();
 
-  bool hasOutputBackend() const { return bool(TheOutputBackend); }
+  bool hasOutputManager() const { return bool(OutputMgr); }
 
-  llvm::vfs::OutputBackend &getOutputBackend();
-  llvm::vfs::OutputBackend &getOrCreateOutputBackend();
+  llvm::vfs::OutputBackend &getOutputManager();
+  llvm::vfs::OutputBackend &getOrCreateOutputManager();
+
+  /// @}
+  /// @name CAS
+  /// @{
 
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
   llvm::cas::ObjectStore &getOrCreateObjectStore();

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -502,7 +502,7 @@ bool CompileJobCache::CachingOutputs::prepareOutputCollectionCommon(
                Path != DependenciesFile;
       });
 
-  Clang.setOutputBackend(llvm::vfs::makeMirroringOutputBackend(
+  Clang.setOutputManager(llvm::vfs::makeMirroringOutputBackend(
       FilterBackend, std::move(OnDiskOutputs)));
 
   DiagProcessor->insertDiagConsumer(Clang.getDiagnostics());

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -512,7 +512,7 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   const DependencyOutputOptions &DepOpts = getDependencyOutputOpts();
   if (!DepOpts.OutputFile.empty())
     addDependencyCollector(
-        std::make_shared<DependencyFileGenerator>(DepOpts, TheOutputBackend));
+        std::make_shared<DependencyFileGenerator>(DepOpts, OutputMgr));
   if (!DepOpts.DOTOutputFile.empty())
     AttachDependencyGraphGen(*PP, DepOpts.DOTOutputFile,
                              getHeaderSearchOpts().Sysroot);
@@ -534,8 +534,8 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   }
 
   // Modules need an output manager.
-  if (!hasOutputBackend())
-    createOutputBackend();
+  if (!hasOutputManager())
+    createOutputManager();
 
   for (auto &Listener : DependencyCollectors)
     Listener->attachToPreprocessor(*PP);
@@ -944,26 +944,28 @@ std::unique_ptr<raw_pwrite_stream> CompilerInstance::createNullOutputFile() {
   return std::make_unique<llvm::raw_null_ostream>();
 }
 
-void CompilerInstance::setOutputBackend(
+// Output Manager
+
+void CompilerInstance::setOutputManager(
     IntrusiveRefCntPtr<llvm::vfs::OutputBackend> NewOutputs) {
-  assert(!TheOutputBackend && "Already has an output manager");
-  TheOutputBackend = std::move(NewOutputs);
+  assert(!OutputMgr && "Already has an output manager");
+  OutputMgr = std::move(NewOutputs);
 }
 
-void CompilerInstance::createOutputBackend() {
-  assert(!TheOutputBackend && "Already has an output manager");
-  TheOutputBackend = llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>();
+void CompilerInstance::createOutputManager() {
+  assert(!OutputMgr && "Already has an output manager");
+  OutputMgr = llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>();
 }
 
-llvm::vfs::OutputBackend &CompilerInstance::getOutputBackend() {
-  assert(TheOutputBackend);
-  return *TheOutputBackend;
+llvm::vfs::OutputBackend &CompilerInstance::getOutputManager() {
+  assert(OutputMgr);
+  return *OutputMgr;
 }
 
-llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputBackend() {
-  if (!hasOutputBackend())
-    createOutputBackend();
-  return getOutputBackend();
+llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputManager() {
+  if (!hasOutputManager())
+    createOutputManager();
+  return getOutputManager();
 }
 
 std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
@@ -1120,7 +1122,7 @@ CompilerInstance::createOutputFileImpl(StringRef OutputPath, bool Binary,
   }
 
   using namespace llvm::vfs;
-  Expected<OutputFile> O = getOrCreateOutputBackend().createFile(
+  Expected<OutputFile> O = getOrCreateOutputManager().createFile(
       OutputPath,
       OutputConfig()
           .setTextWithCRLF(!Binary)
@@ -1458,14 +1460,14 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompileImpl(
   auto WrapGenModuleAction = getGenModuleActionWrapper();
   Instance.setGenModuleActionWrapper(WrapGenModuleAction);
 
-  assert(hasOutputBackend() &&
+  assert(hasOutputManager() &&
          "Expected an output manager to already be set up");
   if (ThreadSafeConfig) {
     // Create a clone of the existing output (pointing to the same destination).
-    Instance.setOutputBackend(getOutputBackend().clone());
+    Instance.setOutputManager(getOutputManager().clone());
   } else {
     // Share the existing output manager.
-    Instance.setOutputBackend(&getOutputBackend());
+    Instance.setOutputManager(&getOutputManager());
   }
 
   if (ThreadSafeConfig) {


### PR DESCRIPTION
(cherry picked from commit 5e597ccad8f90b642f34570da1cb8435a9e9c109)

Cherry-pick a low-risk change to minimise the difference between main and rebranch (swift).

Paired with https://github.com/swiftlang/swift/pull/89479.