### PR TITLE
[Clang] Fix mergeInheritableAttributes() to propagate all AvailabilityAttrs

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3609,11 +3609,12 @@ void mergeInheritableAttributes(ASTReader &Reader, Decl *D, Decl *Previous) {
     D->addAttr(NewAttr);
   }
 
-  const auto *AA = Previous->getAttr<AvailabilityAttr>();
-  if (AA && !D->hasAttr<AvailabilityAttr>()) {
-    NewAttr = AA->clone(Context);
-    NewAttr->setInherited(true);
-    D->addAttr(NewAttr);
+  if (!D->hasAttr<AvailabilityAttr>()) {
+    for (const auto *AA : Previous->specific_attrs<AvailabilityAttr>()) {
+      NewAttr = AA->clone(Context);
+      NewAttr->setInherited(true);
+      D->addAttr(NewAttr);
+    }
   }
 }
 } // namespace

--- a/clang/test/Modules/decl-attr-merge.mm
+++ b/clang/test/Modules/decl-attr-merge.mm
@@ -1,13 +1,21 @@
 // RUN: rm -rf %t.dir
 // RUN: split-file %s %t.dir
+// macOS: single-platform availability worked even before the fix.
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps \
-// RUN:   -fmodules-cache-path=%t.dir/cache -triple x86_64-apple-macosx10.11.0 \
-// RUN:   -I%t.dir/headers %t.dir/main.m -emit-llvm -o %t.dir/main.ll
-// RUN: cat %t.dir/main.ll | FileCheck %s
+// RUN:   -fmodules-cache-path=%t.dir/mcache -triple x86_64-apple-macosx10.11.0 \
+// RUN:   -I%t.dir/headers %t.dir/main-macos.m -emit-llvm -o - | FileCheck %s --check-prefix=CHECK-MACOS
+// iOS: the @interface carries two AvailabilityAttrs (macOS + iOS).
+// Without the fix, mergeInheritableAttributes used getAttr<AvailabilityAttr>()
+// which only copied the first (macOS); the iOS attr was lost on the @class
+// redeclaration, causing isWeakImported() to return false (strong linkage).
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps \
+// RUN:   -fmodules-cache-path=%t.dir/icache -triple arm64-apple-ios12.0 \
+// RUN:   -I%t.dir/headers %t.dir/main-ios.m -emit-llvm -o - | FileCheck %s --check-prefix=CHECK-IOS
 
 //--- headers/a.h
 
 __attribute__((availability(macos,introduced=10.16)))
+__attribute__((availability(ios,introduced=14.0)))
 @interface INIntent
 - (instancetype)self;
 @end
@@ -26,7 +34,7 @@ module B {
   header "b.h"
 }
 
-//--- main.m
+//--- main-macos.m
 
 #import <a.h>
 #import <b.h> // NOTE: Non attributed decl imported after one with attrs.
@@ -38,4 +46,14 @@ int main() {
     F([INIntent self]);
 }
 
-// CHECK: @"OBJC_CLASS_$_INIntent" = extern_weak
+// CHECK-MACOS: @"OBJC_CLASS_$_INIntent" = extern_weak
+
+//--- main-ios.m
+
+#import <a.h>
+#import <b.h>
+
+@implementation INIntent (Testing)
+@end
+
+// CHECK-IOS: @"OBJC_CLASS_$_INIntent" = extern_weak


### PR DESCRIPTION
`getAttr<AvailabilityAttr>()` only returns the first matching attribute, but a declaration can carry multiple AvailabilityAttrs (one per platform, e.g. macOS + iOS).  Use `specific_attrs<AvailabilityAttr>()` to iterate over all of them so every platform's availability is propagated during cross-module redeclaration merging.

This aligns the PCM merge path with how `mergeDeclAttributes` already iterates via `specific_attrs<InheritableAttr>()` on the Sema side.

Extend clang/test/Modules/decl-attr-merge.mm with a multi-platform case and an iOS triple RUN line that triggers the bug without the fix.

Fixes https://github.com/llvm/llvm-project/issues/181298

(cherry picked from commit c6eb268dd15fa8e13d7c3beb8887fec0bb14f5f0 PR #181482)