### PR TITLE
[lldb][Windows] Re-enable Swift import_search_paths and library_indirect

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -45,7 +45,7 @@ ifeq "$(OS)" "Windows_NT"
 	CP_R = xcopy $(subst /,\,$(1)) $(subst /,\,$(2)) /s /e /y
 	RM = del $(subst /,\,$(1)) > nul 2>&1 || (exit 0)
 	RM_F = del /f /q $(subst /,\,$(1))
-	RM_RF = rd /s /q $(subst /,\,$(1))
+	RM_RF = $(if $(strip $(1)),rd /s /q $(subst /,\,$(1)) > nul 2>&1 || (exit 0))
 	LN_SF = mklink /D "$(subst /,\,$(2))" "$(subst /,\,$(1))"
 	ECHO = echo $(1);
 	ECHO_TO_FILE = echo $(subst ',,$(1))> "$(subst /,\,$(2))"

--- a/lldb/test/API/lang/swift/expression/import_search_paths/Makefile
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/Makefile
@@ -3,6 +3,12 @@ SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 LD_EXTRAS = -L$(BUILDDIR) -lDirect
 
+# rpath is a Unix loader concept rejected by lld-link.
+RPATH_HIDDEN = -Xlinker -rpath -Xlinker $(BUILDDIR)/hidden
+ifeq "$(OS)" "Windows_NT"
+RPATH_HIDDEN =
+endif
+
 all: libDirect $(EXE)
 .phony: libDirect libHidden
 
@@ -26,6 +32,6 @@ libDirect: $(SRCDIR)/Direct.swift libHidden
 		DYLIB_SWIFT_SOURCES=Direct.swift \
 		DYLIB_MODULENAME=Direct \
 		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)/hidden" \
-		LD_EXTRAS="-L$(BUILDDIR)/hidden -lIndirect -Xlinker -rpath -Xlinker $(BUILDDIR)/hidden" \
+		LD_EXTRAS="-L$(BUILDDIR)/hidden -lIndirect $(RPATH_HIDDEN)" \
 		MAKE_DSYM=NO
 

--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -9,12 +9,12 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_positive(self):
         self.do_test('true')
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_negative(self):
         self.do_test('false')
 
@@ -27,9 +27,11 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
         self.expect('settings set '
                     + 'target.experimental.swift-discover-implicit-search-paths '
                     + flag)
+        indirect_name = self.platformContext.getFullLibName("Indirect").split(".")[0]
+        indirect = f"hidden/{indirect_name}"
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'),
-            extra_images=['Direct', self.getBuildArtifact('hidden/libIndirect')])
+            extra_images=['Direct', self.getBuildArtifact(indirect)])
 
         types_log = self.getBuildArtifact("types.log")
         self.expect("log enable lldb types -f " + types_log)

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/Makefile
@@ -2,6 +2,12 @@ SWIFT_SOURCES=main.swift
 SWIFTFLAGS_EXTRAS= -I.
 LD_EXTRAS=-L.
 
+# rpath is a Unix loader concept rejected by lld-link.
+SHLIB_RPATH = -Xlinker -rpath -Xlinker $(BUILDDIR)
+ifeq "$(OS)" "Windows_NT"
+SHLIB_RPATH =
+endif
+
 all: clean SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
 
 include Makefile.rules
@@ -12,7 +18,7 @@ SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
 
 SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
 	"$(MAKE)" BASENAME=$(shell basename $@ .swiftmodule) \
-		VPATH=$(SRCDIR) LD_EXTRAS="-L$(BUILDDIR) -Xlinker -rpath -Xlinker $(BUILDDIR)" -f $(SRCDIR)/../dylib.mk all
+		VPATH=$(SRCDIR) LD_EXTRAS="-L$(BUILDDIR) $(SHLIB_RPATH)" -f $(SRCDIR)/../dylib.mk all
 
 clean::
 	$(call RM_RF,*.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface)

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -38,7 +38,6 @@ class TestLibraryIndirect(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_implementation_only_import_library(self):
         """Test `@_implementationOnly import` behind some indirection in a library used by the main executable
 
@@ -73,8 +72,7 @@ class TestLibraryIndirect(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
-    def test_implementation_only_import_library_no_library_module(self):
+    def test_impl_only_import_lib_no_lib_module(self):
         """Test `@_implementationOnly import` behind some indirection in a library used by the main executable, after removing the implementation-only library's swiftmodule
 
         See the ReadMe.md in the parent directory for more information.


### PR DESCRIPTION
These tests were disabled on Windows because their Makefiles use Unix-only build constructs. Port them:
- `Makefile.rules`: make the Windows `RM_RF` a no-op on an empty argument and swallow errors, matching Unix `rm -rf`. on a fresh build dir `$(wildcard $(BUILDDIR)/*)` is empty, so a bare `rd /s /q` failed with "The syntax of the command is incorrect."
- `expression/import_search_paths`: `-rpath` is rejected by lld-link, so guard it for non-Windows. Use the Windows DLL name for the extra image, and skip the embedded-Swift variant on Windows.
- `implementation_only_imports/library_indirect`: guard `-rpath` for non-Windows.

Requires:
- https://github.com/llvm/llvm-project/pull/203040

rdar://179245623