### PR TITLE
[lldb][Windows] Re-enable Swift async task tests that pass

### DIFF
--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -9,7 +9,6 @@ class TestCase(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows # rdar://176009590
     def test_summary_contains_name(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -154,7 +154,6 @@ skip lldb-api :: api/multiple-targets/TestMultipleTargets.py
 ### Tests that fail during setup and thus show up as UNRESOLVED ***
 
 # https://github.com/swiftlang/llvm-project/issues/9887
-skip lldb-api :: lang/swift/async/tasks/TestSwiftTaskBacktrace.py
 skip lldb-api :: lang/swift/async/tasks/TestSwiftTaskSelect.py
 
 skip lldb-api :: functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py


### PR DESCRIPTION
Remove `TestSwiftTaskBacktrace` from `windows-swift-llvm-lit-test-overrides.txt`. It was skipped as fail-during-setup / UNRESOLVED (#9887). This is fixed now.

`TestSwiftTaskName`: drop `@skipIfWindows` from `test_summary_contains_name`. It reads the task name from process memory and has no Darwin dependency. Keep `@skipIfWindows` on `test_thread_contains_name`: mapping a thread to its task needs the reserved-TLS-keys path, which is Darwin-only today.

rdar://176009590