### PR TITLE
[Cherry-pick into swift/release/6.4.x] [LLDB] Add always-on logging for "settings set"  (#201185)

### DIFF
--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -10,6 +10,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include "lldb/Host/Host.h"
 #include "lldb/Host/OptionParser.h"
 #include "lldb/Interpreter/CommandCompletions.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
@@ -191,6 +192,8 @@ protected:
           "'settings set' command requires a valid variable name");
       return;
     }
+
+    LLDB_LOG(GetLog(SystemLog::System), "settings set {0}", command);
 
     // A missing value corresponds to clearing the setting when "force" is
     // specified.


### PR DESCRIPTION
```
commit 7d2dce084307356948a3ef78c902fd68558afe2e
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Jun 2 12:49:49 2026 -0700

    [LLDB] Add always-on logging for "settings set"  (#201185)
    
    When triaging bugreports it can be very useful to understand what LLDB
    defaults have been changed. Adding settings to the always-on logging
    channel helps with that.
    
    rdar://176482205
    
    Assisted-by: claude
```
