### PR TITLE
[lldb] Use wrapper target for RPATH setup in add_python_wrapper

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -285,7 +285,7 @@ function(add_python_wrapper target)
   endif()
 
   if(Python3_RPATH)
-    lldb_setup_rpaths(liblldb
+    lldb_setup_rpaths(${target}
       BUILD_RPATH
         "${Python3_RPATH}"
       INSTALL_RPATH


### PR DESCRIPTION
add_python_wrapper hardcoded liblldb when calling lldb_setup_rpaths, which fails CMake configure with "Can not find target to add properties to: liblldb" in configurations where the wrapper target is not liblldb. Use the target passed into the function instead.