### PR TITLE
[lldb] Rewrite illformed Swift address-to-type casts

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -743,10 +743,10 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
 /// This supports casting expressions users may try when wanting the object
 /// represented by a raw address.
 static std::optional<std::string> ApplyLLDBCastFixIts(StringRef expr_text) {
-  llvm::Regex cast_regex("(0[xX][0-9a-fA-F]{4,})"
-                         "[[:space:]]+"
-                         "as[?!]?[[:space:]]+"
-                         "([[:alpha:]_][[:alnum:]_.]*)");
+  static llvm::Regex cast_regex("(0[xX][0-9a-fA-F]{4,})"
+                                "[[:space:]]+"
+                                "as[?!]?[[:space:]]+"
+                                "([[:alpha:]_][[:alnum:]_.]*)");
 
   llvm::SmallVector<StringRef, 3> matches;
   if (!cast_regex.match(expr_text, &matches))

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -763,7 +763,7 @@ static std::optional<std::string> ApplyLLDBCastFixIts(StringRef expr_text) {
     // Don't rewrite valid casts such as `0xABCDEF as UInt32`
     return std::nullopt;
 
-  // The substitution must preserve the boundary character (capture group 1).
+  // The substitution must preserve any boundary character (capture group 1).
   return cast_regex.sub("\\1unsafeBitCast(\\2, to: \\3.self)", expr_text);
 }
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -32,6 +32,7 @@
 #include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/RegularExpression.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/Timer.h"
 #include "lldb/ValueObject/ValueObject.h"
@@ -42,9 +43,11 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
 #include "swift/Demangling/Demangler.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 
 #include <map>
+#include <optional>
 #include <string>
 #if HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -730,6 +733,37 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
   return parse_result;
 }
 
+/// Rewrite invalid cast expressions.
+///
+/// A substring matching:
+///     <hex-literal> as[?!]? <Type>
+/// will be substituted with:
+///     unsafeBitCast(<hex-literal>, to: <Type>.self)
+///
+/// This supports casting expressions users may try when wanting the object
+/// represented by a raw address.
+static std::optional<std::string> ApplyLLDBCastFixIts(StringRef expr_text) {
+  llvm::Regex cast_regex("(0[xX][0-9a-fA-F]{4,})"
+                         "[[:space:]]+"
+                         "as[?!]?[[:space:]]+"
+                         "([[:alpha:]_][[:alnum:]_.]*)");
+
+  llvm::SmallVector<StringRef, 3> matches;
+  if (!cast_regex.match(expr_text, &matches))
+    return std::nullopt;
+
+  constexpr static llvm::StringRef swift_numeric_type_names[] = {
+      "Int",     "Int8",    "Int16",   "Int32",  "Int64",  "UInt",
+      "UInt8",   "UInt16",  "UInt32",  "UInt64", "Float",  "Float16",
+      "Float32", "Float64", "Float80", "Double", "CGFloat"};
+  StringRef type_name = matches[2];
+  if (llvm::is_contained(swift_numeric_type_names, type_name))
+    // Don't rewrite valid casts such as `0xABCDEF as UInt32`
+    return std::nullopt;
+
+  return cast_regex.sub("unsafeBitCast(\\1, to: \\2.self)", expr_text);
+}
+
 /// If `sc` represents a "closure-like" function according to `lang`, and
 /// `var_name` can be found in a parent context, create a diagnostic
 /// explaining that this variable is available but not captured by the closure.
@@ -901,6 +935,12 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
   //
   // Generate the expression.
   //
+
+  // Apply LLDB-specific expression rewrites before compilation.
+  if (auto rewritten = ApplyLLDBCastFixIts(m_expr_text)) {
+    m_fixed_text = *rewritten;
+    m_expr_text = std::move(*rewritten);
+  }
 
   std::string prefix = m_expr_prefix;
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -743,12 +743,14 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
 /// This supports casting expressions users may try when wanting the object
 /// represented by a raw address.
 static std::optional<std::string> ApplyLLDBCastFixIts(StringRef expr_text) {
-  static llvm::Regex cast_regex("(0[xX][0-9a-fA-F]{4,})"
-                                "[[:space:]]+"
-                                "as[?!]?[[:space:]]+"
-                                "([[:alpha:]_][[:alnum:]_.]*)");
+  static llvm::Regex cast_regex(
+      "(^|[^[:alnum:]_])"      // capture 1: boundary preceeding address
+      "(0[xX][0-9a-fA-F]{4,})" // capture 2: address
+      "[[:space:]]+"
+      "as[?!]?[[:space:]]+"
+      "([[:alpha:]_][[:alnum:]_.]*)"); // capture 3: class name
 
-  llvm::SmallVector<StringRef, 3> matches;
+  llvm::SmallVector<StringRef, 4> matches;
   if (!cast_regex.match(expr_text, &matches))
     return std::nullopt;
 
@@ -756,12 +758,13 @@ static std::optional<std::string> ApplyLLDBCastFixIts(StringRef expr_text) {
       "Int",     "Int8",    "Int16",   "Int32",  "Int64",  "UInt",
       "UInt8",   "UInt16",  "UInt32",  "UInt64", "Float",  "Float16",
       "Float32", "Float64", "Float80", "Double", "CGFloat"};
-  StringRef type_name = matches[2];
+  StringRef type_name = matches[3];
   if (llvm::is_contained(swift_numeric_type_names, type_name))
     // Don't rewrite valid casts such as `0xABCDEF as UInt32`
     return std::nullopt;
 
-  return cast_regex.sub("unsafeBitCast(\\1, to: \\2.self)", expr_text);
+  // The substitution must preserve the boundary character (capture group 1).
+  return cast_regex.sub("\\1unsafeBitCast(\\2, to: \\3.self)", expr_text);
 }
 
 /// If `sc` represents a "closure-like" function according to `lang`, and

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -121,3 +121,10 @@ class TestSwiftFixIts(TestBase):
             ret.GetError(), r"\(unsafeBitCast\(.+, to: SomeClass.self\)\).value"
         )
         self.assertIn(" = 42", ret.GetOutput())
