### PR TITLE
[lldb][debugserver] ifdef guard around newer CPU_TYPEs (#195225)

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -1867,15 +1867,21 @@ nub_bool_t DNBSetArchitecture(const char *arch) {
     else if (strstr(arch, "arm64") == arch || strstr(arch, "aarch64") == arch)
       return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM64,
                                               CPU_SUBTYPE_ARM64_ALL);
+#if defined(CPU_SUBTYPE_ARM_V8M_MAIN)
     else if (strstr(arch, "armv8m.main") == arch)
       return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
                                               CPU_SUBTYPE_ARM_V8M_MAIN);
+#endif
+#if defined(CPU_SUBTYPE_ARM_V8M_BASE)
     else if (strstr(arch, "armv8m.base") == arch)
       return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
                                               CPU_SUBTYPE_ARM_V8M_BASE);
+#endif
+#if defined(CPU_SUBTYPE_ARM_V8_1M_MAIN)
     else if (strstr(arch, "armv8.1m.main") == arch)
       return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
                                               CPU_SUBTYPE_ARM_V8_1M_MAIN);
+#endif
     else if (strstr(arch, "armv8") == arch)
       return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM64,
                                               CPU_SUBTYPE_ARM64_V8);


### PR DESCRIPTION
The uses of the new CPU_SUBTYPEs depends on building with a newer SDK that we don't have on Intel CI bots. Put idef guards around them, debugserver won't be
working with these CPUs either way.

(cherry picked from commit 68d1c40ab2c5a4c1c9ff6dcd9e9d91a211a26c5c)