### PR TITLE
[BoundsSafety] Allow the -fbounds-safety runtime tests to use the just-built LLDB

### DIFF
--- a/compiler-rt/test/bounds_safety/CMakeLists.txt
+++ b/compiler-rt/test/bounds_safety/CMakeLists.txt
@@ -1,4 +1,29 @@
 message(STATUS "Trying to enable -fbounds-safety runtime tests")
+
+# Tri-state control over which LLDB the bounds-safety debugger test suites use.
+# Defined before the early `return()` below so it is always available as a cache
+# variable in both the standalone build and the LLVM_ENABLE_RUNTIMES build.
+#   ON   - only the just-built (in-tree) LLDB is considered; warn if unusable.
+#   OFF  - only a system LLDB is considered; the just-built LLDB is excluded.
+#   AUTO - consider both, preferring the just-built LLDB and falling back to the
+#          system one if the just-built LLDB is not usable.
+set(COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB "AUTO" CACHE STRING
+  "Which LLDB the bounds-safety debugger tests use: \
+ON (just-built only, warns if unusable), OFF (system only), \
+AUTO (prefer just-built, fall back to system)")
+set_property(CACHE COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB
+  PROPERTY STRINGS ON OFF AUTO)
+# Canonicalize to upper case so the comparisons below are case-insensitive
+# (e.g. "auto", "On", "off" are all accepted), and reject anything else.
+string(TOUPPER "${COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB}"
+  COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB)
+if(NOT COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB MATCHES "^(ON|OFF|AUTO)$")
+  message(FATAL_ERROR
+    "Invalid COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB="
+    "'${COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB}'. "
+    "Expected one of: ON, OFF, AUTO.")
+endif()
+
 if (NOT APPLE)
   # FIXME: We should support Linux too.
   message(STATUS "Skipping -fbounds-safety runtime tests on non-Apple platforms")
@@ -9,33 +34,78 @@ set(BOUNDS_SAFETY_HOST_TEST_SUITES)
 # Currently no dependencies
 set(BOUNDS_SAFETY_TEST_DEPS "")
 
-# Detect LLDB availability and Python compatibility
-find_program(LLDB_EXECUTABLE lldb HINTS ${LLVM_TOOLS_DIR})
+# Detect LLDB availability and Python compatibility.
+#
+# Build an ordered list of candidate lldb executables according to
+# COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB, then pick the first "usable"
+# one. A candidate is usable when `lldb -P` succeeds AND the Python interpreter
+# used by lit (${Python3_EXECUTABLE}) can import the lldb module from that path.
+# A Python mismatch (e.g. Homebrew Python 3.13 vs an LLDB built for Python 3.11)
+# would otherwise cause a confusing ImportError at test time.
+set(_just_built_lldb "${LLVM_TOOLS_BINARY_DIR}/lldb${CMAKE_EXECUTABLE_SUFFIX}")
+
+# Locate a system lldb once; only used for the OFF and AUTO modes below.
+find_program(_system_lldb lldb)
+
+set(_lldb_candidates "")
+# In ON and AUTO modes the just-built lldb is a (preferred) candidate.
+if(NOT COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB STREQUAL "OFF")
+  list(APPEND _lldb_candidates "${_just_built_lldb}")
+endif()
+# In OFF and AUTO modes a system lldb is a candidate (excluding the just-built
+# one, which OFF must never consider).
+if(NOT COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB STREQUAL "ON"
+   AND _system_lldb AND NOT _system_lldb STREQUAL _just_built_lldb)
+  list(APPEND _lldb_candidates "${_system_lldb}")
+endif()
+
 set(_LLDB_DETECTED FALSE)
 set(_LLDB_PYTHON_COMPATIBLE FALSE)
