### PR TITLE
[clang][CAS] Remove `FileManager::GetUniqueIDMapping()` usage

### DIFF
--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -128,10 +128,6 @@ private:
   llvm::PrefixMapper &PrefixMapper;
 
   std::optional<cas::ObjectRef> PCHRef;
-  bool StartedEnteringIncludes = false;
-  // When a PCH is used this lists the filenames of the included files as they
-  // are recorded in the PCH, ordered by \p FileEntry::UID index.
-  SmallVector<StringRef> PreIncludedFileNames;
   llvm::BitVector SeenIncludeFiles;
   SmallVector<cas::IncludeTree::FileList::FileEntry> IncludedFiles;
   SmallVector<cas::ObjectRef> IncludedFileLists;
@@ -493,26 +489,6 @@ bool IncludeTreeActionController::finalizeModuleInvocation(
 void IncludeTreeBuilder::enteredInclude(Preprocessor &PP, FileID FID) {
   if (hasErrorOccurred())
     return;
-
-  if (!StartedEnteringIncludes) {
-    StartedEnteringIncludes = true;
-
-    if (!PP.getIncludedFiles().empty()) {
-      SmallVector<OptionalFileEntryRef> UIDToFE;
-      PP.getFileManager().GetUniqueIDMapping(UIDToFE);
-
-      // Get the included files (coming from a PCH), and keep track of the
-      // filenames that were recorded in the PCH.
-      for (const FileEntry *FE : PP.getIncludedFiles()) {
-        unsigned UID = FE->getUID();
-        if (UID >= PreIncludedFileNames.size())
-          PreIncludedFileNames.resize(UID + 1);
-        OptionalFileEntryRef FERef = UIDToFE[FE->getUID()];
-        assert(FERef && "No FileEntryRef with given UID");
-        PreIncludedFileNames[UID] = FERef->getName();
-      }
-    }
-  }
 
   std::optional<cas::ObjectRef> FileRef = check(getObjectForFile(PP, FID));
   if (!FileRef)
@@ -949,16 +925,6 @@ Expected<cas::ObjectRef> IncludeTreeBuilder::addToFileList(FileManager &FM,
          static_cast<cas::IncludeTree::FileList::FileSizeTy>(FE.getSize())});
     return FileNode->getRef();
   };
-
-  // Check whether another path coming from the PCH is associated with the same
-  // file.
-  unsigned UID = FE.getUID();
-  if (UID < PreIncludedFileNames.size() && !PreIncludedFileNames[UID].empty() &&
-      PreIncludedFileNames[UID] != Filename) {
-    auto FileNode = addFile(PreIncludedFileNames[UID]);
-    if (!FileNode)
-      return FileNode.takeError();
-  }
 
   return addFile(Filename);
 }


### PR DESCRIPTION
The include-tree code in question was added in https://github.com/swiftlang/llvm-project/commit/296b4da4 to handle different spellings of the same header between a TU and a PCH. Since then, two changes occurred:
1. Thanks to the push to adopt `FileEntryRef`, `IncludeTreeBuilder::addToFileList()` now knows with certainty the spelling that was used for the given file, removing the need to cross-check with the spelling used in a PCH.
2. Included files are deserialized from the PCH on-demand, meaning at the first include, `PP.getIncludedFiles()` is guaranteed to be empty.

This makes the code in question essentially dead. Until recently (https://github.com/swiftlang/llvm-project/pull/12989), it has been only a performance issue, but with https://github.com/llvm/llvm-project/pull/200968 this becomes the only user of the to-be-deleted `FileManager::GetUniqueIDMapping()`.

This PR removes the mechanism, allowing removal of the expensive `FileManager` API upstream, and cleaning up the include-tree code.