### PR TITLE
🍒 [clang][AST] Hash `AttributedType`'s `Attr` by Arguments (#200961)

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -254,7 +254,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable llvm::FoldingSet<DeducedTemplateSpecializationType>
     DeducedTemplateSpecializationTypes;
   mutable llvm::FoldingSet<AtomicType> AtomicTypes;
-  mutable llvm::FoldingSet<AttributedType> AttributedTypes;
+  mutable llvm::ContextualFoldingSet<AttributedType, ASTContext &>
+      AttributedTypes;
   mutable llvm::FoldingSet<PipeType> PipeTypes;
   mutable llvm::FoldingSet<BitIntType> BitIntTypes;
   mutable llvm::ContextualFoldingSet<DependentBitIntType, ASTContext &>

--- a/clang/include/clang/AST/Attr.h
+++ b/clang/include/clang/AST/Attr.h
@@ -116,6 +116,8 @@ public:
   bool isEquivalent(const Attr &Other,
                     StructuralEquivalenceContext &Context) const;
 
+  void Profile(llvm::FoldingSetNodeID &ID, const ASTContext &Ctx) const;
+
   // Pretty print this attribute.
   void printPretty(raw_ostream &OS, const PrintingPolicy &Policy) const;
 

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -6679,18 +6679,13 @@ public:
   /// \returns the top-level nullability, if present.
   static std::optional<NullabilityKind> stripOuterNullability(QualType &T);
 
-  void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, getAttrKind(), ModifiedType, EquivalentType, Attribute);
+  void Profile(llvm::FoldingSetNodeID &ID, const ASTContext &Ctx) {
+    Profile(ID, Ctx, getAttrKind(), ModifiedType, EquivalentType, Attribute);
   }
 
-  static void Profile(llvm::FoldingSetNodeID &ID, Kind attrKind,
-                      QualType modified, QualType equivalent,
-                      const Attr *attr) {
-    ID.AddInteger(attrKind);
-    ID.AddPointer(modified.getAsOpaquePtr());
-    ID.AddPointer(equivalent.getAsOpaquePtr());
-    ID.AddPointer(attr);
-  }
+  static void Profile(llvm::FoldingSetNodeID &ID, const ASTContext &Ctx,
+                      Kind attrKind, QualType modified, QualType equivalent,
+                      const Attr *attr);
 
   static bool classof(const Type *T) {
     return T->getTypeClass() == Attributed;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -771,10 +771,13 @@ class Attr {
   // Note: Any additional data members will leak and should be constructed
   // externally on the ASTContext.
   code AdditionalMembers = [{}];
+
+  string comparisonFn = "";
+  string profileFn = "";
+
   // Any documentation that should be associated with the attribute. Since an
   // attribute may be documented under multiple categories, more than one
   // Documentation entry may be listed.
-  string comparisonFn = "";
   list<Documentation> Documentation;
 }
 
@@ -900,6 +903,7 @@ def Aligned : InheritableAttr {
                                           CustomKeyword<"_Alignas">]>,
                    Accessor<"isDeclspec",[Declspec<"align">]>];
   let comparisonFn = "areAlignedAttrsEqual";
