### PR TITLE
[BoundsSafety] Automatically pick the right Python interpreter for LLDB based runtime tests

### DIFF
--- a/compiler-rt/test/bounds_safety/CMakeLists.txt
+++ b/compiler-rt/test/bounds_safety/CMakeLists.txt
@@ -38,10 +38,10 @@ set(BOUNDS_SAFETY_TEST_DEPS "")
 #
 # Build an ordered list of candidate lldb executables according to
 # COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB, then pick the first "usable"
-# one. A candidate is usable when `lldb -P` succeeds AND the Python interpreter
-# used by lit (${Python3_EXECUTABLE}) can import the lldb module from that path.
-# A Python mismatch (e.g. Homebrew Python 3.13 vs an LLDB built for Python 3.11)
-# would otherwise cause a confusing ImportError at test time.
+# one. A candidate is usable when `lldb -P` succeeds AND some Python
+# interpreter from a per-LLDB candidate list can import the lldb module from
+# that path. A Python mismatch (e.g. Homebrew Python 3.13 vs an LLDB built for
+# Python 3.11) would otherwise cause a confusing ImportError at test time.
 set(_just_built_lldb "${LLVM_TOOLS_BINARY_DIR}/lldb${CMAKE_EXECUTABLE_SUFFIX}")
 
 # Locate a system lldb once; only used for the OFF and AUTO modes below.
