### PR TITLE
[lldb] Fix race/timeout in TestInternalThreadSuspension (#203202)

### DIFF
--- a/lldb/test/API/macosx/thread_suspend/main.c
+++ b/lldb/test/API/macosx/thread_suspend/main.c
@@ -16,7 +16,9 @@ function_to_call() {
 void *
 suspend_func (void *unused) {
   pthread_setname_np("Look for me");
+  pthread_mutex_lock(&signal_mutex);
   pthread_cond_signal(&signal_cond);
+  pthread_mutex_unlock(&signal_mutex);
   pthread_mutex_lock(&suspend_mutex);
 
   return NULL; // We allowed the suspend thread to run
@@ -41,7 +43,7 @@ main()
   pthread_create(&suspend_thread, NULL, suspend_func, NULL);
 
   pthread_cond_wait(&signal_cond, &signal_mutex);
-  
+
   mach_port_t th_port = pthread_mach_thread_np(suspend_thread);
   thread_suspend(th_port);
 


### PR DESCRIPTION
This test launches a thread and then waits for a signal from the launched thread. Below is one possible interleaving, where the `pthread_cond_signal` (2) wins the race and becomes a no-op while (3) is locking until the test times out.

```
void *
suspend_func (void *unused) {
  [...]
  // 2. Created thread reaches this and signals.
  pthread_cond_signal(&signal_cond);
  [...]
}

int main() {

  pthread_mutex_lock(&signal_mutex);
  // 1. Thread is created
  pthread_create(&suspend_thread, NULL, suspend_func, NULL);

  // Enable this to make race reliable:
  // sleep(1);

  // 3. We start waiting on signal_cond, but 2. already executed.
  pthread_cond_wait(&signal_cond, &signal_mutex);
```

This patch guards (2) with signal_mutex so it can only be executed after pthread_cond_wait unlocks signal_mutex.

(cherry picked from commit 99c80fefdfac69a47773b66f35ae638d63ce5758)