### PR TITLE
[Cherry-pick into next] [LLDB] Enable external descriptor finder when target contains embedded Swift

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -67,6 +67,10 @@ struct DescriptorFinderForwarder : public swift::reflection::DescriptorFinder {
     m_image_added |= image_added;
   }
 
+  /// Record that LLDB has encountered an Embedded Swift type and thus that the
+  /// external descriptor finder should be enabled.
+  void SetEmbedded() { m_embedded = true; }
+
 private:
   bool shouldConsultDescriptorFinder() {
     switch (ModuleList::GetGlobalModuleListProperties()
@@ -76,8 +80,12 @@ private:
     case lldb_private::AutoBool::False:
       return false;
     case lldb_private::AutoBool::Auto:
-      // Full DWARF debugging is auto-enabled if there is no reflection metadata
-      // to read from.
+      // Embedded Swift never has reflection metadata for its types, so the
+      // external descriptor finder is the only source of type information.
+      if (m_embedded)
+        return true;
+      // Otherwise, full DWARF debugging is auto-enabled if there is no
+      // reflection metadata to read from.
       return !m_image_added;
     }
   }
@@ -85,6 +93,7 @@ private:
   llvm::SmallVector<swift::reflection::DescriptorFinder *, 1>
       m_descriptor_finders;
   bool m_image_added = false;
+  bool m_embedded = false;
 };
 
 /// An implementation of the generic ReflectionContextInterface that
@@ -188,6 +197,11 @@ public:
   llvm::Expected<const swift::reflection::TypeInfo &>
   GetTypeInfo(CompilerType type, swift::remote::TypeInfoProvider *provider,
               swift::reflection::DescriptorFinder *descriptor_finder) override {
+    if (SwiftLanguageRuntime::GetManglingFlavor(
+            type.GetMangledTypeName().GetStringRef()) ==
+        swift::Mangle::ManglingFlavor::Embedded)
+      m_forwader.SetEmbedded();
+
     auto type_ref_or_err = GetCanonicalTypeRef(type);
     if (!type_ref_or_err)
       return type_ref_or_err.takeError();

--- a/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
@@ -15,12 +15,12 @@ class TestArchetypeInConditionalBreakpoint(TestBase):
     def test_doesnt_stop_free_function(self):
         self.doesnt_stop("break here for free function")
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_stops_class(self):
         self.stops("break here for class")
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_doesnt_stop_class(self):
         self.doesnt_stop("break here for class")

--- a/lldb/test/API/lang/swift/class_static/TestSwiftClassStatic.py
+++ b/lldb/test/API/lang/swift/class_static/TestSwiftClassStatic.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])

--- a/lldb/test/API/lang/swift/enum_tagged/TestEnumTagged.py
+++ b/lldb/test/API/lang/swift/enum_tagged/TestEnumTagged.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])

--- a/lldb/test/API/lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
+++ b/lldb/test/API/lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])

--- a/lldb/test/API/lang/swift/generic_self/TestSwiftGenericSelf.py
+++ b/lldb/test/API/lang/swift/generic_self/TestSwiftGenericSelf.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])

--- a/lldb/test/API/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
+++ b/lldb/test/API/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
@@ -9,7 +9,7 @@ class TestSwiftOptimizedBoundGenericEnum(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test the bound generic enum types in "optimized" code."""

--- a/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
+++ b/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
@@ -7,7 +7,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 
@@ -38,7 +39,8 @@ class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
         )
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     def test_expr(self):
         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 
@@ -67,7 +69,8 @@ class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
         )
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     def test_expr_from_generic(self):
          """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 

--- a/lldb/test/API/lang/swift/span/TestSwiftSpan.py
+++ b/lldb/test/API/lang/swift/span/TestSwiftSpan.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/variables/enums/TestSwiftEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/enums/TestSwiftEnumVariables.py
@@ -20,7 +20,8 @@ import os
 
 
 class TestEnumVariables(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_enum_variables(self):
         """Tests that Enum variables display correctly"""

--- a/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftGlobals(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_swift_globals(self):
         """Check that we can examine module globals in the expression parser"""


### PR DESCRIPTION
```
commit fed1004ad4c992d61b6a9b511879d8d0afa6b9a9
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Jun 10 08:04:52 2026 -0700

    [LLDB] Enable external descriptor finder when target contains embedded Swift
    
    The current detection mechanism may misfire in a process that mixes
    embedded Swift with images that do have reflection metadata such as am
    embedded Swift program linked against any system frameworks containing
    Swift code.
    
    Assisted-by: claude
```
