### PR TITLE
[lldb] Use skipEmbeddedSwiftOnWindows for rdar-disabled embed-only tests

### DIFF
--- a/lldb/test/API/lang/swift/generic_class_nested_in_function/TestSwiftGenericClassNestedInFunction.py
+++ b/lldb/test/API/lang/swift/generic_class_nested_in_function/TestSwiftGenericClassNestedInFunction.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class SwiftGenericClassNestedInFunctionTest(TestBase):
 
     @swiftTest
-    @skipIfWindows # rdar://173245096
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Tests that a generic class type nested inside a function can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/local_closure_types/TestSwiftLocalClosureTypes.py
+++ b/lldb/test/API/lang/swift/local_closure_types/TestSwiftLocalClosureTypes.py
@@ -19,6 +19,6 @@ lldbinline.MakeInlineTest(
         swiftTest,
         skipEmbeddedSwiftOnLinux,
         skipIf(oslist=["macosx"], bugnumber="rdar://26051759"),
-        skipIfWindows # rdar://173245096
+        skipEmbeddedSwiftOnWindows 
     ],
 )

--- a/lldb/test/API/lang/swift/variables/func/TestSwiftFunctionVariables.py
+++ b/lldb/test/API/lang/swift/variables/func/TestSwiftFunctionVariables.py
@@ -20,7 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestFunctionVariables(TestBase):
     @swiftTest
-    @skipIfWindows # rdar://173245096
+    @skipEmbeddedSwiftOnWindows
     def test_function_variables(self):
         """Tests that function type variables display correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
+++ b/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
@@ -21,7 +21,7 @@ import os
 
 class TestSwiftStdlibSet(TestBase):
     @swiftTest
-    @skipIfWindows # rdar://173243316
+    @skipEmbeddedSwiftOnWindows
     @skipEmbeddedSwiftOnLinux # Linker failure with arc4random_buf
     def test_swift_stdlib_set(self):
         """Tests that we properly vend synthetic children for Swift.Set"""


### PR DESCRIPTION
These were disabled on Windows with `@skipIfWindows`, but only the embedded-Swift variant fails (embedded Swift cannot import the Swift module on Windows).

The regular DWARF variants pass. Switch to `@skipEmbeddedSwiftOnWindows` so the DWARF variants run on Windows.