### PR TITLE
[lldb][Windows] Re-enable lang/swift/variables/swift

### DIFF
--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -22,7 +22,6 @@ import platform
 class TestSwiftTypes(TestBase):
     @swiftTest
     @skipEmbeddedSwift
-    @skipIfWindows
     def test_swift_types(self):
         """Test that we can inspect basic Swift types"""
         self.build()
@@ -129,7 +128,10 @@ class TestSwiftTypes(TestBase):
                 'Double',
                 'float64',
                 'value = 2.5'])
-        if self.getArchitecture() == "x86_64":
+        if (
+            self.getArchitecture() == "x86_64"
+            and lldbplatformutil.getPlatform() != "windows"
+        ):
             self.expect(
                 "frame variable --raw float80",
                 substrs=[
@@ -170,4 +172,3 @@ class TestSwiftTypes(TestBase):
         self.expect(
             'frame variable uint64_max',
             substrs=['18446744073709551615'])
-

--- a/lldb/test/API/lang/swift/variables/swift/main.swift
+++ b/lldb/test/API/lang/swift/variables/swift/main.swift
@@ -29,7 +29,7 @@ func main() -> Int {
     
     var float32 = Float32(1.25)
     var float64 = 2.5
-#if arch(x86_64)
+#if arch(x86_64) && !os(Windows)
     var float80 = Float80(1.0625)
 #endif
     var float = Float(3.75)


### PR DESCRIPTION
`main.swift` declared a `Float80` under `"#if arch(x86_64)"`, but `Float80` is not available on Windows, so the test failed to build on Windows x86_64.

This patch guards it with `"&& !os(Windows)"` and skips the matching frame-variable check on Windows, mirroring the Swift standard library's Float80 availability. The rest of the test (integer/float/string inspection) passes.

rdar://179235052