### PR TITLE
[lldb/test] Adopt test to `Task.sleep(for:)` being `nonisolated(nonsending)`

### DIFF
--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/main.swift
@@ -1,6 +1,6 @@
 @main struct Main {
     static func main() async {
-        let task = Task {
+        let task = Task { @concurrent in
             try? await Task.sleep(for: .seconds(100))
         }
         try? await Task.sleep(for: .seconds(0.5))


### PR DESCRIPTION
The closure used to hop to the generic executor before sleeping, this is no longer the case, which means that the breakpoint can only trigger after the task is done on `@MainActor`.