### PR TITLE
[cherry-pick] 2 commits

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1200,6 +1200,18 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
       break;
     }
 
+    // If this is a function type ref and a reference type info this is an objc
+    // block. Blocks have no children.
+    if (const auto *func_tr =
+            llvm::dyn_cast_or_null<swift::reflection::FunctionTypeRef>(tr)) {
+      assert(func_tr->getFlags().getConvention() ==
+                 swift::FunctionMetadataConvention::Block &&
+             "Unexpected convention for reference function typeref!");
+      if (count_only)
+        return 0;
+      return success;
+    }
+
     bool found_start = false;
     using namespace swift::Demangle;
     Demangler dem;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1571,13 +1571,21 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
     return success;
   }
   if (llvm::dyn_cast_or_null<swift::reflection::BuiltinTypeInfo>(ti)) {
+    Flags type_flags(m_type.GetTypeInfo());
+    // This might be an enum declared with @objc or @c. They cannot carry
+    // a payload so have no children.
+    if (type_flags.AnySet(eTypeIsEnumeration)) {
+      if (count_only)
+        return 0;
+      return success;
+    }
+
     // Clang enums have an artificial rawValue property. We could
     // consider handling them here, but
     // TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex can also
     // handle them and without a Process.
     if (!TypeSystemSwiftTypeRef::IsBuiltinType(m_type) &&
-        !Flags(m_type.GetTypeInfo()).AnySet(eTypeIsMetatype) &&
-        !m_type.IsFunctionType()) {
+        !type_flags.AnySet(eTypeIsMetatype) && !m_type.IsFunctionType()) {
       LLDB_LOG(GetLog(LLDBLog::Types),
                "{0}: unrecognized builtin type info or this is a Clang type "
                "without DWARF debug info",

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3555,6 +3555,7 @@ bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type) {
                     node->getKind() == Node::Kind::ThinFunctionType ||
                     node->getKind() == Node::Kind::NoEscapeFunctionType ||
                     node->getKind() == Node::Kind::CFunctionPointer ||
+                    node->getKind() == Node::Kind::ObjCBlock ||
                     node->getKind() == Node::Kind::ImplFunctionType);
   };
   VALIDATE_AND_RETURN(impl, IsFunctionType, type, g_no_exe_ctx,
@@ -5465,6 +5466,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::FunctionType:
     case Node::Kind::NoEscapeFunctionType:
     case Node::Kind::CFunctionPointer:
+    case Node::Kind::ObjCBlock:
     case Node::Kind::ImplFunctionType: {
       // A few formats, we might need to modify our size and count for
       // depending on how we are trying to display the value.

--- a/lldb/test/API/lang/swift/c_compat_enum/Makefile
+++ b/lldb/test/API/lang/swift/c_compat_enum/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/c_compat_enum/TestSwiftCCompatEnum.py
+++ b/lldb/test/API/lang/swift/c_compat_enum/TestSwiftCCompatEnum.py
@@ -1,0 +1,47 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftCCompatEnum(TestBase):
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        self.build()
+
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+
+        v = thread.GetSelectedFrame().FindVariable("v")
+        self.assertTrue(v.IsValid(), "v not found in frame")
+
+        # We can't actually inspect the enums because of 
+        # rdar://177569037 (lldb can't show cases of an @objc or @c enum)
+        # so we have to resort to reading the logs instead and make 
+        # sure the fallback wasn't triggered.
+        import io
+        with io.open(log, "r", encoding="utf-8") as f:
+            log_contents = f.read()
+
+        def fired_fallback(type_name):
+            for line in log_contents.splitlines():
+                if "had to engage SwiftASTContext fallback" in line and \
+                   type_name in line:
+                    return line
+            return None
+
+        objc_fallback = fired_fallback("TheObjCEnum")
+        self.assertIsNone(
+            objc_fallback,
+            "TypeSystemSwiftTypeRef fell through to AST-context fallback "
+            "for the @objc enum: " + (objc_fallback or ""))
+
+        c_fallback = fired_fallback("TheCEnum")
+        self.assertIsNone(
+            c_fallback,
+            "TypeSystemSwiftTypeRef fell through to AST-context fallback "
+            "for the @c enum: " + (c_fallback or ""))

--- a/lldb/test/API/lang/swift/c_compat_enum/main.swift
+++ b/lldb/test/API/lang/swift/c_compat_enum/main.swift
@@ -1,0 +1,22 @@
+@objc public enum TheObjCEnum: UInt32 {
+  case foo
+  case bar
+}
+
+@c public enum TheCEnum: Int32 {
+  case foo
+  case bar
+}
+
+struct Wrap {
+  let objcValue: TheObjCEnum
+  let cValue: TheCEnum
+}
+
+func entry() {
+  let v = Wrap(objcValue: .foo, cValue: .foo)
+  print("break here")
+  _ = v
+}
+
+entry()

--- a/lldb/test/API/lang/swift/objc_block/Makefile
+++ b/lldb/test/API/lang/swift/objc_block/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc_block/TestSwiftObjCBlock.py
+++ b/lldb/test/API/lang/swift/objc_block/TestSwiftObjCBlock.py
@@ -1,0 +1,32 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftObjCBlock(TestBase):
+    @skipUnlessDarwin
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = self.frame()
+
+        def describe(value):
+            stream = lldb.SBStream()
+            value.GetDescription(stream)
+            return stream.GetData()
+
+        void_container = frame.FindVariable("voidContainer")
+        self.assertTrue(void_container.IsValid(), "voidContainer not found in frame")
+        void_any = void_container.GetChildMemberWithName("any")
+        self.assertIn("(@convention(block) () -> ())", describe(void_any))
+
+        int_container = frame.FindVariable("intContainer")
+        self.assertTrue(int_container.IsValid(), "intContainer not found in frame")
+        int_any = int_container.GetChildMemberWithName("any")
+        self.assertIn("(@convention(block) (Int) -> Int)", describe(int_any))

--- a/lldb/test/API/lang/swift/objc_block/main.swift
+++ b/lldb/test/API/lang/swift/objc_block/main.swift
@@ -1,0 +1,12 @@
+class Container {
+    var any: Any
+    init(_ any: Any) { self.any = any }
+}
+
+func f() {
+    let voidContainer = Container({} as @convention(block) () -> Void)
+    let intContainer = Container({ $0 + 1 } as @convention(block) (Int) -> Int)
+    print("break here")
+}
+
+f()


### PR DESCRIPTION
- [lldb] Fix @objc and @c enums triggering ASTContext fallback (cherry picked from commit 85ff56a5352a1213c7f58bda0d710dfcec7836c2)
- [lldb] Handle ObjC blocks in dynamic-type resolution and DumpTypeValue (cherry picked from commit 5ad9faf4be6d652fba61abc67ac32fd9c70e6357)