### PR TITLE
[lldb][Windows] Use skipEmbeddedSwiftOnWindows for embed-only failing Swift tests

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
@@ -12,7 +12,7 @@ class TestSwiftExtraClangFlags(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=["windows"])
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_extra_clang_flags(self):
         """

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestSwiftForwardInteropClassInNamespace.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestSwiftForwardInteropClassInNamespace.py
@@ -10,7 +10,7 @@ class TestSwiftForwardInteropClassInNamespace(TestBase):
 
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_class(self):
         self.build()
         _, _, _, _= lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
@@ -10,7 +10,7 @@ class TestCxxForwardInteropNestedClasses(TestBase):
 
     @skipIf(swift_module_importer="noclang")
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/swift-class-with-cxx-ivars/TestSwiftForwardInteropClassWithCxxIvars.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/swift-class-with-cxx-ivars/TestSwiftForwardInteropClassWithCxxIvars.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropClassWithCxxIvars(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/swift-generic-with-cxx-type/TestSwiftForwardInteropGenericWithCxxType.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/swift-generic-with-cxx-type/TestSwiftForwardInteropGenericWithCxxType.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropGenericWithCxxType(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/template-types/TestSwiftForwardInteropTemplateTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/template-types/TestSwiftForwardInteropTemplateTypes.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropTemplateTypes(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/typedefed-type/TestSwiftForwardInteropTypedefType.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/typedefed-type/TestSwiftForwardInteropTypedefType.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropTypedefType(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_class(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/variadic-template-types/TestSwiftForwardInteropVariadicTemplateTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/variadic-template-types/TestSwiftForwardInteropVariadicTemplateTypes.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropVariadicTemplateTypes(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/import_spi/TestSwiftImportSPI.py
+++ b/lldb/test/API/lang/swift/import_spi/TestSwiftImportSPI.py
@@ -7,7 +7,7 @@ import os
 
 class TestSwiftImportSPI(lldbtest.TestBase):
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test SPI imports"""
         self.build()

--- a/lldb/test/API/lang/swift/struct_init_display/TestSwiftStructInit.py
+++ b/lldb/test/API/lang/swift/struct_init_display/TestSwiftStructInit.py
@@ -21,7 +21,7 @@ import os
 
 class TestSwiftStructInit(TestBase):
     @swiftTest
-    @skipIf(oslist=['windows'])
+    @skipEmbeddedSwiftOnWindows
     def test_swift_struct_init(self):
         """Test that we display self correctly for an inline-initialized struct"""
         self.build()

--- a/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
+++ b/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
@@ -9,7 +9,7 @@ class TestSwiftHealthCheck(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     @skipIfDarwinEmbedded
     def test_run_healthcheck(self):
         """Test that an underspecified triple is upgraded with a version number.
@@ -39,7 +39,7 @@ class TestSwiftHealthCheck(TestBase):
         self.assertEqual(bad, 0)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     @skipIfDarwinEmbedded
     def test_help_healthcheck(self):
         self.expect("help swift-healthcheck",


### PR DESCRIPTION
These tests were fully skipped on Windows via `@skipIfWindows`, but only their embedded-Swift variant fails (embedded Swift cannot import the Swift module on Windows).

Switch to `@skipEmbeddedSwiftOnWindows` so the regular DWARF variants run and pass on Windows while the embedded variant stays skipped.