### PR TITLE
[lldb][Windows] Re-enable two C++ interop class tests

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
@@ -10,7 +10,6 @@ class TestSwiftForwardInteropCxxClassAsExistential(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
@@ -10,7 +10,6 @@ class TestSwiftForwardInteropCxxClass(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_class(self):
         self.build()
         _, _, _, _= lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
`TestSwiftForwardInteropCxxClass` and `TestSwiftForwardInteropCxxClassAsExistential` pass on Windows now, so remove their `@skipIfWindows` decorators.