### PR TITLE
[lldb][Windows] Re-enable opaque_return_resilient Swift tests

### DIFF
--- a/lldb/test/API/lang/swift/opaque_return_resilient/TestSwiftOpaqueReturnResilient.py
+++ b/lldb/test/API/lang/swift/opaque_return_resilient/TestSwiftOpaqueReturnResilient.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftOpaqueReturnResilient(TestBase):
     @swiftTest
     @skipEmbeddedSwift
-    @skipIfWindows
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/opaque_return_resilient_collection/TestSwiftOpaqueReturnResilientCollection.py
+++ b/lldb/test/API/lang/swift/opaque_return_resilient_collection/TestSwiftOpaqueReturnResilientCollection.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftOpaqueReturnResilientCollection(TestBase):
     @swiftTest
     @skipEmbeddedSwift
-    @skipIfWindows
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")


### PR DESCRIPTION
Both opaque_return_resilient tests pass on Windows now, so remove their @skipIfWindows decorators.