### PR TITLE
[lldb/test] Fix TestSwiftResilienceSwiftInterface on remote-darwin targets

### DIFF
--- a/lldb/test/API/lang/swift/resilience_swiftinterface/Makefile
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/Makefile
@@ -35,6 +35,6 @@ ImplA: ImplB ImplA.swift
 Postprocess:
 	$(call ECHO,"Compiling Impl.swiftinterfact to Impl.swiftmodule")
 	$(call ECHO_TO_FILE,'import Impl',trigger.swift)
-	$(SWIFT_FE) -module-cache-path cache -c trigger.swift -o trigger -I.
+	$(SWIFT_FE) $(SWIFT_FEFLAGS) -module-cache-path cache -c trigger.swift -o trigger -I.
 	mv cache/Impl*.swiftmodule Impl.swiftmodule
 	$(call RM,Impl.swiftinterface)

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
@@ -17,6 +17,7 @@ class TestSwiftResilienceSwiftInterface(TestBase):
         """
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec('main.swift'))
+            self, "break here", lldb.SBFileSpec('main.swift'),
+            extra_images=['Impl'])
 
         self.expect("expression s", substrs=["a", "100", "b", "200"])


### PR DESCRIPTION
Two distinct bugs were preventing TestSwiftResilienceSwiftInterface from running on remote-darwin: the Postprocess step's direct swift-frontend invocation wasn't being told the target / SDK, and the runtime resilience library was never deployed to the device.

1. The Postprocess step invokes $(SWIFT_FE) directly to compile a tiny "import Impl" trigger.swift, but it didn't pass SWIFT_FEFLAGS, so the swift-frontend ran without -sdk / -target and on remote-ios fell back to whatever the default sysroot is, producing:

     error: unable to load standard library for target 'arm64-apple-iosNN'

   Pass $(SWIFT_FEFLAGS) so the SDK and target propagate from the parent make.

2. The test built libImpl.dylib alongside a.out (linked with install_name @executable_path/libImpl.dylib via the -lImpl + -L$(BUILDDIR) line in LD_EXTRAS), but run_to_source_breakpoint was called without extra_images=['Impl'], so on remote targets libImpl.dylib was never uploaded to the device. a.out would crash on launch trying to dlopen the missing dylib and the test failed with "0 != 1 : Expected 1 thread to stop at breakpoint, 0 did." since the process never reached 'break here'.

   Add extra_images=['Impl'] so registerSharedLibrariesWithTarget deploys libImpl.dylib next to a.out on the device. Host-side runs were already finding the dylib locally, so this is a no-op there.