### PR TITLE
[lldb] Fix synthetic formatter for Swift array of ObjC elements

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -96,8 +96,7 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
   if (opt_size)
     m_element_size = *opt_size;
   auto opt_stride = elem_type.GetByteStride(process_sp.get());
-  if (opt_stride)
-    m_element_stride = *opt_stride;
+  m_element_stride = opt_stride.value_or(m_element_size);
   size_t ptr_size = process_sp->GetAddressByteSize();
   Status error;
   lldb::addr_t next_read = native_ptr;

--- a/lldb/test/API/lang/swift/swift_array_of_objc_items/Builder.swift
+++ b/lldb/test/API/lang/swift/swift_array_of_objc_items/Builder.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc(Builder) public class Builder: NSObject {
+    @objc public class func makeArray() -> [Item] {
+        return [Item(name: "hello"), Item(name: "world")]
+    }
+}

--- a/lldb/test/API/lang/swift/swift_array_of_objc_items/Item.h
+++ b/lldb/test/API/lang/swift/swift_array_of_objc_items/Item.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+@interface Item : NSObject
+@property (nonatomic, readonly) NSString *name;
+- (instancetype)initWithName:(NSString *)name;
+@end

--- a/lldb/test/API/lang/swift/swift_array_of_objc_items/Item.m
+++ b/lldb/test/API/lang/swift/swift_array_of_objc_items/Item.m
@@ -1,0 +1,9 @@
+#import "Item.h"
+
+@implementation Item
+- (instancetype)initWithName:(NSString *)name {
+  if (self = [super init])
+    _name = [name copy];
+  return self;
+}
+@end

--- a/lldb/test/API/lang/swift/swift_array_of_objc_items/Makefile
+++ b/lldb/test/API/lang/swift/swift_array_of_objc_items/Makefile
@@ -1,0 +1,7 @@
+OBJC_SOURCES := main.m Item.m
+SWIFT_SOURCES := Builder.swift
+SWIFT_BRIDGING_HEADER := Item.h
+SWIFT_OBJC_INTEROP := 1
+SWIFTFLAGS_EXTRAS := -parse-as-library
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/swift_array_of_objc_items/TestSwiftArrayOfObjCItems.py
+++ b/lldb/test/API/lang/swift/swift_array_of_objc_items/TestSwiftArrayOfObjCItems.py
@@ -1,0 +1,28 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    @skipEmbeddedSwift
+    @skipUnlessDarwin
+    def test(self):
+        """Test that a Swift array of ObjC items prints correctly."""
+
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.m")
+        )
+
+        frame = thread.selected_frame
+        items = frame.var("items").children
+        self.assertEqual(len(items), 2)
+
+        def get_name(item):
+            return item.member["_name"].summary
+
+        self.assertEqual(get_name(items[0]), '@"hello"')
+        self.assertEqual(get_name(items[1]), '@"world"')

--- a/lldb/test/API/lang/swift/swift_array_of_objc_items/main.m
+++ b/lldb/test/API/lang/swift/swift_array_of_objc_items/main.m
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import "Item.h"
+
+@interface Builder : NSObject
++ (NSArray<Item *> *)makeArray;
+@end
+
+int main() {
+  NSArray<Item *> *items = [Builder makeArray];
+  NSLog(@"break here %@", items);
+  return 0;
+}


### PR DESCRIPTION
Fixes a bug where a Swift array containing ObjC elements only prints the first element correctly, with all other elements being duplicate entries of the first. The reason for this is the stride of an ObjC is not defined. The fix is to fall back to the element size when stride is null.

rdar://177018602

Assisted-by: claude for distilling a reproducer project into an lldb test