### PR TITLE
[lldb] Skip ScanContext for context-free po

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -196,6 +196,11 @@ bool SwiftUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
     return true;
   }
 
+  if (m_options.GetUseContextFreeSwiftPrintObject()) {
+    LLDB_LOG(log, "  [SUE::SC] Context-free expression, skipping scan");
+    return true;
+  }
+
   StackFrame *frame = exe_ctx.GetFramePtr();
   if (!frame) {
     LLDB_LOG(log, "  [SUE::SC] Null stack frame");
@@ -303,8 +308,7 @@ bool SwiftUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
       m_is_weak_self = true;
     }
 
-  m_needs_object_ptr =
-      !m_in_static_method && !m_options.GetUseContextFreeSwiftPrintObject();
+  m_needs_object_ptr = !m_in_static_method;
   LLDB_LOGF(log, "  [SUE::SC] Expression captures self: %s",
             m_needs_object_ptr ? "true" : "false");
 

--- a/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
+++ b/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
@@ -31,5 +31,4 @@ class TestCase(TestBase):
         # and not the private dynamic type.
         #
         # CHECK: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a10PublicBaseCD")
-        # CHECK: Expression captures self: false
         # CHECK: stringForPrintObject(_:mangledTypeName:) succeeded

--- a/lldb/test/API/lang/swift/po/static_method/Makefile
+++ b/lldb/test/API/lang/swift/po/static_method/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/po/static_method/TestSwiftPoInClassMethod.py
+++ b/lldb/test/API/lang/swift/po/static_method/TestSwiftPoInClassMethod.py
@@ -1,0 +1,27 @@
+"""
+Test that context-free po works when stopped in a class/static method.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    @skipEmbeddedSwift
+    def test(self):
+        """Context-free po should not emit extension $__lldb_context when
+        stopped in a static method, since the frame's method context is
+        irrelevant to the context-free expression."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        log = self.getBuildArtifact("expr.log")
+        self.runCmd(f"log enable lldb expr -f {log}")
+        self.expect("po value", substrs=["instance of C"])
+        self.filecheck_log(log, __file__)
+        # CHECK-NOT: $__lldb_context
+        # CHECK: stringForPrintObject(_:mangledTypeName:) succeeded

--- a/lldb/test/API/lang/swift/po/static_method/main.swift
+++ b/lldb/test/API/lang/swift/po/static_method/main.swift
@@ -1,0 +1,14 @@
+class C: CustomStringConvertible {
+    var description = "instance of C"
+
+    class func doSomething() {
+        let value = C()
+        print("break here", value)
+    }
+}
+
+@main enum Entry {
+    static func main() {
+        C.doSomething()
+    }
+}


### PR DESCRIPTION
The function `ScanContext` exists to resolve `self` and to determine a number of flag values (`m_needs_object_ptr`, `m_in_static_method`, `m_is_class`, and `m_is_weak_self`). These flags control how the expression wrapper is generated.

Context-free po doesn't use these flags — `m_needs_object_ptr` and `m_in_static_method` are false, which means `m_is_class`/`m_is_weak_self` have no effect on `GetText`.

Skipping the scan allows context-free po to succeed in static methods. Previously, when `m_in_static_method` is true, `WrapExpression` would emit an extension on `$__lldb_context`. But this alias is not defined for context-free po (because `AddRequiredAliases` is skipped in context free mode).

Skipping the scan avoids performing unnecessary (and possibly costly) work which is not needed, such as constructing the value and type of `self`.

Skipping also avoids a false failure when `self` exists but has no valid location (e.g. optimized out), which previously made `ScanContext` return false and blocked expression evaluation entirely.

Assisted-by: claude