### PR TITLE
[lldb/test] Fix TestExpeditedThreadPCs on remote-darwin targets

### DIFF
--- a/lldb/test/API/macosx/expedited-thread-pcs/TestExpeditedThreadPCs.py
+++ b/lldb/test/API/macosx/expedited-thread-pcs/TestExpeditedThreadPCs.py
@@ -34,7 +34,10 @@ class TestExpeditedThreadPCs(TestBase):
         self.source = "main.cpp"
         self.build()
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec(self.source, False)
+            self,
+            "break here",
+            lldb.SBFileSpec(self.source, False),
+            extra_images=["foo"],
         )
 
         # verify that libfoo.dylib hasn't loaded yet
@@ -49,6 +52,7 @@ class TestExpeditedThreadPCs(TestBase):
         thread.StepInto()
 
         # verify that libfoo.dylib has loaded
+        found_libfoo = False
         for m in target.modules:
             if m.GetFileSpec().GetFilename() == "libfoo.dylib":
                 found_libfoo = True


### PR DESCRIPTION
Two distinct bugs were preventing TestExpeditedThreadPCs from running on remote-darwin: the test wasn't deploying libfoo.dylib to the device, and the post-load assertion was guarded by an uninitialized local that raised UnboundLocalError instead of a clean assertion failure when the dylib was missing.

1. main.cpp does dlopen("libfoo.dylib", RTLD_LAZY) at runtime, but run_to_source_breakpoint was called without extra_images=['foo'], so libfoo.dylib (linked with install_name @executable_path/libfoo.dylib) was never deployed to the device. dlopen returned NULL on the device and libfoo never showed up in target.modules; the post-step assertTrue(found_libfoo) then failed with "False is not true".

   Add extra_images=['foo'] so registerSharedLibrariesWithTarget deploys libfoo.dylib next to a.out on the remote target.

2. found_libfoo was only assigned inside the if-branch of the for loop, so when libfoo.dylib was not present in target.modules (the bug above) the assertTrue(found_libfoo) raised UnboundLocalError instead of producing the intended assertion failure message. Initialize the flag to False up front so the original assertion fires cleanly when something else does go wrong.


(cherry picked from commit e2191969bc0dd8d98bf162cb26ddc27099f944cc)