@@ -59,10 +59,36 @@ if(NOT COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB STREQUAL "ON"
   list(APPEND _lldb_candidates "${_system_lldb}")
 endif()
 
+# Derive the Python interpreter bundled inside the same Xcode `.app` as the
+# given LLDB, using the path printed by `lldb -P`. That output looks like
+#   <App>.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python
+# so walking up four directories yields <App>.app/Contents and the bundled
+# interpreter sits at:
+#   <App>.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/Current/bin/python3
+# Sets <out_var> to that path if it exists, or to the empty string otherwise.
+function(_bounds_safety_xcode_python_from_lldb_resources lldb_resources_path out_var)
+  get_filename_component(_resources_dir         "${lldb_resources_path}"    DIRECTORY)
+  get_filename_component(_lldb_framework_dir    "${_resources_dir}"         DIRECTORY)
+  get_filename_component(_shared_frameworks_dir "${_lldb_framework_dir}"    DIRECTORY)
+  get_filename_component(_xcode_contents_dir    "${_shared_frameworks_dir}" DIRECTORY)
+  set(_candidate
+    "${_xcode_contents_dir}/Developer/Library/Frameworks/Python3.framework/Versions/Current/bin/python3")
+  if(EXISTS "${_candidate}")
+    set(${out_var} "${_candidate}" PARENT_SCOPE)
+  else()
+    set(${out_var} "" PARENT_SCOPE)
+  endif()
+endfunction()
+
 set(_LLDB_DETECTED FALSE)
 set(_LLDB_PYTHON_COMPATIBLE FALSE)
+set(_indent "  ")
+message(STATUS "Detecting LLDB usable for -fbounds-safety tests")
+message(STATUS "${_indent}LLDB candidates: ${_lldb_candidates}")
 foreach(_cand ${_lldb_candidates})
+  message(STATUS "${_indent}Considering LLDB: ${_cand}")
   if(NOT EXISTS "${_cand}")
+    message(STATUS "${_indent}${_indent}not found on disk; skipping")
     continue()
   endif()
   execute_process(
@@ -72,25 +98,61 @@ foreach(_cand ${_lldb_candidates})
     RESULT_VARIABLE _cand_p_result
   )
   if(NOT _cand_p_result EQUAL 0)
+    message(STATUS "${_indent}${_indent}'${_cand} -P' failed (exit ${_cand_p_result}); skipping")
     continue()
   endif()
   set(_LLDB_DETECTED TRUE)
-  # Tear LLDB down with SBDebugger::Terminate() after a successful import. An
-  # assertions-enabled LLDB would otherwise abort at interpreter shutdown.
-  execute_process(
-    COMMAND ${Python3_EXECUTABLE} -c
-      "import sys; sys.path.insert(0, '${_cand_py_path}'); import lldb; lldb.SBDebugger.Terminate()"
-    RESULT_VARIABLE _LLDB_IMPORT_RESULT
-    ERROR_VARIABLE _LLDB_IMPORT_ERROR
-    OUTPUT_QUIET
-  )
-  if(_LLDB_IMPORT_RESULT EQUAL 0)
-    set(BOUNDS_SAFETY_LLDB_PYTHON_PATH "${_cand_py_path}")
-    set(_LLDB_PYTHON_COMPATIBLE TRUE)
-    set(_LLDB_EXECUTABLE "${_cand}")
-    break() # First usable candidate wins (just-built first in AUTO).
+  message(STATUS "${_indent}${_indent}LLDB Python bindings: ${_cand_py_path}")
+
+  # Ordered Python-interpreter candidates for this LLDB; first success wins.
+  # When LLDB is from an Xcode bundle, prefer the Python bundled in the same
+  # bundle: a different-Xcode Python can succeed at `import lldb` accidentally
+  # (when both Xcodes happen to ship the same Python ABI) yet still violate
+  # the requirement that bounds-safety tests run against the Python shipped
+  # alongside this LLDB. ${Python3_EXECUTABLE} is the fallback for non-Xcode
+  # (e.g. just-built) LLDB, where no bundled Python is derivable.
+  _bounds_safety_xcode_python_from_lldb_resources("${_cand_py_path}" _xcode_python)
+  set(_python_candidates "")
+  if(NOT _xcode_python STREQUAL "")
+    list(APPEND _python_candidates "${_xcode_python}")
+  endif()
+  list(APPEND _python_candidates "${Python3_EXECUTABLE}")
+  list(REMOVE_DUPLICATES _python_candidates)
+  message(STATUS "${_indent}${_indent}Python interpreter candidates: ${_python_candidates}")
+
+  foreach(_py ${_python_candidates})
+    message(STATUS "${_indent}${_indent}Trying Python: ${_py}")
+    # Tear LLDB down with SBDebugger::Terminate() after a successful import. An
+    # assertions-enabled LLDB would otherwise abort at interpreter shutdown.
+    execute_process(
+      COMMAND ${_py} -c
+        "import sys; sys.path.insert(0, '${_cand_py_path}'); import lldb; lldb.SBDebugger.Terminate()"
+      RESULT_VARIABLE _LLDB_IMPORT_RESULT
+      ERROR_VARIABLE _LLDB_IMPORT_ERROR
+      OUTPUT_QUIET
+    )
+    if(_LLDB_IMPORT_RESULT EQUAL 0)
+      message(STATUS "${_indent}${_indent}${_indent}lldb import OK")
+      set(BOUNDS_SAFETY_LLDB_PYTHON_PATH "${_cand_py_path}")
+      set(BOUNDS_SAFETY_PYTHON_EXECUTABLE "${_py}")
+      set(_LLDB_PYTHON_COMPATIBLE TRUE)
+      set(_LLDB_EXECUTABLE "${_cand}")
+      break() # First usable Python wins for this LLDB.
+    else()
+      message(STATUS "${_indent}${_indent}${_indent}lldb import FAILED (exit ${_LLDB_IMPORT_RESULT})")
+    endif()
+  endforeach()
+  if(_LLDB_PYTHON_COMPATIBLE)
+    break()
   endif()
 endforeach()
+
+# Fallback so lit.site.cfg.py.in always gets a valid Python path. The
+# LLDB-using suites are gated on COMPILER_RT_BOUNDS_SAFETY_USE_LLDB regardless,
+# so a failing detection above does not need to break configure.
+if(NOT BOUNDS_SAFETY_PYTHON_EXECUTABLE)
+  set(BOUNDS_SAFETY_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
 
 # In ON mode the just-built LLDB is the only candidate. If it isn't usable, warn
 # (rather than error) so we preserve COMPILER_RT_BOUNDS_SAFETY_USE_LLDB's graceful
@@ -100,12 +162,12 @@ if(COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB STREQUAL "ON" AND
    NOT _LLDB_PYTHON_COMPATIBLE)
   message(WARNING
     "COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB=ON but the just-built LLDB "
-    "(${_just_built_lldb}) is not usable with the Python interpreter used by "
-    "lit (${Python3_EXECUTABLE}).\n"
+    "(${_just_built_lldb}) is not usable with any of the Python interpreters "
+    "tried (${_python_candidates}).\n"
     "This usually means the just-built LLDB was not built (is lldb in "
     "LLVM_ENABLE_PROJECTS and LLDB_ENABLE_PYTHON enabled?) or it targets a "
-    "different Python version than ${Python3_EXECUTABLE}.\n"
-    "Import error: ${_LLDB_IMPORT_ERROR}")
+    "different Python version than any candidate above.\n"
+    "Last import error: ${_LLDB_IMPORT_ERROR}")
 endif()
 
 # CMake option: defaults to ON if LLDB detected AND the Python interpreter
@@ -122,8 +184,8 @@ endif()
 
 if(COMPILER_RT_BOUNDS_SAFETY_USE_LLDB AND NOT _LLDB_PYTHON_COMPATIBLE)
   message(FATAL_ERROR
-    "COMPILER_RT_BOUNDS_SAFETY_USE_LLDB=ON but the Python interpreter "
-    "used by lit (${Python3_EXECUTABLE}) cannot import the lldb module "
+    "COMPILER_RT_BOUNDS_SAFETY_USE_LLDB=ON but none of the Python interpreters "
+    "tried (${_python_candidates}) could import the lldb module "
     "from ${BOUNDS_SAFETY_LLDB_PYTHON_PATH}.\n"
     "This typically means Python and LLDB were built for different Python "
     "versions. Either:\n"
@@ -131,13 +193,14 @@ if(COMPILER_RT_BOUNDS_SAFETY_USE_LLDB AND NOT _LLDB_PYTHON_COMPATIBLE)
     "(e.g. the one bundled with Xcode), or\n"
     "  - Set COMPILER_RT_BOUNDS_SAFETY_USE_LLDB=OFF to disable debugger "
     "test suites.\n"
-    "Import error: ${_LLDB_IMPORT_ERROR}")
+    "Last import error: ${_LLDB_IMPORT_ERROR}")
 endif()
 
 if (COMPILER_RT_BOUNDS_SAFETY_USE_LLDB)
   message(STATUS "Enabled -fbounds-safety tests using LLDB:\n"
     "LLDB Python bindings: ${BOUNDS_SAFETY_LLDB_PYTHON_PATH}\n"
-    "LLDB executable: ${_LLDB_EXECUTABLE}")
+    "LLDB executable: ${_LLDB_EXECUTABLE}\n"
+    "Python interpreter for LLDB Python bindings: ${BOUNDS_SAFETY_PYTHON_EXECUTABLE}")
 else()
   message(STATUS "Disabled -fbounds-safety tests using LLDB")
 endif()

