### PR TITLE
[lldb/test] Update TestBytecodeSynthetic to use filecheck_log

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -37,5 +37,5 @@ class TestCase(TestBase):
         account = frame.var("acc")
         self.assertEqual(account.num_children, 1)
 
-        self.filecheck(f"platform shell cat {log}", __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: Bytecode formatter can reuse @update: true (type: `Account`, name: `acc`)


### PR DESCRIPTION
\`platform shell cat\` runs on the target, so feeding it a host-side log path produces 'No such file or directory' on remote targets and an empty stdin to FileCheck. Use the filecheck_log helper which feeds the log file directly via FileCheck's -input-file option.

Equivalent to upstream commit a88516baa735.