### PR TITLE
[lldb][Windows] Unskip former unresolved Swift tests

### DIFF
--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -9,7 +9,6 @@ class TestCase(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_unsafe_continuation_printing(self):
         """Print an UnsafeContinuation and verify its children."""
         self.build()
@@ -37,7 +36,6 @@ class TestCase(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_checked_continuation_printing(self):
         """Print an CheckedContinuation and verify its children."""
         self.build()


### PR DESCRIPTION
This patch re-enables tests that were previously unresolved on Windows.

rdar://176009590