### PR TITLE
[lldb/test] Fix TestSwiftMacro on remote-darwin targets

### DIFF
--- a/lldb/test/API/lang/swift/macro/Makefile
+++ b/lldb/test/API/lang/swift/macro/Makefile
@@ -34,6 +34,8 @@ libMacroImpl.dylib:
 		DYLIB_ONLY=YES \
 		SWIFTFLAGS_EXTRAS="-I$(SWIFT_HOSTDIR)" \
 		LD_EXTRAS="-L$(SWIFT_HOSTDIR)" \
+		TARGET_SWIFTFLAGS="-target $(shell uname -m)-apple-macos13.0" \
+		ARCH_CFLAGS="-target $(shell uname -m)-apple-macos13.0" \
 		SWIFT_SOURCES= \
 		all
 

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -37,7 +37,7 @@ class TestSwiftMacro(lldbtest.TestBase):
         self.setupPluginServerForTesting()
         main_spec = lldb.SBFileSpec('main.swift')
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, 'break here', main_spec
+            self, 'break here', main_spec, extra_images=['Macro']
         )
 
         # We're testing line breakpoint setting here:


### PR DESCRIPTION
Two distinct bugs were preventing TestSwiftMacro from running on remote-darwin: the macro-expansion plugin was being cross-compiled for the target instead of the host, and the runtime macro library was never deployed to the device.

1. libMacroImpl.dylib is a macro-expansion plugin loaded by swift-plugin-server, which always runs on the host side. The recursive make for it was inheriting the parent test's TARGET_SWIFTFLAGS (e.g. "-target arm64-apple-iosNN" for remote-ios) which made the build attempt to load SwiftSyntax for the non-host target and fail with "could not find module 'SwiftSyntax' for target 'arm64-apple-ios'; found: arm64-apple-macos".

   Pin TARGET_SWIFTFLAGS and ARCH_CFLAGS to "<arch>-apple-macos13.0" for the plugin build. The 13.0 floor matches what the rest of the swift test suite uses; bare "-apple-macos" with no version trips swift's "minimum deployment target of macOS 10.9.0" check.

2. testDebugging() built libMacro.dylib alongside a.out (linked with install_name @executable_path/libMacro.dylib), but run_to_source_breakpoint was called without extra_images=['Macro'], so on remote targets libMacro.dylib was never uploaded to the device. a.out would crash on launch trying to dlopen the missing dylib and the test failed with "0 != 1 : Expected 1 thread to stop at breakpoint, 0 did." since the process never reached 'break here'.

   Add extra_images=['Macro'] so registerSharedLibrariesWithTarget deploys libMacro.dylib next to a.out on the device. Host-side runs were already finding the dylib locally, so this is a no-op there.