### PR TITLE
[lldb/test] Fix variant double-expansion in LLDBTestCaseFactory

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2016,6 +2016,11 @@ class LLDBTestCaseFactory(type):
             if attrname.startswith("test") and not getattr(
                 attrvalue, "__no_debug_info_test__", False
             ):
+                # Track only the entries created by THIS attrname so that
+                # variant expansion doesn't accidentally double-expand entries
+                # from a sibling test method whose name happens to be a strict
+                # prefix of attrname (e.g. test_foo vs test_foo_bar).
+                this_attr_entries = {}
                 # Create debug info variants unless NO_DEBUG_INFO_TESTCASE
                 if not original_testcase.NO_DEBUG_INFO_TESTCASE:
                     # If any debug info categories were explicitly tagged, assume that list to be
@@ -2064,23 +2069,31 @@ class LLDBTestCaseFactory(type):
                         if skip_reason:
                             test_method = unittest.skip(skip_reason)(test_method)
 
-                        newattrs[method_name] = test_method
+                        this_attr_entries[method_name] = test_method
                 else:
-                    # NO_DEBUG_INFO_TESTCASE — put method in newattrs for variant expansion
-                    newattrs[attrname] = attrvalue
+                    # NO_DEBUG_INFO_TESTCASE — put method in this_attr_entries
+                    # for variant expansion.
+                    this_attr_entries[attrname] = attrvalue
 
-                # Expand test variants (e.g. swift clang/noclang)
+                # Expand test variants (e.g. swift clang/noclang) only on the
+                # entries we just created for this attrname, not on the whole
+                # newattrs dict (which would double-expand sibling methods
+                # whose names share a prefix).
                 for variant in _test_variants:
                     if variant.should_expand(attrvalue):
                         xfail_fns = getattr(attrvalue, "__variant_xfail__", {})
                         skip_fns = getattr(attrvalue, "__variant_skip__", {})
-                        newattrs = _expand_test_variants(
+                        this_attr_entries = _expand_test_variants(
                             attrname,
-                            newattrs,
+                            this_attr_entries,
                             variant,
                             xfail_fns=xfail_fns,
                             skip_fns=skip_fns,
                         )
+
+                # Merge this attrname's variant-expanded entries into
+                # newattrs.
+                newattrs.update(this_attr_entries)
 
             else:
                 newattrs[attrname] = attrvalue

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    @skipEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -37,6 +37,7 @@ class TestSwiftRegex(TestBase):
         self.expect('frame var dslRegex',
                     substrs=['(_StringProcessing.Regex<Substring>) dslRegex = {'])
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_expr_desc(self):


### PR DESCRIPTION
LLDBTestCaseFactory generates the actual test methods that get run: for every `test*` method on a TestBase subclass, it stamps out one copy per debug-info format (dwarf, dsym, ...) and, if a variant like swift_clang's clang/noclang is registered, one copy per variant value on top. When two test methods in the same class have names that share a prefix and the longer one is declared first in the file, the shorter method's expansion ends up re-stamping every copy already produced for the longer one.

The variant-expansion helper decides what to copy by name-prefix match: when processing `test_expr`, it grabs `test_expr`, `test_expr_dwarf`, `test_expr_dsym`, ... and produces a clang/noclang suffix for each one. The factory was handing it the full running dict of already-synthesized methods, so by the time `test_expr`'s turn came, the dict also held `test_expr_stripped_dwarf` and `test_expr_stripped_dsym` from `test_expr_stripped`. Those names start with `test_expr_` too, so they pick up a second clang/noclang suffix and inherit `test_expr`'s xfail/skip predicates.

HiddenIvarsTestCase trips this twice in a row (test_expr_stripped before test_expr; test_frame_variable_stripped before test_frame_variable). Upstream `_test_variants` is empty so the bug is latent on mainline, but any registered variant exposes it.

With swift_clang (values clang/noclang) registered, test_expr_stripped + test_expr should produce eight methods (4 dwarf/dsym × 2 clang/noclang per original). Before this patch the factory emits twelve, four of them junk:

```
  test_expr_stripped_dsym_clang_clang
  test_expr_stripped_dsym_clang_noclang
  test_expr_stripped_dsym_noclang_clang
  test_expr_stripped_dsym_noclang_noclang
  test_expr_stripped_dwarf_clang_clang
  test_expr_stripped_dwarf_clang_noclang
  test_expr_stripped_dwarf_noclang_clang
  test_expr_stripped_dwarf_noclang_noclang
  test_expr_dsym_clang
  test_expr_dsym_noclang
  test_expr_dwarf_clang
  test_expr_dwarf_noclang
```

Track each method's expansion in a local dict and merge it back into the shared dict only once that method is fully processed, so the variant helper never sees another method's copies.

(cherry picked from commit 94337fb6b2d5935cdaa9abecdba8274924119dcc)