### PR TITLE
[lldb/test] Trim @expectedFailureAll(remote=True) decorators (#200529)

### DIFF
--- a/lldb/test/API/assert_messages_test/TestAssertMessages.py
+++ b/lldb/test/API/assert_messages_test/TestAssertMessages.py
@@ -5,6 +5,7 @@ Test the format of API test suite assert failure messages
 
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test import lldbplatform
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 from textwrap import dedent
@@ -23,7 +24,10 @@ class AssertMessagesTestCase(TestBase):
         else:
             self.fail("Initial expect should have raised AssertionError!")
 
-    @expectedFailureAll(oslist=no_match(["linux"]), remote=True)
+    @expectedFailureAll(
+        oslist=no_match(["linux"] + lldbplatform.translate(lldbplatform.darwin_all)),
+        remote=True,
+    )
     def test_createTestTarget(self):
         try:
             self.createTestTarget("doesnt_exist")

--- a/lldb/test/API/lang/objc/objc-optimized/TestObjcOptimized.py
+++ b/lldb/test/API/lang/objc/objc-optimized/TestObjcOptimized.py
@@ -18,12 +18,12 @@ from lldbsuite.test import lldbutil
 # test failure: objc_optimized does not work for "-C clang -A i386"
 
 
+@skipUnlessDarwin
 class ObjcOptimizedTestCase(TestBase):
     myclass = "MyClass"
     mymethod = "description"
     method_spec = "-[%s %s]" % (myclass, mymethod)
 
-    @expectedFailureAll(remote=True)
     def test_break(self):
         """Test 'expr member' continues to work for optimized build."""
         self.build()

--- a/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
+++ b/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
@@ -4,6 +4,7 @@ Test Debugger APIs.
 
 import lldb
 
+from lldbsuite.test import lldbplatform
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
@@ -92,6 +93,7 @@ class DebuggerAPITestCase(TestBase):
         self.assertEqual(get_cache_line_size(), new_cache_line_size)
 
     @expectedFailureAll(
+        oslist=no_match(lldbplatform.translate(lldbplatform.darwin_all)),
         remote=True,
         bugnumber="github.com/llvm/llvm-project/issues/92419",
     )


### PR DESCRIPTION
These three tests pass when run against a remote-darwin platform backed by lldb-platform on device. Update each decorator to reflect where it's still expected to fail rather than blanket-XFAILing every remote run.

- `TestAssertMessages.test_createTestTarget`: was XFAIL on oslist=no_match(["linux"]) + remote=True. Add darwin_all to the no_match list so the XFAIL stays only on remote-windows / remote-freebsd / remote-netbsd / remote-android.
- `TestDebuggerAPI.test_CreateTarget_platform`: scope to non-Darwin remotes (bug llvm/llvm-project#92419 still tracks the underlying issue on those platforms).
- `TestObjcOptimized`: drop @expectedFailureAll(remote=True) from the test method and put @skipUnlessDarwin on the class. The Makefile depends on `-framework Foundation` and `-lobjc`, so the test cannot build on non-Darwin platforms — skip it there outright instead of pretending it could XFAIL.


(cherry picked from commit 524734d88b3cdd874f00853ea6309e70bbb1cd4e)