### PR TITLE
[lldb] Add lldb-mcp to LLVM_DISTRIBUTION_COMPONENTS (#201225)

### DIFF
--- a/lldb/cmake/caches/Apple-lldb-macOS.cmake
+++ b/lldb/cmake/caches/Apple-lldb-macOS.cmake
@@ -23,6 +23,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   liblldb
   lldb-argdumper
   lldb-dap
+  lldb-mcp
   darwin-debug
   debugserver
   repl_swift


### PR DESCRIPTION
Add lldb-mcp to LLVM_DISTRIBUTION_COMPONENTS

(cherry picked from commit 155c6e4f887a9b4fb8900ec655124303e7308b4b)