### PR TITLE
🍒 Cherry-picks to enable PR tests running -fbounds-safety runtime tests

### DIFF
--- a/apple-ci/pr.sh
+++ b/apple-ci/pr.sh
@@ -7,6 +7,25 @@
 LLVM_PROJECT_SRC=$1
 LLVM_ENABLE_PROJECTS=${2:-"clang;clang-tools-extra"}
 
+# These flags are here so we can run the -fbounds-safety runtime tests inside
+# compiler-rt.
+# FIXME: We should be testing all of compiler-rt! Historically none of
+# compiler-rt was tested by this script so the `-DCOMPILER_RT_BUILD_<name>=Off`
+# lines are here to avoid building and testing as much as possible to minimize
+# the problems that suddenly testing all of compiler-rt could cause. We should
+# gradually start building and testing more of these runtimes (rdar://176397238).
+BOUNDS_SAFETY_CMAKE_FLAGS=( \
+  -DLLVM_ENABLE_RUNTIMES=compiler-rt \
+  -DCOMPILER_RT_ENABLE_TEST_SUITES=bounds_safety \
+  -DCOMPILER_RT_BOUNDS_SAFETY_USE_LLDB=On \
+  -DCOMPILER_RT_BUILD_LIBFUZZER=Off \
+  -DCOMPILER_RT_BUILD_MEMPROF=Off \
+  -DCOMPILER_RT_BUILD_PROFILE=Off \
+  -DCOMPILER_RT_BUILD_ORC=Off \
+  -DCOMPILER_RT_BUILD_SANITIZERS=Off \
+  -DCOMPILER_RT_BUILD_XRAY=Off \
+)
+
 echo '--- CMake Config ---'
 cmake -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
@@ -14,6 +33,7 @@ cmake -G Ninja \
  -DLLVM_ENABLE_PROJECTS=${LLVM_ENABLE_PROJECTS} \
  '-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64' \
  '-DLLVM_LIT_ARGS=-v' \
+ "${BOUNDS_SAFETY_CMAKE_FLAGS[@]}" \
  ${LLVM_PROJECT_SRC}/llvm
 
 echo '--- Ninja Build ---'

--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -282,6 +282,11 @@ macro(darwin_add_builtin_library name suffix)
     ${ARGN})
   set(libname "${name}.${suffix}_${LIB_ARCH}_${LIB_OS}")
   add_library(${libname} STATIC ${LIB_SOURCES})
+  
+  # Write out the sources that were used to compile the builtins so that tests can be run in
+  # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
+  file(WRITE "${CMAKE_BINARY_DIR}/${libname}.sources.txt" "${LIB_SOURCES}")
+
   if(DARWIN_${LIB_OS}_SYSROOT)
     set(sysroot_flag -isysroot ${DARWIN_${LIB_OS}_SYSROOT})
   endif()

--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -285,7 +285,7 @@ macro(darwin_add_builtin_library name suffix)
   
   # Write out the sources that were used to compile the builtins so that tests can be run in
   # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
-  file(WRITE "${CMAKE_BINARY_DIR}/${libname}.sources.txt" "${LIB_SOURCES}")
+  file(WRITE "${COMPILER_RT_OUTPUT_LIBRARY_DIR}/${libname}.sources.txt" "${LIB_SOURCES}")
 
   if(DARWIN_${LIB_OS}_SYSROOT)
     set(sysroot_flag -isysroot ${DARWIN_${LIB_OS}_SYSROOT})

--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -280,6 +280,14 @@ else()
   # Architectures supported by compiler-rt libraries.
   filter_available_targets(BUILTIN_SUPPORTED_ARCH
     ${ALL_BUILTIN_SUPPORTED_ARCH})
