### PR TITLE
[clang][cas] Avoid report_fatal_error in cached diagnostic handling

### DIFF
--- a/clang/lib/Frontend/CachedDiagnostics.cpp
+++ b/clang/lib/Frontend/CachedDiagnostics.cpp
@@ -166,10 +166,30 @@ struct CachedDiagnosticSerializer {
   SmallVector<std::unique_ptr<MemoryBuffer>> FileBuffers;
   BumpPtrAllocator Alloc;
   StringSaver Saver{Alloc};
+  /// Error encountered and stored to be returned from the top-level
+  /// \c deserializeCachedDiagnostics or \c serializeEmittedDiagnostics call.
+  ///
+  /// Once set, conversion routines short-circuit.
+  std::optional<Error> SavedError;
 
   CachedDiagnosticSerializer(PrefixMapper &Mapper, FileManager &FileMgr)
       : Mapper(Mapper), DiagEngine(new DiagnosticIDs(), DiagOpts),
         SourceMgr(DiagEngine, FileMgr) {}
+
+  ~CachedDiagnosticSerializer() {
+    // Ensure we do not assert if we never call \c serializeEmittedDiagnostics.
+    if (SavedError)
+      consumeError(std::move(*SavedError));
+  }
+
+  /// Take any saved error, leaving the serializer in a clean state.
+  Error takeSavedError() {
+    if (!SavedError)
+      return Error::success();
+    Error E = std::move(*SavedError);
+    SavedError.reset();
+    return E;
+  }
 
   size_t getNumDiags() const { return CachedDiags.getNumDiags(); }
   bool empty() const { return getNumDiags() == 0; }
@@ -219,7 +239,7 @@ struct CachedDiagnosticSerializer {
   /// different compiler version will create different cache keys, which ensures
   /// that the diagnostics buffer will only be read by the same compiler that
   /// produced it.
-  std::optional<std::string> serializeEmittedDiagnostics();
+  Expected<std::optional<std::string>> serializeEmittedDiagnostics();
   Error deserializeCachedDiagnostics(StringRef Buffer);
 
   /// Capture any custom diagnostics registerd by \p Diags so that they can be
@@ -409,6 +429,8 @@ FileID CachedDiagnosticSerializer::convertCachedSLocEntry(unsigned Idx) {
     FileIDBySlocIdx.resize(Idx + 1);
   if (FileIDBySlocIdx[Idx].isValid())
     return FileIDBySlocIdx[Idx];
+  if (SavedError)
+    return FileID();
 
   const cached_diagnostics::SLocEntry &CachedSLocEntry =
       CachedDiags.SLocEntries[Idx];
@@ -423,9 +445,10 @@ FileID CachedDiagnosticSerializer::convertCachedSLocEntry(unsigned Idx) {
     } else {
       auto MemBufOrErr =
           SourceMgr.getFileManager().getBufferForFile(FI.Filename);
-      if (!MemBufOrErr)
-        report_fatal_error(
-            createFileError(FI.Filename, MemBufOrErr.getError()));
+      if (!MemBufOrErr) {
+        SavedError = createFileError(FI.Filename, MemBufOrErr.getError());
+        return FileID();
+      }
       SmallString<128> PathBuf;
       Mapper.map(FI.Filename, PathBuf);
       if (PathBuf.str() != FI.Filename) {
@@ -636,8 +659,11 @@ void CachedDiagnosticSerializer::captureCustomDiags(
   }
 }
 
-std::optional<std::string>
+Expected<std::optional<std::string>>
 CachedDiagnosticSerializer::serializeEmittedDiagnostics() {
+  if (SavedError)
+    return takeSavedError();
+
   if (empty())
     return std::nullopt;
 
@@ -767,6 +793,8 @@ struct CachingDiagnosticsProcessor::DiagnosticsConsumer
       // 2. If path prefixing is enabled, we'll pass locations with
       // de-canonicalized filenames during compilation (the original diagnostic
       // uses canonical paths).
+      // Note: if conversion hit an error, it  will be surfaced by
+      // serializeEmittedDiagnostics.
       assert(Serializer.DiagEngine.getClient() == OrigConsumer);
       // FIXME: This is not sound: giving the original consumer diagnostics with
       // different SourceManager may break them.
@@ -860,7 +888,10 @@ Error CachingDiagnosticsProcessor::replayCachedDiagnostics(
     return E;
   Serializer.DiagEngine.setClient(&Consumer, /*ShouldOwnClient*/ false);
   for (unsigned I = 0, E = Serializer.getNumDiags(); I != E; I++) {
-    Serializer.DiagEngine.Report(Serializer.getDiag(I));
+    StoredDiagnostic Diag = Serializer.getDiag(I);
+    if (Serializer.SavedError)
+      return Serializer.takeSavedError();
+    Serializer.DiagEngine.Report(Diag);
   }
   return Error::success();
 }

--- a/clang/unittests/Frontend/CMakeLists.txt
+++ b/clang/unittests/Frontend/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_clang_unittest(FrontendTests
   ASTUnitTest.cpp
+  CachedDiagnosticsTest.cpp
   CompileJobCacheKeyTest.cpp
   CompileJobCacheResultTest.cpp
   CompilerInvocationTest.cpp

--- a/clang/unittests/Frontend/CachedDiagnosticsTest.cpp
+++ b/clang/unittests/Frontend/CachedDiagnosticsTest.cpp
@@ -1,0 +1,160 @@
+//===- unittests/Frontend/CachedDiagnosticsTest.cpp -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../../lib/Frontend/CachedDiagnostics.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticOptions.h"
+#include "clang/Basic/FileManager.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Frontend/TextDiagnosticBuffer.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/PrefixMapper.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+
+#include "gtest/gtest.h"
+
+using namespace clang;
+using namespace clang::cas;
+
+namespace {
+
+constexpr llvm::StringLiteral TestPath = "/test.c";
+constexpr llvm::StringLiteral TestContents = "int x;\n";
+
+static llvm::IntrusiveRefCntPtr<FileManager>
+makeInMemoryFileManager(StringRef Path, StringRef Contents) {
+  auto VFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  VFS->addFile(Path, /*ModificationTime=*/0,
+               llvm::MemoryBuffer::getMemBufferCopy(Contents, Path));
+  return llvm::makeIntrusiveRefCnt<FileManager>(FileSystemOptions(),
+                                                std::move(VFS));
+}
+
+/// A VFS proxy that can inject errors on demand.
+class FailableProxyFS : public llvm::vfs::ProxyFileSystem {
+public:
+  FailableProxyFS(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> Underlying)
+      : ProxyFileSystem(std::move(Underlying)) {}
+
+  bool FailOpens = false;
+
+  llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>
+  openFileForRead(const llvm::Twine &Path) override {
+    if (FailOpens)
+      return std::make_error_code(std::errc::no_such_file_or_directory);
+    return ProxyFileSystem::openFileForRead(Path);
+  }
+};
+
+/// Capture and serialize one warning emitted at the start of \p Path.
+static std::string captureOneWarning(FileManager &FileMgr, StringRef Path) {
+  DiagnosticOptions DiagOpts;
+  llvm::IntrusiveRefCntPtr<DiagnosticsEngine> Diags(new DiagnosticsEngine(
+      DiagnosticIDs::create(), DiagOpts, new IgnoringDiagConsumer()));
+  SourceManager SrcMgr(*Diags, FileMgr);
+  Diags->setSourceManager(&SrcMgr);
+
+  llvm::PrefixMapper Mapper;
+  CachingDiagnosticsProcessor Processor(std::move(Mapper), FileMgr);
+  Processor.insertDiagConsumer(*Diags);
+
+  auto FE = FileMgr.getFileRef(Path);
+  EXPECT_TRUE((bool)FE);
+  FileID FID = SrcMgr.createFileID(*FE, SourceLocation(), SrcMgr::C_User);
+  SourceLocation Loc = SrcMgr.getLocForStartOfFile(FID);
+
+  unsigned DiagID =
+      Diags->getCustomDiagID(DiagnosticsEngine::Warning, "test diagnostic");
+  Diags->Report(Loc, DiagID);
+
+  auto Serialized = Processor.serializeEmittedDiagnostics();
+  EXPECT_THAT_EXPECTED(Serialized, llvm::Succeeded());
+  Processor.removeDiagConsumer(*Diags);
+  if (!Serialized || !*Serialized)
+    return {};
+  return **Serialized;
+}
+
+TEST(CachedDiagnosticsTest, ReplayRoundTrip) {
+  auto FileMgr = makeInMemoryFileManager(TestPath, TestContents);
+  std::string Serialized = captureOneWarning(*FileMgr, TestPath);
+  ASSERT_FALSE(Serialized.empty());
+
+  llvm::PrefixMapper Mapper;
+  CachingDiagnosticsProcessor Replay(std::move(Mapper), *FileMgr);
+  TextDiagnosticBuffer Consumer;
+  EXPECT_THAT_ERROR(Replay.replayCachedDiagnostics(Serialized, Consumer),
+                    llvm::Succeeded());
+  EXPECT_EQ(Consumer.getNumWarnings(), 1u);
+}
+
+TEST(CachedDiagnosticsTest, ReplayWithMissingFileReturnsError) {
+  // Capture diagnostics referencing a real file (only the path is recorded).
+  auto FileMgr = makeInMemoryFileManager(TestPath, TestContents);
+  std::string Serialized = captureOneWarning(*FileMgr, TestPath);
+  ASSERT_FALSE(Serialized.empty());
+
+  // Replay against a fresh FileManager whose VFS does not contain the file.
+  auto EmptyVFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  auto EmptyFileMgr = llvm::makeIntrusiveRefCnt<FileManager>(
+      FileSystemOptions(), std::move(EmptyVFS));
+
+  llvm::PrefixMapper Mapper;
+  CachingDiagnosticsProcessor Replay(std::move(Mapper), *EmptyFileMgr);
+  TextDiagnosticBuffer Consumer;
+  EXPECT_THAT_ERROR(Replay.replayCachedDiagnostics(Serialized, Consumer),
+                    llvm::Failed());
+}
+
+TEST(CachedDiagnosticsTest, CaptureFailureAbortsSerialization) {
+  // We jump through hoops here to create a situation that we don't expect to
+  // occur normally, which is for a file buffer to be unavailable during diag
+  // serialization. One way this can happen in real compiles is a diagnostic
+  // located in a file loaded via pch/pcm but not yet opened. Here we do it by
+  // manipulating the VFS to inject an error.
+
+  auto InMem = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  InMem->addFile(TestPath, /*ModificationTime=*/0,
+                 llvm::MemoryBuffer::getMemBufferCopy(TestContents, TestPath));
+  auto FailableFS = llvm::makeIntrusiveRefCnt<FailableProxyFS>(std::move(InMem));
+  auto FileMgr = llvm::makeIntrusiveRefCnt<FileManager>(
+      FileSystemOptions(), FailableFS);
+
+  DiagnosticOptions DiagOpts;
+  llvm::IntrusiveRefCntPtr<DiagnosticsEngine> Diags(new DiagnosticsEngine(
+      DiagnosticIDs::create(), DiagOpts, new IgnoringDiagConsumer()));
+  SourceManager SrcMgr(*Diags, *FileMgr);
+  Diags->setSourceManager(&SrcMgr);
+
+  llvm::PrefixMapper Mapper;
+  CachingDiagnosticsProcessor Processor(std::move(Mapper), *FileMgr);
+  Processor.insertDiagConsumer(*Diags);
+
+  // Register the file entry while reads still succeed.
+  auto FE = FileMgr->getFileRef(TestPath);
+  ASSERT_TRUE((bool)FE);
+  FileID FID = SrcMgr.createFileID(*FE, SourceLocation(), SrcMgr::C_User);
+  SourceLocation Loc = SrcMgr.getLocForStartOfFile(FID);
+
+  // From this point, the captured diagnostic's buffer can no longer be read,
+  // so the cache-miss conversion in HandleDiagnostic must fail.
+  FailableFS->FailOpens = true;
+
+  unsigned DiagID =
+      Diags->getCustomDiagID(DiagnosticsEngine::Warning, "test diagnostic");
+  Diags->Report(Loc, DiagID);
+
+  // The capture failure must propagate out of serializeEmittedDiagnostics so
+  // that the caller does not write an incomplete result to the cache.
+  auto Serialized = Processor.serializeEmittedDiagnostics();
+  EXPECT_THAT_EXPECTED(Serialized, llvm::Failed());
+  Processor.removeDiagConsumer(*Diags);
+}
+
+} // anonymous namespace


### PR DESCRIPTION
The only error in practice is failure to open a file in order to get its buffer. This is effectively a corrupt input in the case of cache replay, since the include-tree filesystem should provide the buffer, but we want to emit a real diagnostic. To avoid a lot of error-handling overhead in the low-level code, we capture the error and return it from the top level API to fail the compilation.  Capturing the Error is fine for now since it only causes invalid locations to be used in the diagnostic, which is allowed. If we ever introduce Errors that would cause invariants to break we will need a different approach.

I confirmed that this does not regress cache replay performance using the same source file.

Claude was used to help write the unit tests.