### PR TITLE
[Cherry-pick into next] [LLDB] Suppress CAS-related warnings for non-existing file paths

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1699,8 +1699,20 @@ loadModuleFromCAS(llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
 
   auto id = cas->parseID(cas_id);
   if (!id) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Modules), id.takeError(),
-                   "'{1}' is not valid CASID: {0}", cas_id);
+    // This function is also called for file paths that do not exist.
+    // An invalid CAS ID is not an error we need to surface to a user.
+    llvm::Error remaining = llvm::handleErrors(
+        id.takeError(),
+        [&](std::unique_ptr<llvm::StringError> SE) -> llvm::Error {
+          if (SE->convertToErrorCode() == std::errc::invalid_argument) {
+            LLDB_LOGV(GetLog(LLDBLog::Modules),
+                      "'{0}' is not a CAS id: {1}", cas_id, SE->getMessage());
+            return llvm::Error::success();
+          }
+          return llvm::Error(std::move(SE));
+        });
+    if (remaining)
+      return std::move(remaining);
     return ModuleSpec();
   }
 

--- a/lldb/test/Shell/SymbolFile/cas-gmodule.test
+++ b/lldb/test/Shell/SymbolFile/cas-gmodule.test
@@ -8,6 +8,19 @@
 # RUN: sed "s|DIR|%/t|g" %t/cas-config.template > %t/.cas-config
 # RUN: cd %t && %lldb main -s lldb.script 2>&1 | FileCheck %s
 
+# When the .pcm path in DWARF is a regular file path (not a CAS id) and
+# the file doesn't exist, GetSharedModuleFromCAS should silently return
+# false rather than logging "is not valid CASID". Build the same source
+# without -cas-path (file-path .pcm refs in DWARF), keep the .cas-config
+# so CAS is initialized, then delete the module cache.
+# RUN: rm -rf %t/nocas-build %t/nocas-cache
+# RUN: mkdir -p %t/nocas-build
+# RUN: cp %t/.cas-config %t/nocas-build/.cas-config
+# RUN: %clang_host -c -g -o %t/nocas-build/test.o %t/tu.c -fmodules -gmodules -fmodules-cache-path=%t/nocas-cache
+# RUN: %clang_host %t/nocas-build/test.o -o %t/nocas-build/main
+# RUN: rm -rf %t/nocas-cache
+# RUN: cd %t/nocas-build && %lldb main -s %t/lldb.script 2>&1 | FileCheck %s --check-prefix=NONCAS
+
 # FAIL: Failed to load module 'Bottom' at '{{.*}}' from CAS: no CAS associated with module
 # FAIL: Unable to locate module needed for external types.
 # CHECK: Loading module 'Bottom' from CAS at
@@ -17,6 +30,9 @@
 # CHECK: CAS at [[CAS]] was garbage-collected
 # CHECK: Initialized CAS at [[CAS]]
 # CHECK: Loading module 'Top' from CAS at
+
+# NONCAS-NOT: is not valid CASID
+# NONCAS: Unable to locate module needed for external types
 
 
 //--- module.modulemap


### PR DESCRIPTION
```
commit 7038d1081d080be9bd27d3075db3b527e32f92a2
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Jun 3 17:26:29 2026 -0700

    [LLDB] Suppress CAS-related warnings for non-existing file paths
    
    Currently all failed CAS lookups for paths that are not CAS IDs create
    a global Debugger::Warning. This is not useful information. Instead
    log it only to the verbose module log.
    
    rdar://175460386
    
    Assisted-by: claude
```
