### PR TITLE
[lldb][Windows] Unskip TestSwiftSubmoduleImport

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftSubmoduleImport(lldbtest.TestBase):
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://173245705
     def test(self):
         """Test imports of Clang submodules"""
         self.build()


### PR DESCRIPTION
This test used to be flaky when Windows DYLD loading was unreliable. This has now been fixed.

rdar://173245705