### PR TITLE
[lldb] Don't resolve typealiases inside a function-local type's name

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -119,13 +119,45 @@ private:
 };
 } // namespace lldb_private
 
-/// Determine wether this demangle tree contains an unresolved type alias.
+/// Is this a type (class/struct/enum) declared inside a function? Such types
+/// use a LocalDeclName for their name, e.g. `LocalBox` in:
+///
+///     func f(input: MyAliasedKey) { class LocalBox { var x = 0 } }
+///
+/// Where "MyAliasedKey" is a C typedef to NSString. LocalBox's mangled name
+/// bakes in f's signature, including the Clang swift_newtype alias
+/// "MyAliasedKey" spelled out (not expanded to NSString). The reflection field
+/// descriptor uses that same spelling, so callers must not expand the aliases
+/// inside such a type or the descriptor lookup will miss.
+static bool IsFunctionLocalType(swift::Demangle::NodePointer node) {
+  using Kind = swift::Demangle::Node::Kind;
+  if (!node)
+    return false;
+  switch (node->getKind()) {
+  case Kind::Class:
+  case Kind::Structure:
+  case Kind::Enum:
+    break;
+  default:
+    return false;
+  }
+
+  return node->getNumChildren() == 2 && node->getChild(1) &&
+         node->getChild(1)->getKind() == Kind::LocalDeclName;
+}
+
+/// Determine whether this demangle tree contains an unresolved type alias.
 static bool ContainsUnresolvedTypeAlias(swift::Demangle::NodePointer node) {
   if (!node)
     return false;
 
   if (node->getKind() == swift::Demangle::Node::Kind::TypeAlias)
     return true;
+
+  // A Clang swift_newtype alias in a function-local type's name is part of the
+  // name, not an unresolved type (see IsFunctionLocalType), so don't flag it.
+  if (IsFunctionLocalType(node))
+    return false;
 
   for (swift::Demangle::NodePointer child : *node)
     if (ContainsUnresolvedTypeAlias(child))
@@ -1685,6 +1717,12 @@ TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
   // preserve all sugar.
   using namespace swift::Demangle;
   node = Canonicalize(dem, node, flavor);
+
+  // Leave function-local types as the compiler wrote them; expanding the
+  // aliases in their name would stop matching the reflection field descriptor
+  // (see IsFunctionLocalType).
+  if (IsFunctionLocalType(node))
+    return node;
 
   llvm::SmallVector<NodePointer, 2> children;
   bool changed = false;

--- a/lldb/test/API/lang/swift/local_type_typealias/Makefile
+++ b/lldb/test/API/lang/swift/local_type_typealias/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_BRIDGING_HEADER := bridging-header.h
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/local_type_typealias/TestSwiftLocalTypeTypealias.py
+++ b/lldb/test/API/lang/swift/local_type_typealias/TestSwiftLocalTypeTypealias.py
@@ -1,0 +1,28 @@
+"""
+A type declared inside a function carries that function's full signature in its
+mangled name. When the signature names a Clang swift_newtype type alias, the
+compiler preserves the alias in the reflection field descriptor.
+"""
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftLocalTypeTypealias(lldbtest.TestBase):
+    @skipUnlessDarwin
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        self.build()
+
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+
+        variable = self.frame().FindVariable("variable")
+        self.assertIn("LocalBox", variable.GetTypeName())
+        lldbutil.check_variable(self, variable, num_children=1)
+        slot = variable.GetChildMemberWithName("slot")
+        lldbutil.check_variable(self, slot, value="7")

--- a/lldb/test/API/lang/swift/local_type_typealias/bridging-header.h
+++ b/lldb/test/API/lang/swift/local_type_typealias/bridging-header.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+// A Clang swift_newtype wrapper. Unlike a plain typedef or a Swift typealias,
+// the compiler preserves this __C type alias verbatim in the mangled name that
+// identifies a type.
+typedef NSString *MyAliasedKey __attribute__((swift_newtype(struct)));

--- a/lldb/test/API/lang/swift/local_type_typealias/main.swift
+++ b/lldb/test/API/lang/swift/local_type_typealias/main.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+func f(input: MyAliasedKey) {
+  class LocalBox { var slot = 7 }
+  let variable = LocalBox()
+  print("break here")
+  _ = variable.slot
+}
+
+f(input: MyAliasedKey(""))


### PR DESCRIPTION
A class/struct/enum declared inside a function has that whole function baked into its mangled name, including the function's argument and return types. When one of those is a Clang swift_newtype alias, the compiler keeps the alias spelled out and uses that same spelling in the reflection field descriptor.

By resolving these typealiases we inadvertently made them impossible to find in reflection metadata.

Detect these types (their name is a LocalDeclName) and leave them unchanged.

Assisted-by: claude

rdar://177196779