### PR TITLE
[ci] fix swiftlang clang build

### DIFF
--- a/.ci/apple-llvm/swiftlang-clang-stage1-RA.groovy
+++ b/.ci/apple-llvm/swiftlang-clang-stage1-RA.groovy
@@ -34,7 +34,8 @@ clangPipeline(
             "-DLLDB_ENABLE_LZMA=OFF",
             "-DCOMPILER_RT_INCLUDE_TESTS=ON",
             "-DCOMPILER_RT_ENABLE_TEST_SUITES=builtins;bounds_safety",
-            "-DCOMPILER_RT_BOUNDS_SAFETY_USE_LLDB=ON"
+            "-DCOMPILER_RT_BOUNDS_SAFETY_USE_LLDB=ON",
+            "-DCOMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB=OFF"
         ]
     ],
     testConfig: [


### PR DESCRIPTION
add `-DCOMPILER_RT_BOUNDS_SAFETY_USE_JUST_BUILT_LLDB`