--- a/compiler-rt/test/bounds_safety/lit.site.cfg.py.in
+++ b/compiler-rt/test/bounds_safety/lit.site.cfg.py.in
@@ -25,7 +25,7 @@ config.apple_target_is_host = @BOUNDS_SAFETY_TEST_APPLE_TARGET_IS_HOST_PYBOOL@
 # things to work.
 config.compiler_rt_obj_root = "@COMPILER_RT_BINARY_DIR@"
 config.clang = "@COMPILER_RT_RESOLVED_TEST_COMPILER@"
-config.python_executable = "@Python3_EXECUTABLE@"
+config.python_executable = "@BOUNDS_SAFETY_PYTHON_EXECUTABLE@"
 # Setup test format.
 import lit
 config.test_format = lit.formats.ShTest(execute_external=False)


### PR DESCRIPTION
Previously, the bounds-safety debugger test detection in `compiler-rt/test/bounds_safety/CMakeLists.txt` assumed the correct python interpreter to use with the select LLDB python bindings was the python that CMake discovered (`${Python3_EXECUTABLE}`) via `find_package(Python3)`.

This is fragile when the chosen LLDB is an LLDB shipped with Xcode (e.g. `/usr/bin/lldb`, which is the Xcode shim). The LLDB Python bindings are linked against the Python interpreter that ships *inside the same Xcode bundle*, and that interpreter is not necessarily the one CMake found. This can manifest in two different ways:

