### PR TITLE
[BoundsSafety] Move late parsing for parameters trigger from ParseDeclaratorInternal to ActOnFunctionDeclarator 

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2530,6 +2530,8 @@ private:
   // Upstream doesn't have the `Declarator` parameter
   void DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
                                   LateParsedAttrList *LateAttrs);
+  // Late-parse a function return type's bounds attrs (called from Sema).
+  void ParseLexedFunctionReturnTypeBoundsAttrs(Declarator &D, Decl *FD);
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// Bounds attributes (e.g., counted_by):

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1594,6 +1594,9 @@ public:
   std::function<void(StringRef, StringRef, Decl *, SourceLocation,
                      IncompleteBoundsAttributeInfo Info)>
       ParseBoundsAttributeArgFromStringCallback;
+  /// Callback to late-parse a function return type's bounds attributes.
+  std::function<void(Declarator &, Decl *)>
+      ParseLexedFunctionReturnTypeBoundsAttrsCallback;
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// VAListTagName - The declaration name corresponding to __va_list_tag.

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -3351,17 +3351,13 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
     LateAttrs->append(DCLateAttrs);
     NestedLevel++;
   }
-  ParseLexedAttributeList(ProtoLateAttrs, /*D=*/nullptr, /*EnterScope=*/false,
+  ParseLexedAttributeList(ProtoLateAttrs, /*D=*/nullptr, /*EnterScope=*/true,
                           /*OnDefinition=*/false);
   /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
 /* TO_UPSTREAM(BoundsSafety) ON */
 void Parser::ParseLexedFunctionReturnTypeBoundsAttrs(Declarator &D, Decl *FD) {
-  std::optional<Sema::ContextRAII> FnContext;
-  if (FunctionDecl *Fn = dyn_cast_or_null<FunctionDecl>(FD))
-    FnContext.emplace(Actions, Fn, /*NewThisContext=*/true);
-
   LateParsedAttrList LateAttrs(/*ParseSoon=*/true);
   DistributeCLateParsedAttrs(D, FD, &LateAttrs);
   assert(LateAttrs.empty() && "stray late attrs before the function chunk");

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -3338,7 +3338,7 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
                                             Scope::DeclScope));
       const DeclaratorChunk::FunctionTypeInfo &FTI = FuncChunk.Fun;
       for (unsigned i = 0; i != FTI.NumParams; ++i) {
-        ParmVarDecl *Param = cast<ParmVarDecl>(FTI.Params[i].Param);
+        ParmVarDecl *Param = cast_or_null<ParmVarDecl>(FTI.Params[i].Param);
         Actions.ActOnReenterCXXMethodParameter(getCurScope(), Param);
       }
       LateAttrs = &ProtoLateAttrs;
@@ -3355,6 +3355,18 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
                           /*OnDefinition=*/false);
   /* TO_UPSTREAM(BoundsSafety) OFF */
 }