+
+  # COMPILER_RT_HAS_${arch}_* defines that are shared between lib/builtins/ and test/builtins/
+  foreach (arch ${BUILTIN_SUPPORTED_ARCH})
+    # NOTE: The corresponding check for if(APPLE) is in CompilerRTDarwinUtils.cmake
+    check_c_source_compiles("_Float16 foo(_Float16 x) { return x; }
+                              int main(void) { return 0; }"
+                            COMPILER_RT_HAS_${arch}_FLOAT16)
+  endforeach()
 endif()
 
 if(OS_NAME MATCHES "Linux|SerenityOS" AND NOT LLVM_USE_SANITIZER AND NOT

--- a/compiler-rt/docs/BuildingCompilerRT.rst
+++ b/compiler-rt/docs/BuildingCompilerRT.rst
@@ -80,6 +80,21 @@ Compiler-RT specific options
   Path where Compiler-RT data should be installed. If a relative
   path, relative to ``COMPILER_RT_INSTALL_PATH``.
 
+.. option:: COMPILER_RT_INCLUDE_TESTS:BOOL
+
+  **Default**: ``LLVM_INCLUDE_TESTS`` in LLVM builds, ``OFF`` in standalone builds.
+
+  Generate and build compiler-rt tests. If ``OFF``,
+  ``COMPILER_RT_ENABLE_TEST_SUITES`` has no effect.
+
+.. option:: COMPILER_RT_ENABLE_TEST_SUITES:STRING
+
+  **Default**: ``all``
+
+  Semicolon-separated list of test suites to enable, or ``all`` to enable all
+  test suites.
+  Example: ``-DCOMPILER_RT_ENABLE_TEST_SUITES="asan;ubsan;lsan"``
+
 .. _LLVM-specific variables:
 
 LLVM-specific options

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -933,9 +933,6 @@ else ()
           endif()
         endif()
       endif()
-      check_c_source_compiles("_Float16 foo(_Float16 x) { return x; }
-                               int main(void) { return 0; }"
-                              COMPILER_RT_HAS_${arch}_FLOAT16)
       append_list_if(COMPILER_RT_HAS_${arch}_FLOAT16 -DCOMPILER_RT_HAS_FLOAT16 BUILTIN_CFLAGS_${arch})
       check_c_source_compiles("__bf16 foo(__bf16 x) { return x; }
                                int main(void) { return 0; }"
@@ -970,6 +967,11 @@ else ()
                               C_STANDARD 11
                               CXX_STANDARD 17
                               PARENT_TARGET builtins)
+
+      # Write out the sources that were used to compile the builtins so that tests can be run in
+      # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
+      set_output_name(BUILTIN_LIB_TARGET_NAME clang_rt.builtins ${arch})
+      file(WRITE "${CMAKE_BINARY_DIR}/${BUILTIN_LIB_TARGET_NAME}.sources.txt" "${${arch}_SOURCES}")
       cmake_pop_check_state()
     endif ()
   endforeach ()

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -970,8 +970,9 @@ else ()
 
       # Write out the sources that were used to compile the builtins so that tests can be run in
       # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
-      set_output_name(BUILTIN_LIB_TARGET_NAME clang_rt.builtins ${arch})
-      file(WRITE "${CMAKE_BINARY_DIR}/${BUILTIN_LIB_TARGET_NAME}.sources.txt" "${${arch}_SOURCES}")
+      get_compiler_rt_output_dir(${arch} BUILTIN_LIB_OUTPUT_DIR)
+      set_output_name(BUILTIN_LIB_OUTPUT_NAME clang_rt.builtins ${arch})
+      file(WRITE "${BUILTIN_LIB_OUTPUT_DIR}/${BUILTIN_LIB_OUTPUT_NAME}.sources.txt" "${${arch}_SOURCES}")
       cmake_pop_check_state()
     endif ()
   endforeach ()

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -66,10 +66,10 @@ endfunction()
 # Run sanitizer tests only if we're sure that clang would produce
 # working binaries.
 if(COMPILER_RT_CAN_EXECUTE_TESTS)
-  # COMPILER_RT_TEST_BUILTINS_DIR allows running tests against builtins built
+  # COMPILER_RT_TEST_EXTERNAL_BUILTINS allows running tests against builtins built
   # in an independent build. This option is only indended to be used by
   # LLVM_ENABLE_RUNTIMES-based builds.
-  if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_BUILTINS_DIR)
+  if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_EXTERNAL_BUILTINS)
     add_subdirectory(builtins)
   endif()
   if(COMPILER_RT_BUILD_SANITIZERS)

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -66,7 +66,10 @@ endfunction()
 # Run sanitizer tests only if we're sure that clang would produce
 # working binaries.
 if(COMPILER_RT_CAN_EXECUTE_TESTS)
