### PR TITLE
[clang][deps] Avoid `CompilerInvocation` copies

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyActionController.h
+++ b/clang/include/clang/DependencyScanning/DependencyActionController.h
@@ -61,7 +61,7 @@ public:
   /// Finalizes the scan instance and modifies the resulting TU invocation.
   /// Returns true on success, false on failure.
   virtual bool finalize(CompilerInstance &ScanInstance,
-                        CompilerInvocation &NewInvocation) {
+                        CowCompilerInvocation &NewInvocation) {
     return true;
   }
 

--- a/clang/include/clang/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/DependencyScanning/ScanAndUpdateArgs.h
@@ -26,6 +26,7 @@ namespace clang {
 
 class CASOptions;
 class CompilerInvocation;
+class CowCompilerInvocation;
 
 namespace dependencies {
 
@@ -33,6 +34,10 @@ namespace dependencies {
 /// enabled.
 void configureInvocationForCaching(CompilerInvocation &CI, CASOptions CASOpts,
                                    std::string InputID,
+                                   CachingInputKind InputKind,
+                                   std::string WorkingDir);
+void configureInvocationForCaching(CowCompilerInvocation &CI,
+                                   CASOptions CASOpts, std::string InputID,
                                    CachingInputKind InputKind,
                                    std::string WorkingDir);
 
@@ -48,6 +53,8 @@ struct DepscanPrefixMapping {
 
   /// Apply the mappings from \p Mapper to \p Invocation.
   static void remapInvocationPaths(CompilerInvocation &Invocation,
+                                   llvm::PrefixMapper &Mapper);
+  static void remapInvocationPaths(CowCompilerInvocation &Invocation,
                                    llvm::PrefixMapper &Mapper);
 };
 } // namespace dependencies

--- a/clang/include/clang/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/DependencyScanning/ScanAndUpdateArgs.h
@@ -32,10 +32,6 @@ namespace dependencies {
 
 /// Apply CAS inputs for compilation caching to the given invocation, if
 /// enabled.
-void configureInvocationForCaching(CompilerInvocation &CI, CASOptions CASOpts,
-                                   std::string InputID,
-                                   CachingInputKind InputKind,
-                                   std::string WorkingDir);
 void configureInvocationForCaching(CowCompilerInvocation &CI,
                                    CASOptions CASOpts, std::string InputID,
                                    CachingInputKind InputKind,
@@ -52,8 +48,6 @@ struct DepscanPrefixMapping {
       llvm::PrefixMapper &Mapper);
 
   /// Apply the mappings from \p Mapper to \p Invocation.
-  static void remapInvocationPaths(CompilerInvocation &Invocation,
-                                   llvm::PrefixMapper &Mapper);
   static void remapInvocationPaths(CowCompilerInvocation &Invocation,
                                    llvm::PrefixMapper &Mapper);
 };

--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -60,7 +60,7 @@ createCompileJobCacheKey(llvm::cas::ObjectStore &CAS, DiagnosticsEngine &Diags,
                          const CompilerInvocation &Invocation);
 std::optional<llvm::cas::CASID>
 createCompileJobCacheKey(llvm::cas::ObjectStore &CAS, DiagnosticsEngine &Diags,
-                         const CowCompilerInvocation &Invocation);
+                         CowCompilerInvocation Invocation);
 
 /// Perform any destructive changes needed to canonicalize \p Invocation for
 /// caching, extracting the settings that affect compilation even if they do not

--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -22,8 +22,10 @@
 #include "clang/Frontend/MigratorOptions.h"
 #include "clang/Frontend/PreprocessorOutputOptions.h"
 #include "clang/StaticAnalyzer/Core/AnalyzerOptions.h"
-#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/ScopeExit.h"
+
 #include <memory>
 #include <string>
 
@@ -330,10 +332,13 @@ public:
   }
   /// @}
 
-  /// Invokes the function with a temporary copy-on-write view of this instance.
-  /// The new invocation cannot escape \a Fn.
-  template <class F>
-  auto withTempCow(F &&Fn) const;
+  /// Invokes the \a Fn with CowCompilerInvocation representing \c this.
+  /// The \a Fn must not directly modify \c this.
+  /// The provided \c CowCompilerInvocation must not escape \a Fn.
+  template <class R>
+  R withCowRef(llvm::function_ref<R(CowCompilerInvocation &)> Fn);
+  template <class R>
+  R withCowRef(llvm::function_ref<R(const CowCompilerInvocation &)> Fn) const;
 
   /// Visitation.
   /// @{
@@ -482,9 +487,25 @@ public:
   using CompilerInvocationBase::visitPaths;
 };
 
