### PR TITLE
[lldb/test] Skip excluded variant combinations in LLDBTestCaseFactory

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1931,6 +1931,8 @@ def _expand_test_variants(attrname, methods, variant, xfail_fns, skip_fns):
             expanded[method_name] = method
             continue
         for value_name in variant.get_enabled_values():
+            if _is_excluded_variant_combination(method, variant.name, value_name):
+                continue
             new_name = method_name + "_" + value_name
 
             @decorators.add_test_categories([value_name])
@@ -1985,9 +1987,37 @@ _test_variants = [
         values=test_categories.embedded_swift_categories,
         predicate=lambda m: getattr(m, "__swift_test__", False),
         setup_fn=_embedded_swift_setup,
-        attrs_to_preserve=("debug_info",),
+        attrs_to_preserve=("debug_info", "swift_module_importer"),
     ),
 ]
+
+
+# Variant value combinations that should never be generated. Each entry maps
+# `variant_name -> value`; a method copy is dropped when its already-set
+# variant attributes plus the new value being added match every key in the
+# entry. Add entries here for crosses that don't exercise anything new and
+# would only inflate the matrix on remote test runs.
+_excluded_variant_combinations = [
+    # Embedded Swift doesn't go through the ClangImporter, so toggling the
+    # importer setting doesn't change anything observable; skip the noclang
+    # cross to halve the embedded variant count.
+    {"swift_module_importer": "noclang", "swift_embedded": "swiftembed"},
+]
+
+
+def _is_excluded_variant_combination(method, variant_name, value_name):
+    """Return True if assigning *variant_name=value_name* to *method* would
+    produce a combination listed in `_excluded_variant_combinations`."""
+    for combo in _excluded_variant_combinations:
+        if combo.get(variant_name) != value_name:
+            continue
+        if all(
+            getattr(method, k, None) == v
+            for k, v in combo.items()
+            if k != variant_name
+        ):
+            return True
+    return False
 
 
 class LLDBTestCaseFactory(type):


### PR DESCRIPTION
LLDBTestCaseFactory fans every `@swiftTest` method along three axes (`debug_info` × `swift_module_importer` × `swift_embedded`), producing 12 copies per method (or 4 with `NO_DEBUG_INFO_TESTCASE`). For instance, Embedded Swift can use ClangImporter, but we don't think that we are adding interesting coverage by having an embedded vs regular no-clangimporter variant, so effectively, the `noclang` × `swiftembed` quadrant is redundant with `clang` × `swiftembed`.

Add `_excluded_variant_combinations`, a list of variant-value dicts that the expansion helper consults before generating each copy, and seed it with `noclang × swiftembed`. Also add `swift_module_importer` to the `swift_embedded` variant's `attrs_to_preserve` so the exclusion check has the prior variant's value to look at when expanding.

Across the 395 swift API test classes this drops the generated test count from 6,176 to 4,633 (-1,543, -25%), which is meaningful on remote-device runs where the per-variant overhead dominates wall time. Adding more excluded crosses later is a one-line append.