### PR TITLE
[lldb/test] Pick the right asan runtime by target platform in TestSwiftAsan

### DIFF
--- a/lldb/test/API/functionalities/asan/swift/Makefile
+++ b/lldb/test/API/functionalities/asan/swift/Makefile
@@ -1,8 +1,38 @@
 
 SWIFT_SOURCES := main.swift
 
+# Pick the matching asan runtime variant for the test's target platform.
+# CLANG_RT_DIR is defined in Makefile.rules and resolves to the directory
+# containing the platform-specific clang_rt asan dylibs.
+ASAN_RT_NAME := asan_osx_dynamic
+ifneq "$(findstring -apple-ios,$(TARGET_SWIFTFLAGS))" ""
+  ifneq "$(findstring simulator,$(TARGET_SWIFTFLAGS))" ""
+    ASAN_RT_NAME := asan_iossim_dynamic
+  else
+    ASAN_RT_NAME := asan_ios_dynamic
+  endif
+else ifneq "$(findstring -apple-tvos,$(TARGET_SWIFTFLAGS))" ""
+  ifneq "$(findstring simulator,$(TARGET_SWIFTFLAGS))" ""
+    ASAN_RT_NAME := asan_tvossim_dynamic
+  else
+    ASAN_RT_NAME := asan_tvos_dynamic
+  endif
+else ifneq "$(findstring -apple-watchos,$(TARGET_SWIFTFLAGS))" ""
+  ifneq "$(findstring simulator,$(TARGET_SWIFTFLAGS))" ""
+    ASAN_RT_NAME := asan_watchossim_dynamic
+  else
+    ASAN_RT_NAME := asan_watchos_dynamic
+  endif
+else ifneq "$(findstring -apple-xros,$(TARGET_SWIFTFLAGS))" ""
+  ifneq "$(findstring simulator,$(TARGET_SWIFTFLAGS))" ""
+    ASAN_RT_NAME := asan_xrossim_dynamic
+  else
+    ASAN_RT_NAME := asan_xros_dynamic
+  endif
+endif
+
 # Note the lazy variable setting - needs to use CLANG_RT_DIR, defined in Makefile.rules
-asan: LD_EXTRAS = -lclang_rt.asan_osx_dynamic -L$(CLANG_RT_DIR)
+asan: LD_EXTRAS = -lclang_rt.$(ASAN_RT_NAME) -L$(CLANG_RT_DIR)
 asan: SWIFTFLAGS += -sanitize=address
 asan: all
 


### PR DESCRIPTION
The TestSwiftAsan Makefile hardcoded -lclang_rt.asan_osx_dynamic, so linking against an iOS / tvOS / watchOS / visionOS target picks up the macOS asan runtime and ld errors out with "libclang_rt.asan_osx_dynamic.dylib built for 'macOS'" while building for the device.

Detect the target platform from TARGET_SWIFTFLAGS and select the matching asan_<plat>(sim)_dynamic variant. Defaults to asan_osx_dynamic when no Apple non-macOS target is specified.