### PR TITLE
[llvm][cas] Remove unused function getDefaultOnDiskActionCachePath NFC

### DIFF
--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -154,10 +154,6 @@ private:
 /// Create an action cache in memory.
 LLVM_ABI std::unique_ptr<ActionCache> createInMemoryActionCache();
 
-/// Get a reasonable default on-disk path for a persistent ActionCache for the
-/// current user.
-std::string getDefaultOnDiskActionCachePath();
-
 /// Create an action cache on disk.
 LLVM_ABI Expected<std::unique_ptr<ActionCache>>
 createOnDiskActionCache(StringRef Path);

--- a/llvm/lib/CAS/ActionCaches.cpp
+++ b/llvm/lib/CAS/ActionCaches.cpp
@@ -19,8 +19,6 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/BLAKE3.h"
 #include "llvm/Support/Compiler.h"
-#include "llvm/Support/Errc.h"
-#include "llvm/Support/Path.h"
 
 #define DEBUG_TYPE "cas-action-caches"
 
@@ -141,17 +139,7 @@ Error InMemoryActionCache::putImpl(ArrayRef<uint8_t> Key, const CASID &Result,
                                         Observed.getValue());
 }
 
-static constexpr StringLiteral DefaultName = "actioncache";
-
 namespace llvm::cas {
-
-std::string getDefaultOnDiskActionCachePath() {
-  SmallString<128> Path;
-  if (!llvm::sys::path::cache_directory(Path))
-    report_fatal_error("cannot get default cache directory");
-  llvm::sys::path::append(Path, builtin::DefaultDir, DefaultName);
-  return Path.str().str();
-}
 
 std::unique_ptr<ActionCache> createInMemoryActionCache() {
   return std::make_unique<InMemoryActionCache>();


### PR DESCRIPTION
This code is unused since 1c6265b2521ea7 where we started preferring the unified on-disk form. Remove the dead code.