### PR TITLE
[lldb] Handle llvm.ptrauth section in InjectPointerSigningFixups

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/InjectPointerSigningFixups.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/InjectPointerSigningFixups.cpp
@@ -42,7 +42,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
-
 #include "llvm/IR/GlobalPtrAuthInfo.h"
 
 using namespace llvm;

--- a/lldb/source/Plugins/ExpressionParser/Clang/InjectPointerSigningFixups.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/InjectPointerSigningFixups.cpp
@@ -43,6 +43,8 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 
+#include "llvm/IR/GlobalPtrAuthInfo.h"
+
 using namespace llvm;
 
 namespace {
@@ -109,6 +111,275 @@ findGlobalInitPtrAuth(Constant *C, GlobalVariable &GV,
   }
 }
 
+namespace {
+struct PerModuleUtils {
+  PerModuleUtils(Module &M) {
+    Int32Ty = Type::getInt32Ty(M.getContext());
+    IntPtrTy = Type::getInt64Ty(M.getContext());
+    BlendIntrinsic =
+        Intrinsic::getOrInsertDeclaration(&M, Intrinsic::ptrauth_blend);
+    SignIntrinsic =
+        Intrinsic::getOrInsertDeclaration(&M, Intrinsic::ptrauth_sign);
+
+    FixupFunction = Function::Create(
+        FunctionType::get(Type::getVoidTy(M.getContext()), false),
+        GlobalValue::InternalLinkage, "lldb.arm64.sign_pointers", &M);
+    FixupFunction->insert(FixupFunction->end(),
+                          BasicBlock::Create(M.getContext()));
+    B = std::make_unique<IRBuilder<>>(&FixupFunction->back());
+  }
+
+  Type *Int32Ty = nullptr;
+  Type *IntPtrTy = nullptr;
+  Function *BlendIntrinsic = nullptr;
+  Function *SignIntrinsic = nullptr;
+  Function *FixupFunction = nullptr;
+  std::unique_ptr<IRBuilder<>> B;
+};
+
+struct PerGlobalUtils {
+  PerGlobalUtils(GlobalPtrAuthInfo PtrAuthInfo)
+      : PtrAuthInfo(std::move(PtrAuthInfo)) {
+    GlobalVariable *AuthGlobal =
+        const_cast<GlobalVariable *>(this->PtrAuthInfo.getGV());
+    Pointee = const_cast<Constant *>(
+        this->PtrAuthInfo.getPointer()->stripPointerCasts());
+    PtrForInsts = new GlobalVariable(
+        *AuthGlobal->getParent(), Pointee->getType(), false,
+        GlobalValue::PrivateLinkage,
+        ConstantExpr::getPointerCast(AuthGlobal, Pointee->getType()));
+  }
+
+  Instruction *getPtrLoadFor(Function &F, Type &T) {
+    auto Key = std::make_pair(&F, &T);
+    auto LI = LoadsForCaller.find(Key);
+    if (LI == LoadsForCaller.end()) {
+      BasicBlock &Entry = F.getEntryBlock();
+      if (&T == PtrForInsts->getType()) {
+        for (auto &I : Entry)
+          if (!isa<AllocaInst>(I)) {
+            auto *Load =
+                new LoadInst(Pointee->getType(), PtrForInsts, Twine(), &I);
+            LI = LoadsForCaller.insert(std::make_pair(Key, Load)).first;
+            break;
+          }
+      } else {
+        auto *OriginalLoad = getPtrLoadFor(F, *PtrForInsts->getType());
+        auto *Cast = new BitCastInst(OriginalLoad, &T, "",
+                                     &*std::next(OriginalLoad->getIterator()));
+        LI = LoadsForCaller.insert(std::make_pair(Key, Cast)).first;
+      }
+    }
+
+    assert(LI != LoadsForCaller.end() && "No load available/added");
+    return LI->second;
+  }
+
+  GlobalPtrAuthInfo PtrAuthInfo;
+  Constant *Pointee = nullptr;
+  GlobalVariable *PtrForInsts = nullptr;
+  std::map<std::pair<Function*, Type*>, Instruction*> LoadsForCaller;
+};
+
+Error makeStringError(const char *Msg, Value *V) {
+  std::string ErrString;
+  raw_string_ostream ErrStringStream(ErrString);
+  ErrStringStream << Msg << " '" << *V << "'";
+  return make_error<StringError>(ErrStringStream.str(),
+                                 inconvertibleErrorCode());
+}
+
+Value *createStructGEP(PerModuleUtils &MUtils, GlobalVariable &V,
+                       std::vector<uint64_t> Idxs) {
+  Idxs.push_back(0);
+  std::vector<Value *> GEPArgs;
+  GEPArgs.reserve(Idxs.size());
+  while (!Idxs.empty()) {
+    GEPArgs.push_back(ConstantInt::get(MUtils.Int32Ty, Idxs.back()));
+    Idxs.pop_back();
+  }
+  return MUtils.B->CreateGEP(V.getValueType(), &V, GEPArgs);
+}
+
+void processGlobalVariable(PerModuleUtils &MUtils, PerGlobalUtils &GUtils,
+                           GlobalVariable &V, std::vector<uint64_t> Idxs) {
+  auto &B = *MUtils.B;
+  Value *Discriminator =
+      const_cast<ConstantInt *>(GUtils.PtrAuthInfo.getDiscriminator());
+  Value *PtrLoc =
+      Idxs.empty() ? &V : createStructGEP(MUtils, V, std::move(Idxs));
+  Type *PtrType =
+      Idxs.empty() ? V.getType()
+                   : GetElementPtrInst::getIndexedType(V.getValueType(), Idxs);
+
+  if (GUtils.PtrAuthInfo.hasAddressDiversity())
+    Discriminator = B.CreateCall(
+        MUtils.BlendIntrinsic,
+        {B.CreatePointerCast(PtrLoc, MUtils.IntPtrTy), Discriminator});
+
+  Value *RawPtr = B.CreateLoad(PtrType, PtrLoc);
+  Value *SignedPtr = B.CreateCall(
+      MUtils.SignIntrinsic,
+      {B.CreatePointerCast(RawPtr, MUtils.IntPtrTy),
+       const_cast<ConstantInt *>(GUtils.PtrAuthInfo.getKey()), Discriminator});
+
+  B.CreateStore(B.CreateBitOrPointerCast(SignedPtr, PtrType), PtrLoc);
+}
+
+void processInstruction(PerModuleUtils &MUtils, PerGlobalUtils &GUtils, Use &U,
+                        std::vector<uint64_t> Idxs) {
+  assert(Idxs.empty() &&
+         "Accessing aggregate in instruction. Need a GEPExpr for this.");
+  Instruction *V = cast<Instruction>(U.getUser());
+  Function &F = *V->getParent()->getParent();
+  Type *UseType = U.get()->getType();
+
+  U.set(GUtils.getPtrLoadFor(F, *UseType));
+}
+
+Error processPtrAuthUsers(PerModuleUtils &MUtils, PerGlobalUtils &GUtils,
+                          Use &U, std::vector<uint64_t> Idxs = {}) {
+  Value *V = U.getUser();
+  assert(V != nullptr);
+
+  // Recurse through any casts.
+  if (isa<ConstantExpr>(V) && cast<ConstantExpr>(V)->isCast()) {
+    for (auto &U2 : V->uses())
+      if (auto Err = processPtrAuthUsers(MUtils, GUtils, U2, Idxs))
+        return Err;
+  } else if (isa<ConstantAggregate>(V)) {
+    Idxs.push_back(U.getOperandNo());
+    for (auto &U2 : V->uses())
+      if (auto Err = processPtrAuthUsers(MUtils, GUtils, U2, Idxs))
+        return Err;
+  } else if (isa<GlobalVariable>(V)) {
+    processGlobalVariable(MUtils, GUtils, cast<GlobalVariable>(*V), Idxs);
+  } else if (isa<Instruction>(V)) {
+    processInstruction(MUtils, GUtils, U, Idxs);
+  } else if (isa<ConstantExpr>(V)) {
+    auto *VExpr = cast<ConstantExpr>(V);
+    if (isa<GEPOperator>(VExpr)) {
+      // We only support constant GEPs introduced when folding pointer casts.
+      Type *VExprType = VExpr->getType();
+
+      // Check that the types line up for a pointer cast.
+      if (VExprType !=
+          PointerType::get(GUtils.PtrAuthInfo.getPointer()->getType(), 0))
+        return makeStringError("Type mismatch while rewriting ptrauth use", V);
+
+      // Check that all indexes are constant zero.
+      for (auto &Op :
+           make_range(std::next(VExpr->op_begin()), VExpr->op_end())) {
+        if (!isa<ConstantInt>(Op))
+          return makeStringError(
+              "Cannot rewrite ptrauth use with non-constant indexes", Op);
+        if (!cast<ConstantInt>(Op)->isZero())
+          return makeStringError(
+              "Cannot rewrite ptrauth use with non-zero indexes", Op);
+      }
+
+      for (auto &U2 : VExpr->uses()) {
+        if (auto Err = processPtrAuthUsers(MUtils, GUtils, U2, Idxs))
+          return Err;
+      }
+    }
+  } else
+    return makeStringError("Unable to rewrite ptrauth use", V);
+
+  return Error::success();
+}
+
+static Error
+HandleLLVMPtrauthSection(llvm::Module &M,
+                         lldb_private::ExecutionPolicy execution_policy) {
+  std::vector<GlobalVariable *> PtrAuthVarsToDelete;
+  PerModuleUtils MUtils(M);
+
+  for (auto &G : M.globals()) {
+    if (G.getSection() != "llvm.ptrauth")
+      continue;
+
+    PtrAuthVarsToDelete.push_back(&G);
+
+    // If this ptrauth global is unused, skip it. The fixup pass could end up
+    // introducing a real use of it otherwise.
+    G.removeDeadConstantUsers();
+    if (G.getNumUses() == 0)
+      continue;
+
+    auto PtrAuthInfo = GlobalPtrAuthInfo::tryAnalyze(&G);
+    if (!PtrAuthInfo)
+      return PtrAuthInfo.takeError();
+
+    PerGlobalUtils GUtils(std::move(*PtrAuthInfo));
+    for (auto &U : G.uses())
+      if (auto Err = processPtrAuthUsers(MUtils, GUtils, U))
+        return Err;
+
+    // Replace all uses of the ptrauth global with the uses of the non-auth
+    // global.
+    G.replaceAllUsesWith(
+        ConstantExpr::getPointerCast(GUtils.Pointee, G.getType()));
+  }
+
+  for (auto *G : PtrAuthVarsToDelete) {
+    assert(G && G->user_empty() &&
+           "All references to G should have been dropped");
+    G->eraseFromParent();
+  }
+
+  // If we never wrote any fixup code, erase the fixup function and bail.
+  if (MUtils.FixupFunction->getEntryBlock().empty()) {
+    MUtils.FixupFunction->eraseFromParent();
+    return Error::success();
+  }
+
+  // Close off the function.
+  MUtils.B->CreateRetVoid();
+
+  // Update the global ctor list to call the pointer fixup function first.
+  auto *UInt8PtrTy =
+      PointerType::getUnqual(llvm::Type::getInt8Ty(M.getContext()));
+  StructType *CtorType = StructType::get(
+      M.getContext(),
+      {MUtils.Int32Ty, MUtils.FixupFunction->getType(), UInt8PtrTy});
+  Constant *PtrFixupCtor = ConstantStruct::get(
+      CtorType, {ConstantInt::get(MUtils.Int32Ty, 0), MUtils.FixupFunction,
+                 Constant::getNullValue(UInt8PtrTy)});
+
+  const char *LLVMGlobalCtorsName = "llvm.global_ctors";
+  GlobalVariable *OldCtorList = M.getNamedGlobal(LLVMGlobalCtorsName);
+  std::vector<Constant *> CtorListArgs;
+  CtorListArgs.push_back(PtrFixupCtor);
+
+  if (OldCtorList) {
+    // If the old ctor list has any uses then bail out. Don't know how to
+    // rewrite them.
+    if (OldCtorList->getNumUses() != 0)
+      return makeStringError("Global ctors variable has users, so can not be "
+                             "rewritten to include pointer fixups: ",
+                             OldCtorList);
+
+    for (auto &Op : OldCtorList->getInitializer()->operands())
+      CtorListArgs.push_back(cast<Constant>(Op.get()));
+  }
+
+  ArrayType *CtorListType = ArrayType::get(CtorType, CtorListArgs.size());
+  Constant *CtorListInit = ConstantArray::get(CtorListType, CtorListArgs);
+
+  GlobalVariable *NewCtorList = new GlobalVariable(
+      M, CtorListType, false, GlobalValue::AppendingLinkage, CtorListInit);
+
+  if (OldCtorList) {
+    NewCtorList->takeName(OldCtorList);
+    OldCtorList->eraseFromParent();
+  } else
+    NewCtorList->setName(LLVMGlobalCtorsName);
+
+  return Error::success();
+}
+} // namespace
+
 namespace lldb_private {
 
 Error InjectPointerSigningFixupCode(llvm::Module &M,
@@ -122,6 +393,21 @@ Error InjectPointerSigningFixupCode(llvm::Module &M,
   // Bail out if we don't need pointer signing fixups.
   if (!T.isArm64e())
     return Error::success();
+
+  // There is an older style of ptrauth support where there is a dedicated
+  // global wrapper section called "llvm.ptrauth". If that is in use, we can
+  // expect ConstantPointerAuth to not be involved. Detect that here and switch
+  // implementations as needed. This should go away "eventually".
+  bool ptrauth_section_found = false;
+  for (auto &G : M.globals()) {
+    if (G.getSection() == "llvm.ptrauth") {
+      ptrauth_section_found = true;
+      break;
+    }
+  }
+
+  if (ptrauth_section_found)
+    return HandleLLVMPtrauthSection(M, execution_policy);
 
   // Collect all ConstantPtrAuth expressions in global initializers.
   SmallVector<GlobalInitPtrAuthFixup> GlobalInitFixups;


### PR DESCRIPTION
This is still the default way clang emits pointer authenticated globals downstream. The number of tests that crash go from 45 to 6 after this change.