### PR TITLE
[clang][cas] Convert invalid cantFail in CachedDiagnostics to real error

### DIFF
--- a/clang/lib/Frontend/CachedDiagnostics.cpp
+++ b/clang/lib/Frontend/CachedDiagnostics.cpp
@@ -570,7 +570,10 @@ template <> struct MappingTraits<cached_diagnostics::SLocEntry::FileInfo> {
       io.mapOptional("buffer", EncodedContents);
       if (EncodedContents) {
         std::vector<char> Decoded;
-        cantFail(decodeBase64(*EncodedContents, Decoded));
+        if (Error E = decodeBase64(*EncodedContents, Decoded)) {
+          io.setError("base64 decode failed: " + toString(std::move(E)));
+          return;
+        }
         s.Buffer = MemoryBuffer::getMemBufferCopy(
             StringRef(Decoded.data(), Decoded.size()), s.Filename);
       }
@@ -677,58 +680,71 @@ CachedDiagnosticSerializer::serializeEmittedDiagnostics() {
   // need to track whether compression was used or not, see doc-comments of \p
   // serializeEmittedDiagnostics().
   SmallVector<uint8_t, 512> CompressedBuffer;
-  if (compression::zstd::isAvailable()) {
-    compression::zstd::compress(arrayRefFromStringRef(YamlContents),
-                                CompressedBuffer);
+  StringRef Output = compressCachedDiagonstics(YamlContents, CompressedBuffer);
+  return Output.str();
+}
 
-  } else if (compression::zlib::isAvailable()) {
-    compression::zlib::compress(arrayRefFromStringRef(YamlContents),
-                                CompressedBuffer);
-  }
-  if (!CompressedBuffer.empty()) {
-    raw_svector_ostream BufOS((SmallVectorImpl<char> &)CompressedBuffer);
+StringRef
+clang::cas::compressCachedDiagonstics(StringRef Buffer,
+                                      SmallVectorImpl<uint8_t> &Storage) {
+  if (!compression::zstd::isAvailable() && !compression::zlib::isAvailable())
+    return Buffer;
+
+  auto Format = compression::zstd::isAvailable() ? compression::Format::Zstd
+                                                 : compression::Format::Zlib;
+  compression::compress(Format, arrayRefFromStringRef(Buffer), Storage);
+  if (!Storage.empty()) {
+    raw_svector_ostream BufOS((SmallVectorImpl<char> &)Storage);
     support::endian::Writer Writer(BufOS, endianness::little);
-    Writer.write(uint32_t(YamlContents.size()));
-    return toStringRef(CompressedBuffer).str();
+    Writer.write(uint32_t(Buffer.size()));
   }
+  return toStringRef(Storage);
+}
 
-  return YamlContents.str();
+Expected<StringRef>
+clang::cas::decompressCachedDiagonstics(StringRef Buffer,
+                                        SmallVectorImpl<uint8_t> &Storage) {
+  if (!compression::zstd::isAvailable() && !compression::zlib::isAvailable())
+    return Buffer;
+
+  auto Format = compression::zstd::isAvailable() ? compression::Format::Zstd
+                                                 : compression::Format::Zlib;
+
+  uint32_t UncompressedSize =
+      support::endian::read<uint32_t, llvm::endianness::little>(
+          Buffer.data() + Buffer.size() - sizeof(uint32_t));
+  StringRef CompressedData = Buffer.drop_back(sizeof(uint32_t));
+  if (Error E =
+          compression::decompress(Format, arrayRefFromStringRef(CompressedData),
+                                  Storage, UncompressedSize))
+    return E;
+  return toStringRef(Storage);
 }
 
 Error CachedDiagnosticSerializer::deserializeCachedDiagnostics(
     StringRef Buffer) {
-
-  StringRef YamlContents;
   SmallVector<uint8_t, 512> UncompressedBuffer;
-  if (compression::zstd::isAvailable() || compression::zlib::isAvailable()) {
-    uint32_t UncompressedSize =
-        support::endian::read<uint32_t, llvm::endianness::little>(
-            Buffer.data() + Buffer.size() - sizeof(uint32_t));
-    StringRef CompressedData = Buffer.drop_back(sizeof(uint32_t));
-    if (compression::zstd::isAvailable()) {
-      if (Error E = compression::zstd::decompress(
-              arrayRefFromStringRef(CompressedData), UncompressedBuffer,
-              UncompressedSize)) {
-        return E;
-      }
-    } else {
-      if (Error E = compression::zlib::decompress(
-              arrayRefFromStringRef(CompressedData), UncompressedBuffer,
-              UncompressedSize)) {
-        return E;
-      }
-    }
-    YamlContents = toStringRef(UncompressedBuffer);
-  } else {
-    YamlContents = Buffer;
-  }
+  StringRef YamlContents;
+  if (Error E = decompressCachedDiagonstics(Buffer, UncompressedBuffer)
+                    .moveInto(YamlContents))
+    return E;
+
+  SmallString<0> YamlParseError;
+  auto CaptureYamlError = [](const SMDiagnostic &D, void *Ctx) {
+    SmallString<0> &YamlParseError = *(SmallString<0> *)Ctx;
+    raw_svector_ostream OS(YamlParseError);
+    D.print(/*ProgName=*/nullptr, OS, /*ShowColors=*/false,
+            /*ShowKindLabel=*/true);
+  };
 
   CachedDiags.clear();
-  yaml::Input YIn(YamlContents);
+  yaml::Input YIn(YamlContents, /*Ctx=*/nullptr, CaptureYamlError,
+                  &YamlParseError);
   YIn >> CachedDiags;
   if (YIn.error())
     return createStringError(YIn.error(),
-                             "failed deserializing cached diagnostics");
+                             "failed deserializing cached diagnostics: " +
+                                 YamlParseError);
 
   assert(DiagEngine.getMaxCustomDiagID() == std::nullopt &&
          "existing custom diagnostics will conflict");

--- a/clang/lib/Frontend/CachedDiagnostics.h
+++ b/clang/lib/Frontend/CachedDiagnostics.h
@@ -62,6 +62,17 @@ private:
   std::unique_ptr<DiagnosticsConsumer> DiagConsumer;
 };
 
+/// Compress serialized diagnostics. This is done transparently by serialization
+/// and is only exposed here for testing.
+StringRef compressCachedDiagonstics(StringRef Buffer,
+                                    SmallVectorImpl<uint8_t> &Storage);
+
+/// Decompress serialized diagnostics. This is done transparently by replay
+/// and is only exposed here for testing.
+Expected<StringRef>
+decompressCachedDiagonstics(StringRef Buffer,
+                            SmallVectorImpl<uint8_t> &Storage);
+
 } // namespace cas
 } // namespace clang
 

