### PR TITLE
[lldb] Remove SymbolFileDWARF assumption in DWARFASTParserSwiftDescri…

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -40,9 +40,9 @@ SWIFTFLAGS ?= $(SWIFT_DEBUG_INFO_FLAG) -Onone -Xfrontend -serialize-debugging-op
 ifeq "$(MAKE_PDB)" "YES"
 SWIFT_LINK_FLAGS = $(SWIFTFLAGS) -Xlinker /debug
 else
-# On Darwin, `-g` automatically runs `dsymutil`. Removed so it can be enabled explicitly
-# as neeeded.
-SWIFT_LINK_FLAGS = $(patsubst -g,,$(SWIFTFLAGS))
+# On Darwin, debug-info flags (`-g`, `-gdwarf-types`) automatically run
+# `dsymutil` at link time. Removed so it can be enabled explicitly as needed.
+SWIFT_LINK_FLAGS = $(patsubst -gdwarf-types,,$(patsubst -g,,$(SWIFTFLAGS)))
 endif
 
 SWIFTFLAGS += $(SWIFTFLAGS_EXTRAS)

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -19,6 +19,7 @@
 #include "DWARFASTParserSwift.h"
 
 #include "DWARFDIE.h"
+#include "SymbolFileDWARFDebugMap.h"
 
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "swift/Demangling/ManglingFlavor.h"
@@ -73,8 +74,11 @@ DWARFASTParserSwift::ResolveTypeAlias(lldb_private::CompilerType alias) {
   if (!ts_sp)
     return {};
   auto &ts = *ts_sp;
-  auto *dwarf = llvm::dyn_cast_or_null<SymbolFileDWARF>(ts.GetSymbolFile());
-  if (!dwarf)
+
+  // The Type system must have a SymbolFileDWARF backing it to answer the
+  // queries below.
+  if (!llvm::isa_and_nonnull<SymbolFileDWARF, SymbolFileDWARFDebugMap>(
+          ts.GetSymbolFile()))
     return {};
 
   // Type aliases are (for LLVM implementation reasons) using the
@@ -88,6 +92,8 @@ DWARFASTParserSwift::ResolveTypeAlias(lldb_private::CompilerType alias) {
   DWARFDIE parent_die;
   if (TypeSP parent_type =
           ts.FindTypeInModule(parent_ctx.GetOpaqueQualType())) {
+    auto *dwarf =
+        llvm::cast<SymbolFileDWARF>(parent_type->GetSymbolFile());
     parent_die = dwarf->GetDIE(parent_type->GetID());
     auto unsubstituted_pair =
         findUnsubstitutedGenericTypeAndDIE(ts, parent_die);
@@ -157,9 +163,6 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
     return {};
   }
 
-  auto *dwarf = llvm::cast_or_null<SymbolFileDWARF>(ts.GetSymbolFile());
-  if (!dwarf)
-    return {};
   TypeSP lldb_type = ts.FindTypeInModule(type.GetOpaqueQualType());
   if (!lldb_type) {
     if (ts.ContainsBoundGenericType(type.GetOpaqueQualType())) {
@@ -170,6 +173,8 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
   if (!lldb_type) {
     std::tie(lldb_type, type) = DWARFASTParserSwift::ResolveTypeAlias(type);
     if (lldb_type) {
+      auto *dwarf =
+          llvm::cast<SymbolFileDWARF>(lldb_type->GetSymbolFile());
       auto die = dwarf->GetDIE(lldb_type->GetID());
       return {{type, die}};
     }
@@ -181,6 +186,7 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
               type.GetMangledTypeName());
     return {};
   }
+  auto *dwarf = llvm::cast<SymbolFileDWARF>(lldb_type->GetSymbolFile());
   auto die = dwarf->GetDIE(lldb_type->GetID());
 
   if (auto unsubstituted_pair = findUnsubstitutedGenericTypeAndDIE(ts, die))
@@ -360,18 +366,18 @@ public:
 class DWARFFieldDescriptorImpl : public swift::reflection::FieldDescriptorBase {
   TypeSystemSwiftTypeRef &m_type_system;
   ConstString m_mangled_name;
-  DIERef m_die_ref;
+  DWARFDIE m_die;
   NodePointer m_superclass_node;
 
 public:
   DWARFFieldDescriptorImpl(swift::reflection::FieldDescriptorKind kind,
                            NodePointer superclass_node,
                            TypeSystemSwiftTypeRef &type_system,
-                           ConstString mangled_name, DIERef die_ref)
+                           ConstString mangled_name, DWARFDIE die)
       : swift::reflection::FieldDescriptorBase(kind,
                                                superclass_node != nullptr),
         m_type_system(type_system), m_mangled_name(mangled_name),
-        m_die_ref(die_ref), m_superclass_node(superclass_node) {}
+        m_die(die), m_superclass_node(superclass_node) {}
 
   ~DWARFFieldDescriptorImpl() override = default;
 
@@ -386,22 +392,16 @@ public:
                lldb_private::AutoBool::False &&
            "Full DWARF debugging for Swift is disabled!");
 
-    auto *dwarf =
-        llvm::dyn_cast<SymbolFileDWARF>(m_type_system.GetSymbolFile());
     auto *dwarf_parser = m_type_system.GetDWARFParser();
-    if (!dwarf || !dwarf_parser)
-      return {};
-
-    auto die = dwarf->GetDIE(m_die_ref);
-    if (!die)
+    if (!m_die || !dwarf_parser)
       return {};
 
     switch (Kind) {
     case swift::reflection::FieldDescriptorKind::Struct:
     case swift::reflection::FieldDescriptorKind::Class:
-      return getFieldRecordsFromStructOrClass(die, dwarf_parser);
+      return getFieldRecordsFromStructOrClass(m_die, dwarf_parser);
     case swift::reflection::FieldDescriptorKind::Enum:
-      return getFieldRecordsFromEnum(die, dwarf_parser);
+      return getFieldRecordsFromEnum(m_die, dwarf_parser);
     default:
       // TODO: handle more cases.
       LLDB_LOG(GetLog(LLDBLog::Types),
@@ -663,5 +663,5 @@ DWARFASTParserSwift::getFieldDescriptor(const swift::reflection::TypeRef *TR) {
 
   return std::make_unique<DWARFFieldDescriptorImpl>(
       *kind, superclass_pointer, m_swift_typesystem, type.GetMangledTypeName(),
-      *die.GetDIERef());
+      die);
 }


### PR DESCRIPTION
…ptorFinder

A SymbolFile representing DWARF can be either a SymbolFileDWARF or a SymbolFileDWARFDebugMap. Prior to this commit
DWARFASTParserSwiftDescriptorFinder assumed it would get a SymbolFileDWARF from the TypeSystem.

By changing the query to obtain the SymbolFile from the `Type` itself (as opposed to `TypeSystem`), we can guarantee that the resulting SymbolFile will be a SymbolFileDWARF representing a specific object file.

This was never discovered because our DWARF variants in embedded swift were still using dsyms.

Existing tests are enough.

rdar://179813200