### PR TITLE
Revert "[lldb] Re-enable explicit_modules Swift tests on Windows"

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -9,6 +9,7 @@ class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @skipEmbeddedSwift
     @swiftTest
+    @skipIfWindows
     def test_missing(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""
         self.build()
@@ -33,6 +34,7 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
+    @skipIfWindows
     def test_sanity(self):
         """Check the normal behavior."""
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")
@@ -61,6 +63,7 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
+    @skipIfWindows
     def test_setting(self):
         """Check the normal behavior."""
         self.build()

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
@@ -9,6 +9,7 @@ class TestSwiftExplicitModulePrivateTypeGeneric(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
+    @skipIfWindows
     def test(self):
         """Test frame variable of a generic struct specialized to a
         private type from another explicitly-built module."""

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part01.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part01.py
@@ -8,6 +8,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
+    @skipIfWindows
     def test(self):
         """Test explicit Swift modules"""
         self.build()
@@ -23,6 +24,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
+    @skipIfWindows
     def test_disable_esml(self):
         """Test disabling the explicit Swift module loader"""
         self.build()


### PR DESCRIPTION
This reverts commit af6bb9964b5732d5031f6693a9dd3f64a6724522.