-  if(COMPILER_RT_BUILD_BUILTINS)
+  # COMPILER_RT_TEST_BUILTINS_DIR allows running tests against builtins built
+  # in an independent build. This option is only indended to be used by
+  # LLVM_ENABLE_RUNTIMES-based builds.
+  if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_BUILTINS_DIR)
     add_subdirectory(builtins)
   endif()
   if(COMPILER_RT_BUILD_SANITIZERS)

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -50,16 +50,70 @@ endif()
 
 umbrella_lit_testsuite_begin(check-compiler-rt)
 
-function(compiler_rt_test_runtime runtime)
-  string(TOUPPER ${runtime} runtime_uppercase)
-  if(COMPILER_RT_HAS_${runtime_uppercase} AND COMPILER_RT_INCLUDE_TESTS)
-    if (${runtime} STREQUAL cfi AND NOT COMPILER_RT_HAS_UBSAN)
-      # CFI tests require diagnostic mode, which is implemented in UBSan.
-    elseif (${runtime} STREQUAL scudo_standalone)
-      add_subdirectory(scudo/standalone)
-    else()
-      add_subdirectory(${runtime})
+set(COMPILER_RT_KNOWN_TEST_SUITES
+    builtins;ctx_profile;fuzzer;interception;lsan;memprof;metadata
+    ;orc;profile;sanitizer_common;shadowcallstack
+    ;ubsan;xray)
+list(APPEND COMPILER_RT_KNOWN_TEST_SUITES ${ALL_SANITIZERS})
+list(REMOVE_DUPLICATES COMPILER_RT_KNOWN_TEST_SUITES)
+list(APPEND COMPILER_RT_KNOWN_TEST_SUITES bounds_safety) # TO_UPSTREAM(BoundsSafety)
+# Sort the list so that's easier to read when emitting errors.
+list(SORT COMPILER_RT_KNOWN_TEST_SUITES)
+
+set(COMPILER_RT_ENABLE_TEST_SUITES "all" CACHE STRING
+    "List of test suites to enable (semicolon-separated), or \"all\" to enable all test suites. Known test suites: ${COMPILER_RT_KNOWN_TEST_SUITES}")
+
+# Validate COMPILER_RT_ENABLE_TEST_SUITES values.
+if(NOT "${COMPILER_RT_ENABLE_TEST_SUITES}" STREQUAL "all")
+  foreach(suite ${COMPILER_RT_ENABLE_TEST_SUITES})
+    if(NOT "${suite}" IN_LIST COMPILER_RT_KNOWN_TEST_SUITES)
+      message(FATAL_ERROR "Unknown test suite '${suite}' in COMPILER_RT_ENABLE_TEST_SUITES. Known test suites are: ${COMPILER_RT_KNOWN_TEST_SUITES}")
     endif()
+  endforeach()
+endif()
+
+function(compiler_rt_test_runtime runtime)
+  cmake_parse_arguments(ARG "NO_COMPILER_RT_HAS_GUARD" "" "" ${ARGN})
+
+  # Validate that the test suite name is known.
+  if(NOT "${runtime}" IN_LIST COMPILER_RT_KNOWN_TEST_SUITES)
+    message(FATAL_ERROR "'${runtime}' is not a known test suite. Known test suites are: ${COMPILER_RT_KNOWN_TEST_SUITES}")
+  endif()
+
+  # If COMPILER_RT_ENABLE_TEST_SUITES is not "all", check that this runtime
+  # is in the enabled list.
+  if(NOT "${COMPILER_RT_ENABLE_TEST_SUITES}" STREQUAL "all")
+    if(NOT "${runtime}" IN_LIST COMPILER_RT_ENABLE_TEST_SUITES)
+      message(STATUS "Skipping compiler-rt ${runtime} test directory")
+      return()
+    endif()
+  endif()
+
+  # FIXME: The old code had this but we should probably remove it
+  # because it's unreachable because `compiler-rt/test` is guarded
+  # by `if(COMPILER_RT_INCLUDE_TESTS)`.
+  if(NOT COMPILER_RT_INCLUDE_TESTS)
+    message(STATUS "Skipping compiler-rt ${runtime} test directory")
+    return()
+  endif()
+
+  if(NOT ARG_NO_COMPILER_RT_HAS_GUARD)
+    string(TOUPPER ${runtime} runtime_uppercase)
+    if(NOT COMPILER_RT_HAS_${runtime_uppercase})
+      message(STATUS "Skipping compiler-rt ${runtime} test directory")
+      return()
+    endif()
+  endif()
+
+  if(${runtime} STREQUAL cfi AND NOT COMPILER_RT_HAS_UBSAN)
+    # CFI tests require diagnostic mode, which is implemented in UBSan.
+    message(STATUS "Skipping ${runtime} test directory")
+  elseif(${runtime} STREQUAL scudo_standalone)
+    message(STATUS "Adding scudo/standalone test directory")
+    add_subdirectory(scudo/standalone)
+  else()
+    message(STATUS "Adding compiler-rt ${runtime} test directory")
+    add_subdirectory(${runtime})
   endif()
 endfunction()
 
