### PR TITLE
[lldb][swift/concurrency] Handle updated layout of UnsafeCurrentTask

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -987,7 +987,14 @@ public:
 
   lldb::ChildCacheState Update() override {
     if (auto reflection_ctx = GetReflectionContext()) {
-      ValueObjectSP task_obj_sp = m_backend.GetChildMemberWithName("_task");
+      // Newer stdlibs store the task as `_rawTask` (a non-owning wrapper
+      // around a `Builtin.RawPointer`); see swiftlang/swift#89283.
+      ValueObjectSP task_obj_sp;
+      if (auto raw_sp = m_backend.GetChildMemberWithName("_rawTask"))
+        task_obj_sp = raw_sp->GetChildMemberWithName("_rawValue");
+      // Fallback, older stdlibs used to store a _task property
+      if (!task_obj_sp)
+        task_obj_sp = m_backend.GetChildMemberWithName("_task");
       if (!task_obj_sp)
         return ChildCacheState::eRefetch;
       m_task_ptr = task_obj_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2574,9 +2574,18 @@ ThreadForLiveTaskArgument(Args &command, ExecutionContext &exe_ctx) {
     if (!status.Success())
       return status.takeError();
 
-    if (valobj_sp)
-      if (auto task_obj_sp = valobj_sp->GetChildMemberWithName("_task"))
+    if (valobj_sp) {
+      // Newer stdlibs store the task as `_rawTask` (a non-owning wrapper
+      // around a `Builtin.RawPointer`); see swiftlang/swift#89283.
+      ValueObjectSP task_obj_sp;
+      if (auto raw_sp = valobj_sp->GetChildMemberWithName("_rawTask"))
+        task_obj_sp = raw_sp->GetChildMemberWithName("_rawValue");
+      // Fallback, older stdlibs used to store a _task property
+      if (!task_obj_sp)
+        task_obj_sp = valobj_sp->GetChildMemberWithName("_task");
+      if (task_obj_sp)
         task_ptr = task_obj_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+    }
   }
 
   if (task_ptr == 0 || task_ptr == LLDB_INVALID_ADDRESS)


### PR DESCRIPTION
This is to handle the change made in: https://github.com/swiftlang/swift/pull/89283/

This will remove an un-necessary retain/release pair when obtaining the unsafe current task; however it does mean we needed to change the storage a bit, thus this lldb change.