### PR TITLE
[lldb/TypeSystem] Add new SourceFileKind case for synthetic macros 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -9615,6 +9615,9 @@ static void DescribeFileUnit(Stream &s, const swift::FileUnit *file_unit) {
       case swift::SourceFileKind::DefaultArgument:
         s.PutCString("Default Argument");
         break;
+      case swift::SourceFileKind::SyntheticMacro:
+        s.PutCString("Synthetic Macro");
+        break;
       }
     }
   } break;


### PR DESCRIPTION
This PR adds a new case for the SourceFileKind::SyntheticMacro in the DescribeFileUnit function from SwiftAstContext. 

The new case was introduced in https://github.com/swiftlang/swift/pull/89419, and both PRs are meant to be tested and merged together. 

This new source file kind represents synthetic macros (which were previously unrepresentable) as part of an effort to port protocol conformance derivation to macros.
