### PR TITLE
[CAS](TestOnly) Remove call to `getBytesAllocated()`

### DIFF
--- a/llvm/unittests/CAS/ThreadSafeAllocatorTest.cpp
+++ b/llvm/unittests/CAS/ThreadSafeAllocatorTest.cpp
@@ -28,7 +28,7 @@ TEST(ThreadSafeAllocatorTest, AllocWithAlign) {
   Threads.wait();
 
   Alloc.applyLocked([](BumpPtrAllocator &Alloc) {
-    EXPECT_EQ(4950U * sizeof(int), Alloc.getBytesAllocated());
+    EXPECT_LE(4950U * sizeof(int), Alloc.getTotalMemory());
   });
 }
 


### PR DESCRIPTION
This API was removed in https://github.com/llvm/llvm-project/pull/205711.