### PR TITLE
[clang] Add Swift support for MIPS

### DIFF
--- a/clang/lib/Basic/Targets/Mips.h
+++ b/clang/lib/Basic/Targets/Mips.h
@@ -430,6 +430,18 @@ public:
   bool validateTarget(DiagnosticsEngine &Diags) const override;
   bool hasBitIntType() const override { return true; }
 
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    switch (CC) {
+    case CC_C:
+    case CC_Swift:
+      return CCCR_OK;
+    case CC_SwiftAsync:
+      return CCCR_Error;
+    default:
+      return CCCR_Warning;
+    }
+  }
+
   std::pair<unsigned, unsigned> hardwareInterferenceSizes() const override {
     return std::make_pair(32, 32);
   }

--- a/clang/lib/CodeGen/Targets/Mips.cpp
+++ b/clang/lib/CodeGen/Targets/Mips.cpp
@@ -57,7 +57,10 @@ class MIPSTargetCodeGenInfo : public TargetCodeGenInfo {
 public:
   MIPSTargetCodeGenInfo(CodeGenTypes &CGT, bool IsO32)
       : TargetCodeGenInfo(std::make_unique<MipsABIInfo>(CGT, IsO32)),
-        SizeOfUnwindException(IsO32 ? 24 : 32) {}
+        SizeOfUnwindException(IsO32 ? 24 : 32) {
+    SwiftInfo =
+        std::make_unique<SwiftABIInfo>(CGT, /*SwiftErrorInRegister=*/false);
+  }
 
   int getDwarfEHStackPointer(CodeGen::CodeGenModule &CGM) const override {
     return 29;

--- a/clang/test/Sema/mips-swiftcall.c
+++ b/clang/test/Sema/mips-swiftcall.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple mips-unknown-linux-gnu -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple mipsel-unknown-linux-gnu -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple mips64-unknown-linux-gnuabi64 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple mips64el-unknown-linux-gnuabi64 -fsyntax-only -verify %s
+
+// swiftcall is supported on MIPS; swiftasynccall is not, because the backend
+// has no guaranteed tail call support for it.
+
+void __attribute__((swiftcall)) f(void *__attribute__((swift_context)) ctx) {}
+
+#if !__has_extension(swiftcc)
+#error swiftcc should be available on MIPS
+#endif
+
+#if __has_extension(swiftasynccc)
+#error swiftasynccc should not be available on MIPS
+#endif
+
+// expected-error@+1 {{'swiftasynccall' calling convention is not supported for this target}}
+void __attribute__((swiftasynccall)) g(void *__attribute__((swift_async_context)) ctx) {}


### PR DESCRIPTION
Adds support for compiling Swift targeting the MIPS ABI

Upstream PR https://github.com/llvm/llvm-project/pull/205461

Resolves https://github.com/apple/swift/issues/58204