### PR TITLE
[libclang][DependencyScanning] Set the correct DependencyScannerServiceOptions member for async scanning

### DIFF
--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -162,7 +162,7 @@ void clang_experimental_DependencyScannerServiceOptions_setCacheNegativeStats(
 
 void clang_experimental_DependencyScannerServiceOptions_setAsyncScanModules(
     CXDependencyScannerServiceOptions Opts, bool AsyncScanModules) {
-  unwrap(Opts)->CacheNegativeStats = AsyncScanModules;
+  unwrap(Opts)->AsyncScanModules = AsyncScanModules;
 }
 
 CXDependencyScannerService


### PR DESCRIPTION
https://github.com/swiftlang/llvm-project/pull/12406 added APIs to configure async scanning, and had a typo in it. This PR fixes the typo so we are setting the correct option. 