### PR TITLE
[lldb/test] Fix NameError in BuilderDarwin.getSwiftTargetFlags

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -78,8 +78,11 @@ class BuilderDarwin(Builder):
             arch = configuration.arch
         if not arch:
             return []
-        vendor, os, version, env = get_triple()
-        if vendor is None or os is None or version is None or env is None:
+        triple = self.getTriple()
+        if not triple:
+            return []
+        _, vendor, os, version, env = split_triple(triple)
+        if vendor is None or os is None or version is None:
             return []
         return [
             'TARGET_SWIFTFLAGS=-target {}-{}-{}{}{}'.format(


### PR DESCRIPTION
The upstream "Rally around triple rather than arch in the API tests" change (f5e2b8b1df07, llvm/llvm-project#192818) removed the helper get_triple() and rewrote BuilderDarwin to query self.getTriple() and split it with the new split_triple() helper. getSwiftTargetFlags is swift-only and wasn't visible to that PR, so it merged in with a dangling get_triple() reference. Every test that calls self.build() on Darwin now crashes with NameError: name 'get_triple' is not defined.

Reach the triple the same way the sibling methods do post-rally (self.getTriple() + split_triple()), and drop the `env is None` guard -- env is already handled by the format string's `("-" + env) if env else ""`, so a missing env just produces no trailing `-env` suffix. The other three components are still guarded because they're interpolated unconditionally.