### PR TITLE
[lldb] Add Swift.UniqueBox<T> synthetic formatter

### DIFF
--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -23,6 +23,7 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   SwiftOptional.cpp
   SwiftFrameRecognizers.cpp
   SwiftSet.cpp
+  SwiftStdlibFormatters.cpp
   SwiftUIFormatters.cpp
   SwiftUnsafeTypes.cpp
   SystemValueTypes.cpp

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -12,6 +12,8 @@
 
 #include "SwiftLanguage.h"
 
+#include "SwiftStdlibFormatters.h"
+#include "SwiftUIFormatters.h"
 #include "SwiftUnsafeTypes.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
@@ -406,6 +408,12 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEndCreator,
       "Swift.[Mutable]Span", ConstString("^Swift\\.(Mutable)?Span<.+>?"),
       synth_flags, true);
+
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::UniqueBoxSyntheticFrontEndCreator,
+      "Swift.UniqueBox", ConstString("^Swift[.]UniqueBox<.+>$"), synth_flags,
+      true);
 
   DictionaryConfig::Get().RegisterSyntheticChildrenCreators(swift_category_sp,
                                                             synth_flags);

--- a/lldb/source/Plugins/Language/Swift/SwiftStdlibFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftStdlibFormatters.cpp
@@ -1,0 +1,69 @@
+//===-- SwiftStdlibFormatters.cpp -------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftStdlibFormatters.h"
+
+#include "lldb/Utility/ConstString.h"
+#include "lldb/ValueObject/ValueObject.h"
+#include "lldb/lldb-enumerations.h"
+#include "llvm/Support/Error.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+namespace {
+
+/// Synthetic children provider for Swift.UniqueBox<T>.
+///
+/// Exposes one child:
+///   [0] value - generic value stored in the box
+class UniqueBoxSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
+public:
+  UniqueBoxSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
+      : SyntheticChildrenFrontEnd(*valobj_sp) {}
+
+  llvm::Expected<uint32_t> CalculateNumChildren() override { return 1; }
+
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override {
+    return idx == 0 ? m_value_sp : nullptr;
+  }
+
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
+    if (name == "value")
+      return 0;
+    return llvm::createStringErrorV("Type has no child named '{0}'", name);
+  }
+
+  lldb::ChildCacheState Update() override {
+    auto value_sp = m_backend.GetValueForExpressionPath(".pointer.pointee");
+    if (!value_sp) {
+      m_value_sp = nullptr;
+      return ChildCacheState::eRefetch;
+    }
+
+    m_value_sp = value_sp->Clone(ConstString("value"));
+    return ChildCacheState::eReuse;
+  }
+
+private:
+  lldb::ValueObjectSP m_value_sp;
+};
+
+} // namespace
+
+SyntheticChildrenFrontEnd *
+lldb_private::formatters::swift::UniqueBoxSyntheticFrontEndCreator(
+    CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+  return new UniqueBoxSyntheticFrontEnd(valobj_sp);
+}

--- a/lldb/source/Plugins/Language/Swift/SwiftStdlibFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftStdlibFormatters.h
@@ -1,0 +1,23 @@
+//===-- SwiftStdlibFormatters.h ---------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_SwiftStdlibFormatters_h_
+#define liblldb_SwiftStdlibFormatters_h_
+
+#include "lldb/DataFormatters/TypeSynthetic.h"
+
+namespace lldb_private::formatters::swift {
+SyntheticChildrenFrontEnd *
+UniqueBoxSyntheticFrontEndCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
+}
+
+#endif

--- a/lldb/test/API/lang/swift/unique_box/Makefile
+++ b/lldb/test/API/lang/swift/unique_box/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xfrontend -disable-availability-checking
+include Makefile.rules

--- a/lldb/test/API/lang/swift/unique_box/TestSwiftUniqueBox.py
+++ b/lldb/test/API/lang/swift/unique_box/TestSwiftUniqueBox.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipIfWindows
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/unique_box/TestSwiftUniqueBox.py
+++ b/lldb/test/API/lang/swift/unique_box/TestSwiftUniqueBox.py
@@ -1,0 +1,26 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test(self):
+        self.build()
+        _, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self._do_test(thread, value=23)
+        process.Continue()
+        self._do_test(thread, value=41)
+
+    def _do_test(self, thread: lldb.SBThread, value: int):
+        frame = thread.selected_frame
+        x = frame.FindVariable("x")
+        self.assertEqual(x.GetNumChildren(), 1)
+        child = x.GetChildMemberWithName("value")
+        self.assertEqual(child.GetName(), "value")
+        self.assertEqual(child.GetValueAsSigned(), value)
+        self.assertEqual(child.GetID(), x.GetChildAtIndex(0).GetID())

--- a/lldb/test/API/lang/swift/unique_box/main.swift
+++ b/lldb/test/API/lang/swift/unique_box/main.swift
@@ -1,0 +1,8 @@
+@main enum Entry {
+    static func main() {
+        var x = UniqueBox(23)
+        print(x.value) // break here
+        x.value = 41
+        print(x.value) // break here
+    }
+}


### PR DESCRIPTION
Add a simple synthetic formatter for `Swift.UniqueBox<T>`. This formatter exposes a single `value` child.

`UniqueBox` is not a complex type, and the main benefit of this formatter is to make `p box.value` run without expression evaluation.

Assisted-by: claude