### PR TITLE
[ExprConstant] Treat `&*p` as not a dereference in C constant initializers

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6274,6 +6274,17 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
       // member can be formed.
       return this->emitGetMemberPtr(cast<DeclRefExpr>(SubExpr)->getDecl(), E);
     }
+    // [C11 6.5.3.2p3]: if the operand of '&' is the result of a unary '*'
+    // operator, neither operator is evaluated and the result is as if both
+    // were omitted. So '&*q' is just 'q' with no dereference; delegate to the
+    // pointer operand directly instead of to the '*' (which would emit a null
+    // check), so that e.g. '&*(int *)0' is not rejected.
+    if (!Ctx.getLangOpts().CPlusPlus) {
+      const Expr *Sub = SubExpr->IgnoreParens();
+      if (const auto *Deref = dyn_cast<UnaryOperator>(Sub);
+          Deref && Deref->getOpcode() == UO_Deref)
+        return this->delegate(Deref->getSubExpr());
+    }
     // We should already have a pointer when we get here.
     return this->delegate(SubExpr);
   case UO_Deref: // *x

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -9873,6 +9873,19 @@ bool PointerExprEvaluator::VisitBinaryOperator(const BinaryOperator *E) {
 }
 
 bool PointerExprEvaluator::VisitUnaryAddrOf(const UnaryOperator *E) {
+  // [C11 6.5.3.2p3]: if the operand of '&' is the result of a unary '*'
+  // operator, neither operator is evaluated and the result is as if both were
+  // omitted (except that the operators' constraints, already enforced by Sema,
+  // still apply, and the result is not an lvalue). So '&*p' is just the pointer
+  // value 'p' with no dereference, and forming it is therefore not undefined
+  // behavior even when 'p' is null, e.g. '&*(int *)0'. Evaluate the pointer
+  // operand directly so we don't spuriously diagnose a null dereference.
+  if (!Info.getLangOpts().CPlusPlus) {
+    const Expr *Sub = E->getSubExpr()->IgnoreParens();
+    if (const auto *Deref = dyn_cast<UnaryOperator>(Sub);
+        Deref && Deref->getOpcode() == UO_Deref)
+      return evaluatePointer(Deref->getSubExpr(), Result);
+  }
   return evaluateLValue(E->getSubExpr(), Result);
 }
 

--- a/clang/test/Sema/static-init.c
+++ b/clang/test/Sema/static-init.c
@@ -22,3 +22,20 @@ union bar u[1];
 struct foo x = {(intptr_t) u}; // expected-error {{initializer element is not a compile-time constant}}
 struct foo y = {(char) u}; // expected-error {{initializer element is not a compile-time constant}}
 intptr_t z = (intptr_t) u; // no-error
+
+// [C11 6.5.3.2p3]: in '&*p' neither operator is evaluated and the result is as
+// if both were omitted, so forming it is not a dereference and is a valid
+// constant initializer even when 'p' is null. This must hold for a bit-field
+// initializer just as it does for a plain scalar (it was previously rejected
+// for bit-fields only, because they take a different evaluation path).
+intptr_t deref_scalar = (intptr_t) &*(int *)0; // no-error
+struct with_bitfield {
+  long v : 8;
+};
+struct with_bitfield deref_bitfield = {.v = (long) &*(int *)0}; // no-error
+
+// '&a[i]' is evaluated as 'a + i'.
+intptr_t subscript_scalar = (intptr_t) &((int *)0)[0]; // no-error
+intptr_t subscript_scalar_offset = (intptr_t) &((int *)0)[2]; // no-error
+struct with_bitfield subscript_bitfield = {.v = (long) &((int *)0)[0]}; // no-error
+struct with_bitfield subscript_bitfield_offset = {.v = (long) &((int *)0)[2]}; // no-error


### PR DESCRIPTION
In C, [C11 6.5.3.2p3] specifies that when the operand of unary `&` is the result of a unary `*` operator, neither operator is evaluated and the result is as if both were omitted. So `&*p` yields the pointer value `p` without performing a dereference, and forming it is well-defined even when `p` is null (e.g. `&*(int *)0`).

The constant evaluator did not honor this: it evaluated the `*` as a real lvalue access and diagnosed a null dereference as undefined behavior. This went unnoticed for ordinary scalar initializers, which use the relaxed `Expr::isConstantInitializer()` check, but a bit-field initializer is evaluated via `EvaluateAsInt()` with `SE_NoSideEffects`, so the same expression was rejected there with "initializer element is not a compile-time constant":

```
  struct S { long v : 8; };
  const struct S s = { .v = (long)&*(int *)0 };   // error
  const long x     = (long)&*(int *)0;            // accepted
```

Handle `&*p` in `PointerExprEvaluator::VisitUnaryAddrOf` (and the corresponding `UO_AddrOf` case in the bytecode interpreter) by evaluating the pointer operand directly in C.

Fixes #197846.

rdar://158774335