### PR TITLE
[lldb] Adjust task name reading for v2 of runtime layout

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -900,13 +900,17 @@ public:
         addr_t parent_addr = 0;
         if (m_task_info.isChildTask) {
           // Read ChildFragment::Parent, the first field of the ChildFragment.
-          if (auto child_offset = lldb_private::GetChildFragmentOffset(
-                  *process_sp, m_task_ptr)) {
+          auto child_offset =
+              lldb_private::GetChildFragmentOffset(*process_sp, m_task_ptr);
+          if (child_offset) {
             Status status;
             parent_addr = process_sp->ReadPointerFromMemory(
                 m_task_ptr + *child_offset, status);
             if (status.Fail() || parent_addr == LLDB_INVALID_ADDRESS)
               parent_addr = 0;
+          } else {
+            LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
+                           child_offset.takeError(), "{0}");
           }
         }
 
@@ -1230,8 +1234,9 @@ public:
       concurrency_version =
           SwiftLanguageRuntime::FindConcurrencyDebugVersion(*process_sp);
 
-    m_is_supported_target = is_64bit &&
-      SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(concurrency_version);
+    m_is_supported_target =
+        is_64bit && SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(
+                        concurrency_version);
   }
 
   llvm::Expected<uint32_t> CalculateNumChildren() override {
@@ -1355,14 +1360,17 @@ private:
     Task getNextChild(Status &status) {
       addr_t next_task = LLDB_INVALID_ADDRESS;
       if (status.Success()) {
-        if (auto child_offset =
-                lldb_private::GetChildFragmentOffset(*process_sp, addr)) {
+        auto child_offset =
+            lldb_private::GetChildFragmentOffset(*process_sp, addr);
+        if (child_offset) {
           // NextChild is the second pointer-sized field in ChildFragment
           // (after `Parent`).
           offset_t next_child_offset =
               *child_offset + process_sp->GetAddressByteSize();
           next_task = process_sp->ReadPointerFromMemory(
               addr + next_child_offset, status);
+        } else {
+          status = Status::FromError(child_offset.takeError());
         }
       }
       return {process_sp, next_task};

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1140,7 +1140,9 @@ public:
       concurrency_version =
           SwiftLanguageRuntime::FindConcurrencyDebugVersion(*process_sp);
 
-    bool is_supported_target = is_64bit && concurrency_version.value_or(0) == 1;
+    bool is_supported_target =
+        is_64bit && SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(
+                        concurrency_version);
     if (!is_supported_target)
       return;
 
@@ -1230,7 +1232,9 @@ public:
       concurrency_version =
           SwiftLanguageRuntime::FindConcurrencyDebugVersion(*process_sp);
 
-    m_is_supported_target = is_64bit && concurrency_version.value_or(0) == 1;
+    // See note on layout versions in CheckedContinuationSyntheticFrontEnd.
+    m_is_supported_target = is_64bit &&
+      SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(concurrency_version);
   }
 
   llvm::Expected<uint32_t> CalculateNumChildren() override {
@@ -1431,7 +1435,10 @@ public:
       concurrency_version =
           SwiftLanguageRuntime::FindConcurrencyDebugVersion(*process_sp);
 
-    m_is_supported_target = is_64bit && concurrency_version.value_or(0) == 1;
+    // See note on layout versions in CheckedContinuationSyntheticFrontEnd.
+    m_is_supported_target =
+        is_64bit && SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(
+                        concurrency_version);
   }
 
   llvm::Expected<uint32_t> CalculateNumChildren() override {

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -752,11 +752,6 @@ namespace lldb_private {
 namespace formatters {
 namespace swift {
 
-/// The size of Swift Tasks. Fragments are tail allocated.
-static constexpr size_t AsyncTaskSize = sizeof(::swift::AsyncTask);
-/// The offset of ChildFragment, which is the first fragment of an AsyncTask.
-static constexpr offset_t ChildFragmentOffset = AsyncTaskSize;
-
 class EnumSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   EnumSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
@@ -905,11 +900,14 @@ public:
         addr_t parent_addr = 0;
         if (m_task_info.isChildTask) {
           // Read ChildFragment::Parent, the first field of the ChildFragment.
-          Status status;
-          parent_addr = process_sp->ReadPointerFromMemory(
-              m_task_ptr + ChildFragmentOffset, status);
-          if (status.Fail() || parent_addr == LLDB_INVALID_ADDRESS)
-            parent_addr = 0;
+          if (auto child_offset = lldb_private::GetChildFragmentOffset(
+                  *process_sp, m_task_ptr)) {
+            Status status;
+            parent_addr = process_sp->ReadPointerFromMemory(
+                m_task_ptr + *child_offset, status);
+            if (status.Fail() || parent_addr == LLDB_INVALID_ADDRESS)
+              parent_addr = 0;
+          }
         }
 
         addr_t value = process_sp->FixDataAddress(parent_addr);
@@ -1232,7 +1230,6 @@ public:
       concurrency_version =
           SwiftLanguageRuntime::FindConcurrencyDebugVersion(*process_sp);
 
-    // See note on layout versions in CheckedContinuationSyntheticFrontEnd.
     m_is_supported_target = is_64bit &&
       SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(concurrency_version);
   }
@@ -1355,13 +1352,19 @@ private:
     bool operator==(const Task &other) const { return addr == other.addr; }
     bool operator!=(const Task &other) const { return !(*this == other); }
 
-    static constexpr offset_t NextChildOffset = ChildFragmentOffset + 0x8;
-
     Task getNextChild(Status &status) {
       addr_t next_task = LLDB_INVALID_ADDRESS;
-      if (status.Success())
-        next_task =
-            process_sp->ReadPointerFromMemory(addr + NextChildOffset, status);
+      if (status.Success()) {
+        if (auto child_offset =
+                lldb_private::GetChildFragmentOffset(*process_sp, addr)) {
+          // NextChild is the second pointer-sized field in ChildFragment
+          // (after `Parent`).
+          offset_t next_child_offset =
+              *child_offset + process_sp->GetAddressByteSize();
+          next_task = process_sp->ReadPointerFromMemory(
+              addr + next_child_offset, status);
+        }
+      }
       return {process_sp, next_task};
     }
   };
@@ -1435,7 +1438,6 @@ public:
       concurrency_version =
           SwiftLanguageRuntime::FindConcurrencyDebugVersion(*process_sp);
 
-    // See note on layout versions in CheckedContinuationSyntheticFrontEnd.
     m_is_supported_target =
         is_64bit && SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(
                         concurrency_version);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -58,6 +58,7 @@
 
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/ABI/Task.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/RemoteAST/RemoteAST.h"
 #include "swift/RemoteInspection/ReflectionContext.h"
@@ -3759,8 +3760,106 @@ struct Task {
 
 }; // namespace
 
-llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task_addr,
-                                                       Process &process) {
+/// Read the `JobFlags` of an async task.
+///
+/// Flags is stable ABI in AsyncTask:
+///   [HeapObject (2 ptrs)] [SchedulerPrivate (2 ptrs)] [Flags (uint32_t)] ...
+std::optional<JobFlags> GetAsyncJobFlags(Process &process,
+                                         lldb::addr_t task_addr) {
+  Status status;
+  const size_t addr_size = process.GetAddressByteSize();
+  constexpr unsigned JobFlagsPointerOffset = 4;
+  const offset_t flags_byte_offset = JobFlagsPointerOffset * addr_size;
+  uint64_t bits = process.ReadUnsignedIntegerFromMemory(
+      task_addr + flags_byte_offset, /*size=*/4, /*fail_value=*/0, status);
+  if (!status.Success())
+    return std::nullopt;
+  return JobFlags{static_cast<uint32_t>(bits)};
+}
+
+lldb::offset_t GetChildFragmentOffset(Process &process, JobFlags flags) {
+  offset_t offset = AsyncTaskSize;
+  if (flags.hasInitialTaskName())
+    offset += NameFragmentSize(process);
+  return offset;
+}
+
+std::optional<lldb::offset_t>
+GetChildFragmentOffset(Process &process, lldb::addr_t task_addr) {
+  auto flags = GetAsyncJobFlags(process, task_addr);
+  if (!flags)
+    return std::nullopt;
+  return GetChildFragmentOffset(process, *flags);
+}
+
+/// Reads the task name out of the tail-allocated `AsyncTask::NameFragment` if available.
+/// Implementation for Concurrency Debug Version 2+
+llvm::Expected<std::optional<std::string>> GetTaskNameFromFragment(
+    Process &process, lldb::addr_t task_addr) {
+
+  Status status;
+  const size_t addr_size = process.GetAddressByteSize();
+  ModuleSP concurrency_module =
+      SwiftLanguageRuntime::FindConcurrencyModule(process);
+  if (!concurrency_module)
+    return llvm::createStringError("Could not load _Concurrency module");
+  const Symbol *offset_symbol =
+      concurrency_module->FindFirstSymbolWithNameAndType(
+          ConstString("_swift_concurrency_debug_asyncTaskNameOffset"));
+  if (!offset_symbol)
+    return std::nullopt;
+  addr_t offset_symbol_addr =
+      offset_symbol->GetLoadAddress(&process.GetTarget());
+  if (offset_symbol_addr == LLDB_INVALID_ADDRESS)
+    return std::nullopt;
+
+  // Find the name fragment offset
+  uint64_t name_fragment_offset = process.ReadUnsignedIntegerFromMemory(
+      offset_symbol_addr, addr_size, /*fail_value=*/0, status);
+  if (!status.Success())
+    return status.takeError();
+  if (name_fragment_offset == 0)
+    return std::nullopt;
+
+  // NameFragment layout:
+  //   const char *Name;       // pointer to NUL-terminated UTF-8 chars
+  //   size_t      NameLength; // length, not counting the trailing '\0'
+  //
+  // Read the whole fragment in one shot, we'll need both values.
+  const size_t fragment_size = 2 * addr_size;
+  uint8_t fragment_buf[2 * sizeof(uint64_t)];
+  if (process.ReadMemory(task_addr + name_fragment_offset, fragment_buf,
+                         fragment_size, status) != fragment_size ||
+      !status.Success()) {
+    if (status.Success())
+      return std::nullopt;
+    return status.takeError();
+  }
+
+  // Decode NameLength and Name pointer the same way.
+  DataExtractor extractor(fragment_buf, fragment_size,
+                          process.GetByteOrder(),
+                          static_cast<uint32_t>(addr_size));
+  offset_t off = 0;
+  addr_t name_addr = extractor.GetAddress(&off);
+  uint64_t name_length = addr_size == 8 ? extractor.GetU64(&off) : extractor.GetU32(&off);
+
+  if (name_addr == 0 || name_addr == LLDB_INVALID_ADDRESS)
+    return std::nullopt;
+
+  std::string name(name_length, '\0');
+  if (name_length > 0) {
+    auto read_length = process.ReadMemory(name_addr, name.data(), name_length, status);
+    if (read_length != name_length || !status.Success()) {
+      return status.takeError();
+    }
+  }
+  return name;
+}
+
+/// Legacy implementation for Concurrency Debug Version 1.
+llvm::Expected<std::optional<std::string>> GetTaskNameFromRecord(
+    Process &process, lldb::addr_t task_addr) {
   Status status;
   Task task{process, task_addr};
   auto status_record = task.getActiveTaskStatusRecord(status);
@@ -3772,6 +3871,31 @@ llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task_addr,
   if (status.Success())
     return std::nullopt;
   return status.takeError();
+}
+
+llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task_addr,
+                                                       Process &process) {
+  std::optional<uint32_t> version =
+      SwiftLanguageRuntime::FindConcurrencyDebugVersion(process);
+  if (!version)
+    return std::nullopt;
+
+  // Check if the task has a name (it will always have the flag set if yes),
+  // so we can potentially avoid expensive lookups.
+  auto job_flags = GetAsyncJobFlags(process, task_addr);
+  if (!job_flags)
+    return llvm::createStringError("could not read job flags from task");
+  if (!job_flags->hasInitialTaskName())
+    return std::nullopt; // This task has no name
+
+  switch (*version) {
+  case 0:
+  case 1:
+    return GetTaskNameFromRecord(process, task_addr);
+  default:
+    // From version 2 onwards, the name is stored in a task fragment.
+    return GetTaskNameFromFragment(process, task_addr);
+  }
 }
 
 llvm::Expected<uint64_t> FindPrologueSize(Process &process,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -57,8 +57,8 @@
 #include "lldb/ValueObject/ValueObjectVariable.h"
 
 #include "lldb/lldb-enumerations.h"
-#include "swift/AST/ASTMangler.h"
 #include "swift/ABI/Task.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/RemoteAST/RemoteAST.h"
 #include "swift/RemoteInspection/ReflectionContext.h"
@@ -241,6 +241,37 @@ SwiftLanguageRuntime::FindConcurrencyDebugVersion(Process &process) {
   if (error.Fail())
     return {};
   return version;
+}
+
+llvm::Expected<lldb::offset_t>
+SwiftLanguageRuntime::FindAsyncTaskNameOffset(Process &process) {
+  ModuleSP concurrency_module = FindConcurrencyModule(process);
+  if (!concurrency_module)
+    return llvm::createStringError("could not load _Concurrency module");
+
+  const Symbol *offset_symbol =
+      concurrency_module->FindFirstSymbolWithNameAndType(
+          ConstString("_swift_concurrency_debug_asyncTaskNameOffset"));
+  if (!offset_symbol)
+    return llvm::createStringError(
+        "_swift_concurrency_debug_asyncTaskNameOffset symbol not found");
+
+  addr_t offset_symbol_addr =
+      offset_symbol->GetLoadAddress(&process.GetTarget());
+  if (offset_symbol_addr == LLDB_INVALID_ADDRESS)
+    return llvm::createStringError(
+        "_swift_concurrency_debug_asyncTaskNameOffset has no load address");
+
+  Status status;
+  uint64_t name_fragment_offset = process.ReadUnsignedIntegerFromMemory(
+      offset_symbol_addr, process.GetAddressByteSize(), /*fail_value=*/0,
+      status);
+  if (!status.Success())
+    return status.takeError();
+  if (name_fragment_offset == 0)
+    return llvm::createStringError(
+        "_swift_concurrency_debug_asyncTaskNameOffset is 0");
+  return name_fragment_offset;
 }
 
 static std::optional<lldb::addr_t>
@@ -3764,8 +3795,8 @@ struct Task {
 ///
 /// Flags is stable ABI in AsyncTask:
 ///   [HeapObject (2 ptrs)] [SchedulerPrivate (2 ptrs)] [Flags (uint32_t)] ...
-std::optional<JobFlags> GetAsyncJobFlags(Process &process,
-                                         lldb::addr_t task_addr) {
+llvm::Expected<JobFlags> GetAsyncJobFlags(Process &process,
+                                          lldb::addr_t task_addr) {
   Status status;
   const size_t addr_size = process.GetAddressByteSize();
   constexpr unsigned JobFlagsPointerOffset = 4;
@@ -3773,7 +3804,7 @@ std::optional<JobFlags> GetAsyncJobFlags(Process &process,
   uint64_t bits = process.ReadUnsignedIntegerFromMemory(
       task_addr + flags_byte_offset, /*size=*/4, /*fail_value=*/0, status);
   if (!status.Success())
-    return std::nullopt;
+    return status.takeError();
   return JobFlags{static_cast<uint32_t>(bits)};
 }
 
@@ -3784,42 +3815,25 @@ lldb::offset_t GetChildFragmentOffset(Process &process, JobFlags flags) {
   return offset;
 }
 
-std::optional<lldb::offset_t>
-GetChildFragmentOffset(Process &process, lldb::addr_t task_addr) {
+llvm::Expected<lldb::offset_t> GetChildFragmentOffset(Process &process,
+                                                      lldb::addr_t task_addr) {
   auto flags = GetAsyncJobFlags(process, task_addr);
   if (!flags)
-    return std::nullopt;
+    return flags.takeError();
   return GetChildFragmentOffset(process, *flags);
 }
 
-/// Reads the task name out of the tail-allocated `AsyncTask::NameFragment` if available.
-/// Implementation for Concurrency Debug Version 2+
-llvm::Expected<std::optional<std::string>> GetTaskNameFromFragment(
-    Process &process, lldb::addr_t task_addr) {
+/// Reads the task name out of the tail-allocated `AsyncTask::NameFragment` if
+/// available. Implementation for Concurrency Debug Version 2+
+llvm::Expected<std::optional<std::string>>
+GetTaskNameFromFragment(Process &process, lldb::addr_t task_addr) {
+  auto offset_or_err = SwiftLanguageRuntime::FindAsyncTaskNameOffset(process);
+  if (!offset_or_err)
+    return offset_or_err.takeError();
+  const lldb::offset_t name_fragment_offset = *offset_or_err;
 
   Status status;
   const size_t addr_size = process.GetAddressByteSize();
-  ModuleSP concurrency_module =
-      SwiftLanguageRuntime::FindConcurrencyModule(process);
-  if (!concurrency_module)
-    return llvm::createStringError("Could not load _Concurrency module");
-  const Symbol *offset_symbol =
-      concurrency_module->FindFirstSymbolWithNameAndType(
-          ConstString("_swift_concurrency_debug_asyncTaskNameOffset"));
-  if (!offset_symbol)
-    return std::nullopt;
-  addr_t offset_symbol_addr =
-      offset_symbol->GetLoadAddress(&process.GetTarget());
-  if (offset_symbol_addr == LLDB_INVALID_ADDRESS)
-    return std::nullopt;
-
-  // Find the name fragment offset
-  uint64_t name_fragment_offset = process.ReadUnsignedIntegerFromMemory(
-      offset_symbol_addr, addr_size, /*fail_value=*/0, status);
-  if (!status.Success())
-    return status.takeError();
-  if (name_fragment_offset == 0)
-    return std::nullopt;
 
   // NameFragment layout:
   //   const char *Name;       // pointer to NUL-terminated UTF-8 chars
@@ -3837,29 +3851,29 @@ llvm::Expected<std::optional<std::string>> GetTaskNameFromFragment(
   }
 
   // Decode NameLength and Name pointer the same way.
-  DataExtractor extractor(fragment_buf, fragment_size,
-                          process.GetByteOrder(),
+  DataExtractor extractor(fragment_buf, fragment_size, process.GetByteOrder(),
                           static_cast<uint32_t>(addr_size));
   offset_t off = 0;
   addr_t name_addr = extractor.GetAddress(&off);
-  uint64_t name_length = addr_size == 8 ? extractor.GetU64(&off) : extractor.GetU32(&off);
+  uint64_t name_length =
+      addr_size == 8 ? extractor.GetU64(&off) : extractor.GetU32(&off);
 
   if (name_addr == 0 || name_addr == LLDB_INVALID_ADDRESS)
     return std::nullopt;
 
   std::string name(name_length, '\0');
   if (name_length > 0) {
-    auto read_length = process.ReadMemory(name_addr, name.data(), name_length, status);
-    if (read_length != name_length || !status.Success()) {
+    auto read_length =
+        process.ReadMemory(name_addr, name.data(), name_length, status);
+    if (read_length != name_length || !status.Success())
       return status.takeError();
-    }
   }
   return name;
 }
 
 /// Legacy implementation for Concurrency Debug Version 1.
-llvm::Expected<std::optional<std::string>> GetTaskNameFromRecord(
-    Process &process, lldb::addr_t task_addr) {
+llvm::Expected<std::optional<std::string>>
+GetTaskNameFromRecord(Process &process, lldb::addr_t task_addr) {
   Status status;
   Task task{process, task_addr};
   auto status_record = task.getActiveTaskStatusRecord(status);
@@ -3884,7 +3898,7 @@ llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task_addr,
   // so we can potentially avoid expensive lookups.
   auto job_flags = GetAsyncJobFlags(process, task_addr);
   if (!job_flags)
-    return llvm::createStringError("could not read job flags from task");
+    return job_flags.takeError();
   if (!job_flags->hasInitialTaskName())
     return std::nullopt; // This task has no name
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -117,6 +117,23 @@ public:
   /// Returns 0 for versions of the module prior to the introduction
   /// of versioning.
   static std::optional<uint32_t> FindConcurrencyDebugVersion(Process &process);
+
+  /// Inclusive range of `_swift_concurrency_debug_internal_layout_version`
+  /// values that LLDB knows how to decode.
+  ///
+  ///   1 - the original layout
+  ///   2 - AsyncTask gained optional tail-allocated `NameFragment` ahead of its
+  ///       other fragments when the task has an initial name (ahead of the ChildFragment).
+  static constexpr uint32_t ConcurrencyDebugVersionBaseline = 1;
+  static constexpr uint32_t ConcurrencyDebugVersionLatest = 2;
+
+  /// True iff `version` is a concurrency runtime layout version this build
+  /// of LLDB supports. A missing version (`std::nullopt`) is never supported.
+  static constexpr bool
+  IsSupportedConcurrencyDebugVersion(std::optional<uint32_t> version) {
+    return version && *version >= ConcurrencyDebugVersionBaseline &&
+           *version <= ConcurrencyDebugVersionLatest;
+  }
   /// \}
 
   /// PluginInterface protocol.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -21,6 +21,7 @@
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/Process.h"
 #include "lldb/lldb-private.h"
+#include "swift/ABI/Task.h"
 #include "swift/Demangling/ManglingFlavor.h"
 
 #include "llvm/ADT/DenseSet.h"
@@ -979,7 +980,7 @@ public:
   GetTaskAddrFromThreadLocalStorage(llvm::ArrayRef<Thread *> threads);
 
 private:
-  /// For each thread in `threads`, return the location of the its task
+  /// For each thread in `threads`, return the location of its task
   /// pointer, if it exists.
   llvm::SmallVector<std::optional<lldb::addr_t>>
   GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads);
@@ -992,6 +993,52 @@ private:
   llvm::DenseMap<uint64_t, lldb::addr_t> m_tid_to_task_addr_location;
 };
 
+/// Represents `swift::JobFlags` as defined in `include/swift/ABI/MetadataValues.h`.
+struct JobFlags {
+  uint32_t bits;
+
+  enum Bit : uint32_t {
+    // Only the flags actually consumed by LLDB are listed; add more as needed.
+    Task_HasInitialTaskName = 30,
+  };
+
+  bool hasFlag(Bit b) const { return (bits >> b) & 1U; }
+
+  /// True when the task was created with `Task(name:)` or similar.
+  bool hasInitialTaskName() const { return hasFlag(Task_HasInitialTaskName); }
+};
+
+/// The offset of ChildFragment, which is the first fragment of an AsyncTask.
+inline constexpr lldb::offset_t AsyncTaskSize = sizeof(::swift::AsyncTask);
+
+/// Size of `AsyncTask::NameFragment` — `const char *Name` + `size_t Length`,
+/// i.e. two pointer-sized words. Tail-allocated immediately after the
+/// AsyncTask iff `JobFlags::hasInitialTaskName()` is set.
+inline lldb::offset_t NameFragmentSize(Process &process) {
+  return 2 * process.GetAddressByteSize();
+}
+
+/// Read the `JobFlags` of an async task from the inferior process.
+/// Returns `std::nullopt` if reading the 4-byte flag word fails.
+std::optional<JobFlags> GetAsyncJobFlags(Process &process,
+                                         lldb::addr_t task_addr);
+
+/// Returns the offset (in bytes) of `ChildFragment` from the start of an
+/// async task. Reads `JobFlags` from the inferior; `std::nullopt` if that
+/// read fails.
+std::optional<lldb::offset_t>
+GetChildFragmentOffset(Process &process, lldb::addr_t task_addr);
+
+/// Returns the offset (in bytes) of `ChildFragment` from the start of an
+/// async task whose `JobFlags` are already known. Infallible.
+///
+/// `flags` must come from the same task whose offset is being computed —
+/// they encode which fragments are tail-allocated, which determines the
+/// offset.
+lldb::offset_t GetChildFragmentOffset(Process &process, JobFlags flags);
+
+/// Get the name of a task.
+/// Names are immutable and specified with `Task(name:)` during initialization.
 llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task,
                                                        Process &process);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -119,12 +119,18 @@ public:
   /// of versioning.
   static std::optional<uint32_t> FindConcurrencyDebugVersion(Process &process);
 
+  /// Returns the byte offset of `AsyncTask::NameFragment` from the start of an
+  /// async task.
+  static llvm::Expected<lldb::offset_t>
+  FindAsyncTaskNameOffset(Process &process);
+
   /// Inclusive range of `_swift_concurrency_debug_internal_layout_version`
   /// values that LLDB knows how to decode.
   ///
   ///   1 - the original layout
   ///   2 - AsyncTask gained optional tail-allocated `NameFragment` ahead of its
-  ///       other fragments when the task has an initial name (ahead of the ChildFragment).
+  ///       other fragments when the task has an initial name (ahead of the
+  ///       ChildFragment).
   static constexpr uint32_t ConcurrencyDebugVersionBaseline = 1;
   static constexpr uint32_t ConcurrencyDebugVersionLatest = 2;
 
@@ -993,7 +999,8 @@ private:
   llvm::DenseMap<uint64_t, lldb::addr_t> m_tid_to_task_addr_location;
 };
 
-/// Represents `swift::JobFlags` as defined in `include/swift/ABI/MetadataValues.h`.
+/// Represents `swift::JobFlags` as defined in
+/// `include/swift/ABI/MetadataValues.h`.
 struct JobFlags {
   uint32_t bits;
 
@@ -1009,32 +1016,29 @@ struct JobFlags {
 };
 
 /// The offset of ChildFragment, which is the first fragment of an AsyncTask.
-inline constexpr lldb::offset_t AsyncTaskSize = sizeof(::swift::AsyncTask);
+inline constexpr size_t AsyncTaskSize = sizeof(::swift::AsyncTask);
 
-/// Size of `AsyncTask::NameFragment` — `const char *Name` + `size_t Length`,
+/// Size of `AsyncTask::NameFragment` = `const char *Name` + `size_t Length`,
 /// i.e. two pointer-sized words. Tail-allocated immediately after the
 /// AsyncTask iff `JobFlags::hasInitialTaskName()` is set.
-inline lldb::offset_t NameFragmentSize(Process &process) {
+inline size_t NameFragmentSize(Process &process) {
   return 2 * process.GetAddressByteSize();
 }
 
-/// Read the `JobFlags` of an async task from the inferior process.
-/// Returns `std::nullopt` if reading the 4-byte flag word fails.
-std::optional<JobFlags> GetAsyncJobFlags(Process &process,
-                                         lldb::addr_t task_addr);
+/// Read the `JobFlags` of an async task.
+llvm::Expected<JobFlags> GetAsyncJobFlags(Process &process,
+                                          lldb::addr_t task_addr);
 
 /// Returns the offset (in bytes) of `ChildFragment` from the start of an
-/// async task. Reads `JobFlags` from the inferior; `std::nullopt` if that
-/// read fails.
-std::optional<lldb::offset_t>
-GetChildFragmentOffset(Process &process, lldb::addr_t task_addr);
+/// async task.
+llvm::Expected<lldb::offset_t> GetChildFragmentOffset(Process &process,
+                                                      lldb::addr_t task_addr);
 
-/// Returns the offset (in bytes) of `ChildFragment` from the start of an
-/// async task whose `JobFlags` are already known. Infallible.
+/// Returns the offset of `ChildFragment` from the start of an
+/// async task.
 ///
 /// `flags` must come from the same task whose offset is being computed —
-/// they encode which fragments are tail-allocated, which determines the
-/// offset.
+/// they encode which fragments are available, which impacts the offset.
 lldb::offset_t GetChildFragmentOffset(Process &process, JobFlags flags);
 
 /// Get the name of a task.

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -113,7 +113,8 @@ OperatingSystem *OperatingSystemSwiftTasks::CreateInstance(Process *process,
   LLDB_LOGF(log,
             "OperatingSystemSwiftTasks: got a concurrency version symbol of %u",
             *concurrency_version);
-  if (*concurrency_version > 1) {
+  if (!SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(
+          concurrency_version)) {
     auto warning =
         llvm::formatv("Unexpected Swift concurrency version {0}. Stepping on "
                       "concurrent code may behave incorrectly.",


### PR DESCRIPTION
This is the lldb part of https://github.com/swiftlang/swift/pull/89678

This implements the v2 of the concurrency debug version;
The change is:
- in order to support other memory reading tools, we're moving where the task name is stored into the fragment just after the `AsyncTask` as this is easier to lookup than record traversal.
- this also is in general more performant since we don't ever have to make a record walk to find the name; it is just offset + deref pointer to get the string data.

I've bumped the debug version in https://github.com/swiftlang/swift/pull/89678 and adjusted all the handling here in a backwards compatible way.

Please review as I'm new to the codebase and I'm not sure if following all the right patterns etc, thank you!