+
+        # Test a legitimate cast.
+        ret = lldb.SBCommandReturnObject()
+        self.ci.HandleCommand(f"expression 0x1234 as Float", ret)
+        self.assertTrue(ret.Succeeded())
+        self.assertNotIn("unsafeBitCast", ret.GetError())
+        self.assertIn(" = 4660", ret.GetOutput())

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -97,3 +97,27 @@ class TestSwiftFixIts(TestBase):
         tmp_value = frame.EvaluateExpression("$tmp2 == 7")
         self.assertSuccess(tmp_value.GetError())
         self.assertTrue(tmp_value.GetSummary() == 'true')
+
+        obj_value = frame.var("obj")
+        self.assertSuccess(obj_value.GetError())
+        obj_addr = obj_value.GetValueAsUnsigned()
+        self.assertNotEqual(obj_addr, 0)
+
+        # Test LLDB-specific casting rewrites.
+        for op in ("as", "as?", "as!"):
+            ret = lldb.SBCommandReturnObject()
+            self.ci.HandleCommand(f"expression 0x{obj_addr:x} {op} SomeClass", ret)
+            self.assertTrue(ret.Succeeded())
+            errors = ret.GetError()
+            self.assertIn("Evaluated this expression after applying Fix-It(s):", errors)
+            self.assertRegex(errors, r"unsafeBitCast\(.+, to: SomeClass.self\)")
+
+        # Test LLDB-specific casting rewrite where the cast is a substring of a
+        # larger expression, in this case a cast followed by property access.
+        ret = lldb.SBCommandReturnObject()
+        self.ci.HandleCommand(f"expression (0x{obj_addr:x} as SomeClass).value", ret)
+        self.assertTrue(ret.Succeeded())
+        self.assertRegex(
+            ret.GetError(), r"\(unsafeBitCast\(.+, to: SomeClass.self\)\).value"
+        )
+        self.assertIn(" = 42", ret.GetOutput())

--- a/lldb/test/API/lang/swift/fixits/main.swift
+++ b/lldb/test/API/lang/swift/fixits/main.swift
@@ -14,6 +14,10 @@ class Wrapper {
   let wrapped = 7
 }
 
+class SomeClass {
+  let value = 42
+}
+
 class HasOptional
 {
     var could_be : Int?
@@ -39,10 +43,11 @@ class HasOptional
     }
 }
 
-func main() -> Int 
+func main() -> Int
 {
     let does_have = HasOptional(input: 100)
     let wrapper: Wrapper? = Wrapper()
+    let obj = SomeClass()
     print ("\(does_have.returnIt()): break here to test fixits.")
     return 0
 }


### PR DESCRIPTION
Rewrite invalid cast expressions of the form `<hex-addr> as[?!]? <Type>`. The substring is replaced with `unsafeBitCast(<hex-addr>, to: <Type>.self)`, before evaluating. Pre-applying is done to handle `as?` casts, which otherwise succeed with no diagnostics (producing a result of `nil`). Without a diagnostic, there's no opportunity to attach a fix-it.

Using an `as` cast is an approach users sometimes use when they want to access an object for which they have the raw address. Example output:

```
(lldb) expression 0x10185dcb0 as? Player
(main.Player) $R2 = 0x000000010185dcb0 {
  number = 23
}
  Evaluated this expression after applying Fix-It(s):
    unsafeBitCast(0x10185dcb0, to: Player.self)
```

The rewrite is skipped for known Swift numeric types (`Int`, `Double`, etc.) and requires at least 4 hex digits to avoid false positives on small integer constants.

rdar://136310363

Assisted-by: claude