### PR TITLE
[lldb] Prevent reference to __lldb_context in context-free po expressions

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -303,6 +303,8 @@ bool SwiftUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
       m_is_weak_self = true;
     }
 
+  if (m_options.GetUseContextFreeSwiftPrintObject())
+    m_in_static_method = false;
   m_needs_object_ptr =
       !m_in_static_method && !m_options.GetUseContextFreeSwiftPrintObject();
   LLDB_LOGF(log, "  [SUE::SC] Expression captures self: %s",

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -303,10 +303,13 @@ bool SwiftUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
       m_is_weak_self = true;
     }
 
-  if (m_options.GetUseContextFreeSwiftPrintObject())
+  if (m_options.GetUseContextFreeSwiftPrintObject()) {
+    // Prevent need for extensions, or passing context, in WrapExpression.
     m_in_static_method = false;
-  m_needs_object_ptr =
-      !m_in_static_method && !m_options.GetUseContextFreeSwiftPrintObject();
+    m_needs_object_ptr = false;
+  } else {
+    m_needs_object_ptr = !m_in_static_method;
+  }
   LLDB_LOGF(log, "  [SUE::SC] Expression captures self: %s",
             m_needs_object_ptr ? "true" : "false");
 

--- a/lldb/test/API/lang/swift/po/static_method/Makefile
+++ b/lldb/test/API/lang/swift/po/static_method/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/po/static_method/TestSwiftPoInClassMethod.py
+++ b/lldb/test/API/lang/swift/po/static_method/TestSwiftPoInClassMethod.py
@@ -1,0 +1,27 @@
+"""
+Test that context-free po works when stopped in a class/static method.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    @skipEmbeddedSwift
+    def test(self):
+        """Context-free po should not emit extension $__lldb_context when
+        stopped in a static method, since the frame's method context is
+        irrelevant to the context-free expression."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        log = self.getBuildArtifact("expr.log")
+        self.runCmd(f"log enable lldb expr -f {log}")
+        self.expect("po value", substrs=["instance of C"])
+        self.filecheck_log(log, __file__)
+        # CHECK-NOT: $__lldb_context
+        # CHECK: stringForPrintObject(_:mangledTypeName:) succeeded

--- a/lldb/test/API/lang/swift/po/static_method/main.swift
+++ b/lldb/test/API/lang/swift/po/static_method/main.swift
@@ -1,0 +1,14 @@
+class C: CustomStringConvertible {
+    var description = "instance of C"
+
+    class func doSomething() {
+        let value = C()
+        print("break here", value)
+    }
+}
+
+@main enum Entry {
+    static func main() {
+        C.doSomething()
+    }
+}


### PR DESCRIPTION
Context-free `po` doesn't use the frame's method context. However in `static` methods, the variable `m_in_static_method` is set to true – and results in `WrapExpression` producing an expression that erroneously usses `$__lldb_context`. However, for context-free `po`, the alias `$__lldb_context` is intentionally not defined (since no context is needed).

This result is that context-free `po` would fail, and lldb would fall back to the normal (full context) `po`.

The fix is to assign `m_in_static_method` to `false` when `UseContextFreeSwiftPrintObject` is set, so the expression takes the simple free-function wrapping path instead of the extension path.

Assisted-by: claude