### PR TITLE
[lldb] Fix mod-while-iteration in IRForTarget

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -540,6 +540,9 @@ bool IRForTarget::RewriteObjCConstStrings() {
 
   ValueSymbolTable &value_symbol_table = m_module->getValueSymbolTable();
 
+  std::vector<std::pair<GlobalVariable *, GlobalVariable *>>
+      nsstring_to_cstr_list;
+
   for (StringMapEntry<llvm::Value *> &value_symbol : value_symbol_table) {
     llvm::StringRef value_name = value_symbol.first();
 
@@ -680,14 +683,17 @@ bool IRForTarget::RewriteObjCConstStrings() {
       if (!cstr_array)
         cstr_global = nullptr;
 
-      if (!RewriteObjCConstString(nsstring_global, cstr_global)) {
-        LLDB_LOG(log, "Error rewriting the constant string");
+      // Queue up replacing the string as we are currently iterating
+      // over the module.
+      nsstring_to_cstr_list.emplace_back(nsstring_global, cstr_global);
+    }
+  }
 
-        // We don't print an error message here because RewriteObjCConstString
-        // has done so for us.
-
-        return false;
-      }
+  for (const auto &nsstring_and_cstr : nsstring_to_cstr_list) {
+    auto [nsstring_global, cstr_global] = nsstring_and_cstr;
+    if (!RewriteObjCConstString(nsstring_global, cstr_global)) {
+      LLDB_LOG(log, "Error rewriting the constant string");
+      return false;
     }
   }
 


### PR DESCRIPTION
We modify the IR module here while iterating over it. Use the usual list trick to delay modification until after the loop.

This was exposed by bccd1b9cb744e5dd96ee59baa4bf4583457feea3 