### PR TITLE
[clang][cas] Fix some invalid cantFail/report_fatal_error uses

### DIFF
--- a/clang/include/clang/Frontend/CompileJobCacheResult.h
+++ b/clang/include/clang/Frontend/CompileJobCacheResult.h
@@ -104,7 +104,8 @@ class CompileJobResultSchema
 public:
   static char ID;
 
-  CompileJobResultSchema(ObjectStore &CAS);
+  /// Create a CompileJobResultSchema.
+  static Expected<CompileJobResultSchema> create(ObjectStore &CAS);
 
   /// Attempt to load \p Ref as a \c CompileJobCacheResult if it matches the
   /// schema.
@@ -115,6 +116,9 @@ public:
 
   /// Get this schema's marker node.
   ObjectRef getKindRef() const { return KindRef; }
+
+private:
+  CompileJobResultSchema(ObjectStore &CAS, ObjectRef KindRef);
 
 private:
   ObjectRef KindRef;

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -774,8 +774,10 @@ Expected<bool> ObjectStoreCachingOutputs::replayCachedResult(
     return false;
 
   std::optional<clang::cas::CompileJobCacheResult> Result;
-  clang::cas::CompileJobResultSchema Schema(*CAS);
-  if (Error E = Schema.load(ResultID).moveInto(Result))
+  auto Schema = clang::cas::CompileJobResultSchema::create(*CAS);
+  if (!Schema)
+    return Schema.takeError();
+  if (Error E = Schema->load(ResultID).moveInto(Result))
     return std::move(E);
 
   return replayCachedResult(ResultCacheKey, *Result, JustComputedResult);

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -18,15 +18,24 @@
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/StringSaver.h"
 #include "llvm/Support/raw_ostream.h"
+#include <optional>
 
 using namespace clang;
 using namespace clang::cas;
 using namespace llvm;
 using namespace llvm::cas;
 
-static llvm::cas::CASID createCompileJobCacheKeyForArgs(
-    ObjectStore &CAS, ArrayRef<const char *> CC1Args, ObjectRef InputRef,
-    CachingInputKind InputKind) {
+template <typename R>
+static std::optional<R> checkStore(DiagnosticsEngine &Diags, Expected<R> Ref) {
+  if (Ref)
+    return *Ref;
+  Diags.Report(diag::err_cas_store) << Ref.takeError();
+  return std::nullopt;
+}
+
+static std::optional<llvm::cas::CASID> createCompileJobCacheKeyForArgs(
+    ObjectStore &CAS, DiagnosticsEngine &Diags, ArrayRef<const char *> CC1Args,
+    ObjectRef InputRef, CachingInputKind InputKind) {
   assert(!CC1Args.empty() && StringRef(CC1Args[0]) == "-cc1");
   SmallString<256> CommandLine;
   for (StringRef Arg : CC1Args) {
@@ -46,15 +55,27 @@ static llvm::cas::CASID createCompileJobCacheKeyForArgs(
     Builder.add("object", InputRef);
     break;
   }
-  Builder.add("command-line",
-              llvm::cantFail(CAS.storeFromString({}, CommandLine)));
-  Builder.add("computation", llvm::cantFail(CAS.storeFromString({}, "-cc1")));
 
+  auto CommandLineRef = checkStore(Diags, CAS.storeFromString({}, CommandLine));
+  if (!CommandLineRef)
+    return std::nullopt;
+  auto CC1Ref = checkStore(Diags, CAS.storeFromString({}, "-cc1"));
+  if (!CC1Ref)
+    return std::nullopt;
+  auto VersionRef =
+      checkStore(Diags, CAS.storeFromString({}, getClangFullVersion()));
+  if (!VersionRef)
+    return std::nullopt;
+
+  Builder.add("command-line", *CommandLineRef);
+  Builder.add("computation", *CC1Ref);
   // FIXME: The version is maybe insufficient...
-  Builder.add("version",
-              llvm::cantFail(CAS.storeFromString({}, getClangFullVersion())));
+  Builder.add("version", *VersionRef);
 
-  return llvm::cantFail(Builder.build()).getID();
+  auto Result = checkStore(Diags, Builder.build());
+  if (!Result)
+    return std::nullopt;
+  return Result->getID();
 }
 
 static void canonicalizeForCacheKey(FrontendOptions &FrontendOpts,
@@ -168,7 +189,8 @@ createCompileJobCacheKeyImpl(ObjectStore &CAS, DiagnosticsEngine &Diags,
     return std::nullopt;
   }
 
-  return createCompileJobCacheKeyForArgs(CAS, Argv, *InputRef, InputKind);
+  return createCompileJobCacheKeyForArgs(CAS, Diags, Argv, *InputRef,
+                                         InputKind);
 }
 
 static CompileJobCachingOptions

--- a/clang/lib/Frontend/CompileJobCacheResult.cpp
+++ b/clang/lib/Frontend/CompileJobCacheResult.cpp
@@ -154,12 +154,15 @@ Error CompileJobCacheResult::Builder::addOutput(StringRef Path,
 }
 
 Expected<ObjectRef> CompileJobCacheResult::Builder::build(ObjectStore &CAS) {
-  CompileJobResultSchema Schema(CAS);
+  auto Schema = CompileJobResultSchema::create(CAS);
+  if (!Schema)
+    return Schema.takeError();
+
   // The resulting Refs contents are:
   // Object 0...N, SchemaKind
   SmallVector<ObjectRef> Refs;
   std::swap(Impl.Objects, Refs);
-  Refs.push_back(Schema.getKindRef());
+  Refs.push_back(Schema->getKindRef());
   return CAS.store(Refs, {(char *)Impl.Kinds.begin(), Impl.Kinds.size()});
 }
 
@@ -168,10 +171,17 @@ static constexpr llvm::StringLiteral CompileJobResultSchemaName =
 
 char CompileJobResultSchema::ID = 0;
 
-CompileJobResultSchema::CompileJobResultSchema(ObjectStore &CAS)
+Expected<CompileJobResultSchema>
+CompileJobResultSchema::create(ObjectStore &CAS) {
+  auto Ref = CAS.storeFromString({}, CompileJobResultSchemaName);
+  if (!Ref)
+    return Ref.takeError();
+  return CompileJobResultSchema(CAS, *Ref);
+}
+
+CompileJobResultSchema::CompileJobResultSchema(ObjectStore &CAS, ObjectRef Ref)
     : CompileJobResultSchema::RTTIExtends(CAS),
-      KindRef(
-          llvm::cantFail(CAS.storeFromString({}, CompileJobResultSchemaName))) {
+      KindRef(Ref) {
 }
 
 Expected<CompileJobCacheResult>

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -2793,8 +2793,11 @@ static bool addCachedModuleFileToInMemoryCacheFromKey(
   }
   auto Output =
       Result->getOutput(cas::CompileJobCacheResult::OutputKind::MainOutput);
-  if (!Output)
-    llvm::report_fatal_error("missing main output");
+  if (!Output) {
+    Diags.Report(diag::err_cas_unloadable_module)
+        << Path << 1 << CacheKey << "cached module missing main output";
+    return true;
+  }
 
   return addCachedModuleFileToInMemoryCache(Path, CAS, Output->Object, ModCache,
                                             Diags);

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1089,8 +1089,10 @@ void CompilerInstance::initializeDelayedInputFileFromCAS() {
     if (!ValueRef)
       return reportError(llvm::cas::ObjectStore::createUnknownObjectError(*ID));
 
-    cas::CompileJobResultSchema Schema(CAS);
-    auto Result = Schema.load(*ValueRef);
+    auto Schema = cas::CompileJobResultSchema::create(CAS);
+    if (!Schema)
+      return reportError(Schema.takeError());
+    auto Result = Schema->load(*ValueRef);
     if (!Result)
       return reportError(Result.takeError());
     auto Output =
@@ -2778,8 +2780,13 @@ static bool addCachedModuleFileToInMemoryCacheFromKey(
   }
 
   std::optional<cas::CompileJobCacheResult> Result;
-  cas::CompileJobResultSchema Schema(CAS);
-  if (llvm::Error E = Schema.load(*ValueRef).moveInto(Result)) {
+  auto Schema = cas::CompileJobResultSchema::create(CAS);
+  if (!Schema) {
+    Diags.Report(diag::err_cas_unloadable_module)
+        << Path << 1 << CacheKey << Schema.takeError();
+    return true;
+  }
+  if (llvm::Error E = Schema->load(*ValueRef).moveInto(Result)) {
     Diags.Report(diag::err_cas_unloadable_module)
         << Path << 1 << CacheKey << std::move(E);
     return true;

--- a/clang/test/CAS/module-file-cache-key-errors.c
+++ b/clang/test/CAS/module-file-cache-key-errors.c
@@ -1,0 +1,34 @@
+// Exercises error paths when -fmodule-file-cache-key resolves to a malformed
+// compile-job result object.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: touch %t/tu.c
+
+// RUN: echo -n "llvm::cas::schema::compile_job_result::v1" > %t/schema-name
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/schema-name > %t/schema-id
+
+// Build a "result" that has the right KindRef but no outputs.
+// RUN: touch %t/empty
+// RUN: llvm-cas --cas %t/cas --make-node --data %t/empty @%t/schema-id > %t/result-empty-id
+
+// Build an invalid result (no KindRef).
+// RUN: echo "not-a-result" > %t/garbage
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/garbage > %t/result-garbage-id
+
+// Create cache keys pointing to the results.
+// RUN: echo "k1" > %t/key1-data
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/key1-data > %t/key1-id
+// RUN: echo "k2" > %t/key2-data
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/key2-data > %t/key2-id
+// RUN: llvm-cas --cas %t/cas --put-cache-key @%t/key1-id @%t/result-empty-id
+// RUN: llvm-cas --cas %t/cas --put-cache-key @%t/key2-id @%t/result-garbage-id
+
+// RUN: not %clang_cc1 -fcas-path %t/cas -fsyntax-only -fmodule-file-cache-key fake.pcm @%t/key1-id %t/tu.c 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=EMPTY
+// EMPTY: error: module file 'fake.pcm' not found: unloadable module cache key llvmcas://{{[[:xdigit:]]+}}: cached module missing main output
+
+// RUN: not %clang_cc1 -fcas-path %t/cas -fsyntax-only -fmodule-file-cache-key fake.pcm @%t/key2-id %t/tu.c 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=BOGUS
+// BOGUS: error: module file 'fake.pcm' not found: unloadable module cache key llvmcas://{{[[:xdigit:]]+}}: not a compile job result

--- a/clang/tools/libclang/CCAS.cpp
+++ b/clang/tools/libclang/CCAS.cpp
@@ -90,8 +90,10 @@ CXCASCachedCompilation WrappedCachedCompilation::fromResultID(
   if (!OptResultRef)
     return nullptr;
 
-  clang::cas::CompileJobResultSchema Schema(*CAS);
-  auto CachedResult = Schema.load(*OptResultRef);
+  auto Schema = clang::cas::CompileJobResultSchema::create(*CAS);
+  if (!Schema)
+    return failure(Schema.takeError());
+  auto CachedResult = Schema->load(*OptResultRef);
   if (!CachedResult)
     return failure(CachedResult.takeError());
   return wrap(new WrappedCachedCompilation{std::move(CacheKey),

--- a/clang/unittests/Frontend/CMakeLists.txt
+++ b/clang/unittests/Frontend/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_clang_unittest(FrontendTests
   ASTUnitTest.cpp
+  CompileJobCacheKeyTest.cpp
   CompileJobCacheResultTest.cpp
   CompilerInvocationTest.cpp
   CompilerInstanceTest.cpp

--- a/clang/unittests/Frontend/CompileJobCacheKeyTest.cpp
+++ b/clang/unittests/Frontend/CompileJobCacheKeyTest.cpp
@@ -1,0 +1,63 @@
+//===- unittests/Frontend/CompileJobCacheKeyTest.cpp ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/CompileJobCacheKey.h"
+#include "FaultingCAS.h"
+#include "clang/Basic/DiagnosticOptions.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/CompilerInvocation.h"
+#include "clang/Frontend/TextDiagnosticBuffer.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+using namespace llvm::cas;
+
+namespace {
+struct CompileJobCacheKeyStoreFailureTest
+    : public ::testing::TestWithParam<unsigned> {};
+} // end anonymous namespace
+
+TEST_P(CompileJobCacheKeyStoreFailureTest, EmitsDiagAndReturnsNullopt) {
+  auto Inner = createInMemoryCAS();
+  // Create the fake input file.
+  ObjectRef InputRef = llvm::cantFail(Inner->storeFromString({}, "input"));
+  std::string InputCASID = Inner->getID(InputRef).toString();
+
+  // Inject an error at the store indexed by the test param.
+  FaultingCAS CAS(std::move(Inner), GetParam());
+
+  DiagnosticOptions DiagOpts;
+  auto *DiagBuffer = new TextDiagnosticBuffer();
+  llvm::IntrusiveRefCntPtr<DiagnosticsEngine> Diags =
+      CompilerInstance::createDiagnostics(*llvm::vfs::getRealFileSystem(),
+                                          DiagOpts, DiagBuffer);
+
+  CompilerInvocation Invocation;
+  ASSERT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, {}, *Diags));
+  Invocation.getFrontendOpts().CASInputFileCASID = InputCASID;
+
+  auto Key = createCompileJobCacheKey(CAS, *Diags, Invocation);
+  EXPECT_FALSE(Key.has_value());
+
+  EXPECT_EQ(DiagBuffer->getNumErrors(), 1u);
+  if (DiagBuffer->getNumErrors())
+    EXPECT_THAT(DiagBuffer->err_begin()->second,
+                ::testing::HasSubstr("failed to store to CAS"));
+}
+
+// There are 5 store calls along the success path of createCompileJobCacheKey
+// when CASInputFileCASID is used (command-line, "-cc1", version, schema
+// kind-ref inside Builder::build, and the final NamedValues object). Injecting
+// a failure at any of them must produce an err_cas_store diagnostic instead of
+// the previous cantFail crash.
+INSTANTIATE_TEST_SUITE_P(AllStoreCalls, CompileJobCacheKeyStoreFailureTest,
+                         ::testing::Range(0u, 5u));

--- a/clang/unittests/Frontend/CompileJobCacheResultTest.cpp
+++ b/clang/unittests/Frontend/CompileJobCacheResultTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Frontend/CompileJobCacheResult.h"
+#include "FaultingCAS.h"
 #include "llvm/Testing/Support/Error.h"
 
 #include "gmock/gmock.h"
@@ -35,8 +36,9 @@ TEST(CompileJobCacheResultTest, Empty) {
   ASSERT_THAT_ERROR(B.build(*CAS).moveInto(Result), Succeeded());
 
   std::optional<CompileJobCacheResult> Proxy;
-  CompileJobResultSchema Schema(*CAS);
-  ASSERT_THAT_ERROR(Schema.load(*Result).moveInto(Proxy), Succeeded());
+  auto Schema = CompileJobResultSchema::create(*CAS);
+  ASSERT_THAT_ERROR(Schema.takeError(), Succeeded());
+  ASSERT_THAT_ERROR(Schema->load(*Result).moveInto(Proxy), Succeeded());
 
   EXPECT_EQ(Proxy->getNumOutputs(), 0u);
 }
@@ -60,8 +62,9 @@ TEST(CompileJobCacheResultTest, AddOutputs) {
   ASSERT_THAT_ERROR(B.build(*CAS).moveInto(Result), Succeeded());
 
   std::optional<CompileJobCacheResult> Proxy;
-  CompileJobResultSchema Schema(*CAS);
-  ASSERT_THAT_ERROR(Schema.load(*Result).moveInto(Proxy), Succeeded());
+  auto Schema = CompileJobResultSchema::create(*CAS);
+  ASSERT_THAT_ERROR(Schema.takeError(), Succeeded());
+  ASSERT_THAT_ERROR(Schema->load(*Result).moveInto(Proxy), Succeeded());
 
   EXPECT_EQ(Proxy->getNumOutputs(), 2u);
   auto Actual = getAllOutputs(*Proxy);
@@ -93,11 +96,31 @@ TEST(CompileJobCacheResultTest, AddKindMap) {
   ASSERT_THAT_ERROR(B.build(*CAS).moveInto(Result), Succeeded());
 
   std::optional<CompileJobCacheResult> Proxy;
-  CompileJobResultSchema Schema(*CAS);
-  ASSERT_THAT_ERROR(Schema.load(*Result).moveInto(Proxy), Succeeded());
+  auto Schema = CompileJobResultSchema::create(*CAS);
+  ASSERT_THAT_ERROR(Schema.takeError(), Succeeded());
+  ASSERT_THAT_ERROR(Schema->load(*Result).moveInto(Proxy), Succeeded());
 
   EXPECT_EQ(Proxy->getNumOutputs(), 2u);
   auto Actual = getAllOutputs(*Proxy);
 
   EXPECT_EQ(Actual, Expected);
+}
+
+TEST(CompileJobCacheResultTest, SchemaCreateStoreFailure) {
+  FaultingCAS CAS(createInMemoryCAS(), /*FailStoreAtCall=*/0);
+
+  auto Schema = CompileJobResultSchema::create(CAS);
+  EXPECT_THAT_ERROR(Schema.takeError(),
+                    llvm::FailedWithMessage("injected store error"));
+}
+
+TEST(CompileJobCacheResultTest, BuilderBuildStoreFailure) {
+  // There are 2 stores
+  for (unsigned I = 0; I < 2; ++I) {
+    FaultingCAS CAS(createInMemoryCAS(), /*FailStoreAtCall=*/I);
+    CompileJobCacheResult::Builder B;
+    std::optional<ObjectRef> Result;
+    EXPECT_THAT_ERROR(B.build(CAS).moveInto(Result),
+                      llvm::FailedWithMessage("injected store error"));
+  }
 }

--- a/clang/unittests/Frontend/FaultingCAS.h
+++ b/clang/unittests/Frontend/FaultingCAS.h
@@ -1,0 +1,91 @@
+//===- FaultingCAS.h - Test helper that injects CAS failures ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_UNITTESTS_FRONTEND_FAULTINGCAS_H
+#define CLANG_UNITTESTS_FRONTEND_FAULTINGCAS_H
+
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace clang {
+
+/// Test wrapper that delegates to an inner CAS but can inject an error on the
+/// N-th call to \c store(). All other mutation/query operations are passed
+/// through unchanged. The handle-based read hooks are intentionally not
+/// implemented: tests that drive this wrapper short-circuit on the injected
+/// store failure before any object is read.
+class FaultingCAS : public llvm::cas::ObjectStore {
+public:
+  FaultingCAS(std::unique_ptr<llvm::cas::ObjectStore> Inner,
+              unsigned FailStoreAtCall)
+      : ObjectStore(Inner->getContext()), Inner(std::move(Inner)),
+        FailStoreAtCall(FailStoreAtCall) {}
+
+  unsigned getStoreCallCount() const { return StoreCallCount; }
+
+  llvm::Expected<llvm::cas::CASID> parseID(llvm::StringRef ID) override {
+    return Inner->parseID(ID);
+  }
+  llvm::Expected<llvm::cas::ObjectRef>
+  store(llvm::ArrayRef<llvm::cas::ObjectRef> Refs,
+        llvm::ArrayRef<char> Data) override {
+    if (StoreCallCount++ == FailStoreAtCall)
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "injected store error");
+    return Inner->store(Refs, Data);
+  }
+  llvm::cas::CASID getID(llvm::cas::ObjectRef Ref) const override {
+    return Inner->getID(Ref);
+  }
+  std::optional<llvm::cas::ObjectRef>
+  getReference(const llvm::cas::CASID &ID) const override {
+    return Inner->getReference(ID);
+  }
+  llvm::Expected<bool> isMaterialized(llvm::cas::ObjectRef Ref) const override {
+    return Inner->isMaterialized(Ref);
+  }
+  llvm::Error validateObject(const llvm::cas::CASID &ID) override {
+    return Inner->validateObject(ID);
+  }
+  llvm::Error validate(bool CheckHash) const override {
+    return Inner->validate(CheckHash);
+  }
+
+protected:
+  llvm::Expected<std::optional<llvm::cas::ObjectHandle>>
+  loadIfExists(llvm::cas::ObjectRef) override {
+    llvm::report_fatal_error("FaultingCAS: loadIfExists not implemented");
+  }
+  uint64_t getDataSize(llvm::cas::ObjectHandle) const override {
+    llvm::report_fatal_error("FaultingCAS: getDataSize not implemented");
+  }
+  llvm::Error forEachRef(
+      llvm::cas::ObjectHandle,
+      llvm::function_ref<llvm::Error(llvm::cas::ObjectRef)>) const override {
+    llvm::report_fatal_error("FaultingCAS: forEachRef not implemented");
+  }
+  llvm::cas::ObjectRef readRef(llvm::cas::ObjectHandle,
+                               size_t) const override {
+    llvm::report_fatal_error("FaultingCAS: readRef not implemented");
+  }
+  size_t getNumRefs(llvm::cas::ObjectHandle) const override {
+    llvm::report_fatal_error("FaultingCAS: getNumRefs not implemented");
+  }
+  llvm::ArrayRef<char> getData(llvm::cas::ObjectHandle, bool) const override {
+    llvm::report_fatal_error("FaultingCAS: getData not implemented");
+  }
+
+private:
+  std::unique_ptr<llvm::cas::ObjectStore> Inner;
+  unsigned StoreCallCount = 0;
+  unsigned FailStoreAtCall;
+};
+
+} // namespace clang
+
+#endif


### PR DESCRIPTION
Fixes some invalid uses of `cantFail` and `report_fatal_error` that depend on CAS store not failing or CAS inputs being well-formed. Instead, emit diagnostics and add test cases that exercise them by injecting errors or invalid data. 