### PR TITLE
[BoundsSafety] Only diagnose address-of incomplete __counted_by array…

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -18304,34 +18304,38 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
   auto GetPointerBoundAttributes = [&](Expr *E) -> BoundsSafetyPointerAttributes {
     BoundsSafetyPointerAttributes FA;
     if (auto ASE = dyn_cast<ArraySubscriptExpr>(E)) {
-      if (auto PT = ASE->getBase()->getType()->getAs<PointerType>()) {
+      if (auto PT = ASE->getBase()->getType()->getAs<PointerType>())
         FA = PT->getPointerAttributes();
-      }
-    } else if (getLangOpts().BoundsSafety) {
+    } else if (E->getType()->isSizeMeaningless()) {
       // Taking the address of an object with a meaningless size results in a
-      // __single pointer.
-      if (E->getType()->isSizeMeaningless()) {
-        FA.setSingle();
-      } else {
-        FA.setBidiIndexable();
-      }
-    }
-    if (E->getType()->isCountAttributedType()) {
-      if (const auto *AT = Context.getAsIncompleteArrayType(E->getType())) {
-        Diag(OpLoc, diag::err_bounds_safety_unsupported_address_of_incomplete_array)
-            << op->getSourceRange();
-        Diag(OpLoc, diag::note_bounds_safety_remove_address_of_operator)
-            << Context.getPointerType(AT->getElementType())
-            << Context.getPointerType(OrigOp.get()->getType())
-            << FixItHint::CreateRemoval(op->getSourceRange());
-        // recover by using __bidi_indexable bounds, which are less likely
-        // to cause spurious warnings
-        FA.setBidiIndexable();
-      }
+      // __single pointer.
+      FA.setSingle();
+    } else {
+      FA.setBidiIndexable();
     }
     return FA;
   };
-  BoundsSafetyPointerAttributes FA = GetPointerBoundAttributes(op);
+
+  BoundsSafetyPointerAttributes FA;
+  if (getLangOpts().BoundsSafety)
+    FA = GetPointerBoundAttributes(op);
+
+  if (getLangOpts().BoundsSafetyAttributes &&
+      op->getType()->isCountAttributedType()) {
+    if (const auto *AT = Context.getAsIncompleteArrayType(op->getType())) {
+      Diag(OpLoc, diag::err_bounds_safety_unsupported_address_of_incomplete_array)
+          << op->getSourceRange();
+      Diag(OpLoc, diag::note_bounds_safety_remove_address_of_operator)
+          << Context.getPointerType(AT->getElementType())
+          << Context.getPointerType(OrigOp.get()->getType())
+          << FixItHint::CreateRemoval(op->getSourceRange());
+      // recover by using __bidi_indexable bounds, which are less likely
+      // to cause spurious warnings
+      if (getLangOpts().BoundsSafety)
+        FA.setBidiIndexable();
+    }
+  }
+
   QualType PT = Context.getPointerType(op->getType(), FA);
   if (const auto *ASE = dyn_cast<ArraySubscriptExpr>(op)) {
     if (const auto *VTT =
@@ -18343,8 +18347,6 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
   }
   return PT;
   /* TO_UPSTREAM(BoundsSafety) OFF*/
-
-  return Context.getPointerType(op->getType());
 }
 
 static void RecordModifiableNonNullParam(Sema &S, const Expr *Exp) {

--- a/clang/test/Sema/attr-counted-by-vla-addrof.c
+++ b/clang/test/Sema/attr-counted-by-vla-addrof.c
@@ -1,24 +1,24 @@
 /* TO_UPSTREAM(BoundsSafety) ON */
 // RUN: %clang_cc1 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes %s -verify
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -verify=bounds %s
+
+// expected-no-diagnostics
 
 #define __counted_by(f) __attribute__((counted_by(f)))
-#define __bdos(P) __builtin_dynamic_object_size(P, 0)
-
-typedef long unsigned int size_t;
 
 struct annotated {
   int count;
   char array[] __counted_by(count);
 };
 
-size_t test1(struct annotated *ptr) {
-  // expected-note@+1{{remove '&' to get address as 'char *' instead of 'char (*)[] __counted_by(count)' (aka 'char (*)[]')}}
-  return __bdos(&ptr->array); // expected-error{{cannot take address of incomplete __counted_by array}}
+void test1(struct annotated *ptr) {
+  // bounds-note@+1{{remove '&' to get address as 'char *' instead of 'char (*)[] __counted_by(count)' (aka 'char (*)[]')}}
+  (void)&ptr->array; // bounds-error{{cannot take address of incomplete __counted_by array}}
 }
 
-size_t test2(struct annotated *ptr) {
-  // expected-note@+1{{remove '&' to get address as 'char *' instead of 'char (*)[] __counted_by(count)' (aka 'char (*)[]')}}
-  return __bdos(&*&*&*&ptr->array); // expected-error{{cannot take address of incomplete __counted_by array}}
+void test2(struct annotated *ptr) {
+  // bounds-note@+1{{remove '&' to get address as 'char *' instead of 'char (*)[] __counted_by(count)' (aka 'char (*)[]')}}
+  (void)&*&*&*&ptr->array; // bounds-error{{cannot take address of incomplete __counted_by array}}
 }
 /* TO_UPSTREAM(BoundsSafety) OFF */

--- a/clang/test/Sema/builtin-counted-by-ref.c
+++ b/clang/test/Sema/builtin-counted-by-ref.c
@@ -34,9 +34,6 @@ void test2(struct fam_struct *ptr, int idx) {
 void test3(struct fam_struct *ptr, int idx) {
   __builtin_counted_by_ref(&ptr->array[0]);                         // expected-error {{'__builtin_counted_by_ref' argument must reference a member with the 'counted_by' attribute}}
   __builtin_counted_by_ref(&ptr->array[idx]);                       // expected-error {{'__builtin_counted_by_ref' argument must reference a member with the 'counted_by' attribute}}
-  // XXX: These are extra diagnostics that -fbounds-safety emits, which the upstream doesn't have yet.
-  // expected-note@+2{{remove '&' to get address as 'int *' instead of 'int (*)[] __counted_by(count)' (aka 'int (*)[]')}}
-  // expected-error@+1{{cannot take address of incomplete __counted_by array}}
   __builtin_counted_by_ref(&ptr->array);                            // expected-error {{'__builtin_counted_by_ref' argument must reference a member with the 'counted_by' attribute}}
   __builtin_counted_by_ref(ptr->x);                                 // expected-error {{'__builtin_counted_by_ref' argument must reference a member with the 'counted_by' attribute}}
   __builtin_counted_by_ref(&ptr->x);                                // expected-error {{'__builtin_counted_by_ref' argument must reference a member with the 'counted_by' attribute}}


### PR DESCRIPTION
… under -fbounds-safety

-fbounds-safety diagnoses this because the operation produces a pointer to an unsized array, which contradicts the __counted_by annotation. However, the error is too conservative for the attribute-only and non-bounds-safety modes.

A follow-up opt-in warning for non-bounds-safety users is tracked in llvm/llvm-project#206536.

rdar://179314728