### PR TITLE
[lldb][Windows] Re-enable explicit_modules Swift tests

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -9,7 +9,6 @@ class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_missing_explicit_modules(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""
         self.build()
@@ -34,7 +33,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_sanity(self):
         """Check the normal behavior."""
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")
@@ -63,7 +61,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_setting(self):
         """Check the normal behavior."""
         self.build()

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
@@ -9,7 +9,6 @@ class TestSwiftExplicitModulePrivateTypeGeneric(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test(self):
         """Test frame variable of a generic struct specialized to a
         private type from another explicitly-built module."""

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -8,7 +8,6 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test(self):
         """Test explicit Swift modules"""
         self.build()
@@ -24,7 +23,6 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_disable_esml(self):
         """Test disabling the explicit Swift module loader"""
         self.build()
@@ -44,7 +42,6 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     @skipUnlessDarwin
     def test_import(self):
         """Test an implicit import inside an explicit build"""


### PR DESCRIPTION
These `lang/swift/explicit_modules` tests (simple, implicit_fallback, private_type_generic) pass on Windows, so remove their `@skipIfWindows` decorators.