### PR TITLE
[clang][CAS] Fix diagnostic replay crash

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -623,9 +623,13 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
     bool WriteOutputHashXAttr, std::optional<llvm::cas::CASID> *OutMCOutputID) {
   CompilerInstance Clang(std::move(Invok));
   llvm::raw_svector_ostream DiagOS(DiagText);
-  Clang.createVirtualFileSystem(llvm::vfs::getRealFileSystem());
-  Clang.createDiagnostics(
-      new TextDiagnosticPrinter(DiagOS, Clang.getDiagnosticOpts()));
+  TextDiagnosticPrinter DiagConsumer(DiagOS, Clang.getDiagnosticOpts());
+  Clang.createVirtualFileSystem(llvm::vfs::getRealFileSystem(), &DiagConsumer);
+  if (DiagConsumer.getNumErrors() != 0)
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "error constructing virtual filesystem for replay: " + DiagOS.str());
+  Clang.createDiagnostics(&DiagConsumer, /*ShouldOwnClient=*/false);
   Clang.setVerboseOutputStream(DiagOS);
 
   // FIXME: we should create an include-tree filesystem based on the cache key

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -291,9 +291,15 @@ static void collectVFSEntries(CompilerInstance &CI,
 
 void CompilerInstance::createVirtualFileSystem(
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS, DiagnosticConsumer *DC) {
+  bool ShouldOwnClient = false;
+  if (!DC) {
+    DC = new DiagnosticConsumer;
+    ShouldOwnClient = true;
+  }
+
   DiagnosticOptions DiagOpts;
   DiagnosticsEngine Diags(DiagnosticIDs::create(), DiagOpts, DC,
-                          /*ShouldOwnClient=*/false);
+                          ShouldOwnClient);
 
   if (getFrontendOpts().needsCAS())
     getOrCreateCASDatabases(&Diags);

--- a/clang/test/CAS/libclang-replay-job.c
+++ b/clang/test/CAS/libclang-replay-job.c
@@ -96,6 +96,18 @@
 // ABS_DIAG: remark: compile job cache hit for
 // ABS_DIAG: libclang-replay-job.c.tmp{{.}}main.c:1:2: warning:
 
+// Check with a bad include-tree ID.
+// RUN: sed "s|llvmcas://[[:xdigit:]]*|llvmcas://bad|" %t/cc1.rsp > %t/cc1.bad.rsp
+// RUN: not c-index-test core -replay-cached-job -cas-path %t/cas @%t/cache-key \
+// RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -fcas-plugin-option no-logging \
+// RUN:   -working-dir %t \
+// RUN: -- @%t/cc1.bad.rsp \
+// RUN:   -serialize-diagnostic-file %t/t4.dia -Rcompile-job-cache-hit \
+// RUN:   -dependency-file %t/t4.d -o %t/output4.o 2> %t/output4.txt
+// RUN: FileCheck %s --input-file=%t/output4.txt -check-prefix=ERR_DIAG
+// ERR_DIAG: error constructing virtual filesystem for replay: fatal error: CAS cannot parse root-id 'llvmcas://bad' specified by '-fcas-*' options
+
 // Use relative path to inputs and outputs.
 //--- cdb.json.template
 [{

--- a/clang/unittests/Frontend/CompilerInstanceTest.cpp
+++ b/clang/unittests/Frontend/CompilerInstanceTest.cpp
@@ -80,6 +80,17 @@ TEST(CompilerInstance, DefaultVFSOverlayFromInvocation) {
   ASSERT_TRUE(Instance.getFileManager().getOptionalFileRef("vfs-virtual.file"));
 }
 
+TEST(CompilerInstance, CreateVFSWithoutDiagnosticConsumer) {
+  auto Invocation = std::make_shared<CompilerInvocation>();
+  Invocation->getHeaderSearchOpts().VFSOverlayFiles.push_back("/missing.yaml");
+  auto BaseFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  CompilerInstance Instance(std::move(Invocation));
+  // Check that omitting the DiagnosticConsumer doesn't crash (e.g. by
+  // dereferencing the null pointer).
+  ASSERT_NO_FATAL_FAILURE(
+      Instance.createVirtualFileSystem(std::move(BaseFS), /*DC=*/nullptr));
+}
+
 TEST(CompilerInstance, AllowDiagnosticLogWithUnownedDiagnosticConsumer) {
   DiagnosticOptions DiagOpts;
   // Tell the diagnostics engine to emit the diagnostic log to STDERR. This


### PR DESCRIPTION
The `CompilerInstance::createVirtualFileSystem()` function can fail but doesn't require a `DiagnosticConsumer` to be passed in. This is useful for infallible tests, but production code does need to provide the consumer. Without it, the function can assert. This PR also adds an early exit if there was an error during VFS creation to prevent non-sensical errors/crashes later on.

For convenience, the `CompilerInstance::createVirtualFileSystem()` API allows omitting the diagnostic consumer for clients that don't care about missing overlay files and other VFS creation errors. However, even in that case, the temporary `DiagnosticsEngine` created internally within the function does need a consumer. This PR sets it up.

This fixes an assertion in cached diagnostic replay.

rdar://176754115