### PR TITLE
[Cherry-pick into next] [LLDB] Shorten testname for Windows PATH limit

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -9,7 +9,7 @@ class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @skipEmbeddedSwift
     @swiftTest
-    def test_missing_explicit_modules(self):
+    def test_missing(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""
         self.build()
 


### PR DESCRIPTION
```
commit 6911de09941de7098944c5c1e8aabf0f47785049
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jun 11 00:47:41 2026 -0700

    [LLDB] Shorten testname for Windows PATH limit
```
