### PR TITLE
Revert "[lldb] Enable Swift Foundation value-type formatters on Windows"

### DIFF
--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -330,38 +330,6 @@ bool lldb_private::formatters::swift::Data_SummaryProvider(
   if (!representation_enum_sp)
     return false;
 
-  // swift-foundation (FoundationEssentials, used on Windows and Linux) replaces
-  // the _Representation enum with a struct:
-  //
-  //   struct _Representation {
-  //       var _storage: __DataStorage
-  //       var _slice: Range<Int>
-  //   }
-  //
-  // where the byte count is the size of _slice. Detect that layout and handle
-  // it before falling through to the legacy enum logic below.
-  {
-    static constexpr llvm::StringLiteral g__slice("_slice");
-    ValueObjectSP slice_sp =
-        representation_enum_sp->GetChildAtNamePath({g__slice});
-    if (slice_sp) {
-      DataExtractor extractor;
-      Status error;
-      if (slice_sp->GetData(extractor, error) < 16 || error.Fail())
-        return false;
-      lldb::offset_t offset = 0;
-      int64_t lowerBound = (int64_t)extractor.GetU64(&offset);
-      int64_t upperBound = (int64_t)extractor.GetU64(&offset);
-
-      int64_t count = upperBound - lowerBound;
-      if (count == 1)
-        stream << "1 byte";
-      else
-        stream.Printf("%" PRId64 " bytes", count);
-      return true;
-    }
-  }
-
   // representation_case holds the name of the enum case we're looking at.
   ConstString representation_case(representation_enum_sp->GetValueAsCString());
   if (!representation_case)

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -729,13 +729,13 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::UUID_SummaryProvider,
-      "UUID summary provider", ConstString("^Foundation(Essentials)?\\.UUID$"),
-      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true), true);
+      "UUID summary provider", ConstString("Foundation.UUID"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
 
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Data_SummaryProvider,
-      "Data summary provider", ConstString("^Foundation(Essentials)?\\.Data$"),
-      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true), true);
+      "Data summary provider", ConstString("Foundation.Data"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
 
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp,

--- a/lldb/test/API/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
@@ -17,7 +17,8 @@ lldbinline.MakeInlineTest(
     globals(),
     decorators=[skipEmbeddedSwift,
         swiftTest,
-        skipIf(oslist=["linux"]),
+        skipUnlessFoundation,
+        skipIf(oslist=["windows"]),
         skipIf(
             bugnumber="rdar://60396797",  # should work but crashes.
             setting=("symbols.use-swift-clangimporter", "false"),

--- a/lldb/test/API/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
@@ -14,4 +14,4 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
                           decorators=[skipEmbeddedSwift,
-        swiftTest,skipIf(oslist=["linux"])])
+        swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])

--- a/lldb/test/API/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
@@ -14,4 +14,4 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
                           decorators=[skipEmbeddedSwift,
-        swiftTest,skipIf(oslist=["linux"])])
+        swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -181,28 +181,11 @@ if is_configured("shared_libs"):
         )
 
 # Windows has no rpath: drivers built by API tests link against
-# liblldb.dll and need its directory on PATH at launch. Swift inferiors
-# additionally need the Swift runtime DLLs (swiftCore, Foundation,
-# FoundationEssentials, ...), which live in the SDK's usr/bin. Locate the SDK
-# from the sysroot: the configured cmake_sysroot if set, otherwise the
-# --sysroot the runner passes through dotest_user_args_str (as the Swift
-# toolchain's test runner does).
+# liblldb.dll and need its directory on PATH at launch.
 if platform.system() == "Windows":
-    win_paths = [config.llvm_shlib_dir]
-    sysroot = ""
-    if is_configured("cmake_sysroot") and config.cmake_sysroot:
-        sysroot = config.cmake_sysroot
-    elif is_configured("dotest_user_args_str"):
-        for arg in config.dotest_user_args_str.split(";"):
-            if arg.startswith("--sysroot="):
-                sysroot = arg[len("--sysroot=") :].strip()
-                break
-    if sysroot:
-        runtime_bin = os.path.join(sysroot, "usr", "bin")
-        if os.path.isdir(runtime_bin):
-            win_paths.append(runtime_bin)
-    win_paths.append(config.environment.get("PATH", ""))
-    config.environment["PATH"] = os.path.pathsep.join(win_paths)
+    config.environment["PATH"] = os.path.pathsep.join(
+        (config.llvm_shlib_dir, config.environment.get("PATH", ""))
+    )
 
 lldb_use_simulator = lit_config.params.get("lldb-run-with-simulator", None)
 if lldb_use_simulator:


### PR DESCRIPTION
This reverts commit ffb559b3f2a0a52fe49d32380887b4927e77c4e9.