--- a/clang/unittests/Frontend/CachedDiagnosticsTest.cpp
+++ b/clang/unittests/Frontend/CachedDiagnosticsTest.cpp
@@ -12,6 +12,8 @@
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/TextDiagnosticBuffer.h"
+#include "llvm/Support/Compression.h"
+#include "llvm/Support/EndianStream.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -52,8 +54,11 @@ public:
   }
 };
 
-/// Capture and serialize one warning emitted at the start of \p Path.
-static std::string captureOneWarning(FileManager &FileMgr, StringRef Path) {
+/// Capture and serialize one warning emitted at the start of a \c FileID
+/// created by the callback \p CreateFile.
+static std::string
+captureOneWarning(FileManager &FileMgr,
+                  llvm::function_ref<FileID(SourceManager &SM)> CreateFile) {
   DiagnosticOptions DiagOpts;
   llvm::IntrusiveRefCntPtr<DiagnosticsEngine> Diags(new DiagnosticsEngine(
       DiagnosticIDs::create(), DiagOpts, new IgnoringDiagConsumer()));
@@ -64,9 +69,7 @@ static std::string captureOneWarning(FileManager &FileMgr, StringRef Path) {
   CachingDiagnosticsProcessor Processor(std::move(Mapper), FileMgr);
   Processor.insertDiagConsumer(*Diags);
 
-  auto FE = FileMgr.getFileRef(Path);
-  EXPECT_TRUE((bool)FE);
-  FileID FID = SrcMgr.createFileID(*FE, SourceLocation(), SrcMgr::C_User);
+  FileID FID = CreateFile(SrcMgr);
   SourceLocation Loc = SrcMgr.getLocForStartOfFile(FID);
 
   unsigned DiagID =
@@ -81,9 +84,18 @@ static std::string captureOneWarning(FileManager &FileMgr, StringRef Path) {
   return **Serialized;
 }
 
+/// Capture and serialize one warning emitted at the start of \p Path.
+static std::string captureOneWarningInFile(FileManager &FM, StringRef Path) {
+  return captureOneWarning(FM, [&](SourceManager &SM) {
+    auto FE = FM.getFileRef(Path);
+    EXPECT_TRUE((bool)FE);
+    return SM.createFileID(*FE, SourceLocation(), SrcMgr::C_User);
+  });
+}
+
 TEST(CachedDiagnosticsTest, ReplayRoundTrip) {
   auto FileMgr = makeInMemoryFileManager(TestPath, TestContents);
-  std::string Serialized = captureOneWarning(*FileMgr, TestPath);
+  std::string Serialized = captureOneWarningInFile(*FileMgr, TestPath);
   ASSERT_FALSE(Serialized.empty());
 
   llvm::PrefixMapper Mapper;
@@ -97,7 +109,7 @@ TEST(CachedDiagnosticsTest, ReplayRoundTrip) {
 TEST(CachedDiagnosticsTest, ReplayWithMissingFileReturnsError) {
   // Capture diagnostics referencing a real file (only the path is recorded).
   auto FileMgr = makeInMemoryFileManager(TestPath, TestContents);
-  std::string Serialized = captureOneWarning(*FileMgr, TestPath);
+  std::string Serialized = captureOneWarningInFile(*FileMgr, TestPath);
   ASSERT_FALSE(Serialized.empty());
 
   // Replay against a fresh FileManager whose VFS does not contain the file.
@@ -155,6 +167,54 @@ TEST(CachedDiagnosticsTest, CaptureFailureAbortsSerialization) {
   auto Serialized = Processor.serializeEmittedDiagnostics();
   EXPECT_THAT_EXPECTED(Serialized, llvm::Failed());
   Processor.removeDiagConsumer(*Diags);
+}
+
+/// Capture and serialize one warning emitted at the start of an in-memory
+/// buffer that is not associated with a \p FileEntry.
+static std::string captureOneInlineBufferWarning(FileManager &FM) {
+  return captureOneWarning(FM, [&](SourceManager &SM) {
+    auto Buf = llvm::MemoryBuffer::getMemBufferCopy(TestContents, "<inline>");
+    return SM.createFileID(std::move(Buf));
+  });
+}
+
+TEST(CachedDiagnosticsTest, ReplayWithInvalidBase64ReturnsError) {
+  // Decompress, replace one character inside the base64 buffer field with an
+  // invalid character, and ensure replay fails with an Error.
+
+  auto FileMgr = makeInMemoryFileManager(TestPath, TestContents);
+  std::string Serialized = captureOneInlineBufferWarning(*FileMgr);
+  ASSERT_FALSE(Serialized.empty());
+
+  SmallVector<uint8_t, 512> Storage;
+  StringRef YamlStr;
+  ASSERT_THAT_ERROR(
+      decompressCachedDiagonstics(Serialized, Storage).moveInto(YamlStr),
+      llvm::Succeeded());
+  std::string Yaml(YamlStr);
+
+  constexpr llvm::StringLiteral BufferKey = "buffer:";
+  size_t Pos = Yaml.find(BufferKey);
+  ASSERT_NE(Pos, std::string::npos);
+  // Skip ahead to the value.
+  size_t ValuePos = Pos + BufferKey.size();
+  while (ValuePos < Yaml.size() &&
+         (Yaml[ValuePos] == ' ' || Yaml[ValuePos] == '\t'))
+    ++ValuePos;
+  ASSERT_LT(ValuePos, Yaml.size());
+  // Corrupt the encoded value.
+  Yaml[ValuePos] = '_';
+
+  std::string Corrupted = std::string(compressCachedDiagonstics(Yaml, Storage));
+
+  llvm::PrefixMapper Mapper;
+  CachingDiagnosticsProcessor Replay(std::move(Mapper), *FileMgr);
+  TextDiagnosticBuffer Consumer;
+  EXPECT_THAT_ERROR(
+      Replay.replayCachedDiagnostics(Corrupted, Consumer),
+      llvm::FailedWithMessage(testing::HasSubstr("base64 decode failed:")));
+  // Error occurs before diagnostic could be emited.
+  EXPECT_EQ(Consumer.getNumWarnings(), 0u);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Capture the deserialization failure using the YAML parser's `setError` and source manager diagnostic handler machinery. Incidentally, refactor the compression and decompression functions so we can use them in tests.