### PR TITLE
[lldb/test] Replace get_triple with getTriple in TestSwiftPlaygrounds.py

### DIFF
--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 import os.path
 import platform
-from lldbsuite.test.builders.darwin import get_triple
 
 import sys
 if sys.version_info.major == 2:
@@ -40,7 +39,7 @@ class TestSwiftPlaygrounds(TestBase):
            availability set in the source file."""
         if lldb.remote_platform:
             arch = self.getArchitecture()
-            vendor, os, version, _ = get_triple()
+            vendor, os, version, _ = self.getTriple()
             # This is made slightly more complex by watchOS having misaligned
             # version numbers.
             if os == 'watchos':


### PR DESCRIPTION
Root cause: f5e2b8b1df079a90f0756d75dcafff8e8efb8eb1
Similar fix to 6fbe39ae675a4b865ec21640ae8cf06b4485dcad