### PR TITLE
APINotes: Add macro constant type lookup

### DIFF
--- a/clang/include/clang/APINotes/APINotesManager.h
+++ b/clang/include/clang/APINotes/APINotesManager.h
@@ -9,13 +9,16 @@
 #ifndef LLVM_CLANG_APINOTES_APINOTESMANAGER_H
 #define LLVM_CLANG_APINOTES_APINOTESMANAGER_H
 
+#include "clang/APINotes/Types.h"
 #include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/VersionTuple.h"
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace clang {
@@ -77,12 +80,18 @@ class APINotesManager {
   /// reader for this directory.
   llvm::DenseMap<const DirectoryEntry *, ReaderEntry> Readers;
 
+  /// A mapping from API notes files to loaded readers.
+  llvm::DenseMap<FileEntryRef, APINotesReader *> FileReaders;
+
   /// Load the API notes associated with the given file, whether it is
   /// the binary or source form of API notes.
   ///
   /// \returns the API notes reader for this file, or null if there is
   /// a failure.
   std::unique_ptr<APINotesReader> loadAPINotes(FileEntryRef APINotesFile);
+
+  /// Load or retrieve a cached reader for the given API notes file.
+  APINotesReader *getAPINotesReader(FileEntryRef APINotesFile);
 
   /// Load the API notes associated with the given buffer, whether it is
   /// the binary or source form of API notes.
@@ -174,6 +183,11 @@ public:
 
   /// Find the API notes readers that correspond to the given source location.
   llvm::SmallVector<APINotesReader *, 2> findAPINotes(SourceLocation Loc);
+
+  /// Lookup global variable API notes for the given module or source location.
+  std::optional<GlobalVariableInfo> lookupGlobalVariable(const Module *M,
+                                                         StringRef Name,
+                                                         SourceLocation Loc);
 
   bool captureVersionIndependentSwift() { return VersionIndependentSwift; }
 };

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1894,6 +1894,15 @@ public:
   ///
   /// Triggered by declaration-attribute processing.
   void ProcessAPINotes(Decl *D);
+  /// Look up the API notes for a macro constant.
+  ///
+  /// Unlike declarations, macro constants do not have a Clang declaration that
+  /// APINotes can mutate in place. Return the raw global-variable API notes for
+  /// the macro (carrying 'Type:', 'SwiftName:', and the other Globals metadata)
+  /// so that an importer can apply them itself, or std::nullopt if none apply.
+  std::optional<api_notes::GlobalVariableInfo>
+  ProcessAPINotes(const Module *M, const IdentifierInfo *II,
+                  SourceLocation Loc);
   /// Apply the 'Nullability:' annotation to the specified declaration
   void ApplyNullability(Decl *D, NullabilityKind Nullability);
   /// Apply the 'Type:' annotation to the specified declaration

--- a/clang/lib/APINotes/APINotesManager.cpp
+++ b/clang/lib/APINotes/APINotesManager.cpp
@@ -59,6 +59,9 @@ APINotesManager::~APINotesManager() {
       delete Reader;
   }
 
+  for (const auto &Entry : FileReaders)
+    delete Entry.second;
+
   delete CurrentModuleReaders[ReaderKind::Public];
   delete CurrentModuleReaders[ReaderKind::Private];
 }
@@ -128,6 +131,17 @@ APINotesManager::loadAPINotes(StringRef Buffer) {
     return nullptr;
   }
   return std::move(Reader.get());
+}
+
+APINotesReader *APINotesManager::getAPINotesReader(FileEntryRef APINotesFile) {
+  auto Known = FileReaders.find(APINotesFile);
+  if (Known != FileReaders.end())
+    return Known->second;
+
+  auto Reader = loadAPINotes(APINotesFile);
+  APINotesReader *Result = Reader.release();
+  FileReaders[APINotesFile] = Result;
+  return Result;
 }
 
 bool APINotesManager::loadAPINotes(const DirectoryEntry *HeaderDir,
@@ -467,4 +481,41 @@ APINotesManager::findAPINotes(SourceLocation Loc) {
     Readers[Visited] = Dir ? ReaderEntry(*Dir) : ReaderEntry();
 
   return Results;
+}
+
+std::optional<GlobalVariableInfo>
+APINotesManager::lookupGlobalVariable(const Module *M, StringRef Name,
+                                      SourceLocation Loc) {
+  auto Lookup =
+      [&](APINotesReader *Reader) -> std::optional<GlobalVariableInfo> {
+    auto Info = Reader->lookupGlobalVariable(Name);
+    auto Selected = Info.getSelected();
+    if (Selected)
+      return Info[*Selected].second;
+
+    return std::nullopt;
+  };
+
+  if (M) {
+    bool FoundModuleAPINotes = false;
+    for (auto File :
+         getCurrentModuleAPINotes(const_cast<Module *>(M->getTopLevelModule()),
+                                  /*LookInModule=*/true, {})) {
+      if (auto *Reader = getAPINotesReader(File)) {
+        FoundModuleAPINotes = true;
+        if (auto Info = Lookup(Reader))
+          return Info;
+      }
+    }
+
+    if (FoundModuleAPINotes)
+      return std::nullopt;
+  }
+
+  for (auto *Reader : findAPINotes(Loc)) {
+    if (auto Info = Lookup(Reader))
+      return Info;
+  }
+
+  return std::nullopt;
 }

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -18,6 +18,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h"
+#include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Sema/SemaObjC.h"
@@ -420,6 +421,15 @@ void Sema::ApplyAPINotesType(Decl *D, StringRef TypeString) {
       }
     }
   }
+}
+
+std::optional<api_notes::GlobalVariableInfo>
+Sema::ProcessAPINotes(const Module *M, const IdentifierInfo *II,
+                      SourceLocation Loc) {
+  if (!II || Loc.isInvalid())
+    return std::nullopt;
+
+  return APINotes.lookupGlobalVariable(M, II->getName(), Loc);
 }
 
 void Sema::ApplyNullability(Decl *D, NullabilityKind Nullability) {


### PR DESCRIPTION
APINotes normally applies Globals metadata by mutating the corresponding Clang declaration. Macro constants do not have a Decl, so clients that preserve the macro identity cannot reuse ProcessAPINotes(Decl *) to ask whether a macro has a Type annotation.

Add an APINotesManager::lookupGlobalVariable(const Module *, StringRef, SourceLocation) helper that selects global-variable API notes from module sidecars or location-based notes. Then expose Sema::ProcessAPINotes(const Module *, const IdentifierInfo *, SourceLocation) for importers that need Clang to parse the replacement type for macro constants.

The optional module lets the query load module APINotes sidecars such as WinSDK.apinotes; location-only lookup falls back to directory APINotes.apinotes files and can miss module-local notes for imported macros.

This keeps APINotes reader selection, parsing, and type resolution in Clang while allowing external importers to apply typed macro constants without duplicating the underlying macro values.

(cherry picked from commit 4ab8fa565ef7d0be840f1d303eea67ee170c87fb)