### PR TITLE
[compiler-rt] Fix default builtins target _Float16 detection on x86_64/i386 (#204474)

### DIFF
--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -283,10 +283,16 @@ else()
 
   # COMPILER_RT_HAS_${arch}_* defines that are shared between lib/builtins/ and test/builtins/
   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
+    cmake_push_check_state()
+    list(APPEND CMAKE_REQUIRED_FLAGS
+      ${TARGET_${arch}_CFLAGS})
+    list(JOIN CMAKE_REQUIRED_FLAGS " " CMAKE_REQUIRED_FLAGS)
+
     # NOTE: The corresponding check for if(APPLE) is in CompilerRTDarwinUtils.cmake
     check_c_source_compiles("_Float16 foo(_Float16 x) { return x; }
                               int main(void) { return 0; }"
                             COMPILER_RT_HAS_${arch}_FLOAT16)
+    cmake_pop_check_state()
   endforeach()
 endif()
 


### PR DESCRIPTION
A change landed upstream that moved the Float16 support but didn't include the `CMAKE_REQUIRED_FLAGS` needed for accurately performing the check. This resulted in `-m32` not being passed for `i386` targets. The FreeBSD i386 target does not support Float16, so we are seeing `error: _Float16 is not supported on this target` on the FreeBSD CI.

Cherry-picking the fix to unblock the bot.

(cherry picked from commit 1343b646697fff896af5c2a0a99135db177ae43d)