-template <class F>
-auto CompilerInvocation::withTempCow(F &&Fn) const {
-  return Fn(CowCompilerInvocation(ShallowConstructor{}, *this));
+template <class R>
+R CompilerInvocation::withCowRef(
+    llvm::function_ref<R(CowCompilerInvocation &)> Fn) {
+  // We use moves to avoid bumping the ref-count of the shared_ptr that holds
+  // individual options. Since we expect \a Fn to actually modify \c CowRef,
+  // this prevents temporary copies.
+  CowCompilerInvocation CowRef = std::move(*this);
+  llvm::scope_exit Mutate([&]() { *this = std::move(CowRef); });
+  return Fn(CowRef);
+}
+
+template <class R>
+R CompilerInvocation::withCowRef(
+    llvm::function_ref<R(const CowCompilerInvocation &)> Fn) const {
+  // We use the shallow constructor. Since \a Fn cannot modify \c CowRef, no
+  // copies will be created, despite the bump to the ref-count of the shared_ptr
+  // that holds individual options.
+  CowCompilerInvocation CowRef(ShallowConstructor{}, *this);
+  return Fn(CowRef);
 }
 
 inline CompilerInvocation::CompilerInvocation(CowCompilerInvocation &&X)

--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -483,8 +483,7 @@ public:
   /// up front; if the callback only inspects (and does not mutate) the paths,
   /// the const \c visitPaths overload should be used instead to avoid those
   /// per-group copies.
-  void visitPaths(llvm::function_ref<bool(std::string &)> Callback);
-  using CompilerInvocationBase::visitPaths;
+  void visitMutPaths(llvm::function_ref<bool(std::string &)> Callback);
 };
 
 template <class R>

--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -129,6 +129,9 @@ protected:
   /// prevent creation of the reference-counted option objects.
   struct EmptyConstructor {};
 
+  /// Tag for the shallow-copy constructor below.
+  struct ShallowConstructor {};
+
   CompilerInvocationBase();
   CompilerInvocationBase(EmptyConstructor) {}
   CompilerInvocationBase(const CompilerInvocationBase &X) = delete;
@@ -268,6 +271,15 @@ public:
   explicit CompilerInvocation(const CowCompilerInvocation &X);
   CompilerInvocation &operator=(const CowCompilerInvocation &X);
 
+  /// Move-construct/move-assign from a \c CowCompilerInvocation. Steals the
+  /// (potentially copy-on-written) option group pointers without deep-copying;
+  /// \p X is left empty. Useful to receive results of mutating a temporary
+  /// Cow alias back into a \c CompilerInvocation.
+  /// @{
+  explicit CompilerInvocation(CowCompilerInvocation &&X);
+  CompilerInvocation &operator=(CowCompilerInvocation &&X);
+  /// @}
+
   /// Const getters.
   /// @{
   // Note: These need to be pulled in manually. Otherwise, they get hidden by
@@ -317,6 +329,11 @@ public:
     this->CASOpts = CASOpts;
   }
   /// @}
+
+  /// Invokes the function with a temporary copy-on-write view of this instance.
+  /// The new invocation cannot escape \a Fn.
+  template <class F>
+  auto withTempCow(F &&Fn) const;
 
   /// Visitation.
   /// @{
@@ -425,6 +442,16 @@ public:
   CowCompilerInvocation(CompilerInvocation &&X)
       : CompilerInvocationBase(std::move(X)) {}
 
+  /// Construct a CowCompilerInvocation that aliases the option storage of \p
+  /// X without deep-copying. Subsequent mutations through getMut*Opts() will
+  /// copy-on-write per group as usual, leaving \p X unaffected. The caller
+  /// must guarantee that \p X is not mutated for the lifetime of the
+  /// constructed invocation.
+  CowCompilerInvocation(ShallowConstructor, const CompilerInvocation &X)
+      : CompilerInvocationBase(EmptyConstructor{}) {
+    shallow_copy_assign(X);
+  }
+
   // Const getters are inherited from the base class.
 
   /// Mutable getters.
@@ -444,7 +471,30 @@ public:
   DependencyOutputOptions &getMutDependencyOutputOpts();
   PreprocessorOutputOptions &getMutPreprocessorOutputOpts();
   /// @}