-if(LLDB_EXECUTABLE)
-  execute_process(
-    COMMAND ${LLDB_EXECUTABLE} -P
-    OUTPUT_VARIABLE BOUNDS_SAFETY_LLDB_PYTHON_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE LLDB_P_RESULT
-  )
-  if(LLDB_P_RESULT EQUAL 0)
-    set(_LLDB_DETECTED TRUE)
-    # Check that the Python interpreter used by lit can import the lldb module.
-    # A mismatch (e.g. Homebrew Python 3.13 vs Xcode LLDB built for Python 3.11)
-    # causes a confusing ImportError at test time.
-    execute_process(
-      COMMAND ${Python3_EXECUTABLE} -c
-        "import sys; sys.path.insert(0, '${BOUNDS_SAFETY_LLDB_PYTHON_PATH}'); import lldb"
-      RESULT_VARIABLE _LLDB_IMPORT_RESULT
-      ERROR_VARIABLE _LLDB_IMPORT_ERROR
-      OUTPUT_QUIET
-    )
-    if(_LLDB_IMPORT_RESULT EQUAL 0)
-      set(_LLDB_PYTHON_COMPATIBLE TRUE)
-    endif()
+foreach(_cand ${_lldb_candidates})
+  if(NOT EXISTS "${_cand}")
+    continue()
   endif()
+  execute_process(
+    COMMAND ${_cand} -P
+    OUTPUT_VARIABLE _cand_py_path
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _cand_p_result
+  )
+  if(NOT _cand_p_result EQUAL 0)
+    continue()
+  endif()
+  set(_LLDB_DETECTED TRUE)
+  # Tear LLDB down with SBDebugger::Terminate() after a successful import. An
+  # assertions-enabled LLDB would otherwise abort at interpreter shutdown.
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c
+      "import sys; sys.path.insert(0, '${_cand_py_path}'); import lldb; lldb.SBDebugger.Terminate()"
+    RESULT_VARIABLE _LLDB_IMPORT_RESULT
+    ERROR_VARIABLE _LLDB_IMPORT_ERROR
+    OUTPUT_QUIET
+  )
+  if(_LLDB_IMPORT_RESULT EQUAL 0)
+    set(BOUNDS_SAFETY_LLDB_PYTHON_PATH "${_cand_py_path}")
+    set(_LLDB_PYTHON_COMPATIBLE TRUE)
+    set(_LLDB_EXECUTABLE "${_cand}")
+    break() # First usable candidate wins (just-built first in AUTO).
+  endif()
+endforeach()
+
+# In ON mode the just-built LLDB is the only candidate. If it isn't usable, warn
+# (rather than error) so we preserve COMPILER_RT_BOUNDS_SAFETY_USE_LLDB's graceful
+# behavior: it then auto-defaults OFF and disables the debugger suites, unless the
+# user explicitly set it ON, in which case the checks below turn this into an error.
+if(COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB STREQUAL "ON" AND
+   NOT _LLDB_PYTHON_COMPATIBLE)
+  message(WARNING
+    "COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB=ON but the just-built LLDB "
+    "(${_just_built_lldb}) is not usable with the Python interpreter used by "
+    "lit (${Python3_EXECUTABLE}).\n"
+    "This usually means the just-built LLDB was not built (is lldb in "
+    "LLVM_ENABLE_PROJECTS and LLDB_ENABLE_PYTHON enabled?) or it targets a "
+    "different Python version than ${Python3_EXECUTABLE}.\n"
+    "Import error: ${_LLDB_IMPORT_ERROR}")
 endif()
 
 # CMake option: defaults to ON if LLDB detected AND the Python interpreter
@@ -65,7 +135,9 @@ if(COMPILER_RT_BOUNDS_SAFETY_USE_LLDB AND NOT _LLDB_PYTHON_COMPATIBLE)
 endif()
 
 if (COMPILER_RT_BOUNDS_SAFETY_USE_LLDB)
-  message(STATUS "Enabled -fbounds-safety tests using LLDB: ${BOUNDS_SAFETY_LLDB_PYTHON_PATH}")
+  message(STATUS "Enabled -fbounds-safety tests using LLDB:\n"
+    "LLDB Python bindings: ${BOUNDS_SAFETY_LLDB_PYTHON_PATH}\n"
+    "LLDB executable: ${_LLDB_EXECUTABLE}")
 else()
   message(STATUS "Disabled -fbounds-safety tests using LLDB")
 endif()