+  let profileFn = "profileAlignedAttr";
   let Documentation = [Undocumented];
 }
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -945,11 +945,11 @@ ASTContext::ASTContext(LangOptions &LOpts, SourceManager &SM,
       FunctionProtoTypes(this_(), FunctionProtoTypesLog2InitSize),
       DependentTypeOfExprTypes(this_()), DependentDecltypeTypes(this_()),
       DependentPackIndexingTypes(this_()), TemplateSpecializationTypes(this_()),
-      DependentTemplateSpecializationTypes(this_()),
+      DependentTemplateSpecializationTypes(this_()), AttributedTypes(this_()),
       DependentBitIntTypes(this_()), ValueTerminatedTypes(this_()),
-      SubstTemplateTemplateParmPacks(this_()),
-      DeducedTemplates(this_()), ArrayParameterTypes(this_()),
-      CanonTemplateTemplateParms(this_()), SourceMgr(SM), LangOpts(LOpts),
+      SubstTemplateTemplateParmPacks(this_()), DeducedTemplates(this_()),
+      ArrayParameterTypes(this_()), CanonTemplateTemplateParms(this_()),
+      SourceMgr(SM), LangOpts(LOpts),
       NoSanitizeL(new NoSanitizeList(LangOpts.NoSanitizeFiles, SM)),
       XRayFilter(new XRayFunctionFilter(LangOpts.XRayAlwaysInstrumentFiles,
                                         LangOpts.XRayNeverInstrumentFiles,
@@ -6101,7 +6101,8 @@ QualType ASTContext::getAttributedType(attr::Kind attrKind,
                                        QualType equivalentType,
                                        const Attr *attr) const {
   llvm::FoldingSetNodeID id;
-  AttributedType::Profile(id, attrKind, modifiedType, equivalentType, attr);
+  AttributedType::Profile(id, *this, attrKind, modifiedType, equivalentType,
+                          attr);
 
   void *insertPos = nullptr;
   AttributedType *type = AttributedTypes.FindNodeOrInsertPos(id, insertPos);

--- a/clang/lib/AST/AttrImpl.cpp
+++ b/clang/lib/AST/AttrImpl.cpp
@@ -395,4 +395,88 @@ bool areAlignedAttrsEqual(const AlignedAttr &A1, const AlignedAttr &A2,
 }
 } // namespace
 
+namespace {
+// Machinery to unique attributes based on the arguments.
+// The construction mirrors the equivalent testing code above.
+// The content of the arguments are added to the FoldingSetNodeID instance,
+// which allows the AttributedTypes to unique the attributes based on
+// the value of the arguments.
+
+#define USE_DEFAULT_PROFILE                                                    \
+  (std::is_same_v<T, StringRef> || std::is_same_v<T, VersionTuple> ||          \
+   std::is_same_v<T, IdentifierInfo *> ||                                      \
+   std::is_same_v<T, const IdentifierInfo *> || std::is_enum_v<T> ||           \
+   std::is_integral_v<T>)
+
+template <class T>
+typename std::enable_if_t<!USE_DEFAULT_PROFILE>
+profileAttrArg(llvm::FoldingSetNodeID &, const ASTContext &, T) {}
+
+template <class T>
+typename std::enable_if_t<USE_DEFAULT_PROFILE>
+profileAttrArg(llvm::FoldingSetNodeID &ID, const ASTContext &, T V) {
+  if constexpr (std::is_same_v<T, StringRef>)
+    ID.AddString(V);
+  else if constexpr (std::is_same_v<T, VersionTuple>) {
+    ID.AddInteger(V.getMajor());
+    ID.AddInteger(V.getMinor().value_or(0));
+    ID.AddInteger(V.getSubminor().value_or(0));
+    ID.AddInteger(V.getBuild().value_or(0));
+  } else if constexpr (std::is_same_v<T, IdentifierInfo *> ||
+                       std::is_same_v<T, const IdentifierInfo *>)
+    ID.AddPointer(V);
+  else
+    ID.AddInteger(static_cast<long long>(V));
+}
+
+template <>
+inline void profileAttrArg<ParamIdx>(llvm::FoldingSetNodeID &ID,
+                                     const ASTContext &, ParamIdx P) {
+  ID.AddBoolean(P.isValid());
+  if (P.isValid())
+    ID.AddInteger(P.getASTIndex());
+}
+
+template <class T>
+inline void profileAttrArg(llvm::FoldingSetNodeID &ID, const ASTContext &Ctx,
+                           T *Begin, T *End) {
+  ID.AddInteger(End - Begin);
+  for (; Begin != End; ++Begin)
+    profileAttrArg(ID, Ctx, *Begin);
+}
+
+template <>
+inline void profileAttrArg<Attr *>(llvm::FoldingSetNodeID &ID,
+                                   const ASTContext &Ctx, Attr *A) {
+  if (!A) {
+    ID.AddPointer(nullptr);
+    return;
+  }
+  ID.AddInteger(A->getKind());
+  A->Profile(ID, Ctx);
+}
+
+template <>
+inline void profileAttrArg<Expr *>(llvm::FoldingSetNodeID &ID,
+                                   const ASTContext &Ctx, Expr *E) {
+  E->Profile(ID, Ctx, /*Canonical=*/true);
+}
+
+template <>
+inline void profileAttrArg<QualType>(llvm::FoldingSetNodeID &ID,
+                                     const ASTContext &, QualType T) {
+  ID.AddPointer(T.getCanonicalType().getAsOpaquePtr());
+}
+
+void profileAlignedAttr(const AlignedAttr &A, llvm::FoldingSetNodeID &ID,
+                        const ASTContext &Ctx) {
+  ID.AddInteger(A.getSpellingListIndex());
+  ID.AddBoolean(A.isAlignmentExpr());
+  if (A.isAlignmentExpr())
+    profileAttrArg(ID, Ctx, A.getAlignmentExpr());
+  else
+    profileAttrArg(ID, Ctx, A.getAlignmentType()->getType());
+}
+} // namespace
+
 #include "clang/AST/AttrImpl.inc"

--- a/clang/lib/AST/AttrImpl.cpp
+++ b/clang/lib/AST/AttrImpl.cpp
@@ -410,7 +410,9 @@ namespace {
 
 template <class T>
 typename std::enable_if_t<!USE_DEFAULT_PROFILE>
-profileAttrArg(llvm::FoldingSetNodeID &, const ASTContext &, T) {}
+profileAttrArg(llvm::FoldingSetNodeID &, const ASTContext &, T) {
+  llvm_unreachable("profile not implemented for this type");
+}
 
 template <class T>
 typename std::enable_if_t<USE_DEFAULT_PROFILE>

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -14,7 +14,6 @@
 #include "Linkage.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
-#include "clang/AST/Attrs.inc"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -14,6 +14,7 @@
 #include "Linkage.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/Attrs.inc"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
@@ -5254,6 +5255,16 @@ AttributedType::stripOuterNullability(QualType &T) {
   }
 
   return std::nullopt;
+}
+
+void AttributedType::Profile(llvm::FoldingSetNodeID &ID, const ASTContext &Ctx,
+                             Kind attrKind, QualType modified,
+                             QualType equivalent, const Attr *attr) {
+  ID.AddInteger(attrKind);
+  ID.AddPointer(modified.getAsOpaquePtr());
+  ID.AddPointer(equivalent.getAsOpaquePtr());
+  if (attr)
+    attr->Profile(ID, Ctx);
 }
 
 bool Type::isSignableIntegerType(const ASTContext &Ctx) const {

--- a/clang/test/AST/attributed-type-dedup-address-space.c
+++ b/clang/test/AST/attributed-type-dedup-address-space.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -emit-pch -o %t.pch %s
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t.pch | FileCheck %s
+
+__attribute__((address_space(1))) int *a;
+__attribute__((address_space(1))) int *b;
+__attribute__((address_space(2))) int *c;
+
+// CHECK-COUNT-2: <TYPE_ATTRIBUTED
+// CHECK-NOT:     <TYPE_ATTRIBUTED

--- a/clang/test/AST/attributed-type-dedup-annotate-type-args.c
+++ b/clang/test/AST/attributed-type-dedup-annotate-type-args.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -emit-pch -o %t.pch %s
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t.pch | FileCheck %s
+
+// annotate_type with VariadicExprArgument. The attribued types should
+// dedupe not only based on the string argument, but all of the variadic
+// arguments.
+
+int *[[clang::annotate_type("foo", 1)]] a;
+int *[[clang::annotate_type("foo", 1)]] b;
+int *[[clang::annotate_type("foo", 2)]] c;
+int *[[clang::annotate_type("foo")]] d;
+
+// CHECK-COUNT-3: <TYPE_ATTRIBUTED
+// CHECK-NOT:     <TYPE_ATTRIBUTED

--- a/clang/test/AST/attributed-type-dedup-annotate-type.m
+++ b/clang/test/AST/attributed-type-dedup-annotate-type.m
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -emit-pch -o %t.pch %s
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t.pch | FileCheck %s
+
+// Only two unique string arguments are present. Correspondingly,
+// we should have two TYPE_ATTRIBUTED records.
+
+int *[[clang::annotate_type("foo")]] a;
+int *[[clang::annotate_type("foo")]] b;
+int *[[clang::annotate_type("bar")]] c;
+
+// CHECK-COUNT-2: <TYPE_ATTRIBUTED
+// CHECK-NOT:     <TYPE_ATTRIBUTED

--- a/clang/test/AST/attributed-type-dedup-nullability.m
+++ b/clang/test/AST/attributed-type-dedup-nullability.m
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -fobjc-arc -emit-pch -o %t.pch %s
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t.pch | FileCheck %s
+
+// All three non-null types below should share a single AttributedType node and
+// serialize as exactly one TYPE_ATTRIBUTED record.
+
+@class NSString;
+
+#pragma clang assume_nonnull begin
+@interface T
+- (NSString *)a;
+- (NSString *)b;
+- (NSString *)c;
+@end
+#pragma clang assume_nonnull end
+
+// CHECK-COUNT-1: <TYPE_ATTRIBUTED
+// CHECK-NOT:     <TYPE_ATTRIBUTED

--- a/clang/test/AST/attributed-type-dedup-objc-ownership.m
+++ b/clang/test/AST/attributed-type-dedup-objc-ownership.m
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fobjc-arc -emit-pch -o %t.pch %s
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t.pch | FileCheck %s
+
+@class NSString;
+
+__attribute__((objc_ownership(strong))) NSString *a;
+__attribute__((objc_ownership(strong))) NSString *b;
+__attribute__((objc_ownership(none)))   NSString *c;
+
+// CHECK-COUNT-2: <TYPE_ATTRIBUTED
+// CHECK-NOT:     <TYPE_ATTRIBUTED

--- a/clang/test/AST/attributed-type-dedup-pcs.c
+++ b/clang/test/AST/attributed-type-dedup-pcs.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple arm-none-eabi -emit-pch -o %t.pch %s
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t.pch | FileCheck %s
+
+// Pcs uses an EnumArgument and is encoded in the FunctionProtoType's
+// calling convention bits on ARM targets, so the equivalent type
+// discriminates aapcs vs aapcs-vfp. Two same-PCS uses must dedup; a
+// different-PCS use must be distinct. Requires an ARM triple — on x86 /
+// arm64-apple-darwin, pcs is silently ignored and no records are emitted.
+
+void __attribute__((pcs("aapcs")))     f1(void);
+void __attribute__((pcs("aapcs")))     f2(void);
+void __attribute__((pcs("aapcs-vfp"))) f3(void);
+
+// CHECK-COUNT-2: <TYPE_ATTRIBUTED
+// CHECK-NOT:     <TYPE_ATTRIBUTED

--- a/clang/test/AST/attributed-type-dedup-swift-attr.m
+++ b/clang/test/AST/attributed-type-dedup-swift-attr.m
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -fobjc-arc -emit-pch -o %t.pch %s
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t.pch | FileCheck %s
+
+// Checks that swift_attr deduplication works correctly.
+// The following test should generate two attributed types, not three.
+
+#define ATTR_A __attribute__((swift_attr("@A")))
+#define ATTR_B __attribute__((swift_attr("@B")))
+
+void f1(int * ATTR_A p);
+void f2(int * ATTR_A p);
+void f3(int * ATTR_B p);
+
+// CHECK-COUNT-2: <TYPE_ATTRIBUTED
+// CHECK-NOT:     <TYPE_ATTRIBUTED

--- a/clang/test/BoundsSafety/AST/redundant-attrs.c
+++ b/clang/test/BoundsSafety/AST/redundant-attrs.c
@@ -22,4 +22,4 @@ my_c_ptr_nullable_bidi_t __bidi_indexable def_c_nullable_bidi_ptr;
 // CHECK-NEXT: PointerType {{.*}} 'const int *__bidi_indexable'
 // CHECK-NEXT: QualType {{.*}} 'const int' const
 // CHECK-NEXT: BuiltinType {{.*}} 'int'
-// CHECK-NEXT: VarDecl {{.*}} def_c_nullable_bidi_ptr 'const int *__bidi_indexable _Nullable':'const int *__bidi_indexable'
+// CHECK-NEXT: VarDecl {{.*}} def_c_nullable_bidi_ptr 'my_c_ptr_nullable_bidi_t':'const int *__bidi_indexable'

--- a/clang/test/BoundsSafety/Sema/complex-typespecs-with-bounds.c
+++ b/clang/test/BoundsSafety/Sema/complex-typespecs-with-bounds.c
@@ -53,7 +53,7 @@ typedef typeof(*bar) * my_manual_ptr_t;
 void typedefs_of_typeof() {
     // expected-error@+1{{initializing 'my_t *__single' (aka 'char *__single') with an expression of incompatible type 'char * _Nullable' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
     my_t * __single p1 = bar;
-    // expected-error@+1{{initializing 'char *__single _Nullable' with an expression of incompatible type 'char * _Nullable' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
+    // expected-error@+1{{initializing 'my_ptr_t __single' (aka 'char *__single') with an expression of incompatible type 'char * _Nullable' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
     my_ptr_t __single p2 = bar;
     // expected-error@+1{{initializing 'my_manual_ptr_t __single' (aka 'char *__single') with an expression of incompatible type 'char * _Nullable' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
     my_manual_ptr_t __single p3 = bar;

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -287,6 +287,10 @@ namespace {
       std::string S = std::string("get") + std::string(getUpperName()) + "()";
       return getArgEqualityFn().str() + "(" + S + ", Other." + S + ", Context)";
     }
+
+    virtual std::string emitAttrArgProfileCall() const {
+      return "profileAttrArg(ID, Ctx, get" + getUpperName().str() + "())";
+    }
   };
 
   class SimpleArgument : public Argument {
@@ -866,6 +870,11 @@ namespace {
       return getArgEqualityFn().str() + "(" + GenIter(false, "begin") + ", " +
              GenIter(false, "end") + ", " + GenIter(true, "begin") + ", " +
              GenIter(true, "end") + ", Context)";
+    }
+
+    std::string emitAttrArgProfileCall() const override {
+      std::string LN = getLowerName().str();
+      return "profileAttrArg(ID, Ctx, " + LN + "_begin(), " + LN + "_end())";
     }
   };
 
@@ -3257,6 +3266,22 @@ static void emitAttributes(const RecordKeeper &Records, raw_ostream &OS,
       OS << "}\n\n";
     }
 
+    std::string ProfileSig = "Profile(llvm::FoldingSetNodeID &ID, "
+                             "const ASTContext &Ctx) const";
+    if (Header) {
+      OS << "  void " << ProfileSig << ";\n";
+    } else {
+      OS << "void " << R.getName() << "Attr::" << ProfileSig << " {\n";
+      std::string CustomFn = R.getValueAsString("profileFn").str();
+      if (CustomFn.empty()) {
+        for (const auto &ai : Args)
+          OS << "  " << ai->emitAttrArgProfileCall() << ";\n";
+      } else {
+        OS << "  " << CustomFn << "(*this, ID, Ctx);\n";
+      }
+      OS << "}\n\n";
+    }
+
     if (Header) {
       if (DelayedArgs) {
         DelayedArgs->writeAccessors(OS);
@@ -3329,6 +3354,23 @@ static void emitEquivalenceFunction(const RecordKeeper &Records,
   OS << "}\n\n";
 }
 
+static void emitProfileFunction(const RecordKeeper &Records, raw_ostream &OS) {
+  OS << "void Attr::Profile(llvm::FoldingSetNodeID &ID, "
+        "const ASTContext &Ctx) const {\n";
+  OS << "  switch (getKind()) {\n";
+  for (const auto *Attr : Records.getAllDerivedDefinitions("Attr")) {
+    const Record &R = *Attr;
+    if (!R.getValueAsBit("ASTNode"))
+      continue;
+    OS << "  case attr::" << R.getName() << ":\n";
+    OS << "    return cast<" << R.getName()
+       << "Attr>(this)->Profile(ID, Ctx);\n";
+  }
+  OS << "  }\n";
+  OS << "  llvm_unreachable(\"Unexpected attribute kind!\");\n";
+  OS << "}\n\n";
+}
+
 // Emits the class method definitions for attributes.
 void clang::EmitClangAttrImpl(const RecordKeeper &Records, raw_ostream &OS) {
   emitSourceFileHeader("Attribute classes' member function definitions", OS,
@@ -3365,6 +3407,7 @@ void clang::EmitClangAttrImpl(const RecordKeeper &Records, raw_ostream &OS) {
   EmitFunc("printPretty(OS, Policy)");
 
   emitEquivalenceFunction(Records, OS);
+  emitProfileFunction(Records, OS);
 }
 
 static void emitAttrList(raw_ostream &OS, StringRef Class,

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3266,8 +3266,8 @@ static void emitAttributes(const RecordKeeper &Records, raw_ostream &OS,
       OS << "}\n\n";
     }
 
-    std::string ProfileSig = "Profile(llvm::FoldingSetNodeID &ID, "
-                             "const ASTContext &Ctx) const";
+    StringRef ProfileSig = "Profile(llvm::FoldingSetNodeID &ID, "
+                           "const ASTContext &Ctx) const";
     if (Header) {
       OS << "  void " << ProfileSig << ";\n";
     } else {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/108631 added `ID.AddPointer(attr)` to `AttributedType::Profile`, which turned the `ID` into a pointer-identity key. This inhibits deduplication of attributed types (such as types with `_Nonnull/_Nullable` attributes). Such duplications can lead to significant increases in pcm/pch sizes.

This PR adds the arguments of the attributes to the folding set ID, so that the content of the argument is taken into account when computing the ID in addition to the existing inputs. The implementation teaches tablegen to generate the `profile` method for each attribute, similar to how we generate methods to check equivalence. This way, the argument contents are handled automatically. Additionally, an attribute can have an escape hatch to add its own customized profile method, through the `profileFn` tablegen field, in case something special is needed.

Assisted-by: claude-opus-4.7

Fixes rdar://170586474.

(cherry picked from commit 44ef831f9da0283e16c11c903d81d4186ed8ea6d)