### PR TITLE
[swift/release/6.4.x][NFC][BoundsSafety] Fix BoundsSafety/CodeGen/range-check-optimizations-structs(|-no-bringup-missing-checks.c) failures

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations-structs-no-bringup-missing-checks.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations-structs-no-bringup-missing-checks.c
@@ -47,17 +47,18 @@ struct struct_1 * access_struct_1_all_checks_removable(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[IDX_EXT:%.*]] = zext i32 [[SIZE:%.*]] to i64
 // CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds nuw [[STRUCT_STRUCT_1:%.*]], ptr [[SRC:%.*]], i64 [[IDX_EXT]]
-// CHECK-NEXT:    br label [[FOR_COND:%.*]]
+// CHECK-NEXT:    [[EXITCOND_NOT27:%.*]] = icmp eq i32 [[SIZE]], 0
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT27]], label [[CLEANUP13:%.*]], label [[FOR_BODY:%.*]]
 // CHECK:       for.cond:
-// CHECK-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ [[INDVARS_IV_NEXT:%.*]], [[CONT1:%.*]] ], [ 0, [[ENTRY:%.*]] ]
-// CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i64 [[INDVARS_IV]], [[IDX_EXT]]
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[CLEANUP13:%.*]], label [[FOR_BODY:%.*]]
+// CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i64 [[INDVARS_IV_NEXT:%.*]], [[IDX_EXT]]
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[CLEANUP13]], label [[FOR_BODY]]
 // CHECK:       for.body:
-// CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
+// CHECK-NEXT:    [[INDVARS_IV28:%.*]] = phi i64 [ [[INDVARS_IV_NEXT]], [[FOR_COND:%.*]] ], [ 0, [[ENTRY:%.*]] ]
+// CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV28]], 1
 // CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [[STRUCT_STRUCT_1]], ptr [[SRC]], i64 [[INDVARS_IV_NEXT]]
 // CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[BOUND_PTR_ARITH]], i64 8
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[TMP0]], [[ADD_PTR]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP:%.*]], label [[CONT1]], !prof [[PROF10:![0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP:%.*]], label [[CONT1:%.*]], !prof [[PROF10:![0-9]+]], {{!annotation ![0-9]+}}
 // CHECK:       trap:
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
@@ -69,7 +70,7 @@ struct struct_1 * access_struct_1_all_checks_removable(
 // CHECK-NEXT:    [[TMP2:%.*]] = icmp ult ptr [[BOUND_PTR_ARITH]], [[ADD_PTR]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[TMP2]], label [[CLEANUP13]], label [[TRAP]], !prof [[PROF12:![0-9]+]], {{!annotation ![0-9]+}}
 // CHECK:       cleanup13:
-// CHECK-NEXT:    [[SPEC_SELECT:%.*]] = phi ptr [ [[BOUND_PTR_ARITH]], [[BOUNDSCHECK_NOTNULL]] ], [ null, [[FOR_COND]] ]
+// CHECK-NEXT:    [[SPEC_SELECT:%.*]] = phi ptr [ [[BOUND_PTR_ARITH]], [[BOUNDSCHECK_NOTNULL]] ], [ null, [[ENTRY]] ], [ null, [[FOR_COND]] ]
 // CHECK-NEXT:    ret ptr [[SPEC_SELECT]]
 //
 struct struct_1 * access_struct_1_checks_needed(

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations-structs.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations-structs.c
@@ -47,17 +47,18 @@ struct struct_1 * access_struct_1_all_checks_removable(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[IDX_EXT:%.*]] = zext i32 [[SIZE:%.*]] to i64
 // CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds nuw [[STRUCT_STRUCT_1:%.*]], ptr [[SRC:%.*]], i64 [[IDX_EXT]]
-// CHECK-NEXT:    br label [[FOR_COND:%.*]]
+// CHECK-NEXT:    [[EXITCOND_NOT33:%.*]] = icmp eq i32 [[SIZE]], 0
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT33]], label [[CLEANUP14:%.*]], label [[FOR_BODY:%.*]]
 // CHECK:       for.cond:
-// CHECK-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ [[INDVARS_IV_NEXT:%.*]], [[CONT1:%.*]] ], [ 0, [[ENTRY:%.*]] ]
-// CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i64 [[INDVARS_IV]], [[IDX_EXT]]
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[CLEANUP14:%.*]], label [[FOR_BODY:%.*]]
+// CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i64 [[INDVARS_IV_NEXT:%.*]], [[IDX_EXT]]
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[CLEANUP14]], label [[FOR_BODY]]
 // CHECK:       for.body:
-// CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
+// CHECK-NEXT:    [[INDVARS_IV34:%.*]] = phi i64 [ [[INDVARS_IV_NEXT]], [[FOR_COND:%.*]] ], [ 0, [[ENTRY:%.*]] ]
+// CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV34]], 1
 // CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [[STRUCT_STRUCT_1]], ptr [[SRC]], i64 [[INDVARS_IV_NEXT]]
 // CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[BOUND_PTR_ARITH]], i64 8
 // CHECK-NEXT:    [[DOTNOT25:%.*]] = icmp ugt ptr [[TMP0]], [[ADD_PTR]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[DOTNOT25]], label [[TRAP:%.*]], label [[CONT1]], !prof [[PROF10:![0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[DOTNOT25]], label [[TRAP:%.*]], label [[CONT1:%.*]], !prof [[PROF10:![0-9]+]], {{!annotation ![0-9]+}}
 // CHECK:       trap:
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
@@ -69,7 +70,7 @@ struct struct_1 * access_struct_1_all_checks_removable(
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[TMP0]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP]], label [[CLEANUP14]], !prof [[PROF13:![0-9]+]], {{!annotation ![0-9]+}}
 // CHECK:       cleanup14:
-// CHECK-NEXT:    [[SPEC_SELECT:%.*]] = phi ptr [ [[BOUND_PTR_ARITH]], [[BOUNDSCHECK_NOTNULL]] ], [ null, [[FOR_COND]] ]
+// CHECK-NEXT:    [[SPEC_SELECT:%.*]] = phi ptr [ [[BOUND_PTR_ARITH]], [[BOUNDSCHECK_NOTNULL]] ], [ null, [[ENTRY]] ], [ null, [[FOR_COND]] ]
 // CHECK-NEXT:    ret ptr [[SPEC_SELECT]]
 //
 struct struct_1 * access_struct_1_checks_needed(

--- a/llvm/utils/update_cc_test_checks.py
+++ b/llvm/utils/update_cc_test_checks.py
@@ -359,11 +359,6 @@ def update_test(ti: common.TestInfo):
         # and append args.clang_args
         clang_args = exec_args
         # DO_NOT_UPSTREAM(BoundsSafety) ON
-        original_subst = clang_args[0] # Apple Internal
-        # DO_NOT_UPSTREAM(BoundsSafety) OFF
-        clang_args[0:1] = SUBST[clang_args[0]]
-
-        # DO_NOT_UPSTREAM(BoundsSafety) ON
         # The -fbounds-safety tests under:
         #
         # * `clang/test/BoundsSafety` expect to be run with the new bounds checks enabled.
@@ -377,16 +372,17 @@ def update_test(ti: common.TestInfo):
         #
         # This can be removed once support for the legacy bounds checks are
         # removed (rdar://134095901)
+        original_subst = clang_args[0] # Apple Internal
         if is_bounds_safety_test_with_new_bounds_checks(ti) and original_subst == "%clang_cc1":
-            enable_bounds_safety_checks_flag = '-fbounds-safety-bringup-missing-checks=batch_0'
-            print(f"Implicitly adding {enable_bounds_safety_checks_flag}")
-            clang_args.append(enable_bounds_safety_checks_flag)
-
-        if is_bounds_safety_test_with_legacy_bounds_checks(ti) and original_subst == "%clang_cc1":
-            enable_bounds_safety_legacy_checks_flag = '-fno-bounds-safety-bringup-missing-checks=all'
-            print(f"Implicitly adding {enable_bounds_safety_legacy_checks_flag}")
-            clang_args.append(enable_bounds_safety_legacy_checks_flag)
+            default_bounds_safety_checks_flag = ['-fbounds-safety-bringup-missing-checks=batch_0']
+            print(f"Implicitly adding {default_bounds_safety_checks_flag[0]}")
+        elif is_bounds_safety_test_with_legacy_bounds_checks(ti) and original_subst == "%clang_cc1":
+            default_bounds_safety_checks_flag = ['-fno-bounds-safety-bringup-missing-checks=all']
+            print(f"Implicitly adding {default_bounds_safety_checks_flag[0]}")
+        else:
+            default_bounds_safety_checks_flag = []
         # DO_NOT_UPSTREAM(BoundsSafety) OFF
+        clang_args[0:1] = SUBST[clang_args[0]] + default_bounds_safety_checks_flag
 
         for s in subs:
             clang_args = [i.replace(s, subs[s]) if s in i else i for i in clang_args]


### PR DESCRIPTION
The CHECK lines for the access_struct_1_checks_needed function in
these two tests expected an un-rotated loop shape. After cherry-picking
b272c36f15b0 ([LoopRotate] Use SCEV exit counts to improve rotation
profitability (https://github.com/llvm/llvm-project/pull/187483)), this loop now gets rotated, and the previous
CHECK lines no longer match.

This was verified by capturing the canonical default<O2> pipeline
string from opt --print-pipeline-passes and re-running it after
flipping the LPM loop-rotate<...;check-exit-count> parameter to
no-check-exit-count. With the new behavior disabled the un-rotated
shape comes back; with it enabled (the post-cherry-pick default) the
rotated shape is produced.

CHECK lines were regenerated with llvm/utils/update_cc_test_checks.py
using the in-tree clang, after picking up c35b15eef009 ([UTC] Fix
bounds safety default checks in update_cc_test_checks.py) so the
script no longer clobbers tests that explicitly pass
-fno-bounds-safety-bringup-missing-checks=all.

Assisted-by: Claude Code

rdar://179378974