### PR TITLE
[lldb] Make ProcessRunLock recursive on the read side per-thread

### DIFF
--- a/lldb/include/lldb/Host/ProcessRunLock.h
+++ b/lldb/include/lldb/Host/ProcessRunLock.h
@@ -9,26 +9,31 @@
 #ifndef LLDB_HOST_PROCESSRUNLOCK_H
 #define LLDB_HOST_PROCESSRUNLOCK_H
 
+#include <cassert>
 #include <cstdint>
 #include <ctime>
+#include <mutex>
+
+#include "llvm/ADT/DenseMap.h"
 
 #include "lldb/lldb-defines.h"
+#include "lldb/lldb-types.h"
 
 /// Enumerations for broadcasting.
 namespace lldb_private {
 
 /// \class ProcessRunLock ProcessRunLock.h "lldb/Host/ProcessRunLock.h"
-/// A class used to prevent the process from starting while other
-/// threads are accessing its data, and prevent access to its data while it is
-/// running.
+/// Read/write lock around the process running/stopped state.
+///
+/// POSIX rwlocks aren't reader-recursive: a thread holding the read
+/// lock can deadlock against a pending writer if it re-acquires
+/// directly. ProcessRunLocker tracks a per-thread recursion count so
+/// re-entry skips the rwlock; the raw primitives are private.
 
 class ProcessRunLock {
 public:
   ProcessRunLock();
   ~ProcessRunLock();
-
-  bool ReadTryLock();
-  bool ReadUnlock();
 
   /// Set the process to running. Returns true if the process was stopped.
   /// Return false if the process was running.
@@ -38,51 +43,32 @@ public:
   /// Returns false if the process was stopped.
   bool SetStopped();
 
+  /// RAII helper around the read-lock side of ProcessRunLock. Supports
+  /// same-thread recursion (see class doc).
+  ///
+  /// Move-assignment unlocks the destination first, then takes the
+  /// source's lock. Cross-thread move of a held locker is fatal — the
+  /// same thread that called rdlock must call unlock.
   class ProcessRunLocker {
   public:
     ProcessRunLocker() = default;
-    ProcessRunLocker(ProcessRunLocker &&other) : m_lock(other.m_lock) {
-      other.m_lock = nullptr;
-    }
-    ProcessRunLocker &operator=(ProcessRunLocker &&other) {
-      if (this != &other) {
-        Unlock();
-        m_lock = other.m_lock;
-        other.m_lock = nullptr;
-      }
-      return *this;
-    }
-
+    ProcessRunLocker(ProcessRunLocker &&other);
+    ProcessRunLocker &operator=(ProcessRunLocker &&other);
     ~ProcessRunLocker() { Unlock(); }
 
     bool IsLocked() const { return m_lock; }
 
-    // Try to lock the read lock, but only do so if there are no writers.
-    bool TryLock(ProcessRunLock *lock) {
-      if (m_lock) {
-        if (m_lock == lock)
-          return true; // We already have this lock locked
-        else
-          Unlock();
-      }
-      if (lock) {
-        if (lock->ReadTryLock()) {
-          m_lock = lock;
-          return true;
-        }
-      }
-      return false;
-    }
+    /// Try to acquire the read lock. If this thread already holds the
+    /// read lock on this ProcessRunLock, the underlying rwlock is bypassed
+    /// and the per-instance recursion count for this thread is bumped
+    /// instead.
+    bool TryLock(ProcessRunLock *lock);
 
   protected:
-    void Unlock() {
-      if (m_lock) {
-        m_lock->ReadUnlock();
-        m_lock = nullptr;
-      }
-    }
+    void Unlock();
 
     ProcessRunLock *m_lock = nullptr;
+    uint64_t m_thread = 0;
 
   private:
     ProcessRunLocker(const ProcessRunLocker &) = delete;
@@ -96,6 +82,13 @@ protected:
 private:
   ProcessRunLock(const ProcessRunLock &) = delete;
   const ProcessRunLock &operator=(const ProcessRunLock &) = delete;
+
+  bool ReadTryLock();
+  bool ReadUnlock();
+  friend class ProcessRunLocker;
+
+  std::mutex m_recursion_mutex;
+  llvm::DenseMap<uint64_t, uint32_t> m_recursion;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Host/common/ProcessRunLock.cpp
+++ b/lldb/source/Host/common/ProcessRunLock.cpp
@@ -6,10 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _WIN32
 #include "lldb/Host/ProcessRunLock.h"
 
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Threading.h"
+
+#include <cassert>
+#include <cstdint>
+
 namespace lldb_private {
+
+#ifndef _WIN32
 
 ProcessRunLock::ProcessRunLock() {
   int err = ::pthread_rwlock_init(&m_rwlock, nullptr);
@@ -51,6 +58,102 @@ bool ProcessRunLock::SetStopped() {
   return was_running;
 }
 
-} // namespace lldb_private
+#endif // !_WIN32
 
-#endif
+ProcessRunLock::ProcessRunLocker::ProcessRunLocker(ProcessRunLocker &&other) {
+  if (other.m_lock && other.m_thread != llvm::get_threadid())
+    llvm::report_fatal_error(
+        "ProcessRunLocker moved across threads while held");
+  assert(!m_lock && "move-construct into a held ProcessRunLocker");
+  m_lock = other.m_lock;
+  m_thread = other.m_thread;
+  other.m_lock = nullptr;
+}
+
+ProcessRunLock::ProcessRunLocker &
+ProcessRunLock::ProcessRunLocker::operator=(ProcessRunLocker &&other) {
+  if (this != &other) {
+    if (other.m_lock && other.m_thread != llvm::get_threadid())
+      llvm::report_fatal_error(
+          "ProcessRunLocker move-assigned across threads while held");
+    Unlock();
+    m_lock = other.m_lock;
+    m_thread = other.m_thread;
+    other.m_lock = nullptr;
+  }
+  return *this;
+}
+
+bool ProcessRunLock::ProcessRunLocker::TryLock(ProcessRunLock *lock) {
+  if (m_lock) {
+    if (m_lock == lock)
+      return true;
+    Unlock();
+  }
+  if (!lock)
+    return false;
+
+  const uint64_t this_thread = llvm::get_threadid();
+
+  // Fast path: already holding as a reader on this thread, bump the count.
+  {
+    std::lock_guard<std::mutex> guard(lock->m_recursion_mutex);
+    auto it = lock->m_recursion.find(this_thread);
+    if (it != lock->m_recursion.end()) {
+      ++it->second;
+      m_lock = lock;
+      m_thread = this_thread;
+      return true;
+    }
+  }
+
+  // Acquire the rwlock with m_recursion_mutex released: ReadTryLock can
+  // block waiting for a writer, and holding the recursion mutex through
+  // that wait would stall fast-path bumps that only need the map.
+  if (!lock->ReadTryLock())
+    return false;
+
+  std::lock_guard<std::mutex> guard(lock->m_recursion_mutex);
+  lock->m_recursion[this_thread] = 1;
+  m_lock = lock;
+  m_thread = this_thread;
+  return true;
+}
+
+void ProcessRunLock::ProcessRunLocker::Unlock() {
+  if (!m_lock)
+    return;
+
+  const uint64_t this_thread = llvm::get_threadid();
+  if (m_thread != this_thread)
+    // pthread_rwlock_unlock from a different thread than the one that
+    // called pthread_rwlock_rdlock is UB. The move ctor / operator= are
+    // the only way a held locker can change object identity, and both
+    // fatal on cross-thread transfer; this is the last-line check on
+    // the destructor path in case a held locker escaped that trap.
+    llvm::report_fatal_error(
+        "ProcessRunLocker destroyed on a different thread while held");
+
+  bool release_rwlock = false;
+  {
+    std::lock_guard<std::mutex> guard(m_lock->m_recursion_mutex);
+    auto it = m_lock->m_recursion.find(this_thread);
+    assert(
+        it != m_lock->m_recursion.end() &&
+        "ProcessRunLocker released without a matching TryLock on this thread");
+    if (it == m_lock->m_recursion.end()) {
+      m_lock = nullptr;
+      return;
+    }
+    if (--it->second == 0) {
+      m_lock->m_recursion.erase(it);
+      release_rwlock = true;
+    }
+  }
+
+  if (release_rwlock)
+    m_lock->ReadUnlock();
+  m_lock = nullptr;
+}
+
+} // namespace lldb_private

--- a/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/Makefile
+++ b/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+include Makefile.rules

--- a/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/TestRunLockReentrantDeadlock.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/TestRunLockReentrantDeadlock.py
@@ -1,0 +1,129 @@
+"""
+Test that ProcessRunLock re-entrant read locks don't deadlock when a frame
+provider's get_frame_at_index calls SB API methods.
+
+This reproduces the deadlock seen in lldb-rpc-server where:
+
+  - An RPC client thread holds a ProcessRunLock read lock (from the outer
+    SB API call) and enters a provider's get_frame_at_index, which calls
+    SBFrame.IsValid -> GetStoppedExecutionContext -> ReadTryLock (re-entrant).
+
+  - The override PST is exiting RunPrivateStateThread and calls SetStopped
+    -> pthread_rwlock_wrlock (blocked by client thread's read lock).
+
+  - The client thread's re-entrant ReadTryLock blocks because the pending
+    writer prevents new readers on a write-preferring rwlock.
+
+  - The original PST is blocked joining the override thread.
+"""
+
+import os
+import threading
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TestRunLockReentrantDeadlock(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @expectedFailureAll(
+        oslist=["windows"],
+        bugnumber="llvm.org/pr24528 (scripted breakpoint resolvers fail on "
+        "Windows; same XFAIL as the sibling tests in this directory)",
+    )
+    def test_runlock_reentrant_no_deadlock(self):
+        """
+        Test that a frame provider calling SBFrame.IsValid from
+        get_frame_at_index does not deadlock with the override PST's
+        SetStopped when another thread triggers EvaluateExpression.
+        """
+        self.build()
+
+        target, process, thread, _ = lldbutil.run_to_name_breakpoint(self, "main")
+
+        resolver_path = os.path.join(self.getSourceDir(), "bkpt_resolver.py")
+        provider_path = os.path.join(self.getSourceDir(), "frame_provider.py")
+        self.runCmd("command script import " + resolver_path)
+        self.runCmd("command script import " + provider_path)
+
+        error = lldb.SBError()
+        provider_id = target.RegisterScriptedFrameProvider(
+            "frame_provider.SBAPIAccessInGetFrameProvider",
+            lldb.SBStructuredData(),
+            error,
+        )
+        self.assertTrue(
+            error.Success(),
+            f"Should register frame provider: {error}",
+        )
+        self.assertNotEqual(provider_id, 0, "Provider ID should be non-zero")
+
+        extra_args = lldb.SBStructuredData()
+        stream = lldb.SBStream()
+        stream.Print('{"symbol": "target_func"}')
+        extra_args.SetFromJSON(stream)
+
+        bkpt = target.BreakpointCreateFromScript(
+            "bkpt_resolver.ExprEvalResolver",
+            extra_args,
+            lldb.SBFileSpecList(),
+            lldb.SBFileSpecList(),
+        )
+        self.assertTrue(bkpt.IsValid(), "Scripted breakpoint should be valid")
+        self.assertGreater(
+            bkpt.GetNumLocations(), 0, "Breakpoint should have locations"
+        )
+
+        # Spawn a thread that repeatedly accesses frames through the provider.
+        # This simulates an RPC client thread that holds the ProcessRunLock
+        # read lock and enters get_frame_at_index -> SBFrame.IsValid.
+        stop_frame_access = threading.Event()
+        frame_access_error = [None]
+
+        def access_frames():
+            try:
+                while not stop_frame_access.is_set():
+                    t = process.GetSelectedThread()
+                    if t.IsValid():
+                        for i in range(t.GetNumFrames()):
+                            f = t.GetFrameAtIndex(i)
+                            f.IsValid()
+            except Exception as e:
+                frame_access_error[0] = str(e)
+
+        frame_thread = threading.Thread(target=access_frames, daemon=True)
+        frame_thread.start()
+
+        # Continue into the breakpoint. was_hit calls EvaluateExpression on
+        # the PST, which triggers RunThreadPlan -> override PST.
+        # The frame access thread is concurrently calling GetFrameAtIndex ->
+        # provider get_frame_at_index -> SBFrame.IsValid.
+        # Without the fix, this deadlocks.
+        process.Continue()
+        self.assertState(process.GetState(), lldb.eStateStopped)
+
+        stop_frame_access.set()
+        frame_thread.join(timeout=5)
+        self.assertFalse(frame_thread.is_alive(), "Frame access thread should exit")
+        self.assertIsNone(
+            frame_access_error[0],
+            f"Frame access thread hit an error: {frame_access_error[0]}",
+        )
+
+        thread = process.GetSelectedThread()
+        self.assertTrue(thread.IsValid(), "Thread should be valid")
+        self.assertEqual(
+            thread.GetStopReason(),
+            lldb.eStopReasonBreakpoint,
+            "Should stop at breakpoint",
+        )
+
+        g_value = target.FindFirstGlobalVariable("g_value")
+        self.assertTrue(g_value.IsValid(), "Should find g_value")
+        self.assertGreater(
+            g_value.GetValueAsUnsigned(),
+            0,
+            "g_value should have been incremented by the was_hit callback",
+        )

--- a/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/bkpt_resolver.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/bkpt_resolver.py
@@ -1,0 +1,44 @@
+"""
+Scripted breakpoint resolver whose was_hit callback calls EvaluateExpression.
+
+Used to trigger the deadlock scenario described in
+TestRunLockReentrantDeadlock.py: was_hit -> EvaluateExpression spins up the
+override PST and starts an expression, setting up the conditions under
+which a re-entrant ReadTryLock from a frame provider would deadlock against
+the pending writer.
+"""
+
+import lldb
+
+
+class ExprEvalResolver:
+    """Scripted breakpoint resolver that evaluates an expression in was_hit."""
+
+    def __init__(self, bkpt, extra_args, dict):
+        self.bkpt = bkpt
+        sym_name = extra_args.GetValueForKey("symbol").GetStringValue(100)
+        self.sym_name = sym_name
+        self.facade_loc = None
+
+    def __callback__(self, sym_ctx):
+        sym = sym_ctx.module.FindSymbol(self.sym_name, lldb.eSymbolTypeCode)
+        if sym.IsValid():
+            self.bkpt.AddLocation(sym.GetStartAddress())
+            self.facade_loc = self.bkpt.AddFacadeLocation()
+
+    def get_short_help(self):
+        return f"ExprEvalResolver for {self.sym_name}"
+
+    def was_hit(self, frame, bp_loc):
+        # This runs on the private state thread. Calling EvaluateExpression
+        # here triggers RunThreadPlan -> Halt -> WaitForProcessToStop, which
+        # holds a mutex and waits for a state change event.
+        options = lldb.SBExpressionOptions()
+        options.SetStopOthers(True)
+        options.SetTryAllThreads(False)
+
+        result = frame.EvaluateExpression("increment()", options)
+        if not result.error.success:
+            return lldb.LLDB_INVALID_BREAK_ID
+
+        return self.facade_loc

--- a/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/frame_provider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/frame_provider.py
@@ -1,0 +1,32 @@
+"""
+Frame provider whose get_frame_at_index calls SBFrame::IsValid on input frames.
+
+Used to trigger the deadlock scenario described in
+TestRunLockReentrantDeadlock.py: when a client thread accesses frames
+through this provider, get_frame_at_index re-enters the SB API and tries
+to re-acquire the ProcessRunLock read lock, which (without the recursion
+fix in ProcessRunLocker) deadlocks against the override PST's pending
+writer.
+"""
+
+import lldb
+from lldb.plugins.scripted_frame_provider import ScriptedFrameProvider
+
+
+class SBAPIAccessInGetFrameProvider(ScriptedFrameProvider):
+    """Provider that calls SBFrame.IsValid from get_frame_at_index."""
+
+    @staticmethod
+    def get_description():
+        return "Provider that accesses SB API in get_frame_at_index"
+
+    def get_frame_at_index(self, idx):
+        if idx < len(self.input_frames):
+            frame = self.input_frames.GetFrameAtIndex(idx)
+            # This call triggers GetStoppedExecutionContext ->
+            # ProcessRunLock::ReadTryLock. If the current thread already
+            # holds the read lock (from the outer SB API entry point),
+            # and a writer is pending, this re-entrant read lock blocks.
+            frame.IsValid()
+            return idx
+        return None

--- a/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/main.c
+++ b/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+int g_value = 0;
+
+int increment() { return ++g_value; }
+
+int target_func() {
+  printf("target_func: %d\n", g_value);
+  return g_value;
+}
+
+int main() {
+  for (int i = 0; i < 10; i++) {
+    target_func();
+  }
+  increment();
+  return 0;
+}

--- a/lldb/unittests/Host/CMakeLists.txt
+++ b/lldb/unittests/Host/CMakeLists.txt
@@ -16,6 +16,7 @@ set (FILES
   NativeProcessProtocolTest.cpp
   PipeTest.cpp
   ProcessLaunchInfoTest.cpp
+  ProcessRunLockTest.cpp
   SocketAddressTest.cpp
   SocketTest.cpp
   ThreadLauncherTest.cpp

--- a/lldb/unittests/Host/ProcessRunLockTest.cpp
+++ b/lldb/unittests/Host/ProcessRunLockTest.cpp
@@ -1,0 +1,185 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Host/ProcessRunLock.h"
+
+#include "gtest/gtest.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+using namespace lldb_private;
+
+TEST(ProcessRunLockTest, BasicLockUnlock) {
+  ProcessRunLock lock;
+  ProcessRunLock::ProcessRunLocker locker;
+  EXPECT_FALSE(locker.IsLocked());
+  EXPECT_TRUE(locker.TryLock(&lock));
+  EXPECT_TRUE(locker.IsLocked());
+  // Destructor releases.
+}
+
+TEST(ProcessRunLockTest, SameThreadRecursion) {
+  ProcessRunLock lock;
+  ProcessRunLock::ProcessRunLocker outer;
+  EXPECT_TRUE(outer.TryLock(&lock));
+
+  // Re-entrant acquisition on the same thread must succeed without
+  // deadlocking on the underlying rwlock.
+  ProcessRunLock::ProcessRunLocker inner;
+  EXPECT_TRUE(inner.TryLock(&lock));
+  EXPECT_TRUE(inner.IsLocked());
+}
+
+TEST(ProcessRunLockTest, ConcurrentReaders) {
+  ProcessRunLock lock;
+  ProcessRunLock::ProcessRunLocker outer;
+  EXPECT_TRUE(outer.TryLock(&lock));
+
+  // Another thread concurrently acquires the same lock and is also
+  // able to recurse on its own. Both threads must get the same-thread
+  // recursion fast-path.
+  bool other_outer_ok = false, other_inner_ok = false;
+  std::thread t([&] {
+    ProcessRunLock::ProcessRunLocker thread_outer;
+    other_outer_ok = thread_outer.TryLock(&lock);
+    ProcessRunLock::ProcessRunLocker thread_inner;
+    other_inner_ok = thread_inner.TryLock(&lock);
+  });
+  t.join();
+  EXPECT_TRUE(other_outer_ok);
+  EXPECT_TRUE(other_inner_ok);
+}
+
+TEST(ProcessRunLockTest, MoveUnlocked) {
+  // Moving an unlocked locker is always allowed.
+  ProcessRunLock::ProcessRunLocker a;
+  ProcessRunLock::ProcessRunLocker b(std::move(a));
+  EXPECT_FALSE(b.IsLocked());
+
+  ProcessRunLock::ProcessRunLocker c;
+  c = std::move(b);
+  EXPECT_FALSE(c.IsLocked());
+}
+
+TEST(ProcessRunLockTest, MoveLockedSameThread) {
+  // Moving a held locker on the owning thread is allowed.
+  ProcessRunLock lock;
+  ProcessRunLock::ProcessRunLocker a;
+  EXPECT_TRUE(a.TryLock(&lock));
+  ProcessRunLock::ProcessRunLocker b(std::move(a));
+  EXPECT_TRUE(b.IsLocked());
+  EXPECT_FALSE(a.IsLocked());
+}
+
+TEST(ProcessRunLockTest, MoveAssignReleasesWaitingWriter) {
+  // Move-assigning a fresh locker into a held one calls Unlock() on
+  // the destination. If the rwlock isn't actually released, the writer
+  // hangs in pthread_rwlock_wrlock and never reaches the flag.
+  ProcessRunLock lock;
+  ProcessRunLock::ProcessRunLocker reader;
+  ASSERT_TRUE(reader.TryLock(&lock));
+
+  bool writer_acquired = false;
+  std::thread writer([&] {
+    lock.SetRunning();
+    writer_acquired = true;
+  });
+
+  ProcessRunLock::ProcessRunLocker replacement;
+  reader = std::move(replacement);
+  EXPECT_FALSE(reader.IsLocked());
+
+  writer.join();
+  EXPECT_TRUE(writer_acquired);
+}
+
+TEST(ProcessRunLockTest, MoveAssignFromHeldKeepsWriterWaiting) {
+  // Opposite of MoveAssignReleasesWaitingWriter: move-assigning a held
+  // locker into a fresh one transfers ownership without releasing the
+  // rwlock. The writer must only succeed *after* new_owner is destroyed.
+  ProcessRunLock lock;
+  ProcessRunLock::ProcessRunLocker source;
+  ASSERT_TRUE(source.TryLock(&lock));
+
+  std::mutex sync_mutex;
+  std::condition_variable sync_cv;
+  bool writer_started = false;
+  bool release_signaled = false;
+  bool acquired_after_release = false;
+
+  std::thread writer([&] {
+    {
+      std::lock_guard<std::mutex> g(sync_mutex);
+      writer_started = true;
+    }
+    sync_cv.notify_one();
+    lock.SetRunning();
+    // If move-assign held the lock correctly, the writer only gets here
+    // after the listener signaled release. If move-assign released
+    // early, the writer can race ahead and observe the flag unset.
+    std::lock_guard<std::mutex> g(sync_mutex);
+    acquired_after_release = release_signaled;
+  });
+
+  std::thread listener([&] {
+    std::unique_lock<std::mutex> g(sync_mutex);
+    sync_cv.wait(g, [&] { return writer_started; });
+    release_signaled = true;
+  });
+
+  {
+    ProcessRunLock::ProcessRunLocker new_owner;
+    new_owner = std::move(source);
+    EXPECT_TRUE(new_owner.IsLocked());
+    EXPECT_FALSE(source.IsLocked());
+
+    listener.join();
+    // new_owner destructs here, releasing the rwlock.
+  }
+
+  writer.join();
+  EXPECT_TRUE(acquired_after_release);
+}
+
+TEST(ProcessRunLockTest, MoveUnlockedAcrossThreads) {
+  // Moving an unlocked locker across threads is allowed, and the
+  // locker can then be used (TryLock + Unlock) entirely on the worker
+  // thread. Note that `lock` is owned by the outer scope so it
+  // outlives the worker thread (the captured locker holds a pointer
+  // into it).
+  ProcessRunLock lock;
+  ProcessRunLock::ProcessRunLocker a;
+  std::thread t([&lock, locker = std::move(a)]() mutable {
+    EXPECT_FALSE(locker.IsLocked());
+    EXPECT_TRUE(locker.TryLock(&lock));
+    EXPECT_TRUE(locker.IsLocked());
+    // ~locker runs on this worker thread, the same thread that
+    // acquired -- so the destructor's thread-affinity check passes
+    // and the rwlock is released here.
+  });
+  t.join();
+}
+
+#if GTEST_HAS_DEATH_TEST
+TEST(ProcessRunLockDeathTest, MoveLockedAcrossThreads) {
+  ProcessRunLock lock;
+  ProcessRunLock::ProcessRunLocker a;
+  ASSERT_TRUE(a.TryLock(&lock));
+  // The expected message will vary based on the call site so match the
+  // "ProcessRunLocker" common prefix only.
+  EXPECT_DEATH(
+      {
+        std::thread t([locker = std::move(a)]() mutable { (void)locker; });
+        t.join();
+      },
+      "ProcessRunLocker");
+}
+#endif


### PR DESCRIPTION
When SB API code enters a Python callback (frame provider, breakpoint callback, ...) and the callback re-enters the SB API, the inner call tries to re-acquire the ProcessRunLock read lock. Recursive shared acquisition deadlocks against a queued writer on a write-preferring rwlock (POSIX), and is UB on Windows SRW.

Each ProcessRunLock now keeps a per-instance map of thread id -> recursion count under its own std::mutex. ProcessRunLocker::TryLock checks that map first: if this thread already has a non-zero count it bumps and returns, skipping the rwlock. Unlock decrements; only the final Unlock releases the rwlock. Per-instance (not thread_local) so the bookkeeping is colocated with the lock and concurrent readers from multiple threads each get the fast path.

Thread identity is taken from llvm::get_threadid() (uint64_t). Not Host::GetCurrentThread(): on Windows that wraps ::GetCurrentThread(), which returns a pseudo-handle ((HANDLE)-2) that compares equal across threads -- both the recursion map and the cross-thread invariant checks would silently collapse all threads onto a single key. llvm::get_threadid() returns the real GetCurrentThreadId() on Windows and the kernel TID on POSIX. uint64_t also has a stock DenseMapInfo, so the map needs no extra plumbing.

ProcessRunLocker move policy: unlocked moves are always fine; moving a held locker is only valid on the owning thread. Cross-thread move asserts in debug and llvm::report_fatal_error in release. The destructor enforces the same invariant.

rdar://176223894


(cherry picked from commit e0cb053cba40919adf468b66a232592ca362ab8c)