@@ -70,7 +124,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
   # in an independent build. This option is only indended to be used by
   # LLVM_ENABLE_RUNTIMES-based builds.
   if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_EXTERNAL_BUILTINS)
-    add_subdirectory(builtins)
+    compiler_rt_test_runtime(builtins NO_COMPILER_RT_HAS_GUARD)
   endif()
   if(COMPILER_RT_BUILD_SANITIZERS)
     compiler_rt_test_runtime(interception)
@@ -84,7 +138,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
       compiler_rt_test_runtime(fuzzer)
 
       # These tests don't need an additional runtime but use asan runtime.
-      add_subdirectory(metadata)
+      compiler_rt_test_runtime(metadata NO_COMPILER_RT_HAS_GUARD)
     endif()
 
     foreach(sanitizer ${COMPILER_RT_SANITIZERS_TO_BUILD})
@@ -108,18 +162,12 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
   endif()
   # ShadowCallStack does not yet provide a runtime with compiler-rt, the tests
   # include their own minimal runtime
-  add_subdirectory(shadowcallstack)
+  compiler_rt_test_runtime(shadowcallstack NO_COMPILER_RT_HAS_GUARD)
 
   # TO_UPSTREAM(BoundsSafety)
-  # -fbounds-safety doesn't have a runtime in compiler-rt so guarding with
-  # `COMPILER_RT_HAS_BOUNDS_SAFETY` is unnecessary so that is why
-  # `compiler_rt_test_runtime` is not used here.
-  if(COMPILER_RT_INCLUDE_TESTS)
-    option(COMPILER_RT_TEST_BOUNDS_SAFETY "Include -fbounds-safety runtime tests" ON)
-    if(COMPILER_RT_TEST_BOUNDS_SAFETY)
-      add_subdirectory(bounds_safety)
-    endif()
-  endif()
+  # -fbounds-safety doesn't have a runtime in compiler-rt so there is no
+  # `COMPILER_RT_HAS_BOUNDS_SAFETY` hence the use of `NO_COMPILER_RT_HAS_GUARD`
+  compiler_rt_test_runtime(bounds_safety NO_COMPILER_RT_HAS_GUARD)
 endif()
 
 # Now that we've traversed all the directories and know all the lit testsuites,

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -1,6 +1,16 @@
 set(BUILTINS_LIT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS} builtins)
+# If COMPILER_RT_TEST_BUILTINS_DIR is set, the builtins
+# were already built and we are just going to test them.
+# NOTE: This is currently an LLVM-internal option which should
+# only be used by the LLVM_ENABLE_RUNTIMES build configured
+# in llvm/runtimes/CMakeLists.txt
+if(COMPILER_RT_TEST_BUILTINS_DIR)
+  set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS})
+else()
+  set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS} builtins)
+endif()
+
 set(BUILTINS_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/TestCases)
 
 # Test cases.
@@ -77,12 +87,21 @@ foreach(arch ${BUILTIN_TEST_ARCH})
     # TODO: Support other Apple platforms.
     set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins_${arch}_osx")
   else()
-    set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins-${arch}")
+    set_output_name(BUILTIN_LIB_TARGET_NAME clang_rt.builtins ${arch})
   endif()
