### PR TITLE
[lldb][windows] Revert re-enabling one TestSwiftExplicitModulesImplicitFallback.py test case for trunk CI 

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -9,6 +9,7 @@ class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @skipEmbeddedSwift
     @swiftTest
+    @skipIfWindows
     def test_missing_explicit_modules(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""
         self.build()


### PR DESCRIPTION
This reverts one line from addb2ee4348e0954bbbd3cb72098cfb66ed5a01d.