+
+/* TO_UPSTREAM(BoundsSafety) ON */
+void Parser::ParseLexedFunctionReturnTypeBoundsAttrs(Declarator &D, Decl *FD) {
+  std::optional<Sema::ContextRAII> FnContext;
+  if (FunctionDecl *Fn = dyn_cast_or_null<FunctionDecl>(FD))
+    FnContext.emplace(Actions, Fn, /*NewThisContext=*/true);
+
+  LateParsedAttrList LateAttrs(/*ParseSoon=*/true);
+  DistributeCLateParsedAttrs(D, FD, &LateAttrs);
+  assert(LateAttrs.empty() && "stray late attrs before the function chunk");
+}
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 void Parser::ParsePtrauthQualifier(ParsedAttributes &Attrs) {
   assert(Tok.is(tok::kw___ptrauth));
@@ -6847,50 +6859,6 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
     Actions.runWithSufficientStackSpace(
         D.getBeginLoc(), [&] { ParseDeclaratorInternal(D, DirectDeclParser); });
     if (Kind == tok::star) {
-      /* TO_UPSTREAM(BoundsSafety) ON */
-      // We parse '__counted_by' or '__ended_by' attributes immediately
-      // if this is a function declarator. We need these attributes to be
-      // parsed early so we can construct the full function type before Sema
-      // is checking and merging the function declaration with the previous
-      // declaration.
-      if (getLangOpts().hasBoundsSafetyAttributes() &&
-          getLangOpts().ExperimentalLateParseAttributes && !LateAttrs.empty()) {
-        unsigned FuncIndex = 0;
-        if (D.isFunctionDeclarator(FuncIndex)) {
-          // Upstream doesn't support bounds safety attributes on functions yet
-          // so avoid taking this path when bounds safety is off.
-          DeclaratorChunk::FunctionTypeInfo FTI = D.getFunctionTypeInfo();
-          ParseScope PrototypeScope(this, Scope::FunctionPrototypeScope |
-                                          Scope::FunctionDeclarationScope |
-                                          Scope::DeclScope);
-          for (unsigned i = 0; i != FTI.NumParams; ++i) {
-            if (Decl *D = FTI.Params[i].Param) {
-              // Param can be missing if the declaration is malformed. The
-              // diagnostic is emitted later.
-              Actions.ActOnReenterCXXMethodParameter(
-                  getCurScope(), cast<ParmVarDecl>(D));
-            }
-          }
-          // Handling nested return type with counted_by, e.g.:
-          //  T *__counted_by(x) *foo(size_t x);
-          unsigned NestedLevel = 0;
-          for (unsigned i = FuncIndex + 1; i != D.getNumTypeObjects(); ++i) {
-            if (D.getTypeObject(i).Kind == DeclaratorChunk::Pointer)
-              NestedLevel++;
-          }
-
-          if (NestedLevel != 0) {
-            for (auto *LateAttr : LateAttrs) {
-              LateAttr->NestedTypeLevel = NestedLevel;
-            }
-          }
-          ParseLexedAttributeList(LateAttrs, /*D=*/nullptr,
-                                  /*EnterScope=*/false, /*OnDefinition=*/false,
-                                  &D.getAttributes());
-          LateAttrs.clear();
-        }
-      }
-      /* TO_UPSTREAM(BoundsSafety) OFF */
       // Remember that we parsed a pointer type, and remember the type-quals.
       D.AddTypeInfo(DeclaratorChunk::getPointer(
                         DS.getTypeQualifiers(), Loc, DS.getConstSpecLoc(),

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -91,6 +91,10 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
         return this->ParseBoundsAttributeArgFromString(ExprStr, Context, Parent,
                                                        IncludeLoc, Payload);
       };
+  Actions.ParseLexedFunctionReturnTypeBoundsAttrsCallback =
+      [this](Declarator &D, Decl *FD) {
+        this->ParseLexedFunctionReturnTypeBoundsAttrs(D, FD);
+      };
   /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
@@ -483,6 +487,7 @@ Parser::~Parser() {
   // Clear out the parse-*-from-string callbacks.
   Actions.ParseTypeFromStringCallback = nullptr;
   Actions.ParseBoundsAttributeArgFromStringCallback = nullptr;
+  Actions.ParseLexedFunctionReturnTypeBoundsAttrsCallback = nullptr;
 
   // If we still have scopes active, delete the scope tree.
   delete getCurScope();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11680,6 +11680,14 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
   }
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  // Late-parse the return type's bounds attributes before we merge with a
+  // previous declaration, so the full type is built first.
+  if (getLangOpts().BoundsSafetyAttributes &&
+      ParseLexedFunctionReturnTypeBoundsAttrsCallback)
+    ParseLexedFunctionReturnTypeBoundsAttrsCallback(D, NewFD);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
+
   // If this declarator is a declaration and not a definition, its parameters
   // will not be pushed onto a scope chain. That means we will not issue any
   // reserved identifier warnings for the declaration, but we will for the

--- a/clang/test/BoundsSafety/Sema/func-no-prototype-k-and-r-counted-by-decl.c
+++ b/clang/test/BoundsSafety/Sema/func-no-prototype-k-and-r-counted-by-decl.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c -verify %s
+#include <ptrcheck.h>
+
+// A K&R identifier-list declaration has no ParmVarDecl for its parameters, so
+// late-parsing the return type's bounds attribute must tolerate a null
+// parameter rather than crash.
+int *__counted_by(n) foo(n);
+// expected-error@-1{{use of undeclared identifier 'n'}}
+// expected-error@-2{{a parameter list without types is only allowed in a function definition}}


### PR DESCRIPTION
Part of #12758
Fixes #12766