-  if (NOT TARGET "${BUILTIN_LIB_TARGET_NAME}")
-    message(FATAL_ERROR "Target ${BUILTIN_LIB_TARGET_NAME} does not exist")
+  # Normally, we can just inspect the target directly to get the sources, but if
+  # we are testing an externally-built builtins library, we expect
+  # COMPILER_RT_TEST_BUILTINS_DIR to be set and contain a file named
+  # ${BUILTIN_LIB_TARGET_NAME}.sources.txt from the builtins build. This file
+  # is created by compiler-rt/lib/builtins/CMakeLists.txt
+  if(NOT COMPILER_RT_TEST_BUILTINS_DIR)
+    if (NOT TARGET "${BUILTIN_LIB_TARGET_NAME}")
+      message(FATAL_ERROR "Target ${BUILTIN_LIB_TARGET_NAME} does not exist")
+    endif()
+    get_target_property(BUILTIN_LIB_SOURCES "${BUILTIN_LIB_TARGET_NAME}" SOURCES)
+  else()
+    file(READ "${COMPILER_RT_TEST_BUILTINS_DIR}/${BUILTIN_LIB_TARGET_NAME}.sources.txt" BUILTIN_LIB_SOURCES)
   endif()
-  get_target_property(BUILTIN_LIB_SOURCES "${BUILTIN_LIB_TARGET_NAME}" SOURCES)
   list(LENGTH BUILTIN_LIB_SOURCES BUILTIN_LIB_SOURCES_LENGTH)
   if (BUILTIN_LIB_SOURCES_LENGTH EQUAL 0)
     message(FATAL_ERROR "Failed to find source files for ${arch} builtin library")

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(BUILTINS_LIT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-# If COMPILER_RT_TEST_BUILTINS_DIR is set, the builtins
+# If COMPILER_RT_TEST_EXTERNAL_BUILTINS is set, the builtins
 # were already built and we are just going to test them.
 # NOTE: This is currently an LLVM-internal option which should
 # only be used by the LLVM_ENABLE_RUNTIMES build configured
 # in llvm/runtimes/CMakeLists.txt
-if(COMPILER_RT_TEST_BUILTINS_DIR)
+if(COMPILER_RT_TEST_EXTERNAL_BUILTINS)
   set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS})
 else()
   set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS} builtins)
@@ -86,21 +86,23 @@ foreach(arch ${BUILTIN_TEST_ARCH})
   if(APPLE)
     # TODO: Support other Apple platforms.
     set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins_${arch}_osx")
+    set(BUILTIN_LIB_OUTPUT_NAME "clang_rt.builtins_${arch}_osx")
   else()
-    set_output_name(BUILTIN_LIB_TARGET_NAME clang_rt.builtins ${arch})
+    set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins-${arch}")
+    set_output_name(BUILTIN_LIB_OUTPUT_NAME clang_rt.builtins ${arch})
   endif()
   # Normally, we can just inspect the target directly to get the sources, but if
-  # we are testing an externally-built builtins library, we expect
-  # COMPILER_RT_TEST_BUILTINS_DIR to be set and contain a file named
-  # ${BUILTIN_LIB_TARGET_NAME}.sources.txt from the builtins build. This file
-  # is created by compiler-rt/lib/builtins/CMakeLists.txt
-  if(NOT COMPILER_RT_TEST_BUILTINS_DIR)
+  # we are testing an externally-built builtins library, we expect a file named
+  # ${BUILTIN_LIB_OUTPUT_NAME}.sources.txt in the compiler-rt output directory.
+  # This file is created by compiler-rt/lib/builtins/CMakeLists.txt
+  if(NOT COMPILER_RT_TEST_EXTERNAL_BUILTINS)
     if (NOT TARGET "${BUILTIN_LIB_TARGET_NAME}")
       message(FATAL_ERROR "Target ${BUILTIN_LIB_TARGET_NAME} does not exist")
     endif()
     get_target_property(BUILTIN_LIB_SOURCES "${BUILTIN_LIB_TARGET_NAME}" SOURCES)
   else()