* Hard mismatch (e.g. Homebrew Python 3.14 vs. an LLDB built for Python 3.9): the import fails, the debugger test suites get silently disabled, or the build errors out under `COMPILER_RT_BOUNDS_SAFETY_USE_LLDB=ON`.
* Soft mismatch (e.g. `Python3_EXECUTABLE` is the Python from a *different* Xcode that happens to ship the same Python 3.x ABI): the import succeeds accidentally, but the tests run against the wrong Python.

This patch makes the detection loop try a per-LLDB ordered list of Python interpreter candidates and pick the first one that successfully imports the `lldb` module. The list, in order of preference, is:

1. The Python interpreter bundled inside the same Xcode `.app` as this LLDB (when derivable). The path is computed from `lldb -P`'s output, which looks like:

   ``` <App>.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python ```

   so walking up four directories yields `<App>.app/Contents` and the bundled interpreter sits at:

   ``` <App>.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/Current/bin/python3 ```

   This is encapsulated in the new `_bounds_safety_xcode_python_from_lldb_resources` helper, which returns the empty string when the derived path does not exist (e.g. for the just-built LLDB or a non-Xcode system LLDB).

2. `${Python3_EXECUTABLE}`. This is the fallback for non-Xcode LLDBs (just-built or other system installs) where no bundled Python is derivable.

The Xcode-bundled Python is preferred over `${Python3_EXECUTABLE}` specifically to avoid the soft-mismatch case described above.

The chosen Python is exported as `BOUNDS_SAFETY_PYTHON_EXECUTABLE` and substituted into `lit.site.cfg.py.in` for `config.python_executable`, which the bounds-safety lit suite uses to invoke
`scripts/expect_trap.py` and `scripts/expect_no_trap.py` (both of which `import lldb`). The override is scoped to this lit suite only — the rest of compiler-rt continues to use `${Python3_EXECUTABLE}`. When detection fails entirely, `BOUNDS_SAFETY_PYTHON_EXECUTABLE` falls back to `${Python3_EXECUTABLE}` so `lit.site.cfg.py.in` still configures to a valid path; the LLDB-using suites are gated separately on `COMPILER_RT_BOUNDS_SAFETY_USE_LLDB`.

To make CI logs easier to debug, the detection loop now emits `message(STATUS ...)` lines for each step:

```
-- Detecting LLDB usable for -fbounds-safety tests
--   LLDB candidates: /usr/bin/lldb
--   Considering LLDB: /usr/bin/lldb
--     LLDB Python bindings: <App>.app/.../Resources/Python
--     Python interpreter candidates: <App>.app/.../python3;/opt/homebrew/.../python
--     Trying Python: <App>.app/.../python3
--       lldb import OK
```

Failure modes are surfaced too (`not found on disk; skipping`, `'<lldb> -P' failed; skipping`, `lldb import FAILED`), so a misconfigured build is diagnosable from the configure log alone. The pre-existing `WARNING` and `FATAL_ERROR` messages have been updated to list the full set of Python interpreters tried rather than only `${Python3_EXECUTABLE}`.

This change has been tested using a standalone compiler-rt build against four scenarios:

1. Matched: `Python3_EXECUTABLE` is the Xcode-bundled `python3`. Single Python tried, import OK, 20/20 lit tests pass.
2. Mismatched: `Python3_EXECUTABLE` is Homebrew Python 3.14 and the system LLDB is from an Xcode shipping Python 3.9. The Xcode-bundled `python3` is tried first and wins; 20/20 lit tests pass — this is the case the change unblocks.
3. `COMPILER_RT_BOUNDS_SAFETY_USE_LLDB=OFF`: configure clean, debugger suites disabled.
4. `COMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB=ON` with no in-tree LLDB: warning preserved, suites disabled, `BOUNDS_SAFETY_PYTHON_EXECUTABLE` falls back to `${Python3_EXECUTABLE}`.

Assisted-by: Claude Code

rdar://179159377