### PR TITLE
[libclang][cas] Handle errors creating a VFS during diagnostic replay

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -631,9 +631,9 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
   TextDiagnosticPrinter DiagConsumer(DiagOS, Clang.getDiagnosticOpts());
   Clang.createVirtualFileSystem(llvm::vfs::getRealFileSystem(), &DiagConsumer);
   if (DiagConsumer.getNumErrors() != 0)
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "error diagnostic during replay: " +
-                                       DiagOS.str());
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "error constructing virtual filesystem for replay: " + DiagOS.str());
   Clang.createDiagnostics(&DiagConsumer, /*ShouldOwnClient=*/false);
   Clang.setVerboseOutputStream(DiagOS);
 

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -628,9 +628,13 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
     bool WriteOutputHashXAttr, std::optional<llvm::cas::CASID> *OutMCOutputID) {
   CompilerInstance Clang(std::move(Invok));
   llvm::raw_svector_ostream DiagOS(DiagText);
-  Clang.createVirtualFileSystem(llvm::vfs::getRealFileSystem());
-  Clang.createDiagnostics(
-      new TextDiagnosticPrinter(DiagOS, Clang.getDiagnosticOpts()));
+  TextDiagnosticPrinter DiagConsumer(DiagOS, Clang.getDiagnosticOpts());
+  Clang.createVirtualFileSystem(llvm::vfs::getRealFileSystem(), &DiagConsumer);
+  if (DiagConsumer.getNumErrors() != 0)
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "error diagnostic during replay: " +
+                                       DiagOS.str());
+  Clang.createDiagnostics(&DiagConsumer, /*ShouldOwnClient=*/false);
   Clang.setVerboseOutputStream(DiagOS);
 
   // FIXME: we should create an include-tree filesystem based on the cache key

--- a/clang/test/CAS/libclang-replay-job.c
+++ b/clang/test/CAS/libclang-replay-job.c
@@ -97,6 +97,18 @@
 // ABS_DIAG: remark: compile job cache hit for
 // ABS_DIAG: libclang-replay-job.c.tmp{{.}}main.c:1:2: warning:
 
+// Check with a bad include-tree ID.
+// RUN: sed "s|llvmcas://[[:xdigit:]]*|llvmcas://bad|" %t/cc1.rsp > %t/cc1.bad.rsp
+// RUN: not c-index-test core -replay-cached-job -cas-path %t/cas @%t/cache-key \
+// RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -fcas-plugin-option no-logging \
+// RUN:   -working-dir %t \
+// RUN: -- @%t/cc1.bad.rsp \
+// RUN:   -serialize-diagnostic-file %t/t4.dia -Rcompile-job-cache-hit \
+// RUN:   -dependency-file %t/t4.d -o %t/output4.o 2> %t/output4.txt
+// RUN: FileCheck %s --input-file=%t/output4.txt -check-prefix=ERR_DIAG
+// ERR_DIAG: error diagnostic during replay: fatal error: CAS cannot parse root-id 'llvmcas://bad' specified by '-fcas-*' options
+
 // Use relative path to inputs and outputs.
 //--- cdb.json.template
 [{


### PR DESCRIPTION
The `CompilerInstance::createVirtualFileSystem()` function can fail but doesn't require a `DiagnosticConsumer` to be passed in. This is useful for infallible tests, but production code does need to provide the consumer. Without it, the function can assert. This PR also adds an early exit if there was an error during VFS creation to prevent non-sensical errors/crashes later on.

rdar://176754115