### PR TITLE
[Cherry-pick into next] [LLDB] Simplify the hint when po-ing an object with no object descrip… (#200499)

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -111,23 +111,23 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
     // Objective-C
     // "<Name: 0x...>. The regex is:
     // - Start with "<".
-    // - Followed by 1 or more non-whitespace characters.
+    // - Capture 1 or more non-whitespace characters (the class name).
     // - Followed by ": 0x".
     // - Followed by 5 or more hex digits.
     // - Followed by ">".
     // - End with zero or more whitespace characters.
     static const std::regex swift_class_regex(
-        "^<\\S+: 0x[[:xdigit:]]{5,}>\\s*$");
+        "^<(\\S+): 0x[[:xdigit:]]{5,}>\\s*$");
 
+    std::cmatch match;
     if (GetDebugger().GetShowDontUsePoHint() && !target.IsDummyTarget() &&
         (language.AsLanguageType() == lldb::eLanguageTypeSwift ||
          language.IsObjC()) &&
-        std::regex_match(output.data(), swift_class_regex)) {
+        std::regex_match(output.data(), match, swift_class_regex)) {
 
-      result.AppendNote(
-          "object description requested, but type doesn't implement "
-          "a custom object description. Consider using \"p\" instead of "
-          "\"po\" (this note will only be shown once per debug session)");
+      result.AppendNoteWithFormatv(
+          "{0} has no custom object description, use \"p\" to see its children",
+          match[1].str());
       note_shown = true;
     }
   };

--- a/lldb/test/API/lang/objc/objc-po-hint/TestObjcPoHint.py
+++ b/lldb/test/API/lang/objc/objc-po-hint/TestObjcPoHint.py
@@ -17,8 +17,7 @@ class TestObjcPoHint(TestBase):
         self.expect(
             "dwim-print -O -- foo",
             substrs=[
-                "note: object description requested, but type doesn't implement "
-                'a custom object description. Consider using "p" instead of "po"',
+                "note: Foo has no custom object description",
                 "<Foo: 0x",
             ],
         )
@@ -40,6 +39,6 @@ class TestObjcPoHint(TestBase):
         # Make sure the hint is not printed
         self.expect(
             "dwim-print -O -- foo",
-            substrs=["note: object description"],
+            substrs=["note: Foo"],
             matching=False,
         )


### PR DESCRIPTION
```
commit f561d59856c1a2a1f7adb9604d47e9e1e940c7a0
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri May 29 17:32:36 2026 -0700

    [LLDB] Simplify the hint when po-ing an object with no object descrip… (#200499)
    
    …tion
    
    The current wording of the hint is so long that the output obscures the
    output of the command, which can be confusing. By shortening the message
    the command output hopefully comes back into the center of attention.
```
