### PR TITLE
Add a check for null CompUnit in GetTypeFromCU.

### DIFF
--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -49,6 +49,10 @@ llvm::Expected<lldb::TypeSystemSP>
 GetTypeSystemFromCU(std::shared_ptr<StackFrame> ctx) {
   SymbolContext symbol_context =
       ctx->GetSymbolContext(lldb::eSymbolContextCompUnit);
+  if (!symbol_context.comp_unit)
+    return llvm::createStringErrorV("no compile unit for frame: {}",
+                                    ctx.GetFunctionName());
+
   lldb::LanguageType language = symbol_context.comp_unit->GetLanguage();
 
   symbol_context = ctx->GetSymbolContext(lldb::eSymbolContextModule);

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -50,8 +50,8 @@ GetTypeSystemFromCU(std::shared_ptr<StackFrame> ctx) {
   SymbolContext symbol_context =
       ctx->GetSymbolContext(lldb::eSymbolContextCompUnit);
   if (!symbol_context.comp_unit)
-    return llvm::createStringErrorV("no compile unit for frame: {}",
-                                    ctx.GetFunctionName());
+    return llvm::createStringError(llvm::formatv("no compile unit for frame: {}",
+                                                 ctx->GetFunctionName()));
 
   lldb::LanguageType language = symbol_context.comp_unit->GetLanguage();
 


### PR DESCRIPTION
This check is present on the llvm.org side, but isn't suitable for a cherry pick because there's a significant refactor between the code on this branch and the code with the fix.

I'm also not adding a test because this is just patching this branch, the proper fix is on lldb.org:main.