### PR TITLE
[lldb/test] Fix TestSwiftObjCSuperClassNoDebugInfo on remote-darwin targets

### DIFF
--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/Makefile
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/Makefile
@@ -11,8 +11,12 @@ libMyObjCBase.dylib: $(SRCDIR)/MyObjCBase.m $(SRCDIR)/MyObjCBase.h
 	$(CC) -isysroot "$(SDKROOT)" -g0 -c $(SRCDIR)/MyObjCBase.m \
 		-o $(BUILDDIR)/MyObjCBase.o
 	$(CC) -isysroot "$(SDKROOT)" -dynamiclib -lobjc \
+		-install_name @executable_path/libMyObjCBase.dylib \
 		$(BUILDDIR)/MyObjCBase.o \
 		-o $(BUILDDIR)/libMyObjCBase.dylib
+ifneq "$(CODESIGN)" ""
+	$(CODESIGN) -s - "$(BUILDDIR)/libMyObjCBase.dylib"
+endif
 
 libMyLib.dylib: $(SRCDIR)/MyLib.swift libMyObjCBase.dylib
 	"$(MAKE)" -f $(MAKEFILE_RULES) \


### PR DESCRIPTION
libMyObjCBase.dylib is built by a hand-rolled "$(CC) -dynamiclib" recipe in TestSwiftObjCSuperClassNoDebugInfo's Makefile that bypasses Makefile.rules. Two things were missing for remote-darwin runs:

1. The recipe didn't set -install_name, so the dylib's LC_ID_DYLIB pointed at its absolute host build location. dyld on the remote target looked it up at that absolute path and failed to find the deployed copy.

   Set -install_name to @executable_path/libMyObjCBase.dylib so the load command matches where extra_images=['MyObjCBase'] actually deploys the dylib on the device.

2. The recipe also bypassed Makefile.rules' codesign step, so the produced dylib was unsigned. iOS dyld refuses to load unsigned libraries and exits with:

     dyld: Library not loaded: @executable_path/libMyObjCBase.dylib
     Reason: ... 'Trying to load an unsigned library'

   Replicate Makefile.rules' standard "$(CODESIGN) -s -" step so the dylib is adhoc-signed the same way every other test dylib is.