+
+  /// Visits paths stored in the invocation, allowing the callback to mutate
+  /// them. To preserve the copy-on-write invariant for groups whose paths the
+  /// caller might modify, this ensures unique ownership of every option group
+  /// up front; if the callback only inspects (and does not mutate) the paths,
+  /// the const \c visitPaths overload should be used instead to avoid those
+  /// per-group copies.
+  void visitPaths(llvm::function_ref<bool(std::string &)> Callback);
+  using CompilerInvocationBase::visitPaths;
 };
+
+template <class F>
+auto CompilerInvocation::withTempCow(F &&Fn) const {
+  return Fn(CowCompilerInvocation(ShallowConstructor{}, *this));
+}
+
+inline CompilerInvocation::CompilerInvocation(CowCompilerInvocation &&X)
+    : CompilerInvocationBase(std::move(X)) {}
+
+inline CompilerInvocation &
+CompilerInvocation::operator=(CowCompilerInvocation &&X) {
+  CompilerInvocationBase::operator=(std::move(X));
+  return *this;
+}
 
 IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 createVFSFromCompilerInvocation(const CompilerInvocation &CI,

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -856,7 +856,11 @@ bool DependencyScanningAction::runInvocation(
     if (MDC)
       MDC->applyDiscoveredDependencies(*OriginalInvocation);
 
-    if (!Controller.finalize(ScanInstance, *OriginalInvocation))
+    bool Success = OriginalInvocation->withCowRef<bool>(
+        [&](CowCompilerInvocation &CowOriginalInvocation) {
+          return Controller.finalize(ScanInstance, CowOriginalInvocation);
+        });
+    if (!Success)
       return false;
 
     std::optional<std::string> CacheKey =
@@ -947,7 +951,11 @@ bool DependencyScanningAction::runInvocation(
       MDC->applyDiscoveredDependencies(*OriginalInvocation);
     }
 
-    if (!Controller.finalize(ScanInstance, *OriginalInvocation))
+    bool Success = OriginalInvocation->withCowRef<bool>(
+        [&](CowCompilerInvocation &CowOriginalInvocation) {
+          return Controller.finalize(ScanInstance, CowOriginalInvocation);
+        });
+    if (!Success)
       return false;
 
     // Forward any CAS results to consumer.

--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -41,7 +41,7 @@ private:
   bool initialize(CompilerInstance &ScanInstance,
                   CompilerInvocation &NewInvocation) override;
   bool finalize(CompilerInstance &ScanInstance,
-                CompilerInvocation &NewInvocation) override;
+                CowCompilerInvocation &NewInvocation) override;
   std::optional<std::string>
   getCacheKey(const CompilerInvocation &NewInvocation) override;
 
@@ -78,7 +78,7 @@ public:
 
   Expected<cas::IncludeTreeRoot>
   finishIncludeTree(CompilerInstance &ScanInstance,
-                    CompilerInvocation &NewInvocation);
+                    const CompilerInvocationBase &NewInvocation);
 
   void enteredInclude(Preprocessor &PP, FileID FID);
 
@@ -352,8 +352,8 @@ bool IncludeTreeActionController::initialize(
   return true;
 }
 