--- a/compiler-rt/test/bounds_safety/scripts/lldb_utils.py
+++ b/compiler-rt/test/bounds_safety/scripts/lldb_utils.py
@@ -1,10 +1,15 @@
 """Shared utilities for bounds-safety test scripts."""
 
+import atexit
 import logging
 import os
 import sys
+import threading
 
 log = logging.getLogger(__name__)
+# Used to serialize `import_lldb`
+_import_lock = threading.Lock()
+_terminate_registered = False
 
 
 class LLDBLaunchError(Exception):
@@ -14,24 +19,47 @@ class LLDBLaunchError(Exception):
 
 def import_lldb(lldb_python_path):
     """Import and return the lldb module, adjusting sys.path if needed.
+
+    Thread-safe: concurrent calls are serialized so the shared sys.path
+    mutation and the one-time process teardown registration cannot race.
     """
-    if lldb_python_path:
-        sys.path.insert(0, lldb_python_path)
-    import lldb
-    # The interpreter running these scripts may already have an unrelated `lldb`
-    # module installed (e.g. one shipped in the toolchain's site-packages for a
-    # different LLDB). Inserting lldb_python_path at the front of sys.path makes
-    # our copy win, but to be sure we didn't silently pick up a different one we
-    # verify the imported module actually lives under lldb_python_path.
-    if lldb_python_path:
-        expected = os.path.realpath(lldb_python_path)
-        actual = os.path.realpath(lldb.__file__)
-        if os.path.commonpath([expected, actual]) != expected:
-            raise LLDBLaunchError(
-                f"imported the wrong lldb module: expected it under '{expected}' but "
-                f"loaded '{lldb.__file__}'. Another lldb may be installed earlier on "
-                "sys.path."
-            )
+    global _terminate_registered
+    with _import_lock:
+        if lldb_python_path:
+            sys.path.insert(0, lldb_python_path)
+        import lldb
+        # The interpreter running these scripts may already have an unrelated
+        # `lldb` module installed (e.g. one shipped in the toolchain's
+        # site-packages for a different LLDB). Inserting lldb_python_path at the
+        # front of sys.path makes our copy win, but to be sure we didn't
+        # silently pick up a different one we verify the imported module
+        # actually lives under lldb_python_path.
+        if lldb_python_path:
+            expected = os.path.realpath(lldb_python_path)
+            actual = os.path.realpath(lldb.__file__)
+            if os.path.commonpath([expected, actual]) != expected:
+                raise LLDBLaunchError(
+                    f"imported the wrong lldb module: expected it under '{expected}' but "
+                    f"loaded '{lldb.__file__}'. Another lldb may be installed earlier on "
+                    "sys.path."
+                )
+
+        if not _terminate_registered:
+            # SBDebugger.Terminate() is the process-global counterpart to the
+            # SBDebugger.Initialize() that the lldb Python module runs at import
+            # time (lldb.py runs `SBDebugger.Initialize()` at module scope),
+            # which registers all plugins. It must run once, at process exit,
+            # after all debuggers are destroyed; otherwise an assertions-enabled
+            # LLDB aborts at shutdown with:
+            #
+            #   Assertion failed: (m_instances.empty() && "forgot to unregister
+            #   plugin?").
+            #
+            # atexit runs before the LLDB library's static plugin-instance
+            # destructors, so registering it here is sufficient.
+            atexit.register(lldb.SBDebugger.Terminate)
+            _terminate_registered = True
+
     return lldb
 
 
@@ -85,12 +113,11 @@ class LLDBProcessContextManager:
             )
 
     def _cleanup(self):
-        """Kill the process (if any) and tear LLDB down cleanly.
+        """Kill the process (if any) and destroy this instance's debugger.
 
