### PR TITLE
[BoundsSafety] update tests to reflect typedef name (NFC)

### DIFF
--- a/clang/test/BoundsSafety/AST/redundant-attrs.c
+++ b/clang/test/BoundsSafety/AST/redundant-attrs.c
@@ -22,4 +22,4 @@ my_c_ptr_nullable_bidi_t __bidi_indexable def_c_nullable_bidi_ptr;
 // CHECK-NEXT: PointerType {{.*}} 'const int *__bidi_indexable'
 // CHECK-NEXT: QualType {{.*}} 'const int' const
 // CHECK-NEXT: BuiltinType {{.*}} 'int'
-// CHECK-NEXT: VarDecl {{.*}} def_c_nullable_bidi_ptr 'const int *__bidi_indexable _Nullable':'const int *__bidi_indexable'
+// CHECK-NEXT: VarDecl {{.*}} def_c_nullable_bidi_ptr 'my_c_ptr_nullable_bidi_t':'const int *__bidi_indexable'

--- a/clang/test/BoundsSafety/Sema/complex-typespecs-with-bounds.c
+++ b/clang/test/BoundsSafety/Sema/complex-typespecs-with-bounds.c
@@ -53,7 +53,7 @@ typedef typeof(*bar) * my_manual_ptr_t;
 void typedefs_of_typeof() {
     // expected-error@+1{{initializing 'my_t *__single' (aka 'char *__single') with an expression of incompatible type 'char * _Nullable' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
     my_t * __single p1 = bar;
-    // expected-error@+1{{initializing 'char *__single _Nullable' with an expression of incompatible type 'char * _Nullable' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
+    // expected-error@+1{{initializing 'my_ptr_t __single' (aka 'char *__single') with an expression of incompatible type 'char * _Nullable' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
     my_ptr_t __single p2 = bar;
     // expected-error@+1{{initializing 'my_manual_ptr_t __single' (aka 'char *__single') with an expression of incompatible type 'char * _Nullable' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
     my_manual_ptr_t __single p3 = bar;


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/200961 landed, `_Nullable` `AttributedType`s no longer include the `Attr` pointer in its ProfileID, since all `_Nullable` attributes affect the type in the same way.

In MakeAutoPointer::VisitTypedefType, we only reapply the `TypedefType` if the inner type hasn't changed, but in `VisitAttributedType` we reapply the `AttributedType` with a null `Attr*`. Now that the `AttributedType` is correctly recognised as being the same type despite having different `Attr` pointers, `MakeAutoPointer` correctly reapplies the typedef again.

rdar://179268737
rdar://179268623