### PR TITLE
[clang][test] Fix unit test build after bad merge

### DIFF
--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -518,9 +518,9 @@ TEST_F(FileManagerTest, TraceCount) {
   FileSystemOptions Opts;
   FileManager Manager(Opts, InstrumentingFS);
 
-  llvm::vfs::Status Status;
-  Manager.getOptionalFileEntryRef("/foo");
-  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 1u);
+  // One status call for "/foo" itself, the other for the parent directory.
+  Manager.getOptionalFileRef("/foo");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 2u);
 
   Manager.getBufferForFile("/foo");
   EXPECT_EQ(InstrumentingFS->NumOpenFileForReadCalls, 1u);


### PR DESCRIPTION
This test was added in ac3d6ecc, but used function that's been removed upstream in https://github.com/llvm/llvm-project/pull/198411. The merge conflict resolution does not compile and the test expectation needed updating too.