-        The Terminate() call is important: without it, an assertions-enabled
-        LLDB (e.g. a just-built in-tree lldb) aborts at interpreter shutdown
-        with "forgot to unregister plugin?", turning a passing test into a
-        spurious failure.
+        The process-global SBDebugger.Terminate() teardown is handled separately
+        via an atexit handler registered in import_lldb(); it must not run here
+        because it is a once-per-process operation.
         """
         if self.process is not None:
             try:
@@ -105,17 +132,6 @@ class LLDBProcessContextManager:
             except Exception:
                 pass
             self.debugger = None
-            try:
-                # Needed to avoid an assertion in LLDB:
-                #
-                # Assertion failed: (m_instances.empty() && "forgot to unregister plugin?").
-                #
-                # FIXME: Technically this shouldn't be here because it prevents
-                # using this class multiple times in a script but right now this
-                # is the most convenient place to put this.
-                self._lldb.SBDebugger.Terminate()
-            except Exception:
-                pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._cleanup()

--- a/compiler-rt/test/bounds_safety/scripts/lldb_utils.py
+++ b/compiler-rt/test/bounds_safety/scripts/lldb_utils.py
@@ -1,6 +1,7 @@
 """Shared utilities for bounds-safety test scripts."""
 
 import logging
+import os
 import sys
 
 log = logging.getLogger(__name__)
@@ -12,10 +13,25 @@ class LLDBLaunchError(Exception):
 
 
 def import_lldb(lldb_python_path):
-    """Import and return the lldb module, adjusting sys.path if needed."""
+    """Import and return the lldb module, adjusting sys.path if needed.
+    """
     if lldb_python_path:
         sys.path.insert(0, lldb_python_path)
     import lldb
+    # The interpreter running these scripts may already have an unrelated `lldb`
+    # module installed (e.g. one shipped in the toolchain's site-packages for a
+    # different LLDB). Inserting lldb_python_path at the front of sys.path makes
+    # our copy win, but to be sure we didn't silently pick up a different one we
+    # verify the imported module actually lives under lldb_python_path.
+    if lldb_python_path:
+        expected = os.path.realpath(lldb_python_path)
+        actual = os.path.realpath(lldb.__file__)
+        if os.path.commonpath([expected, actual]) != expected:
+            raise LLDBLaunchError(
+                f"imported the wrong lldb module: expected it under '{expected}' but "
+                f"loaded '{lldb.__file__}'. Another lldb may be installed earlier on "
+                "sys.path."
+            )
     return lldb
 
 
@@ -45,6 +61,10 @@ class LLDBProcessContextManager:
 
         self.target = self.debugger.CreateTarget(self._binary)
         if not self.target:
+            # Tear down before raising: __exit__ is not called when __enter__
+            # raises, so without this the debugger created above would leak and
+            # an assertions-enabled LLDB would abort at interpreter shutdown.
+            self._cleanup()
             raise LLDBLaunchError(
                 "could not create target for '{}'".format(self._binary)
             )
@@ -64,11 +84,40 @@ class LLDBProcessContextManager:
                 "could not launch process: {}".format(error)
             )
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def _cleanup(self):
+        """Kill the process (if any) and tear LLDB down cleanly.
+
+        The Terminate() call is important: without it, an assertions-enabled
+        LLDB (e.g. a just-built in-tree lldb) aborts at interpreter shutdown
+        with "forgot to unregister plugin?", turning a passing test into a
+        spurious failure.
+        """
         if self.process is not None:
             try:
                 if self.process.is_alive:
                     self.process.Kill()
             except Exception:
                 pass
+            self.process = None
+        if self.debugger is not None:
+            try:
+                self._lldb.SBDebugger.Destroy(self.debugger)
+            except Exception:
+                pass
+            self.debugger = None
+            try:
+                # Needed to avoid an assertion in LLDB:
+                #
+                # Assertion failed: (m_instances.empty() && "forgot to unregister plugin?").
+                #
+                # FIXME: Technically this shouldn't be here because it prevents
+                # using this class multiple times in a script but right now this
+                # is the most convenient place to put this.
+                self._lldb.SBDebugger.Terminate()
+            except Exception:
+                pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._cleanup()
         return False
+

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -543,6 +543,31 @@ if(build_runtimes)
     endif()
   endif()
 
+  # TO_UPSTREAM(BoundsSafety) ON
+  # Ensure a just-built lldb (and its python bindings) are built before the
+  # runtimes configure step runs `lldb -P`, so compiler-rt's bounds-safety tests
+  # can use the in-tree lldb. lldb is already built when it is in
+  # LLVM_ENABLE_PROJECTS.
+  set(_compiler_rt_is_runtime FALSE)
+  if("compiler-rt" IN_LIST LLVM_ENABLE_RUNTIMES)
+    set(_compiler_rt_is_runtime TRUE)
+  else()
+    foreach(target ${LLVM_RUNTIME_TARGETS})
+      if("compiler-rt" IN_LIST RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES)
+        set(_compiler_rt_is_runtime TRUE)
+        break()
+      endif()
+    endforeach()
+  endif()
+  if(_compiler_rt_is_runtime)
+    foreach(dep lldb lldb-python)
+      if(TARGET ${dep})
+        list(APPEND extra_deps ${dep})
+      endif()
+    endforeach()
+  endif()
+  # TO_UPSTREAM(BoundsSafety) OFF
+
   # Forward user-provived system configuration to runtimes for requirement introspection.
   # CMAKE_PREFIX_PATH is the search path for CMake packages.
   if(CMAKE_PREFIX_PATH)


### PR DESCRIPTION
Previously the -fbounds-safety runtime tests would try to locate the just built LLDB via `find_program(LLDB_EXECUTABLE lldb HINTS ${LLVM_TOOLS_DIR})`. This was wrong in two ways.

1. Nothing enforced that LLDB (and it's python bindings) were built **before** the compiler-rt configure step happens. This could mean the system LLDB could be picked up instead.
2. The correct variable to use is `LLVM_TOOLS_BINARY_DIR` not `LLVM_TOOLS_DIR`.

To fix (1.) additional dependencies on the `lldb` and `lldb-python` targets is added in `llvm/runtimes/CMakeLists.txt` if they exist.

To fix (2.) the correct directory path is used to find the just built LLDB.

To give the user control of which LLDB is used a tri-state cache variable (`COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB`) has been added, that controls which LLDB is used:

* `ON`   - only the just-built (in-tree) LLDB is considered; warn if it
           is unusable.
* `OFF`  - only a system LLDB is considered; the just-built LLDB is
           excluded.
* `AUTO` - (default) consider both, preferring the just-built LLDB and
           falling back to a system LLDB if the just-built one is not
           usable.

The detection logic now tries an ordered list of candidate `lldb` executables according to the mode above and picks the first "usable" one. A candidate is usable when `lldb -P` succeeds AND the Python interpreter used by lit (`${Python3_EXECUTABLE}`) can import the `lldb` module from that path. The just-built LLDB is taken from `${LLVM_TOOLS_BINARY_DIR}/lldb${CMAKE_EXECUTABLE_SUFFIX}` and a system LLDB is located once via `find_program`. In `AUTO` mode the just-built LLDB is tried first so it wins when both are usable.

In `ON` mode, if the just-built LLDB is not usable we `message(WARNING)` rather than erroring so that the existing graceful behavior of `COMPILER_RT_BOUNDS_SAFETY_USE_LLDB` is preserved (it auto-defaults to `OFF` and disables the debugger suites unless the user explicitly requested it, in which case the existing checks turn this into an error).

This patch also includes some minor changes that were necessary to use the just built LLDB if it had assertions enabled. Without the changes we hit:

```
Assertion failed: (m_instances.empty() && "forgot to unregister plugin?"), function ~PluginInstances, file PluginManager.cpp, line 503
```

so now we call SBDebugger.Terminate() on exit paths to avoid this.

Assisted-by: Claude Code

rdar://178459096