### PR TITLE
Handle objc_msgSend being a re-export symbol from libobjc.A.dylib. (#…202776)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
@@ -498,14 +498,14 @@ bool AppleObjCTrampolineHandler::AppleObjCVTables::IsAddressInVTables(
 
 const AppleObjCTrampolineHandler::DispatchFunction
     AppleObjCTrampolineHandler::g_dispatch_functions[] = {
-        // NAME                              STRET  SUPER  SUPER2
-        {"objc_msgSend", false, false, false},
+        // NAME          STRET  SUPER  SUPER2 ReExp
+        {"objc_msgSend", false, false, false, true},
         {"objc_msgSend_stret", true, false, false},
         {"objc_msgSend_fpret", false, false, false},
         {"objc_msgSend_fp2ret", false, false, true},
-        {"objc_msgSendSuper", false, true, false},
+        {"objc_msgSendSuper", false, true, false, true},
         {"objc_msgSendSuper_stret", true, true, false},
-        {"objc_msgSendSuper2", false, true, true},
+        {"objc_msgSendSuper2", false, true, true, true},
         {"objc_msgSendSuper2_stret", true, true, true},
 };
 
@@ -614,20 +614,29 @@ AppleObjCTrampolineHandler::AppleObjCTrampolineHandler(
   // map from there.
 
   for (size_t i = 0; i != std::size(g_dispatch_functions); i++) {
-    ConstString name_const_str(g_dispatch_functions[i].name);
-    const Symbol *msgSend_symbol =
-        m_objc_module_sp->FindFirstSymbolWithNameAndType(name_const_str,
-                                                         eSymbolTypeCode);
-    if (msgSend_symbol && msgSend_symbol->ValueIsAddress()) {
-      // FIXME: Make g_dispatch_functions static table of
-      // DispatchFunctions, and have the map be address->index.
-      // Problem is we also need to lookup the dispatch function.  For
-      // now we could have a side table of stret & non-stret dispatch
-      // functions.  If that's as complex as it gets, we're fine.
+    const AppleObjCTrampolineHandler::DispatchFunction &dispatch_function =
+        g_dispatch_functions[i];
+    ConstString name_const_str(dispatch_function.name);
+    // If this might be a re-exported symbol look there first.
+    const Symbol *msgSend_symbol = nullptr;
+    if (dispatch_function.might_be_reexport) {
+      msgSend_symbol = m_objc_module_sp->FindFirstSymbolWithNameAndType(
+          name_const_str, eSymbolTypeReExported);
+      if (msgSend_symbol) {
+        while (msgSend_symbol->GetType() == eSymbolTypeReExported) {
+          msgSend_symbol = msgSend_symbol->ResolveReExportedSymbol(*target);
+          if (!msgSend_symbol)
+            break;
+        }
+      }
+    }
+    if (!msgSend_symbol)
+      msgSend_symbol = m_objc_module_sp->FindFirstSymbolWithNameAndType(
+          name_const_str, eSymbolTypeCode);
 
+    if (msgSend_symbol && msgSend_symbol->ValueIsAddress()) {
       lldb::addr_t sym_addr =
           msgSend_symbol->GetAddressRef().GetOpcodeLoadAddress(target);
-
       m_msgSend_map.insert(std::pair<lldb::addr_t, int>(sym_addr, i));
     }
   }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.h
@@ -40,6 +40,7 @@ public:
     bool stret_return = false;
     bool is_super = false;
     bool is_super2 = false;
+    bool might_be_reexport = false;
   };
 
   lldb::addr_t SetupDispatchFunction(Thread &thread,


### PR DESCRIPTION


In some cases, objc_msgSend and the objc_msgSendSuper can be re-exported symbols in libobjc.A.dylib. Handle that case here. There were a number of failures in the ObjC stepping tests before this was handled, so we didn't need more tests.

If there isn't a re-exported symbol, we'll fall back to a code symbol.

---------


(cherry picked from commit e6db723ce7b1e43327d265081f7e5818194569a0)