### PR TITLE
[lldb/test] Skip TestCancelAttach on remote targets

### DIFF
--- a/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
+++ b/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
@@ -16,8 +16,8 @@ import lldbsuite.test.lldbutil
 class AttachCancelTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfRemote
     @skipIf(
-        remote=True,
         hostoslist=["windows", "linux"],
         bugnumber="https://github.com/llvm/llvm-project/issues/115618",
     )

--- a/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
+++ b/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
@@ -18,7 +18,7 @@ class AttachCancelTestCase(TestBase):
 
     @skipIf(
         remote=True,
-        hostoslist=["windows"],
+        hostoslist=["windows", "linux"],
         bugnumber="https://github.com/llvm/llvm-project/issues/115618",
     )
     def test_scripted_implementation(self):


### PR DESCRIPTION
This cherry-picks 2 test skips:
- https://github.com/llvm/llvm-project/pull/180092
- https://github.com/llvm/llvm-project/pull/203069