-    file(READ "${COMPILER_RT_TEST_BUILTINS_DIR}/${BUILTIN_LIB_TARGET_NAME}.sources.txt" BUILTIN_LIB_SOURCES)
+    get_compiler_rt_output_dir(${arch} BUILTIN_LIB_OUTPUT_DIR)
+    file(READ "${BUILTIN_LIB_OUTPUT_DIR}/${BUILTIN_LIB_OUTPUT_NAME}.sources.txt" BUILTIN_LIB_SOURCES)
   endif()
   list(LENGTH BUILTIN_LIB_SOURCES BUILTIN_LIB_SOURCES_LENGTH)
   if (BUILTIN_LIB_SOURCES_LENGTH EQUAL 0)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -255,7 +255,10 @@ function(runtime_default_target)
 
   if(LLVM_INCLUDE_TESTS)
     set_property(GLOBAL APPEND PROPERTY LLVM_ALL_LIT_TESTSUITES "@${LLVM_BINARY_DIR}/runtimes/runtimes-bins/lit.tests")
-    list(APPEND test_targets runtimes-test-depends check-runtimes)
+    list(APPEND test_targets runtimes-test-depends check-runtimes check-builtins)
+
+    # The default runtimes target can run tests the default builtins target
+    list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-bins/")
   endif()
 
   set_enable_per_target_runtime_dir()
@@ -362,6 +365,15 @@ function(runtime_register_target name)
       list(APPEND ${name}_test_targets ${target}-${name})
       list(APPEND test_targets ${target}-${name})
     endforeach()
+
+    # If a builtins-${name} target exists, we'll test those builtins
+    # with this runtimes build
+    if(TARGET builtins-${name})
+      list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-${name}-bins/")
+      set(check-builtins-${name} check-builtins)
+      list(APPEND ${name}_test_targets check-builtins-${name})
+      list(APPEND test_targets check-builtins-${name})
+    endif()
     set(test_targets "${test_targets}" PARENT_SCOPE)
   endif()
 
@@ -427,6 +439,9 @@ function(runtime_register_target name)
   if(LLVM_INCLUDE_TESTS)
     add_dependencies(check-runtimes check-runtimes-${name})
     add_dependencies(runtimes-test-depends runtimes-test-depends-${name})
+    if(TARGET builtins-${name})
+      add_dependencies(check-builtins check-builtins-${name})
+    endif()
   endif()
   foreach(runtime_name ${runtime_names})
     if(NOT TARGET ${runtime_name})
@@ -585,6 +600,17 @@ if(build_runtimes)
           PROPERTIES FOLDER "Runtimes"
         )
         set(test_targets "")
+
+        # NOTE: Currently, the builtins tests are run with the runtimes build,
+        # and the default runtimes target installs a check-builtins target
+        # which forwards to the default builtins build. If the default runtimes
+        # target is not used, we create a custom target which will depend on
+        # each check-builtins-${name}.
+        add_custom_target(check-builtins)
+        set_target_properties(
+          check-builtins
+          PROPERTIES FOLDER "Compiler-RT"
+        )
       endif()
       if(LLVM_RUNTIME_DISTRIBUTION_COMPONENTS)
         foreach(component ${LLVM_RUNTIME_DISTRIBUTION_COMPONENTS})

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -256,9 +256,7 @@ function(runtime_default_target)
   if(LLVM_INCLUDE_TESTS)
     set_property(GLOBAL APPEND PROPERTY LLVM_ALL_LIT_TESTSUITES "@${LLVM_BINARY_DIR}/runtimes/runtimes-bins/lit.tests")
     list(APPEND test_targets runtimes-test-depends check-runtimes check-builtins)
-
-    # The default runtimes target can run tests the default builtins target
-    list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-bins/")
+    list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_EXTERNAL_BUILTINS=ON")
   endif()
 
   set_enable_per_target_runtime_dir()
@@ -369,7 +367,7 @@ function(runtime_register_target name)
     # If a builtins-${name} target exists, we'll test those builtins
     # with this runtimes build
     if(TARGET builtins-${name})
-      list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-${name}-bins/")
+      list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_EXTERNAL_BUILTINS=ON")
       set(check-builtins-${name} check-builtins)
       list(APPEND ${name}_test_targets check-builtins-${name})
       list(APPEND test_targets check-builtins-${name})


### PR DESCRIPTION
This cherry-picks the necessary changes from `next` so that the `-fbounds-safety` runtime tests will run for PR testing

rdar://176477660
rdar://176405989