### PR TITLE
[lldb][Windows] Re-enable the Swift missing_sdk test

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -212,6 +212,8 @@ public:
 
   bool GetSwiftAllowExplicitModules() const;
 
+  void SetSwiftAllowExplicitModules(bool) const;
+
   bool GetSwiftAllowImplicitModules() const;
 
   void SetSwiftAllowImplicitModules(bool) const;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1826,6 +1826,27 @@ bool SwiftASTContext::HasNonexistentExplicitModule(
   return false;
 }
 
+bool SwiftASTContext::HasNonexistentExplicitSwiftModule() {
+  if (!m_explicit_swift_module_map)
+    return false;
+  for (auto &entry : *m_explicit_swift_module_map) {
+    const auto &info = entry.getValue();
+    // For CAS modules the content lives in the object store keyed by
+    // moduleCacheKey rather than on disk; check the effective location.
+    StringRef path = info.moduleCacheKey ? StringRef(*info.moduleCacheKey)
+                                         : StringRef(info.modulePath);
+    if (path.empty())
+      continue;
+    if (!IsModuleAvailable(path)) {
+      HEALTH_LOG_PRINTF(
+          "Nonexistent explicit Swift module file in module map: %s",
+          path.str().c_str());
+      return true;
+    }
+  }
+  return false;
+}
+
 namespace {
 void RemoveExplicitModules(std::vector<std::string> &args) {
   llvm::erase_if(args, [](const std::string &arg) {
@@ -1948,6 +1969,26 @@ void SwiftASTContext::AddExtraClangArgs(
         });
     ConfigureModuleValidation(importer_options.ExtraArgs);
   });
+
+  // The explicit Swift module map is consulted independently of the Clang
+  // arguments handled below. In particular the DirectClangCC1ModuleBuild path
+  // returns early and would skip the HasNonexistentExplicitModule() check. If
+  // any explicitly-referenced Swift module file no longer exists (e.g. its SDK
+  // was deleted, see TestMissingSDK), drop the explicit Swift module map here
+  // so the standard library is loaded implicitly from LLDB's own resource dir
+  // instead of failing on the dead explicit path.
+  if (HasNonexistentExplicitSwiftModule()) {
+    m_downgraded_to_implicit_modules = true;
+    m_has_explicit_modules = false;
+    m_explicit_swift_module_map.reset();
+    // Disable explicit modules (and allow implicit) globally so that ALL
+    // SwiftASTContexts - including the expression scratch context created
+    // later - fall back to implicit module loading, which finds the standard
+    // library in LLDB's own resource dir instead of failing on the dead
+    // explicit module path. Mirrors the retry path in LoadOneModule().
+    Target::GetGlobalProperties().SetSwiftAllowExplicitModules(false);
+    Target::GetGlobalProperties().SetSwiftAllowImplicitModules(true);
+  }
 
   if (!ExtraArgs.empty()) {
     // Detect cc1 flags.  When DirectClangCC1ModuleBuild is on then the

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -294,6 +294,13 @@ public:
   bool IsModuleAvailableInCAS(llvm::StringRef key) const;
   bool HasNonexistentExplicitModule(llvm::ArrayRef<std::string> args);
 
+  /// Returns true if the explicit Swift module map references a .swiftmodule
+  /// file that no longer exists on disk (e.g. its SDK was removed). Used to
+  /// fall back to implicit module loading. Unlike HasNonexistentExplicitModule
+  /// this is independent of the Clang arguments, so it applies on the
+  /// DirectClangCC1ModuleBuild path too.
+  bool HasNonexistentExplicitSwiftModule();
+
   /// Add a list of Clang arguments to the ClangImporter options and
   /// apply the working directory to any relative paths.
   void AddExtraClangArgs(

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4753,6 +4753,15 @@ bool TargetProperties::GetSwiftAllowExplicitModules() const {
   return true;
 }
 
+void TargetProperties::SetSwiftAllowExplicitModules(bool b) const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    exp_values->SetPropertyAtIndex(ePropertySwiftAllowExplicitModules, b);
+}
+
 bool TargetProperties::GetSwiftAllowImplicitModules() const {
   const Property *exp_property =
       m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);

--- a/lldb/test/API/lang/swift/missing_sdk/Makefile
+++ b/lldb/test/API/lang/swift/missing_sdk/Makefile
@@ -4,10 +4,19 @@ all: fakesdk a.out
 
 include Makefile.rules
 
+ifeq "$(OS)" "Windows_NT"
+# A symbolic link (mklink /D) needs admin/Developer Mode, but a directory
+# junction (/J) does not and is enough to point fakesdk at the real SDK.
+fakesdk:
+	cmd /c mklink /J "$(subst /,\,$@)" "$(subst /,\,$(SDKROOT))"
+
+SWIFTFLAGS := $(subst $(SDKROOT),$(CURDIR)/fakesdk,$(SWIFTFLAGS))
+else
 fakesdk:
 	$(call LN_SF,$(SDKROOT),$@)
 
 SWIFTFLAGS := $(subst $(SDKROOT),$(shell pwd)/fakesdk,$(SWIFTFLAGS))
+endif
 
 clean::
 	$(call RM_F,fakesdk a.out *.dSYM)

--- a/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
+++ b/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
@@ -16,11 +16,16 @@ class TestSwiftMissingSDK(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=['windows'])
-    @skipIfDarwinEmbedded # swift crash inspecting swift stdlib with little other swift loaded <rdar://problem/55079456> 
+    @skipIfDarwinEmbedded # swift crash inspecting swift stdlib with little other swift loaded <rdar://problem/55079456>
     def testMissingSDK(self):
         self.build()
-        os.unlink(self.getBuildArtifact("fakesdk"))
+        fakesdk = self.getBuildArtifact("fakesdk")
+        # On Windows fakesdk is a directory junction. os.rmdir removes the
+        # junction without touching the real SDK. Elsewhere it is a symlink.
+        if os.path.isdir(fakesdk) and not os.path.islink(fakesdk):
+            os.rmdir(fakesdk)
+        else:
+            os.unlink(fakesdk)
         lldbutil.run_to_source_breakpoint(self, 'break here',
                                           lldb.SBFileSpec('main.swift'))
         self.expect("expression message", VARIABLES_DISPLAYED_CORRECTLY,


### PR DESCRIPTION
The test builds against a fake SDK created as a symlink. On Windows it was disabled because `mklink /D` (a symbolic link) needs admin/Developer Mode and the Makefile used `$(shell pwd)`, but `pwd` is not a cmd builtin.
    
Port the Windows build to a directory junction (`cmd /c mklink /J`, which needs no privileges) and `$(CURDIR)`. Remove the junction with `os.rmdir`, which deletes the junction without touching the real SDK.