-bool IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
-                                           CompilerInvocation &NewInvocation) {
+bool IncludeTreeActionController::finalize(
+    CompilerInstance &ScanInstance, CowCompilerInvocation &NewInvocation) {
   auto GetInputCacheKey = [&]() -> std::optional<StringRef> {
     if (NewInvocation.getFrontendOpts().Inputs.size() != 1)
       return {};
@@ -647,9 +647,9 @@ getIncludeTreeModule(cas::ObjectStore &DB, Module *M) {
                           ExportList, LinkLibraries, RequirementsList);
 }
 
-Expected<cas::IncludeTreeRoot>
-IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
-                                      CompilerInvocation &NewInvocation) {
+Expected<cas::IncludeTreeRoot> IncludeTreeBuilder::finishIncludeTree(
+    CompilerInstance &ScanInstance,
+    const CompilerInvocationBase &NewInvocation) {
   if (ErrorToReport)
     return std::move(*ErrorToReport);
 
@@ -709,7 +709,7 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
     if (Error E = addModuleInputs(*Reader))
       return E;
 
-    PreprocessorOptions &PPOpts = NewInvocation.getPreprocessorOpts();
+    const PreprocessorOptions &PPOpts = NewInvocation.getPreprocessorOpts();
     if (PPOpts.ImplicitPCHInclude.empty())
       return Error::success(); // no need for additional work.
 

--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -472,16 +472,12 @@ bool IncludeTreeActionController::finalizeModuleInvocation(
     return false;
   }
 
-  // TODO: Avoid this copy.
-  CompilerInvocation CI(CowCI);
-
-  configureInvocationForCaching(CI, CASOpts, *MD.IncludeTreeID,
+  configureInvocationForCaching(CowCI, CASOpts, *MD.IncludeTreeID,
                                 CachingInputKind::IncludeTree,
                                 /*CASFSWorkingDir=*/"");
 
-  DepscanPrefixMapping::remapInvocationPaths(CI, PrefixMapper);
+  DepscanPrefixMapping::remapInvocationPaths(CowCI, PrefixMapper);
 
-  CowCI = CI;
   return true;
 }
 

--- a/clang/lib/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -153,18 +153,6 @@ void dependencies::configureInvocationForCaching(CowCompilerInvocation &CI,
   }
 }
 
-void dependencies::configureInvocationForCaching(CompilerInvocation &CI,
-                                                 CASOptions CASOpts,
-                                                 std::string InputID,
-                                                 CachingInputKind InputKind,
-                                                 std::string WorkingDir) {
-  CI.withTempCow([&](CowCompilerInvocation CowCI) {
-    configureInvocationForCaching(CowCI, std::move(CASOpts), std::move(InputID),
-                                  InputKind, std::move(WorkingDir));
-    CI = std::move(CowCI);
-  });
-}
-
 void DepscanPrefixMapping::remapInvocationPaths(
     CowCompilerInvocation &Invocation, llvm::PrefixMapper &Mapper) {
   auto &FrontendOpts = Invocation.getMutFrontendOpts();
@@ -192,14 +180,6 @@ void DepscanPrefixMapping::remapInvocationPaths(
   Invocation.visitPaths([&Mapper](std::string &Path) {
     Mapper.mapInPlace(Path);
     return false;
-  });
-}
-
-void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
-                                                llvm::PrefixMapper &Mapper) {
-  Invocation.withTempCow([&](CowCompilerInvocation CowCI) {
-    remapInvocationPaths(CowCI, Mapper);
-    Invocation = std::move(CowCI);
   });
 }
 

--- a/clang/lib/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -29,20 +29,20 @@ static void updateRelativePath(std::string &Path,
   Path = PathStorage.str();
 }
 
-void dependencies::configureInvocationForCaching(CompilerInvocation &CI,
+void dependencies::configureInvocationForCaching(CowCompilerInvocation &CI,
                                                  CASOptions CASOpts,
                                                  std::string InputID,
                                                  CachingInputKind InputKind,
                                                  std::string WorkingDir) {
-  CI.getCASOpts() = std::move(CASOpts);
-  auto &FrontendOpts = CI.getFrontendOpts();
+  CI.getMutCASOpts() = std::move(CASOpts);
+  auto &FrontendOpts = CI.getMutFrontendOpts();
   FrontendOpts.CacheCompileJob = true;
   FrontendOpts.IncludeTimestamps = false;
 
   // Clear this otherwise it defeats the purpose of making the compilation key
   // independent of certain arguments.
-  auto &CodeGenOpts = CI.getCodeGenOpts();
-  if (CI.getFrontendOpts().ProgramAction != frontend::ActionKind::EmitObj) {
+  auto &CodeGenOpts = CI.getMutCodeGenOpts();
+  if (FrontendOpts.ProgramAction != frontend::ActionKind::EmitObj) {
     CodeGenOpts.UseCASBackend = false;
     CodeGenOpts.EmitCASIDFile = false;
     auto &LLVMArgs = FrontendOpts.LLVMArgs;
@@ -52,12 +52,12 @@ void dependencies::configureInvocationForCaching(CompilerInvocation &CI,
   resetBenignCodeGenOptions(FrontendOpts.ProgramAction, CI.getLangOpts(),
                             CodeGenOpts);
 
-  HeaderSearchOptions &HSOpts = CI.getHeaderSearchOpts();
+  HeaderSearchOptions &HSOpts = CI.getMutHeaderSearchOpts();
   // Avoid writing potentially volatile diagnostic options into pcms.
   HSOpts.ModulesSkipDiagnosticOptions = true;
 
   // "Fix" the CAS options.
-  auto &FileSystemOpts = CI.getFileSystemOpts();
+  auto &FileSystemOpts = CI.getMutFileSystemOpts();
   switch (InputKind) {
   case CachingInputKind::IncludeTree: {
     using llvm::sys::path::is_relative;
@@ -107,7 +107,7 @@ void dependencies::configureInvocationForCaching(CompilerInvocation &CI,
     HSOpts.UseStandardSystemIncludes = false;
     HSOpts.UseStandardCXXIncludes = false;
 
-    auto &PPOpts = CI.getPreprocessorOpts();
+    auto &PPOpts = CI.getMutPreprocessorOpts();
     // We don't need this because we save the contents of the PCH file in the
     // include tree root.
     PPOpts.ImplicitPCHInclude.clear();
@@ -122,7 +122,7 @@ void dependencies::configureInvocationForCaching(CompilerInvocation &CI,
       PPOpts.Includes.clear();
     }
     // Clear APINotes options.
-    CI.getAPINotesOpts().ModuleSearchPaths = {};
+    CI.getMutAPINotesOpts().ModuleSearchPaths = {};
 
     // Reset debug/coverage compilation directory if source paths are absolute.
     if (!HasRelativeIncludes) {
@@ -133,9 +133,10 @@ void dependencies::configureInvocationForCaching(CompilerInvocation &CI,
     // Update output paths, and clear working directory.
     auto CWD = FileSystemOpts.WorkingDir;
     updateRelativePath(FrontendOpts.OutputFile, CWD);
-    updateRelativePath(CI.getDiagnosticOpts().DiagnosticSerializationFile, CWD);
-    updateRelativePath(CI.getDiagnosticOpts().DiagnosticLogFile, CWD);
-    updateRelativePath(CI.getDependencyOutputOpts().OutputFile, CWD);
+    updateRelativePath(CI.getMutDiagnosticOpts().DiagnosticSerializationFile,
+                       CWD);
+    updateRelativePath(CI.getMutDiagnosticOpts().DiagnosticLogFile, CWD);
+    updateRelativePath(CI.getMutDependencyOutputOpts().OutputFile, CWD);
     FileSystemOpts.WorkingDir.clear();
     break;
   }
@@ -152,9 +153,21 @@ void dependencies::configureInvocationForCaching(CompilerInvocation &CI,
   }
 }
 
-void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
-                                                llvm::PrefixMapper &Mapper) {
-  auto &FrontendOpts = Invocation.getFrontendOpts();
+void dependencies::configureInvocationForCaching(CompilerInvocation &CI,
+                                                 CASOptions CASOpts,
+                                                 std::string InputID,
+                                                 CachingInputKind InputKind,
+                                                 std::string WorkingDir) {
+  CI.withTempCow([&](CowCompilerInvocation CowCI) {
+    configureInvocationForCaching(CowCI, std::move(CASOpts), std::move(InputID),
+                                  InputKind, std::move(WorkingDir));
+    CI = std::move(CowCI);
+  });
+}
+
+void DepscanPrefixMapping::remapInvocationPaths(
+    CowCompilerInvocation &Invocation, llvm::PrefixMapper &Mapper) {
+  auto &FrontendOpts = Invocation.getMutFrontendOpts();
   FrontendOpts.PathPrefixMappings.clear();
 
   // If there are no mappings, we're done. Otherwise, continue and remap
@@ -179,6 +192,14 @@ void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
   Invocation.visitPaths([&Mapper](std::string &Path) {
     Mapper.mapInPlace(Path);
     return false;
+  });
+}
+
+void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
+                                                llvm::PrefixMapper &Mapper) {
+  Invocation.withTempCow([&](CowCompilerInvocation CowCI) {
+    remapInvocationPaths(CowCI, Mapper);
+    Invocation = std::move(CowCI);
   });
 }
 

--- a/clang/lib/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -177,7 +177,7 @@ void DepscanPrefixMapping::remapInvocationPaths(
   // are in the module context hash, which indirectly impacts the cache key when
   // importing a module. In the future we may change how -fmodule-file-cache-key
   // works when remapping to avoid needing this.
-  Invocation.visitPaths([&Mapper](std::string &Path) {
+  Invocation.visitMutPaths([&Mapper](std::string &Path) {
     Mapper.mapInPlace(Path);
     return false;
   });

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -57,10 +57,9 @@ static llvm::cas::CASID createCompileJobCacheKeyForArgs(
   return llvm::cantFail(Builder.build()).getID();
 }
 
-static void canonicalizeForCacheKey(CompilerInvocation &CI) {
-  FrontendOptions &FrontendOpts = CI.getFrontendOpts();
-  DependencyOutputOptions &DepOpts = CI.getDependencyOutputOpts();
-
+static void canonicalizeForCacheKey(FrontendOptions &FrontendOpts,
+                                    DependencyOutputOptions &DepOpts,
+                                    DiagnosticOptions &DiagOpts) {
   // Keep the key independent of the paths of these outputs.
   if (!FrontendOpts.OutputFile.empty())
     FrontendOpts.OutputFile = "-";
@@ -90,7 +89,6 @@ static void canonicalizeForCacheKey(CompilerInvocation &CI) {
 
   // Canonicalize diagnostic options.
 
-  DiagnosticOptions &DiagOpts = CI.getDiagnosticOpts();
   // These options affect diagnostic rendering but not the cached diagnostics.
   DiagOpts.ShowLine = false;
   DiagOpts.ShowColumn = false;
@@ -128,8 +126,10 @@ static void canonicalizeForCacheKey(CompilerInvocation &CI) {
 
 static std::optional<llvm::cas::CASID>
 createCompileJobCacheKeyImpl(ObjectStore &CAS, DiagnosticsEngine &Diags,
-                             CompilerInvocation CI) {
-  canonicalizeForCacheKey(CI);
+                             CowCompilerInvocation CI) {
+  canonicalizeForCacheKey(CI.getMutFrontendOpts(),
+                          CI.getMutDependencyOutputOpts(),
+                          CI.getMutDiagnosticOpts());
   // Generate a new command-line in case Invocation has been canonicalized.
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
@@ -173,9 +173,8 @@ createCompileJobCacheKeyImpl(ObjectStore &CAS, DiagnosticsEngine &Diags,
 
 static CompileJobCachingOptions
 canonicalizeForCaching(const llvm::cas::ObjectStore &CAS,
-                       CompilerInvocation &Invocation) {
+                       FrontendOptions &FrontendOpts, CASOptions &CASOpts) {
   CompileJobCachingOptions Opts;
-  FrontendOptions &FrontendOpts = Invocation.getFrontendOpts();
 
   // Canonicalize settings for caching, extracting settings that affect the
   // compilation even if will clear them during the main compilation.
@@ -199,10 +198,9 @@ canonicalizeForCaching(const llvm::cas::ObjectStore &CAS,
   //
   // TODO: Extract CASOptions.Path first if we need it later since it'll
   // disappear here.
-  Invocation.getCASOpts() = {};
+  CASOpts = {};
   // Set the CASPath to the hash schema.
-  Invocation.getCASOpts().CASPath =
-      CAS.getContext().getHashSchemaIdentifier().str();
+  CASOpts.CASPath = CAS.getContext().getHashSchemaIdentifier().str();
 
   // TODO: Canonicalize DiagnosticOptions here to be "serialized" only. Pass in
   // a hook to mirror diagnostics to stderr (when writing there), and handle
@@ -214,8 +212,13 @@ canonicalizeForCaching(const llvm::cas::ObjectStore &CAS,
 
 void clang::canonicalizeCASCompilerInvocation(const ObjectStore &CAS,
                                               CompilerInvocation &CI) {
-  (void)canonicalizeForCaching(CAS, CI);
-  canonicalizeForCacheKey(CI);
+  // Mutate \p CI in place to preserve the identity of its shared option
+  // objects (e.g., \c DiagnosticsEngine holds a plain reference to the same
+  // \c DiagnosticOptions instance and would dangle if we replaced the
+  // shared_ptr).
+  (void)canonicalizeForCaching(CAS, CI.getFrontendOpts(), CI.getCASOpts());
+  canonicalizeForCacheKey(CI.getFrontendOpts(), CI.getDependencyOutputOpts(),
+                          CI.getDiagnosticOpts());
 }
 
 std::optional<std::pair<llvm::cas::CASID, llvm::cas::CASID>>
@@ -223,8 +226,10 @@ clang::canonicalizeAndCreateCacheKeys(ObjectStore &CAS, ActionCache &Cache,
                                       DiagnosticsEngine &Diags,
                                       CompilerInvocation &CI,
                                       CompileJobCachingOptions &Opts) {
-  Opts = canonicalizeForCaching(CAS, CI);
-  auto CacheKey = createCompileJobCacheKeyImpl(CAS, Diags, CI);
+  Opts = canonicalizeForCaching(CAS, CI.getFrontendOpts(), CI.getCASOpts());
+  auto CacheKey = CI.withTempCow([&](CowCompilerInvocation CowCI) {
+    return createCompileJobCacheKeyImpl(CAS, Diags, std::move(CowCI));
+  });
   if (!CacheKey)
     return std::nullopt;
 
@@ -252,9 +257,9 @@ clang::canonicalizeAndCreateCacheKeys(ObjectStore &CAS, ActionCache &Cache,
   CI.getFrontendOpts().CASInputFileCASID = Value.get()->toString();
   CI.getFrontendOpts().CASInputFileCacheKey.clear();
 
-  CompilerInvocation CICopy = CI;
-  (void)canonicalizeForCaching(CAS, CICopy);
-  auto CanonicalCacheKey = createCompileJobCacheKeyImpl(CAS, Diags, CICopy);
+  auto CanonicalCacheKey = CI.withTempCow([&](CowCompilerInvocation CowCI) {
+    return createCompileJobCacheKeyImpl(CAS, Diags, std::move(CowCI));
+  });
   if (!CanonicalCacheKey)
     return std::nullopt;
 
@@ -264,16 +269,16 @@ clang::canonicalizeAndCreateCacheKeys(ObjectStore &CAS, ActionCache &Cache,
 std::optional<llvm::cas::CASID>
 clang::createCompileJobCacheKey(ObjectStore &CAS, DiagnosticsEngine &Diags,
                                 const CompilerInvocation &OriginalCI) {
-  CompilerInvocation CI(OriginalCI);
-  (void)canonicalizeForCaching(CAS, CI);
-  return createCompileJobCacheKeyImpl(CAS, Diags, std::move(CI));
+  return OriginalCI.withTempCow([&](CowCompilerInvocation CowOriginalCI) {
+    return createCompileJobCacheKey(CAS, Diags, std::move(CowOriginalCI));
+  });
 }
 
 std::optional<llvm::cas::CASID>
 clang::createCompileJobCacheKey(ObjectStore &CAS, DiagnosticsEngine &Diags,
-                                const CowCompilerInvocation &OriginalCI) {
-  CompilerInvocation CI(OriginalCI);
-  (void)canonicalizeForCaching(CAS, CI);
+                                CowCompilerInvocation CI) {
+  (void)canonicalizeForCaching(CAS, CI.getMutFrontendOpts(),
+                               CI.getMutCASOpts());
   return createCompileJobCacheKeyImpl(CAS, Diags, std::move(CI));
 }
 

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -227,9 +227,10 @@ clang::canonicalizeAndCreateCacheKeys(ObjectStore &CAS, ActionCache &Cache,
                                       CompilerInvocation &CI,
                                       CompileJobCachingOptions &Opts) {
   Opts = canonicalizeForCaching(CAS, CI.getFrontendOpts(), CI.getCASOpts());
-  auto CacheKey = CI.withTempCow([&](CowCompilerInvocation CowCI) {
-    return createCompileJobCacheKeyImpl(CAS, Diags, std::move(CowCI));
-  });
+  auto CacheKey = CI.withCowRef<std::optional<CASID>>(
+      [&](const CowCompilerInvocation &CowCI) {
+        return createCompileJobCacheKeyImpl(CAS, Diags, std::move(CowCI));
+      });
   if (!CacheKey)
     return std::nullopt;
 
@@ -257,9 +258,10 @@ clang::canonicalizeAndCreateCacheKeys(ObjectStore &CAS, ActionCache &Cache,
   CI.getFrontendOpts().CASInputFileCASID = Value.get()->toString();
   CI.getFrontendOpts().CASInputFileCacheKey.clear();
 
-  auto CanonicalCacheKey = CI.withTempCow([&](CowCompilerInvocation CowCI) {
-    return createCompileJobCacheKeyImpl(CAS, Diags, std::move(CowCI));
-  });
+  auto CanonicalCacheKey = CI.withCowRef<std::optional<CASID>>(
+      [&](const CowCompilerInvocation &CowCI) {
+        return createCompileJobCacheKeyImpl(CAS, Diags, CowCI);
+      });
   if (!CanonicalCacheKey)
     return std::nullopt;
 
@@ -269,9 +271,10 @@ clang::canonicalizeAndCreateCacheKeys(ObjectStore &CAS, ActionCache &Cache,
 std::optional<llvm::cas::CASID>
 clang::createCompileJobCacheKey(ObjectStore &CAS, DiagnosticsEngine &Diags,
                                 const CompilerInvocation &OriginalCI) {
-  return OriginalCI.withTempCow([&](CowCompilerInvocation CowOriginalCI) {
-    return createCompileJobCacheKey(CAS, Diags, std::move(CowOriginalCI));
-  });
+  return OriginalCI.withCowRef<std::optional<CASID>>(
+      [&](const CowCompilerInvocation &CowOriginalCI) {
+        return createCompileJobCacheKey(CAS, Diags, CowOriginalCI);
+      });
 }
 
 std::optional<llvm::cas::CASID>

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5939,6 +5939,29 @@ void CompilerInvocation::visitPaths(
   visitPathsImpl(Callback);
 }
 
+void CowCompilerInvocation::visitPaths(
+    llvm::function_ref<bool(std::string &)> Callback) {
+  // Ensure exclusive ownership of every option group, so that visitPathsImpl()
+  // doesn't affect any other invocations.
+  // FIXME: Do this only if \c Callback does decide to modify any strings in an
+  // option group.
+  (void)ensureOwned(LangOpts);
+  (void)ensureOwned(TargetOpts);
+  (void)ensureOwned(DiagnosticOpts);
+  (void)ensureOwned(HSOpts);
+  (void)ensureOwned(PPOpts);
+  (void)ensureOwned(AnalyzerOpts);
+  (void)ensureOwned(MigratorOpts);
+  (void)ensureOwned(APINotesOpts);
+  (void)ensureOwned(CASOpts);
+  (void)ensureOwned(CodeGenOpts);
+  (void)ensureOwned(FSOpts);
+  (void)ensureOwned(FrontendOpts);
+  (void)ensureOwned(DependencyOutputOpts);
+  (void)ensureOwned(PreprocessorOutputOpts);
+  visitPathsImpl(Callback);
+}
+
 void CompilerInvocationBase::generateCC1CommandLine(
     ArgumentConsumer Consumer) const {
   llvm::Triple T(getTargetOpts().Triple);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5939,7 +5939,7 @@ void CompilerInvocation::visitPaths(
   visitPathsImpl(Callback);
 }
 
-void CowCompilerInvocation::visitPaths(
+void CowCompilerInvocation::visitMutPaths(
     llvm::function_ref<bool(std::string &)> Callback) {
   // Ensure exclusive ownership of every option group, so that visitPathsImpl()
   // doesn't affect any other invocations.

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -583,10 +583,12 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
   // Turn off dependency outputs. Should have already been emitted.
   Invocation.getDependencyOutputOpts().OutputFile.clear();
 
-  configureInvocationForCaching(Invocation, Tool.getCASOpts(), Root->toString(),
-                                CachingInputKind::IncludeTree,
-                                WorkingDirectory.str());
-  DepscanPrefixMapping::remapInvocationPaths(Invocation, Mapper);
+  Invocation.withCowRef<void>([&](CowCompilerInvocation &CowInvocation) {
+    configureInvocationForCaching(
+        CowInvocation, Tool.getCASOpts(), Root->toString(),
+        CachingInputKind::IncludeTree, WorkingDirectory.str());
+    DepscanPrefixMapping::remapInvocationPaths(CowInvocation, Mapper);
+  });
   return *Root;
 }
 
@@ -746,7 +748,11 @@ bool CompilerInstanceWithContext::computeDependencies(
   MDC->run(Consumer);
   MDC->applyDiscoveredDependencies(ModuleInvocation);
 
-  if (!Controller.finalize(CI, ModuleInvocation))
+  bool Success = ModuleInvocation.withCowRef<bool>(
+      [&](CowCompilerInvocation &CowModuleInvocation) {
+        return Controller.finalize(CI, CowModuleInvocation);
+      });
+  if (!Success)
     return false;
 
   std::string ID = ModuleInvocation.getFrontendOpts().CASIncludeTreeID;


### PR DESCRIPTION
When constructing the dependency graph for compilation caching, the dependency scanner needs to do some extra operations on the compiler invocations. Historically, these have not utilized the copy-on-write variant well. This patch takes care to minimize `CompilerInvocation` copies, which improves incremental scans with populated up-to-date scanning module cache by 16-18%. Together with https://github.com/llvm/llvm-project/pull/203350 which operates in the same space, wall-times are improved by 1.54x and instruction counts by 1.66x.