### PR TITLE
[lldb][Windows] Unskip Swift tests

### DIFF
--- a/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
@@ -10,7 +10,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://173245096
     def test_swift_po_address(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
@@ -24,7 +23,6 @@ class TestCase(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://173245096
     def test_swift_po_non_address_hex(self):
         """No special handling of non-memory integer values."""
         self.build()
@@ -35,7 +33,6 @@ class TestCase(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://173245096
     def test_print_swift_object_does_not_show_name(self):
         """Ensure that objects are printed without a name, and without the '='
         that would follow the name."""

--- a/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
+++ b/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
@@ -22,7 +22,6 @@ import os
 class TestSwiftArchetypeResolution(TestBase):
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://173245096
     def test_swift_archetype_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""
         self.build()

--- a/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
+++ b/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
@@ -8,7 +8,6 @@ class TestSwiftClassBaseClass(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://173245096
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here",


### PR DESCRIPTION
These tests were skipped when enabling the tests. Subsequent patches to lldb fixed some of them.

rdar://173245096