### PR TITLE
LLDB: Swift ELF metadata extraction update

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -148,6 +148,51 @@ LLDBMemoryReader::getSymbolAddress(const std::string &name) {
       load_addr, swift::remote::RemoteAddress::DefaultAddressSpace);
 }
 
+swift::remote::RemoteAddress
+LLDBMemoryReader::getSymbolAddress(swift::remote::RemoteAddress image_start,
+                                   const std::string &name) {
+  if (name.empty())
+    return swift::remote::RemoteAddress();
+  Log *log = GetLog(LLDBLog::Types);
+
+  Target &target = m_process.GetTarget();
+  Address image_addr;
+  if (!target.ResolveLoadAddress(image_start.getRawAddress(), image_addr)) {
+    LLDB_LOG(log, "[MemoryReader] could not resolve image start {0:x} for {1}",
+             image_start.getRawAddress(), name);
+    return swift::remote::RemoteAddress();
+  }
+
+  ModuleSP module_sp = image_addr.GetModule();
+  if (!module_sp) {
+    LLDB_LOG(log, "[MemoryReader] no module at image start {0:x} for {1}",
+             image_start.getRawAddress(), name);
+    return swift::remote::RemoteAddress();
+  }
+
+  ConstString name_cs(name.c_str(), name.size());
+  SymbolContextList sc_list;
+  module_sp->FindSymbolsWithNameAndType(name_cs, lldb::eSymbolTypeAny, sc_list);
+
+  SymbolContext sym_ctx;
+  for (size_t idx = 0, e = sc_list.GetSize(); idx < e; ++idx) {
+    if (!sc_list.GetContextAtIndex(idx, sym_ctx) || !sym_ctx.symbol)
+      continue;
+    if (sym_ctx.symbol->GetType() == lldb::eSymbolTypeUndefined)
+      continue;
+    auto load_addr = sym_ctx.symbol->GetLoadAddress(&target);
+    if (load_addr == LLDB_INVALID_ADDRESS)
+      continue;
+    LLDB_LOGV(log, "[MemoryReader] {0} resolved to {1:x} within image", name,
+              load_addr);
+    return swift::remote::RemoteAddress(
+        load_addr, swift::remote::RemoteAddress::DefaultAddressSpace);
+  }
+  LLDB_LOG(log, "[MemoryReader] symbol resolution failed for {0} in image",
+           name);
+  return swift::remote::RemoteAddress();
+}
+
 std::unique_ptr<swift::SwiftObjectFileFormat>
 GetSwiftObjectFileFormat(llvm::Triple::ObjectFormatType obj_format_type) {
   std::unique_ptr<swift::SwiftObjectFileFormat> obj_file_format;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -79,6 +79,10 @@ public:
   swift::remote::RemoteAddress
   getSymbolAddress(const std::string &name) override;
 
+  swift::remote::RemoteAddress
+  getSymbolAddress(swift::remote::RemoteAddress image_start,
+                   const std::string &name) override;
+
   std::optional<swift::remote::RemoteAbsolutePointer>
   resolvePointerAsSymbol(swift::remote::RemoteAddress address) override;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -132,16 +132,6 @@ public:
     return id;
   }
 
-  std::optional<uint32_t> ReadELF(
-      swift::remote::RemoteAddress ImageStart,
-      std::optional<llvm::sys::MemoryBlock> FileBuffer,
-      llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) override {
-    auto id = m_reflection_ctx.readELF(ImageStart, FileBuffer,
-                                    likely_module_names);
-    m_forwader.SetImageAdded(id.has_value());
-    return id;
-  }
-
   llvm::Expected<const swift::reflection::TypeRef &>
   GetTypeRef(StringRef mangled_type_name) override {
     swift::Demangle::Demangler dem;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -80,10 +80,6 @@ public:
   virtual std::optional<uint32_t>
   AddImage(swift::remote::RemoteAddress image_start,
            llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
-  virtual std::optional<uint32_t>
-  ReadELF(swift::remote::RemoteAddress ImageStart,
-          std::optional<llvm::sys::MemoryBlock> FileBuffer,
-          llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
   virtual llvm::Expected<const swift::reflection::TypeRef &>
   GetTypeRef(llvm::StringRef mangled_type_name) = 0;
   virtual llvm::Expected<const swift::reflection::TypeRef &>

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -804,20 +804,7 @@ bool SwiftLanguageRuntime::AddModuleToReflectionContext(
       GetMemoryReader()->readMetadataFromFileCacheEnabled();
 
   std::optional<uint32_t> info_id;
-  // When dealing with ELF, we need to pass in the contents of the on-disk
-  // file, since the Section Header Table is not present in the child process
-  if (obj_file->GetPluginName() == "elf") {
-    DataExtractorSP extractor_sp;
-    auto size = obj_file->GetData(0, obj_file->GetByteSize(), extractor_sp);
-    const uint8_t *file_data = extractor_sp->GetDataStart();
-    llvm::sys::MemoryBlock file_buffer((void *)file_data, size);
-    info_id = m_reflection_ctx->ReadELF(
-        swift::remote::RemoteAddress(
-            load_ptr, swift::remote::RemoteAddress::DefaultAddressSpace),
-        std::optional<llvm::sys::MemoryBlock>(file_buffer),
-        likely_module_names);
-  } else if (read_from_file_cache &&
-             obj_file->GetPluginName() == "mach-o") {
+  if (read_from_file_cache && obj_file->GetPluginName() == "mach-o") {
     info_id = AddObjectFileToReflectionContext(module_sp, likely_module_names);
     if (!info_id)
       info_id = m_reflection_ctx->AddImage(


### PR DESCRIPTION
New machinery in Swift reflection data no longer uses the section header table to find the start/stop pointers, but instead accesses it through a special symbol that points to a table of section start/stop pointers.

This means that LLDB no longer needs to open and pass in the file object and doesn't need to special-case ELF.

This patch implements the `getSymbolAddress(swift::remote::RemoteAddress image_start, const std::string &name)` API for extracting the address of a symbol in a specific image.

It also drops the special-case ELF code.

This is paired with https://github.com/swiftlang/swift/pull/87285, which re-works how Swift ReflectionContext extracts the metadata.