### PR TITLE
[lldb] Test reflection lowering of mixed @objc/Swift existentials

### DIFF
--- a/lldb/test/API/lang/swift/mixed_objc_swift_existential/Makefile
+++ b/lldb/test/API/lang/swift/mixed_objc_swift_existential/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/mixed_objc_swift_existential/TestSwiftMixedObjCSwiftExistential.py
+++ b/lldb/test/API/lang/swift/mixed_objc_swift_existential/TestSwiftMixedObjCSwiftExistential.py
@@ -1,0 +1,34 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class SwiftMixedObjCSwiftExistentialTest(TestBase):
+    @swiftTest
+    @skipUnlessObjCInterop
+    @skipEmbeddedSwift
+    def test(self):
+        """Reflection lowers class-bound @objc/Swift mixed existentials."""
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.GetSelectedFrame()
+
+        for name, expected in [("classConstrained", "42"), ("unconstrained", "43")]:
+            var = frame.FindVariable(name)
+            self.assertTrue(var.IsValid(), "%s not found in frame" % name)
+            self.assertTrue(var.GetError().Success(), var.GetError().GetCString())
+            payload = var.GetDynamicValue(
+                lldb.eDynamicCanRunTarget
+            ).GetChildMemberWithName("payload")
+            lldbutil.check_variable(self, payload, value=expected)
+
+        # The existential metatype of the same composition must also lower.
+        metatype = frame.FindVariable("metatype")
+        self.assertTrue(metatype.IsValid(), "metatype not found in frame")
+        self.assertTrue(
+            metatype.GetError().Success(), metatype.GetError().GetCString()
+        )

--- a/lldb/test/API/lang/swift/mixed_objc_swift_existential/main.swift
+++ b/lldb/test/API/lang/swift/mixed_objc_swift_existential/main.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@objc protocol ObjCProto {}
+
+protocol ClassConstrainedProto: AnyObject {
+  var payload: Int { get }
+}
+
+protocol UnconstrainedProto {
+  var payload: Int { get }
+}
+
+final class Concrete: ObjCProto, ClassConstrainedProto, UnconstrainedProto {
+  var payload: Int
+  init(_ p: Int) {
+    self.payload = p
+  }
+}
+
+func entry() {
+  // @objc protocol + a Swift protocol that is independently class-constrained.
+  let classConstrained: ObjCProto & ClassConstrainedProto = Concrete(42)
+  // @objc protocol + a Swift protocol that is NOT independently
+  // class-constrained; the @objc member still class-constrains the existential.
+  let unconstrained: ObjCProto & UnconstrainedProto = Concrete(43)
+  // The existential metatype of the mixed composition.
+  let metatype: (ObjCProto & UnconstrainedProto).Type = Concrete.self
+  print("break here")
+  _ = classConstrained
+  _ = unconstrained
+  _ = metatype
+}
+
+entry()


### PR DESCRIPTION
Add an API test that inspects class-bound existentials mixing an @objc protocol with a Swift protocol.

rdar://177199463

Assisted-by: claude