### PR TITLE
[lldb/test] Skip playground tests on remote Darwin platforms

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
@@ -109,6 +109,7 @@ class PlaygroundREPLTest(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
+    @skipIfRemote
     def test_playgrounds(self):
         # Build
         self.build_all()

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -34,6 +34,7 @@ def execute_command(command):
     return exit_status
 
 
+@skipIfRemote
 class TestSwiftPlaygrounds(TestBase):
     def get_build_triple(self):
         """We want to build the file with a deployment target earlier than the


### PR DESCRIPTION
Playground tests require infrastructure that isn't available in remote test environments. Add `@skipIfRemote` at the class level on `TestSwiftPlaygrounds` and on `test_playgrounds()` in `PlaygroundREPLTest`, which covers `TestPlaygroundREPLImport`.