### PR TITLE
[lldb] check for interop type aliases in tests

### DIFF
--- a/lldb/test/Shell/SwiftREPL/ImportDispatch.test
+++ b/lldb/test/Shell/SwiftREPL/ImportDispatch.test
@@ -3,7 +3,7 @@
 // REQUIRES: swift
 
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
-// CHECK: UInt
+// CHECK: CUnsignedLong
 
 import Dispatch
 DISPATCH_WALLTIME_NOW

--- a/lldb/test/Shell/SwiftREPL/SleepREPL.test
+++ b/lldb/test/Shell/SwiftREPL/SleepREPL.test
@@ -6,4 +6,4 @@
 
 import Foundation
 sleep(2)
-// SLEEP: $R0: UInt32 = 0
+// SLEEP: $R0: CUnsignedInt = 0


### PR DESCRIPTION
This updates two tests to align with the new behavior in https://github.com/swiftlang/swift/pull/89531