### PR TITLE
[sanitizer_common] Add llvm_sanitizer_report_global for crash reporting

### DIFF
--- a/compiler-rt/lib/asan/CMakeLists.txt
+++ b/compiler-rt/lib/asan/CMakeLists.txt
@@ -16,6 +16,7 @@ set(ASAN_SOURCES
   asan_interceptors_memintrinsics.cpp
   asan_linux.cpp
   asan_mac.cpp
+  asan_mac_crashreport.cpp  # TO_UPSTREAM(crashreporter_global)
   asan_malloc_linux.cpp
   asan_malloc_mac.cpp
   asan_malloc_win.cpp

--- a/compiler-rt/lib/asan/asan_mac_crashreport.cpp
+++ b/compiler-rt/lib/asan/asan_mac_crashreport.cpp
@@ -1,0 +1,139 @@
+//===-- asan_mac_crashreport.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// TO_UPSTREAM(crashreporter_global)
+//
+// Darwin-only adapter that translates the current ASan error into the
+// llvm_sanitizer_report_global crash-reporter payload using the public
+// asan_interface.h accessors.
+//
+// We collect every address the public interface can hand out for the
+// current report (the access address plus the dealloc/src/dest/first/second
+// accessors), dedupe, classify each via __asan_locate_address, and for
+// heap-resident addresses pull the allocation / deallocation stacks via
+// __asan_get_alloc_stack / __asan_get_free_stack.
+//
+// Failing stacks (the offending op's call stack — second_free, mismatched
+// delete, the offending memory access, etc.) are intentionally not captured
+// here since the crash stack (i.e. to the abort in the ASAN runtime) already
+// captures that.
+//
+//===----------------------------------------------------------------------===//
+
+#include "sanitizer_common/sanitizer_platform.h"
+
+#if SANITIZER_APPLE
+
+#  include <stdint.h>
+
+#  include "sanitizer/asan_interface.h"
+#  include "sanitizer_common/sanitizer_common.h"
+#  include "sanitizer_common/sanitizer_darwin_crashreport.h"
+#  include "sanitizer_common/sanitizer_flags.h"
+
+namespace __asan {
+
+namespace {
+
+constexpr unsigned long kTraceCap = LLVM_SANITIZER_V1_FRAMES_PER_STACK;
+
+using StackVec = InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>;
+
+// Append an alloc and (if present) free stack for a single heap address.
+void AppendStacksForHeapAddr(StackVec &stacks, uptr addr) {
+  void *region_addr = nullptr;
+  uptr region_size = 0;
+  const char *kind = __asan_locate_address(
+      reinterpret_cast<void *>(addr), /*name=*/nullptr, /*name_size=*/0,
+      &region_addr, &region_size);
+  if (!kind || internal_strcmp(kind, "heap") != 0)
+    return;
+
+  void *trace[kTraceCap];
+  int thread_id = 0;
+
+  for (unsigned long i = 0; i < kTraceCap; i++) trace[i] = nullptr;
+  if (__asan_get_alloc_stack(reinterpret_cast<void *>(addr), trace, kTraceCap,
+                             &thread_id))
+    GetDarwinStack(stacks, thread_id, trace, kTraceCap,
+                   LLVM_SANITIZER_V1_STACK_TYPE_ALLOCATION, "Allocated");
+
+  for (unsigned long i = 0; i < kTraceCap; i++) trace[i] = nullptr;
+  thread_id = 0;
+  if (__asan_get_free_stack(reinterpret_cast<void *>(addr), trace, kTraceCap,
+                            &thread_id))
+    GetDarwinStack(stacks, thread_id, trace, kTraceCap,
+                   LLVM_SANITIZER_V1_STACK_TYPE_DEALLOCATION, "Freed");
+}
+
+void TryAppend(StackVec &stacks, InternalMmapVector<uptr> &seen, uptr addr) {
+  if (!addr) return;
+  for (uptr i = 0; i < seen.size(); i++)
+    if (seen[i] == addr) return;
+  seen.push_back(addr);
+  AppendStacksForHeapAddr(stacks, addr);
+}
+
+}  // namespace
+
+void OnAsanReportPrinted(void) {
+  if (!common_flags()->crashreporter_global)
+    return;
+  if (!__asan_report_present())
+    return;
+
+  const char *type_str = __asan_get_report_description();
+  if (!type_str || !*type_str)
+    type_str = "<unknown>";
+
+  uptr fault_address =
+      reinterpret_cast<uptr>(__asan_get_report_address());
+  uptr allocation_address = 0, allocation_size = 0;
+
+  // For heap-resident faults, fill in chunk addr/size from locate_address.
+  if (fault_address) {
+    void *region_addr = nullptr;
+    uptr region_size = 0;
+    const char *kind = __asan_locate_address(
+        reinterpret_cast<void *>(fault_address), nullptr, 0, &region_addr,
+        &region_size);
+    if (kind && internal_strcmp(kind, "heap") == 0) {
+      allocation_address = reinterpret_cast<uptr>(region_addr);
+      allocation_size = region_size;
+    }
+  }
+
+  StackVec stacks;
+  stacks.reserve(LLVM_SANITIZER_V1_MAXSTACKS);
+
+  // Walk every address the public accessors can hand out for this report.
+  // Each is a candidate for an associated heap allocation whose alloc/free
+  // stacks belong in the payload. Different error kinds populate different
+  // accessors; we just try them all and dedupe.
+  InternalMmapVector<uptr> seen;
+  seen.reserve(8);
+  const void *out_addr = nullptr;
+  uptr out_size = 0;
+  TryAppend(stacks, seen, fault_address);
+  if (__asan_get_report_dealloc_address(&out_addr, &out_size))
+    TryAppend(stacks, seen, reinterpret_cast<uptr>(out_addr));
+  if (__asan_get_report_src_address(&out_addr, &out_size))
+    TryAppend(stacks, seen, reinterpret_cast<uptr>(out_addr));
+  if (__asan_get_report_dest_address(&out_addr, &out_size))
+    TryAppend(stacks, seen, reinterpret_cast<uptr>(out_addr));
+  if (__asan_get_report_first_address(&out_addr, &out_size))
+    TryAppend(stacks, seen, reinterpret_cast<uptr>(out_addr));
+  if (__asan_get_report_second_address(&out_addr, &out_size))
+    TryAppend(stacks, seen, reinterpret_cast<uptr>(out_addr));
+
+  SetCrashReporterGlobalForReport(type_str, fault_address, allocation_address,
+                                  allocation_size, stacks);
+}
+
+}  // namespace __asan
+
+#endif  // SANITIZER_APPLE

--- a/compiler-rt/lib/asan/asan_report.cpp
+++ b/compiler-rt/lib/asan/asan_report.cpp
@@ -32,6 +32,16 @@
 
 namespace __asan {
 
+#if SANITIZER_APPLE
+// TO_UPSTREAM(crashreporter_global)
+// Defined in asan_mac_crashreport.cpp; populates the Darwin crash-reporter
+// payload for the current error. Walks state via the public
+// __asan_get_report_* / __asan_locate_address / __asan_get_alloc_stack /
+// __asan_get_free_stack interface, so it doesn't depend on internal types
+// here. Must be called with the asanThreadRegistry locked.
+void OnAsanReportPrinted(void);
+#endif
+
 // -------------------- User-specified callbacks ----------------- {{{1
 static void (*error_report_callback)(const char*);
 using ErrorMessageBuffer = InternalMmapVectorNoCtor<char, true>;
@@ -173,6 +183,11 @@ class ScopedInErrorReport {
 
     // Make sure the current thread is announced.
     DescribeThread(GetCurrentThread());
+#if SANITIZER_APPLE
+    // TO_UPSTREAM(crashreporter_global)
+    if (current_error_.IsValid())
+      OnAsanReportPrinted();
+#endif
     // We may want to grab this lock again when printing stats.
     asanThreadRegistry().Unlock();
     // Print memory stats.

--- a/compiler-rt/lib/sanitizer_common/CMakeLists.txt
+++ b/compiler-rt/lib/sanitizer_common/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(SANITIZER_SOURCES_NOTERMINATION
   sanitizer_allocator.cpp
   sanitizer_common.cpp
+  sanitizer_darwin_crashreport.cpp  # TO_UPSTREAM(crashreporter_global)
   sanitizer_deadlock_detector1.cpp
   sanitizer_deadlock_detector2.cpp
   sanitizer_errno.cpp
@@ -139,6 +140,7 @@ set(SANITIZER_IMPL_HEADERS
   sanitizer_common_interface.inc
   sanitizer_common_interface_posix.inc
   sanitizer_common_syscalls.inc
+  sanitizer_darwin_crashreport.h  # TO_UPSTREAM(crashreporter_global)
   sanitizer_coverage_interface.inc
   sanitizer_dbghelp.h
   sanitizer_deadlock_detector.h

--- a/compiler-rt/lib/sanitizer_common/sanitizer_darwin_crashreport.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_darwin_crashreport.cpp
@@ -1,0 +1,82 @@
+//===-- sanitizer_darwin_crashreport.cpp ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// TO_UPSTREAM(crashreporter_global)
+
+#include "sanitizer_platform.h"
+
+#if SANITIZER_APPLE
+
+#  include "sanitizer_common.h"
+#  include "sanitizer_darwin_crashreport.h"
+#  include "sanitizer_libc.h"
+
+llvm_sanitizer_report_payload llvm_sanitizer_report_global;
+
+namespace __sanitizer {
+
+void GetDarwinStack(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1> &stacks, int tid,
+    void *const *trace, uptr cap, uint16_t type, const char *description,
+    bool include_thread_name) {
+  stacks.resize(stacks.size() + 1);
+  llvm_sanitizer_report_payload_stack_v1 &res = stacks.back();
+  internal_memset(&res, 0, sizeof(res));
+  res.type = type;
+  res.stack.thread_id = tid;
+  res.stack.time = 0;
+
+  // Count populated leading slots in `trace` (the public-API getters fill
+  // in order and leave the rest zeroed) and clamp to the payload capacity.
+  uptr n = 0;
+  while (n < cap && trace[n]) ++n;
+  const uptr payload_cap =
+      sizeof(res.stack.frames) / sizeof(res.stack.frames[0]);
+  res.stack.num_frames = Min(n, payload_cap);
+
+  // Public-API traces are top-of-stack-first; the payload stores them
+  // top-of-stack-last.
+  for (uptr i = 0; i < res.stack.num_frames; i++) {
+    res.stack.frames[i] =
+        (uintptr_t)trace[res.stack.num_frames - i - 1];
+  }
+  if (include_thread_name) {
+    internal_snprintf(res.description, sizeof(res.description),
+                      "%s by thread %d", description, tid);
+  } else {
+    internal_strncpy(res.description, description, sizeof(res.description));
+    res.description[sizeof(res.description) - 1] = 0;
+  }
+}
+
+void SetCrashReporterGlobalForReport(
+    const char *error_name, uptr fault_addr, uptr allocation_addr,
+    uptr allocation_size,
+    const InternalMmapVector<llvm_sanitizer_report_payload_stack_v1> &stacks) {
+  llvm_sanitizer_report_global.vers = 1;
+  internal_strncpy(llvm_sanitizer_report_global.v1.category, SanitizerToolName,
+                   LLVM_SANITIZER_V1_CATEGORY_MAXLEN);
+  llvm_sanitizer_report_global.v1
+      .category[LLVM_SANITIZER_V1_CATEGORY_MAXLEN - 1] = 0;
+  internal_strncpy(llvm_sanitizer_report_global.v1.type, error_name,
+                   LLVM_SANITIZER_V1_TYPE_MAXLEN);
+  llvm_sanitizer_report_global.v1.type[LLVM_SANITIZER_V1_TYPE_MAXLEN - 1] = 0;
+
+  llvm_sanitizer_report_global.v1.fault_address = fault_addr;
+  llvm_sanitizer_report_global.v1.allocation_address = allocation_addr;
+  llvm_sanitizer_report_global.v1.allocation_size = allocation_size;
+
+  llvm_sanitizer_report_global.v1.nstacks =
+      Min(stacks.size(), (uptr)LLVM_SANITIZER_V1_MAXSTACKS);
+  internal_memcpy(llvm_sanitizer_report_global.v1.stacks, stacks.data(),
+                  llvm_sanitizer_report_global.v1.nstacks *
+                      sizeof(llvm_sanitizer_report_payload_stack_v1));
+}
+
+}  // namespace __sanitizer
+
+#endif  // SANITIZER_APPLE

--- a/compiler-rt/lib/sanitizer_common/sanitizer_darwin_crashreport.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_darwin_crashreport.h
@@ -1,0 +1,88 @@
+//===-- sanitizer_darwin_crashreport.h --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// TO_UPSTREAM(crashreporter_global)
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_DARWIN_CRASHREPORT_H
+#define SANITIZER_DARWIN_CRASHREPORT_H
+
+#include "sanitizer_common.h"
+#include "sanitizer_platform.h"
+
+#if SANITIZER_APPLE
+
+#  include <stddef.h>
+#  include <stdint.h>
+
+#  define LLVM_SANITIZER_V1_CATEGORY_MAXLEN 32
+#  define LLVM_SANITIZER_V1_TYPE_MAXLEN 32
+#  define LLVM_SANITIZER_V1_STACK_DESCRIPTION_MAXLEN 128
+#  define LLVM_SANITIZER_V1_MAXSTACKS 4
+#  define LLVM_SANITIZER_V1_FRAMES_PER_STACK 64
+
+#  define LLVM_SANITIZER_V1_STACK_TYPE_OTHER 0
+#  define LLVM_SANITIZER_V1_STACK_TYPE_ALLOCATION 1
+#  define LLVM_SANITIZER_V1_STACK_TYPE_DEALLOCATION 2
+
+typedef struct {
+  uint64_t thread_id;
+  uint64_t time;
+  uint32_t num_frames;
+  uintptr_t frames[LLVM_SANITIZER_V1_FRAMES_PER_STACK];
+} sanitizers_stack_trace_t;
+
+typedef struct {
+  uint32_t type;
+  char description[LLVM_SANITIZER_V1_STACK_DESCRIPTION_MAXLEN];
+  sanitizers_stack_trace_t stack;
+} llvm_sanitizer_report_payload_stack_v1;
+
+typedef struct {
+  char category[LLVM_SANITIZER_V1_CATEGORY_MAXLEN];
+  char type[LLVM_SANITIZER_V1_TYPE_MAXLEN];
+
+  // These three fields may be 0 for non-heap errors.
+  uintptr_t fault_address;
+  uintptr_t allocation_address;
+  size_t allocation_size;
+
+  uint16_t nstacks;
+  llvm_sanitizer_report_payload_stack_v1 stacks[LLVM_SANITIZER_V1_MAXSTACKS];
+} llvm_sanitizer_report_payload_v1;
+
+typedef struct __attribute__((packed)) {
+  uint16_t vers;
+  union {
+    llvm_sanitizer_report_payload_v1 v1;
+  };
+} llvm_sanitizer_report_payload;
+
+namespace __sanitizer {
+
+// Append a single backtrace + description tuple to `stacks` in the Darwin
+// crash-reporter payload format. `trace` is a buffer of `cap` PC slots in
+// top-of-stack-first order (matching what `__asan_get_alloc_stack` /
+// `__tsan_get_report_mop` write); the populated length is taken to be the
+// number of non-null leading slots. The payload's frames[] array is written
+// in the reversed (top-of-stack-last) order. If `include_thread_name` is
+// true, the description is suffixed with "by thread <tid>".
+void GetDarwinStack(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1> &stacks, int tid,
+    void *const *trace, uptr cap, uint16_t type, const char *description,
+    bool include_thread_name = true);
+
+// Populate `llvm_sanitizer_report_global` with the given report metadata and
+// stacks. Truncates fields that don't fit. Called once per report.
+void SetCrashReporterGlobalForReport(
+    const char *error_name, uptr fault_addr, uptr allocation_addr,
+    uptr allocation_size,
+    const InternalMmapVector<llvm_sanitizer_report_payload_stack_v1> &stacks);
+
+}  // namespace __sanitizer
+
+#endif  // SANITIZER_APPLE
+#endif  // SANITIZER_DARWIN_CRASHREPORT_H

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
@@ -258,6 +258,12 @@ COMMON_FLAG(
     bool, abort_on_error, (bool)SANITIZER_ANDROID || (bool)SANITIZER_APPLE,
     "If set, the tool calls abort() instead of _exit() after printing the "
     "error report.")
+#if SANITIZER_APPLE
+// TO_UPSTREAM(crashreporter_global)
+COMMON_FLAG(bool, crashreporter_global, (bool)SANITIZER_APPLE,
+            "Uses a global to communicate sanitizer report information to the "
+            "Darwin crash reporting system")
+#endif
 COMMON_FLAG(bool, suppress_equal_pcs, true,
             "Deduplicate multiple reports for single source location in "
             "halt_on_error=false mode (asan only).")

--- a/compiler-rt/lib/tsan/rtl/CMakeLists.txt
+++ b/compiler-rt/lib/tsan/rtl/CMakeLists.txt
@@ -64,6 +64,7 @@ if(APPLE)
   list(APPEND TSAN_SOURCES
     tsan_interceptors_mac.cpp
     tsan_interceptors_mach_vm.cpp
+    tsan_mac_crashreport.cpp  # TO_UPSTREAM(crashreporter_global)
     tsan_platform_mac.cpp
     tsan_platform_posix.cpp
     )

--- a/compiler-rt/lib/tsan/rtl/tsan_mac_crashreport.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_mac_crashreport.cpp
@@ -1,0 +1,146 @@
+//===-- tsan_mac_crashreport.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// TO_UPSTREAM(crashreporter_global)
+//
+// Darwin-only adapter that translates the current TSan report into the
+// llvm_sanitizer_report_global crash-reporter payload using the public
+// __tsan_get_current_report / __tsan_get_report_* / __tsan_describe_*
+// interface.
+//
+//===----------------------------------------------------------------------===//
+
+#include "sanitizer_common/sanitizer_platform.h"
+
+#if SANITIZER_APPLE && !SANITIZER_GO
+
+#  include <stdint.h>
+#  include <string.h>
+
+#  include "sanitizer/tsan_interface.h"
+#  include "sanitizer_common/sanitizer_common.h"
+#  include "sanitizer_common/sanitizer_darwin_crashreport.h"
+#  include "sanitizer_common/sanitizer_flags.h"
+
+namespace __tsan {
+
+namespace {
+
+// Match the payload's per-stack frame capacity so the trace buffer the
+// public TSan getters fill never gets truncated before reaching the
+// payload.
+constexpr unsigned long kTraceCap = LLVM_SANITIZER_V1_FRAMES_PER_STACK;
+constexpr unsigned long kDescCap = LLVM_SANITIZER_V1_STACK_DESCRIPTION_MAXLEN;
+
+using StackVec = InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>;
+
+}  // namespace
+
+void OnTsanReportPrinted(void) {
+  if (!common_flags()->crashreporter_global)
+    return;
+
+  void *report = __tsan_get_current_report();
+  if (!report)
+    return;
+
+  // Single reusable trace buffer kept off the (small) signal stack.
+  InternalMmapVector<void *> trace_buf(kTraceCap);
+  void **trace = trace_buf.data();
+  auto reset_trace = [&]() {
+    for (unsigned long i = 0; i < kTraceCap; i++) trace[i] = nullptr;
+  };
+
+  reset_trace();
+  const char *type_str = nullptr;
+  int count = 0, stack_count = 0, mop_count = 0, loc_count = 0,
+      mutex_count = 0, thread_count = 0, unique_tid_count = 0;
+  __tsan_get_report_data(report, &type_str, &count, &stack_count, &mop_count,
+                         &loc_count, &mutex_count, &thread_count,
+                         &unique_tid_count, trace, kTraceCap);
+
+  StackVec stacks;
+  stacks.reserve(LLVM_SANITIZER_V1_MAXSTACKS);
+
+  uptr fault_address = 0, allocation_addr = 0, allocation_size = 0;
+  char desc[kDescCap];
+
+  for (int i = 0; i < mop_count; i++) {
+    int tid = 0, size = 0, write = 0, atomic = 0;
+    void *addr = nullptr;
+    reset_trace();
+    if (!__tsan_get_report_mop(report, i, &tid, &addr, &size, &write, &atomic,
+                               trace, kTraceCap))
+      continue;
+    __tsan_describe_mop(report, i, /*first=*/i == 0, desc, sizeof(desc));
+    GetDarwinStack(stacks, tid, trace, kTraceCap,
+                   LLVM_SANITIZER_V1_STACK_TYPE_OTHER, desc,
+                   /*include_thread_name=*/false);
+    if (i == 0)
+      fault_address = (uptr)addr;
+  }
+
+  for (int i = 0; i < loc_count; i++) {
+    const char *loc_type = nullptr;
+    void *loc_addr = nullptr;
+    void *start = nullptr;
+    unsigned long size = 0;
+    int tid = 0, fd = 0, suppressable = 0;
+    reset_trace();
+    if (!__tsan_get_report_loc(report, i, &loc_type, &loc_addr, &start, &size,
+                               &tid, &fd, &suppressable, trace, kTraceCap))
+      continue;
+    int has_stack = __tsan_describe_loc(report, i, desc, sizeof(desc));
+    if (has_stack && trace[0])
+      GetDarwinStack(stacks, tid, trace, kTraceCap,
+                     LLVM_SANITIZER_V1_STACK_TYPE_OTHER, desc,
+                     /*include_thread_name=*/false);
+    if (loc_type && internal_strcmp(loc_type, "heap") == 0) {
+      allocation_addr = reinterpret_cast<uptr>(start);
+      allocation_size = size;
+    }
+  }
+
+  for (int i = 0; i < mutex_count; i++) {
+    uint64_t mutex_id = 0;
+    void *mutex_addr = nullptr;
+    int destroyed = 0;
+    reset_trace();
+    if (!__tsan_get_report_mutex(report, i, &mutex_id, &mutex_addr, &destroyed,
+                                 trace, kTraceCap))
+      continue;
+    if (!trace[0])
+      continue;
+    __tsan_describe_mutex(report, i, desc, sizeof(desc));
+    GetDarwinStack(stacks, kInvalidTid, trace, kTraceCap,
+                   LLVM_SANITIZER_V1_STACK_TYPE_OTHER, desc,
+                   /*include_thread_name=*/false);
+  }
+
+  for (int i = 0; i < thread_count; i++) {
+    int tid = 0, running = 0, parent_tid = 0;
+    uint64_t os_id = 0;
+    const char *name = nullptr;
+    reset_trace();
+    if (!__tsan_get_report_thread(report, i, &tid, &os_id, &running, &name,
+                                  &parent_tid, trace, kTraceCap))
+      continue;
+    int has_stack = __tsan_describe_thread(report, i, desc, sizeof(desc));
+    if (has_stack && trace[0])
+      GetDarwinStack(stacks, parent_tid, trace, kTraceCap,
+                     LLVM_SANITIZER_V1_STACK_TYPE_OTHER, desc,
+                     /*include_thread_name=*/false);
+  }
+
+  SetCrashReporterGlobalForReport(type_str ? type_str : "<unknown>",
+                                  fault_address, allocation_addr,
+                                  allocation_size, stacks);
+}
+
+}  // namespace __tsan
+
+#endif  // SANITIZER_APPLE && !SANITIZER_GO

--- a/compiler-rt/lib/tsan/rtl/tsan_report.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_report.cpp
@@ -19,6 +19,15 @@
 
 namespace __tsan {
 
+#if !SANITIZER_GO && SANITIZER_APPLE
+// TO_UPSTREAM(crashreporter_global)
+// Defined in tsan_mac_crashreport.cpp; populates the Darwin crash-reporter
+// payload from the just-printed report. Walks the report via the public
+// __tsan_get_current_report() / __tsan_get_report_* / __tsan_describe_*
+// interface, so it doesn't depend on internal types here.
+void OnTsanReportPrinted(void);
+#endif
+
 class Decorator: public __sanitizer::SanitizerCommonDecorator {
  public:
   Decorator() : SanitizerCommonDecorator() { }
@@ -359,6 +368,11 @@ void PrintReport(const ReportDesc *rep) {
     DumpProcessMap();
 
   Printf("==================\n");
+
+#if SANITIZER_APPLE
+  // TO_UPSTREAM(crashreporter_global)
+  OnTsanReportPrinted();
+#endif
 }
 
 #else  // #if !SANITIZER_GO


### PR DESCRIPTION
Add a global llvm_sanitizer_report_global that is filled with structured sanitizer report information (including backtraces) when a report is printed to the screen. Crash reporting infrastructure can inspect the process after it aborts to extract the structured sanitizer report (which could be used for automatic triage or out-of-band symbolication).

This re-uses the existing sanitizer interface functions.

rdar://176058208