### PR TITLE
[lldb] Detect how the swift runtime stores currently executing task

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -156,7 +156,7 @@ static bool IsStaticSwiftRuntime(Module &image) {
 }
 
 static bool IsStaticSwiftConcurrency(Module &image) {
-  static const ConstString task_switch_symbol("_swift_task_switch");
+  static const ConstString task_switch_symbol("swift_task_switch");
   return image.FindFirstSymbolWithNameAndType(task_switch_symbol);
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -62,7 +62,6 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/RemoteAST/RemoteAST.h"
 #include "swift/RemoteInspection/ReflectionContext.h"
-#include "swift/Threading/ThreadLocalStorage.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclCXX.h"
@@ -220,8 +219,14 @@ ModuleSP SwiftLanguageRuntime::FindConcurrencyModule(Process &process) {
   return concurrency_module;
 }
 
+// _swift_concurrency_debug_internal_layout_version packs the current-task
+// storage kind in its top 8 bits; the low 24 bits are the layout version. See
+// swift/stdlib/public/Concurrency/Debug.h.
+static constexpr uint32_t g_concurrency_version_mask = 0x00FFFFFF;
+static constexpr uint32_t g_concurrency_storage_kind_shift = 24;
+
 static std::optional<uint32_t>
-FindConcurrencyDebugVersion(Process &process, Module &concurrency_module) {
+FindConcurrencyVersionWord(Process &process, Module &concurrency_module) {
   const Symbol *version_symbol =
       concurrency_module.FindFirstSymbolWithNameAndType(
           ConstString("_swift_concurrency_debug_internal_layout_version"));
@@ -232,11 +237,11 @@ FindConcurrencyDebugVersion(Process &process, Module &concurrency_module) {
   if (symbol_addr == LLDB_INVALID_ADDRESS)
     return {};
   Status error;
-  uint64_t version = process.ReadUnsignedIntegerFromMemory(
+  uint64_t version_word = process.ReadUnsignedIntegerFromMemory(
       symbol_addr, /*width*/ 4, /*fail_value=*/0, error);
   if (error.Fail())
     return {};
-  return version;
+  return version_word;
 }
 
 llvm::Expected<lldb::offset_t>
@@ -275,7 +280,11 @@ SwiftLanguageRuntime::FindConcurrencyDebugVersion(Process &process) {
   ModuleSP concurrency_module = FindConcurrencyModule(process);
   if (!concurrency_module)
     return {};
-  return ::FindConcurrencyDebugVersion(process, *concurrency_module);
+  std::optional<uint32_t> version_word =
+      ::FindConcurrencyVersionWord(process, *concurrency_module);
+  if (!version_word)
+    return {};
+  return *version_word & g_concurrency_version_mask;
 }
 
 static std::optional<lldb::addr_t>
@@ -315,6 +324,35 @@ FindSymbolForSwiftObject(Process &process, RuntimeKind runtime_kind,
     return addr;
 
   return {};
+}
+
+using CurrentTaskStorageKind = SwiftLanguageRuntime::CurrentTaskStorageKind;
+
+static std::optional<CurrentTaskStorageKind>
+DeriveStorageKind(uint32_t concurrency_version, uint8_t storage_kind_raw) {
+  // Prior to version 3, pthread_reserved_key is assumed.
+  if (concurrency_version <= 2)
+    return CurrentTaskStorageKind::pthread_reserved_key;
+  if (storage_kind_raw == 0 ||
+      storage_kind_raw >= static_cast<uint32_t>(CurrentTaskStorageKind::last))
+    return std::nullopt;
+  return CurrentTaskStorageKind{storage_kind_raw};
+}
+
+SwiftLanguageRuntime::ConcurrencyInfo
+SwiftLanguageRuntime::FindConcurrencyInfo(Process &process) {
+  ModuleSP concurrency_module = FindConcurrencyModule(process);
+  if (!concurrency_module)
+    return {};
+
+  std::optional<uint32_t> version_word =
+      ::FindConcurrencyVersionWord(process, *concurrency_module);
+  if (!version_word)
+    return {};
+
+  uint32_t version = *version_word & g_concurrency_version_mask;
+  uint8_t storage_kind = *version_word >> g_concurrency_storage_kind_shift;
+  return {version, DeriveStorageKind(version, storage_kind)};
 }
 
 static lldb::BreakpointResolverSP

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -220,14 +220,10 @@ ModuleSP SwiftLanguageRuntime::FindConcurrencyModule(Process &process) {
   return concurrency_module;
 }
 
-std::optional<uint32_t>
-SwiftLanguageRuntime::FindConcurrencyDebugVersion(Process &process) {
-  ModuleSP concurrency_module = FindConcurrencyModule(process);
-  if (!concurrency_module)
-    return {};
-
+static std::optional<uint32_t>
+FindConcurrencyDebugVersion(Process &process, Module &concurrency_module) {
   const Symbol *version_symbol =
-      concurrency_module->FindFirstSymbolWithNameAndType(
+      concurrency_module.FindFirstSymbolWithNameAndType(
           ConstString("_swift_concurrency_debug_internal_layout_version"));
   if (!version_symbol)
     return 0;
@@ -272,6 +268,14 @@ SwiftLanguageRuntime::FindAsyncTaskNameOffset(Process &process) {
     return llvm::createStringError(
         "_swift_concurrency_debug_asyncTaskNameOffset is 0");
   return name_fragment_offset;
+}
+
+std::optional<uint32_t>
+SwiftLanguageRuntime::FindConcurrencyDebugVersion(Process &process) {
+  ModuleSP concurrency_module = FindConcurrencyModule(process);
+  if (!concurrency_module)
+    return {};
+  return ::FindConcurrencyDebugVersion(process, *concurrency_module);
 }
 
 static std::optional<lldb::addr_t>

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2434,13 +2434,13 @@ class TaskExplorer {
 public:
   TaskExplorer(ReflectionContextInterface &reflection_ctx, Process &process)
       : m_reflection_ctx(reflection_ctx) {
-    TaskInspector task_inspector;
+    auto task_finder = GetTaskFinder(process);
 
     for (const ThreadSP &thread : process.GetThreadList().Threads()) {
       if (!thread)
         continue;
       std::optional<lldb::addr_t> maybe_task_addr =
-          task_inspector.GetTaskAddrFromThreadLocalStorage(*thread);
+          task_finder->GetTaskAddrForThread(*thread);
       if (!maybe_task_addr)
         continue;
       int32_t max_nodes = 1000;
@@ -2988,9 +2988,9 @@ private:
         return;
       }
 
-      TaskInspector task_inspector;
+      auto task_finder = GetTaskFinder(m_exe_ctx.GetProcessRef());
       std::optional<lldb::addr_t> maybe_task_addr =
-          task_inspector.GetTaskAddrFromThreadLocalStorage(
+          task_finder->GetTaskAddrForThread(
               m_exe_ctx.GetThreadRef());
       if (!maybe_task_addr) {
         result.AppendError("could not find the task address");
@@ -3595,33 +3595,6 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
   return pc_value;
 }
 
-/// Compute the location where the Task pointer for `real_thread` is stored by
-/// the runtime.
-static llvm::Expected<lldb::addr_t>
-ComputeTaskAddrLocationFromThreadLocalStorage(Thread &real_thread) {
-#if !SWIFT_THREADING_USE_RESERVED_TLS_KEYS
-  return llvm::createStringError(
-      "getting the current task from a thread is not supported");
-#else
-  // Compute the thread local storage address for this thread.
-  addr_t tsd_addr = LLDB_INVALID_ADDRESS;
-
-  if (auto info_sp = real_thread.GetExtendedInfo())
-    if (auto *info_dict = info_sp->GetAsDictionary())
-      info_dict->GetValueForKeyAsInteger("tsd_address", tsd_addr);
-
-  if (tsd_addr == LLDB_INVALID_ADDRESS)
-    return llvm::createStringError("could not read current task from thread");
-
-  // Offset of the Task pointer in a Thread's local storage.
-  Process &process = *real_thread.GetProcess();
-  size_t ptr_size = process.GetAddressByteSize();
-  uint64_t task_ptr_offset_in_tls =
-      swift::tls_get_key(swift::tls_key::concurrency_task) * ptr_size;
-  return tsd_addr + task_ptr_offset_in_tls;
-#endif
-}
-
 /// Helper function to read all `pointers` from process memory at once.
 /// Consumes any errors from the input by propagating them to the output.
 static llvm::SmallVector<std::optional<addr_t>>
@@ -3663,13 +3636,46 @@ static std::optional<addr_t> ReadPointer(Process &process,
   return MultiReadPointers(process, addr)[0];
 }
 
-std::optional<lldb::addr_t>
-TaskInspector::GetTaskAddrFromThreadLocalStorage(Thread &thread) {
-  return GetTaskAddrFromThreadLocalStorage(&thread)[0];
-}
+namespace {
+struct NoTaskFinder : TaskFinder {
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrForThread(llvm::ArrayRef<Thread *> threads) override {
+    return llvm::SmallVector<std::optional<lldb::addr_t>>(threads.size(),
+                                                          std::nullopt);
+  }
+};
+
+/// A TaskFinder that caches each thread's (immutable) Task-pointer location,
+/// which is expensive to compute. Subclasses supply the storage-kind specific
+/// computation by overriding ComputeTaskAddrLocation.
+struct CachingTaskFinder : TaskFinder {
+  /// Inspects thread local storage to find the address of the currently
+  /// executing task, if any.
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrForThread(llvm::ArrayRef<Thread *> threads) override;
+
+protected:
+  /// The only storage-kind specific step: where the runtime stores
+  /// `real_thread`'s Task pointer.
+  virtual llvm::Expected<lldb::addr_t>
+  ComputeTaskAddrLocation(Thread &real_thread) = 0;
+
+private:
+  /// For each thread in `threads`, return the location of its task
+  /// pointer, if it exists.
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads);
+
+  /// If reading from a cached task address location failed, invalidate the
+  /// cache and try again.
+  std::optional<lldb::addr_t> RetryRead(Thread &thread,
+                                        lldb::addr_t task_addr_location);
+
+  llvm::DenseMap<uint64_t, lldb::addr_t> m_tid_to_task_addr_location;
+};
 
 llvm::SmallVector<std::optional<lldb::addr_t>>
-TaskInspector::GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads) {
+CachingTaskFinder::GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads) {
   llvm::SmallVector<std::optional<addr_t>> addr_locations;
   addr_locations.reserve(threads.size());
 
@@ -3683,18 +3689,16 @@ TaskInspector::GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads) {
 #ifndef NDEBUG
       // In assert builds, check that caching did not produce incorrect results.
       llvm::Expected<lldb::addr_t> task_addr_location =
-          ComputeTaskAddrLocationFromThreadLocalStorage(real_thread);
+          ComputeTaskAddrLocation(real_thread);
       assert(task_addr_location);
       assert(it->second == *task_addr_location);
 #endif
       continue;
     }
-    llvm::Expected<addr_t> addr_loc =
-        ComputeTaskAddrLocationFromThreadLocalStorage(real_thread);
+    llvm::Expected<addr_t> addr_loc = ComputeTaskAddrLocation(real_thread);
     if (!addr_loc) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::OS), addr_loc.takeError(),
-                     "TaskInspector: failed to compute task address location "
-                     "from TLS: {0}");
+                     "failed to compute task address location: {0}");
       addr_locations.push_back(std::nullopt);
     } else
       addr_locations.push_back(*addr_loc);
@@ -3702,8 +3706,8 @@ TaskInspector::GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads) {
   return addr_locations;
 }
 
-std::optional<addr_t> TaskInspector::RetryRead(Thread &thread,
-                                               addr_t task_addr_location) {
+std::optional<addr_t> CachingTaskFinder::RetryRead(Thread &thread,
+                                                   addr_t task_addr_location) {
   Thread &real_thread =
       thread.GetBackingThread() ? *thread.GetBackingThread() : thread;
   user_id_t tid = real_thread.GetID();
@@ -3712,17 +3716,16 @@ std::optional<addr_t> TaskInspector::RetryRead(Thread &thread,
   if (!m_tid_to_task_addr_location.erase(tid))
     return std::nullopt;
 
-  LLDB_LOG(GetLog(LLDBLog::OS), "TaskInspector: evicted task location "
-                                "address due to invalid memory read");
+  LLDB_LOG(GetLog(LLDBLog::OS),
+           "PthreadReservedKeyTaskFinder: evicted task location "
+           "address due to invalid memory read");
 
   // The cached address could not be loaded. "This should never happen", but
   // recompute the address and try again for completeness.
-  llvm::Expected<addr_t> task_addr_loc =
-      ComputeTaskAddrLocationFromThreadLocalStorage(real_thread);
+  llvm::Expected<addr_t> task_addr_loc = ComputeTaskAddrLocation(real_thread);
   if (!task_addr_loc) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::OS), task_addr_loc.takeError(),
-                   "TaskInspector: failed to compute task address location "
-                   "from TLS: {0}");
+                   "failed to compute task address location from TLS: {0}");
     return std::nullopt;
   }
 
@@ -3734,7 +3737,7 @@ std::optional<addr_t> TaskInspector::RetryRead(Thread &thread,
 }
 
 llvm::SmallVector<std::optional<addr_t>>
-TaskInspector::GetTaskAddrFromThreadLocalStorage(
+CachingTaskFinder::GetTaskAddrForThread(
     llvm::ArrayRef<Thread *> threads) {
   if (threads.empty())
     return {};
@@ -3762,7 +3765,38 @@ TaskInspector::GetTaskAddrFromThreadLocalStorage(
   return mem_read_results;
 }
 
-namespace {
+/// Finds tasks on runtimes that store the current-task pointer in a reserved
+/// pthread TLS key (Darwin). See CurrentTaskStorageKind::pthread_reserved_key.
+struct PthreadReservedKeyTaskFinder : CachingTaskFinder {
+  llvm::Expected<lldb::addr_t>
+  ComputeTaskAddrLocation(Thread &real_thread) override;
+};
+
+llvm::Expected<addr_t>
+PthreadReservedKeyTaskFinder::ComputeTaskAddrLocation(Thread &real_thread) {
+  // Compute the thread local storage address for this thread.
+  addr_t tsd_addr = LLDB_INVALID_ADDRESS;
+
+  if (auto info_sp = real_thread.GetExtendedInfo())
+    if (auto *info_dict = info_sp->GetAsDictionary())
+      info_dict->GetValueForKeyAsInteger("tsd_address", tsd_addr);
+
+  if (tsd_addr == LLDB_INVALID_ADDRESS)
+    return llvm::createStringError("PthreadReservedKeyTaskFinder: could not "
+                                   "read current task from thread");
+
+  // Offset of the Task pointer in a Thread's local storage.
+  Process &process = *real_thread.GetProcess();
+  size_t ptr_size = process.GetAddressByteSize();
+  // The value 103 comes from the define below in swift/Threading/Impl/Darwin.h
+  // #define __PTK_FRAMEWORK_SWIFT_KEY3 103
+  // However, access to that and to:
+  // swift::tls_get_key(swift::tls_key::concurrency_task)
+  // depend on how the _target_ concurrency lib was compiled, so it cannot be
+  // used here.
+  uint64_t task_ptr_offset_in_tls = 103 * ptr_size;
+  return tsd_addr + task_ptr_offset_in_tls;
+}
 
 /// Lightweight wrapper around TaskStatusRecord pointers, providing:
 ///   * traversal over the embedded linnked list of status records
@@ -3997,5 +4031,28 @@ llvm::Expected<uint64_t> FindPrologueSize(Process &process,
         sc.GetFunctionName(Mangled::NamePreference::ePreferMangled)));
 
   return prologue_size;
+}
+
+using CurrentTaskStorageKind = SwiftLanguageRuntime::CurrentTaskStorageKind;
+
+std::unique_ptr<TaskFinder>
+GetTaskFinder(std::optional<CurrentTaskStorageKind> storage_kind) {
+  if (!storage_kind)
+    return std::make_unique<NoTaskFinder>();
+  switch (*storage_kind) {
+  case CurrentTaskStorageKind::pthread_reserved_key:
+    return std::make_unique<PthreadReservedKeyTaskFinder>();
+  case CurrentTaskStorageKind::cxx_thread_local:
+  case CurrentTaskStorageKind::pthread_allocated_key:
+  case CurrentTaskStorageKind::global:
+  case CurrentTaskStorageKind::last:
+    break;
+  }
+  return std::make_unique<NoTaskFinder>();
+}
+
+std::unique_ptr<TaskFinder> GetTaskFinder(Process &process) {
+  return GetTaskFinder(
+      SwiftLanguageRuntime::FindConcurrencyInfo(process).task_storage_kind);
 }
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2442,13 +2442,13 @@ class TaskExplorer {
 public:
   TaskExplorer(ReflectionContextInterface &reflection_ctx, Process &process)
       : m_reflection_ctx(reflection_ctx) {
-    TaskInspector task_inspector;
+    auto task_finder = GetTaskFinder(process);
 
     for (const ThreadSP &thread : process.GetThreadList().Threads()) {
       if (!thread)
         continue;
       std::optional<lldb::addr_t> maybe_task_addr =
-          task_inspector.GetTaskAddrFromThreadLocalStorage(*thread);
+          task_finder->GetTaskAddrFromThreadLocalStorage(*thread);
       if (!maybe_task_addr)
         continue;
       int32_t max_nodes = 1000;
@@ -2996,9 +2996,9 @@ private:
         return;
       }
 
-      TaskInspector task_inspector;
+      auto task_finder = GetTaskFinder(m_exe_ctx.GetProcessRef());
       std::optional<lldb::addr_t> maybe_task_addr =
-          task_inspector.GetTaskAddrFromThreadLocalStorage(
+          task_finder->GetTaskAddrFromThreadLocalStorage(
               m_exe_ctx.GetThreadRef());
       if (!task_addr) {
         result.AppendError("could find the task address");
@@ -3607,10 +3607,6 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
 /// the runtime.
 static llvm::Expected<lldb::addr_t>
 ComputeTaskAddrLocationFromThreadLocalStorage(Thread &real_thread) {
-#if !SWIFT_THREADING_USE_RESERVED_TLS_KEYS
-  return llvm::createStringError(
-      "getting the current task from a thread is not supported");
-#else
   // Compute the thread local storage address for this thread.
   addr_t tsd_addr = LLDB_INVALID_ADDRESS;
 
@@ -3627,7 +3623,6 @@ ComputeTaskAddrLocationFromThreadLocalStorage(Thread &real_thread) {
   uint64_t task_ptr_offset_in_tls =
       swift::tls_get_key(swift::tls_key::concurrency_task) * ptr_size;
   return tsd_addr + task_ptr_offset_in_tls;
-#endif
 }
 
 /// Helper function to read all `pointers` from process memory at once.
@@ -3671,13 +3666,40 @@ static std::optional<addr_t> ReadPointer(Process &process,
   return MultiReadPointers(process, addr)[0];
 }
 
-std::optional<lldb::addr_t>
-TaskInspector::GetTaskAddrFromThreadLocalStorage(Thread &thread) {
-  return GetTaskAddrFromThreadLocalStorage(&thread)[0];
-}
+namespace {
+struct NoTaskFinder : TaskFinder {
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrFromThreadLocalStorage(llvm::ArrayRef<Thread *> threads) override {
+    return llvm::SmallVector<std::optional<lldb::addr_t>>(threads.size(),
+                                                          std::nullopt);
+  }
+};
+
+/// A class to find and cache the location of Task pointer inside TLS.
+struct PthreadReservedKeyTaskFinder : TaskFinder {
+  /// Inspects thread local storage to find the address of the currently
+  /// executing task, if any.
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrFromThreadLocalStorage(llvm::ArrayRef<Thread *> threads) override;
+
+private:
+  /// For each thread in `threads`, return the location of the its task
+  /// pointer, if it exists.
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads);
+
+  /// If reading from a cached task address location failed, invalidate the
+  /// cache and try again.
+  std::optional<lldb::addr_t> RetryRead(Thread &thread,
+                                        lldb::addr_t task_addr_location);
+
+  llvm::DenseMap<uint64_t, lldb::addr_t> m_tid_to_task_addr_location;
+};
+} // namespace
 
 llvm::SmallVector<std::optional<lldb::addr_t>>
-TaskInspector::GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads) {
+PthreadReservedKeyTaskFinder::GetTaskAddrLocations(
+    llvm::ArrayRef<Thread *> threads) {
   llvm::SmallVector<std::optional<addr_t>> addr_locations;
   addr_locations.reserve(threads.size());
 
@@ -3701,7 +3723,8 @@ TaskInspector::GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads) {
         ComputeTaskAddrLocationFromThreadLocalStorage(real_thread);
     if (!addr_loc) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::OS), addr_loc.takeError(),
-                     "TaskInspector: failed to compute task address location "
+                     "PthreadReservedKeyTaskFinder: failed to compute task "
+                     "address location "
                      "from TLS: {0}");
       addr_locations.push_back(std::nullopt);
     } else
@@ -3710,8 +3733,9 @@ TaskInspector::GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads) {
   return addr_locations;
 }
 
-std::optional<addr_t> TaskInspector::RetryRead(Thread &thread,
-                                               addr_t task_addr_location) {
+std::optional<addr_t>
+PthreadReservedKeyTaskFinder::RetryRead(Thread &thread,
+                                        addr_t task_addr_location) {
   Thread &real_thread =
       thread.GetBackingThread() ? *thread.GetBackingThread() : thread;
   user_id_t tid = real_thread.GetID();
@@ -3720,17 +3744,19 @@ std::optional<addr_t> TaskInspector::RetryRead(Thread &thread,
   if (!m_tid_to_task_addr_location.erase(tid))
     return std::nullopt;
 
-  LLDB_LOG(GetLog(LLDBLog::OS), "TaskInspector: evicted task location "
-                                "address due to invalid memory read");
+  LLDB_LOG(GetLog(LLDBLog::OS),
+           "PthreadReservedKeyTaskFinder: evicted task location "
+           "address due to invalid memory read");
 
   // The cached address could not be loaded. "This should never happen", but
   // recompute the address and try again for completeness.
   llvm::Expected<addr_t> task_addr_loc =
       ComputeTaskAddrLocationFromThreadLocalStorage(real_thread);
   if (!task_addr_loc) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::OS), task_addr_loc.takeError(),
-                   "TaskInspector: failed to compute task address location "
-                   "from TLS: {0}");
+    LLDB_LOG_ERROR(
+        GetLog(LLDBLog::OS), task_addr_loc.takeError(),
+        "PthreadReservedKeyTaskFinder: failed to compute task address location "
+        "from TLS: {0}");
     return std::nullopt;
   }
 
@@ -3742,7 +3768,7 @@ std::optional<addr_t> TaskInspector::RetryRead(Thread &thread,
 }
 
 llvm::SmallVector<std::optional<addr_t>>
-TaskInspector::GetTaskAddrFromThreadLocalStorage(
+PthreadReservedKeyTaskFinder::GetTaskAddrFromThreadLocalStorage(
     llvm::ArrayRef<Thread *> threads) {
   if (threads.empty())
     return {};
@@ -4005,5 +4031,27 @@ llvm::Expected<uint64_t> FindPrologueSize(Process &process,
         sc.GetFunctionName(Mangled::NamePreference::ePreferMangled)));
 
   return prologue_size;
+}
+
+using CurrentTaskStorageKind = SwiftLanguageRuntime::CurrentTaskStorageKind;
+
+std::unique_ptr<TaskFinder>
+GetTaskFinder(std::optional<CurrentTaskStorageKind> storage_kind) {
+  if (!storage_kind)
+    return std::make_unique<NoTaskFinder>();
+  switch (*storage_kind) {
+  case CurrentTaskStorageKind::pthread_reserved_key:
+    return std::make_unique<PthreadReservedKeyTaskFinder>();
+  case CurrentTaskStorageKind::cxx_thread_local:
+  case CurrentTaskStorageKind::pthread_allocated_key:
+  case CurrentTaskStorageKind::global:
+    break;
+  }
+  return std::make_unique<NoTaskFinder>();
+}
+
+std::unique_ptr<TaskFinder> GetTaskFinder(Process &process) {
+  return GetTaskFinder(
+      SwiftLanguageRuntime::FindConcurrencyInfo(process).task_storage_kind);
 }
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -317,6 +317,45 @@ FindSymbolForSwiftObject(Process &process, RuntimeKind runtime_kind,
   return {};
 }
 
+static std::optional<uint8_t>
+FindConcurrencyTaskStorageKind(Process &process, Module &concurrency_module) {
+  const Symbol *symbol = concurrency_module.FindFirstSymbolWithNameAndType(
+      ConstString("_swift_concurrency_debug_currentTaskStorageKind"));
+  if (!symbol)
+    return {};
+
+  addr_t symbol_addr = symbol->GetLoadAddress(&process.GetTarget());
+  if (symbol_addr == LLDB_INVALID_ADDRESS)
+    return {};
+  Status error;
+  uint64_t storage_kind = process.ReadUnsignedIntegerFromMemory(
+      symbol_addr, /*width*/ 1, /*fail_value=*/0, error);
+  if (error.Fail())
+    return {};
+  return storage_kind;
+}
+
+SwiftLanguageRuntime::ConcurrencyInfo
+SwiftLanguageRuntime::FindConcurrencyInfo(Process &process) {
+  ModuleSP concurrency_module = FindConcurrencyModule(process);
+  if (!concurrency_module)
+    return {};
+
+  std::optional<uint32_t> version =
+      ::FindConcurrencyDebugVersion(process, *concurrency_module);
+  if (!version)
+    return {};
+
+  std::optional<uint8_t> storage_kind =
+      ::FindConcurrencyTaskStorageKind(process, *concurrency_module);
+  // There are only four known values for this. See
+  // swift/stdlib/public/Concurrency/Debug.h
+  if (!storage_kind || storage_kind == 0 || storage_kind > 4)
+    return {version, std::nullopt};
+
+  return {version, CurrentTaskStorageKind{*storage_kind}};
+}
+
 static lldb::BreakpointResolverSP
 CreateExceptionResolver(const lldb::BreakpointSP &bkpt, bool catch_bp, bool throw_bp) {
   BreakpointResolverSP resolver_sp;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -132,7 +132,7 @@ public:
   ///       other fragments when the task has an initial name (ahead of the
   ///       ChildFragment).
   static constexpr uint32_t ConcurrencyDebugVersionBaseline = 1;
-  static constexpr uint32_t ConcurrencyDebugVersionLatest = 2;
+  static constexpr uint32_t ConcurrencyDebugVersionLatest = 3;
 
   /// True iff `version` is a concurrency runtime layout version this build
   /// of LLDB supports. A missing version (`std::nullopt`) is never supported.
@@ -141,6 +141,20 @@ public:
     return version && *version >= ConcurrencyDebugVersionBaseline &&
            *version <= ConcurrencyDebugVersionLatest;
   }
+
+  // These should match the values in swift/stdlib/public/Concurrency/Debug.h
+  enum class CurrentTaskStorageKind {
+    cxx_thread_local = 1,
+    global = 2,
+    pthread_reserved_key = 3,
+    pthread_allocated_key = 4,
+    last = 5,
+  };
+  struct ConcurrencyInfo {
+    std::optional<uint32_t> version;
+    std::optional<CurrentTaskStorageKind> task_storage_kind;
+  };
+  static ConcurrencyInfo FindConcurrencyInfo(Process &process);
   /// \}
 
   /// PluginInterface protocol.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -1002,31 +1002,33 @@ struct AsyncUnwindRegisterNumbers {
 std::optional<AsyncUnwindRegisterNumbers>
 GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
 
-/// A helper class to find and cache the location of Task pointer inside TLS.
-class TaskInspector {
-public:
-  /// Inspects thread local storage to find the address of the currently
-  /// executing task, if any.
-  std::optional<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
+/// Abstract class to find tasks in the different concurrency runtime
+/// implementations.
+struct TaskFinder {
+  // For each input thread, returns the address of the Task this thread is
+  // executing, if any, otherwise returns std::nullopt. The returned vector must
+  // have as many entries as the number of input threads.
+  virtual llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrForThread(llvm::ArrayRef<Thread *> threads) = 0;
 
-  /// Inspects thread local storage to find the address of the currently
-  /// executing task, if any.
-  llvm::SmallVector<std::optional<lldb::addr_t>>
-  GetTaskAddrFromThreadLocalStorage(llvm::ArrayRef<Thread *> threads);
+  // Equivalent to GetTaskAddrForThread(&thread);
+  std::optional<lldb::addr_t> GetTaskAddrForThread(Thread &thread) {
+    return GetTaskAddrForThread(&thread)[0];
+  }
 
-private:
-  /// For each thread in `threads`, return the location of its task
-  /// pointer, if it exists.
-  llvm::SmallVector<std::optional<lldb::addr_t>>
-  GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads);
-
-  /// If reading from a cached task address location failed, invalidate the
-  /// cache and try again.
-  std::optional<lldb::addr_t> RetryRead(Thread &thread,
-                                        lldb::addr_t task_addr_location);
-
-  llvm::DenseMap<uint64_t, lldb::addr_t> m_tid_to_task_addr_location;
+  virtual ~TaskFinder() = default;
 };
+
+/// Returns a TaskFinder for the current storage_kind. The pointer is guaranteed
+/// to be non-null, but the returned object may be a NoTaskFinder, if the
+/// storage kind is not supported.
+std::unique_ptr<TaskFinder>
+    GetTaskFinder(std::optional<SwiftLanguageRuntime::CurrentTaskStorageKind>);
+
+/// Inspects the concurrency library in the process, if any, to construct a
+/// TaskFinder. The pointer is guaranteed to be non-null, but the returned
+/// object is a NoTaskFinder if the runtime is not supported or can't be found.
+std::unique_ptr<TaskFinder> GetTaskFinder(Process &Process);
 
 /// Represents `swift::JobFlags` as defined in
 /// `include/swift/ABI/MetadataValues.h`.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -141,6 +141,19 @@ public:
     return version && *version >= ConcurrencyDebugVersionBaseline &&
            *version <= ConcurrencyDebugVersionLatest;
   }
+
+  // These should match the values in swift/stdlib/public/Concurrency/Debug.h
+  enum class CurrentTaskStorageKind {
+    cxx_thread_local = 1,
+    global = 2,
+    pthread_reserved_key = 3,
+    pthread_allocated_key = 4,
+  };
+  struct ConcurrencyInfo {
+    std::optional<uint32_t> version;
+    std::optional<CurrentTaskStorageKind> task_storage_kind;
+  };
+  static ConcurrencyInfo FindConcurrencyInfo(Process &process);
   /// \}
 
   /// PluginInterface protocol.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -986,31 +986,34 @@ struct AsyncUnwindRegisterNumbers {
 std::optional<AsyncUnwindRegisterNumbers>
 GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
 
-/// A helper class to find and cache the location of Task pointer inside TLS.
-class TaskInspector {
-public:
-  /// Inspects thread local storage to find the address of the currently
-  /// executing task, if any.
-  std::optional<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
+/// Abstract class to find tasks in the different concurrency runtime
+/// implementations.
+struct TaskFinder {
+  // For each input thread, returns the address of the Task this thread is
+  // executing, if any, otherwise returns std::nullopt. The returned vector must
+  // have as many entries as the number of input threads.
+  virtual llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrFromThreadLocalStorage(llvm::ArrayRef<Thread *> threads) = 0;
 
-  /// Inspects thread local storage to find the address of the currently
-  /// executing task, if any.
-  llvm::SmallVector<std::optional<lldb::addr_t>>
-  GetTaskAddrFromThreadLocalStorage(llvm::ArrayRef<Thread *> threads);
+  // Equivalent to GetTaskAddrFromThreadLocalStorage(&thread);
+  std::optional<lldb::addr_t>
+  GetTaskAddrFromThreadLocalStorage(Thread &thread) {
+    return GetTaskAddrFromThreadLocalStorage(&thread)[0];
+  }
 
-private:
-  /// For each thread in `threads`, return the location of its task
-  /// pointer, if it exists.
-  llvm::SmallVector<std::optional<lldb::addr_t>>
-  GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads);
-
-  /// If reading from a cached task address location failed, invalidate the
-  /// cache and try again.
-  std::optional<lldb::addr_t> RetryRead(Thread &thread,
-                                        lldb::addr_t task_addr_location);
-
-  llvm::DenseMap<uint64_t, lldb::addr_t> m_tid_to_task_addr_location;
+  virtual ~TaskFinder() = default;
 };
+
+/// Returns a TaskFinder for the current storage_kind. The pointer is guaranteed
+/// to be non-null, but the returned object may be a NoTaskFinder, if the
+/// storage kind is not supported.
+std::unique_ptr<TaskFinder>
+    GetTaskFinder(std::optional<SwiftLanguageRuntime::CurrentTaskStorageKind>);
+
+/// Inspects the concurrency library in the process, if any, to construct a
+/// TaskFinder. The pointer is guaranteed to be non-null, but the returned
+/// object is a NoTaskFinder if the runtime is not supported or can't be found.
+std::unique_ptr<TaskFinder> GetTaskFinder(Process &Process);
 
 /// Represents `swift::JobFlags` as defined in
 /// `include/swift/ABI/MetadataValues.h`.

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -26,6 +26,8 @@
 using namespace lldb;
 using namespace lldb_private;
 
+using CurrentTaskStorageKind = SwiftLanguageRuntime::CurrentTaskStorageKind;
+
 LLDB_PLUGIN_DEFINE(OperatingSystemSwiftTasks)
 
 void OperatingSystemSwiftTasks::Initialize() {
@@ -102,29 +104,38 @@ OperatingSystem *OperatingSystemSwiftTasks::CreateInstance(Process *process,
     return nullptr;
 
   Log *log = GetLog(LLDBLog::OS);
-  std::optional<uint32_t> concurrency_version =
-      SwiftLanguageRuntime::FindConcurrencyDebugVersion(*process);
-  if (!concurrency_version) {
-    LLDB_LOG(log,
-             "OperatingSystemSwiftTasks: did not find concurrency module.");
+  SwiftLanguageRuntime::ConcurrencyInfo concurrency_info =
+      SwiftLanguageRuntime::FindConcurrencyInfo(*process);
+  if (!concurrency_info.version) {
+    LLDB_LOG(
+        log,
+        "OperatingSystemSwiftTasks: did not find concurrency module version");
     return nullptr;
   }
 
   LLDB_LOGF(log,
             "OperatingSystemSwiftTasks: got a concurrency version symbol of %u",
-            *concurrency_version);
+            *concurrency_info.version);
   if (!SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(
-          concurrency_version)) {
+          *concurrency_info.version)) {
     auto warning =
         llvm::formatv("Unexpected Swift concurrency version {0}. Stepping on "
                       "concurrent code may behave incorrectly.",
-                      *concurrency_version);
+                      *concurrency_info.version);
     lldb::user_id_t debugger_id = process->GetTarget().GetDebugger().GetID();
     static std::once_flag concurrency_warning_flag;
     Debugger::ReportWarning(warning, debugger_id, &concurrency_warning_flag);
     return nullptr;
   }
-  return new OperatingSystemSwiftTasks(*process);
+
+  // Versions 1 and below did not have a storage description field. Assume
+  // pthread_reserved_key.
+  if (concurrency_info.version <= 1)
+    concurrency_info.task_storage_kind =
+        CurrentTaskStorageKind::pthread_reserved_key;
+
+  return new OperatingSystemSwiftTasks(*process,
+                                       concurrency_info.task_storage_kind);
 }
 
 llvm::StringRef OperatingSystemSwiftTasks::GetPluginDescriptionStatic() {
@@ -134,8 +145,14 @@ llvm::StringRef OperatingSystemSwiftTasks::GetPluginDescriptionStatic() {
 OperatingSystemSwiftTasks::~OperatingSystemSwiftTasks() = default;
 
 OperatingSystemSwiftTasks::OperatingSystemSwiftTasks(
-    lldb_private::Process &process)
-    : OperatingSystem(&process) {}
+    lldb_private::Process &process,
+    std::optional<CurrentTaskStorageKind> storage_kind)
+    : OperatingSystem(&process), m_task_finder(GetTaskFinder(storage_kind)) {
+  LLDB_LOG(
+      GetLog(LLDBLog::OS),
+      "OperatingSystemSwiftTasks: concurrency runtime using storage kind {0}",
+      storage_kind ? static_cast<uint32_t>(*storage_kind) : 0);
+}
 
 ThreadSP
 OperatingSystemSwiftTasks::FindOrCreateSwiftThread(ThreadList &old_thread_list,
@@ -156,7 +173,7 @@ OperatingSystemSwiftTasks::FindOrCreateSwiftThread(ThreadList &old_thread_list,
 /// For each thread in `threads_it`, computes the task address that is being run
 /// by the thread, if any.
 static llvm::SmallVector<std::optional<addr_t>>
-FindTaskAddresses(TaskInspector &task_inspector,
+FindTaskAddresses(TaskFinder &task_finder,
                   ThreadCollection::ThreadIterable &threads_it) {
   llvm::SmallVector<Thread *> threads;
   for (const ThreadSP &thread : threads_it)
@@ -166,7 +183,7 @@ FindTaskAddresses(TaskInspector &task_inspector,
   task_addrs.reserve(threads.size());
 
   for (std::optional<addr_t> &task_addr :
-       task_inspector.GetTaskAddrFromThreadLocalStorage(threads)) {
+       task_finder.GetTaskAddrForThread(threads)) {
     if (!task_addr) {
       LLDB_LOG(GetLog(LLDBLog::OS), "OperatingSystemSwiftTasks: failed to find "
                                     "task address in thread local storage");
@@ -228,7 +245,7 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
   ThreadCollection::ThreadIterable locked_core_threads =
       core_thread_list.Threads();
   llvm::SmallVector<std::optional<addr_t>> task_addrs =
-      FindTaskAddresses(m_task_inspector, locked_core_threads);
+      FindTaskAddresses(*m_task_finder, locked_core_threads);
 
   assert(m_process != nullptr);
   llvm::SmallVector<std::optional<addr_t>> task_ids =

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -26,6 +26,8 @@
 using namespace lldb;
 using namespace lldb_private;
 
+using CurrentTaskStorageKind = SwiftLanguageRuntime::CurrentTaskStorageKind;
+
 LLDB_PLUGIN_DEFINE(OperatingSystemSwiftTasks)
 
 void OperatingSystemSwiftTasks::Initialize() {
@@ -102,29 +104,38 @@ OperatingSystem *OperatingSystemSwiftTasks::CreateInstance(Process *process,
     return nullptr;
 
   Log *log = GetLog(LLDBLog::OS);
-  std::optional<uint32_t> concurrency_version =
-      SwiftLanguageRuntime::FindConcurrencyDebugVersion(*process);
-  if (!concurrency_version) {
-    LLDB_LOG(log,
-             "OperatingSystemSwiftTasks: did not find concurrency module.");
+  SwiftLanguageRuntime::ConcurrencyInfo concurrency_info =
+      SwiftLanguageRuntime::FindConcurrencyInfo(*process);
+  if (!concurrency_info.version) {
+    LLDB_LOG(
+        log,
+        "OperatingSystemSwiftTasks: did not find concurrency module version");
     return nullptr;
   }
 
   LLDB_LOGF(log,
             "OperatingSystemSwiftTasks: got a concurrency version symbol of %u",
-            *concurrency_version);
+            *concurrency_info.version);
   if (!SwiftLanguageRuntime::IsSupportedConcurrencyDebugVersion(
-          concurrency_version)) {
+          *concurrency_info.version)) {
     auto warning =
         llvm::formatv("Unexpected Swift concurrency version {0}. Stepping on "
                       "concurrent code may behave incorrectly.",
-                      *concurrency_version);
+                      *concurrency_info.version);
     lldb::user_id_t debugger_id = process->GetTarget().GetDebugger().GetID();
     static std::once_flag concurrency_warning_flag;
     Debugger::ReportWarning(warning, debugger_id, &concurrency_warning_flag);
     return nullptr;
   }
-  return new OperatingSystemSwiftTasks(*process);
+
+  // Versions 1 and below did not have a storage description field. Assume
+  // pthread_reserved_key.
+  if (concurrency_info.version <= 1)
+    concurrency_info.task_storage_kind =
+        CurrentTaskStorageKind::pthread_reserved_key;
+
+  return new OperatingSystemSwiftTasks(*process,
+                                       concurrency_info.task_storage_kind);
 }
 
 llvm::StringRef OperatingSystemSwiftTasks::GetPluginDescriptionStatic() {
@@ -134,8 +145,9 @@ llvm::StringRef OperatingSystemSwiftTasks::GetPluginDescriptionStatic() {
 OperatingSystemSwiftTasks::~OperatingSystemSwiftTasks() = default;
 
 OperatingSystemSwiftTasks::OperatingSystemSwiftTasks(
-    lldb_private::Process &process)
-    : OperatingSystem(&process) {}
+    lldb_private::Process &process,
+    std::optional<CurrentTaskStorageKind> storage_kind)
+    : OperatingSystem(&process), m_task_finder(GetTaskFinder(storage_kind)) {}
 
 ThreadSP
 OperatingSystemSwiftTasks::FindOrCreateSwiftThread(ThreadList &old_thread_list,
@@ -156,7 +168,7 @@ OperatingSystemSwiftTasks::FindOrCreateSwiftThread(ThreadList &old_thread_list,
 /// For each thread in `threads_it`, computes the task address that is being run
 /// by the thread, if any.
 static llvm::SmallVector<std::optional<addr_t>>
-FindTaskAddresses(TaskInspector &task_inspector,
+FindTaskAddresses(TaskFinder &task_finder,
                   ThreadCollection::ThreadIterable &threads_it) {
   llvm::SmallVector<Thread *> threads;
   for (const ThreadSP &thread : threads_it)
@@ -166,7 +178,7 @@ FindTaskAddresses(TaskInspector &task_inspector,
   task_addrs.reserve(threads.size());
 
   for (std::optional<addr_t> &task_addr :
-       task_inspector.GetTaskAddrFromThreadLocalStorage(threads)) {
+       task_finder.GetTaskAddrFromThreadLocalStorage(threads)) {
     if (!task_addr) {
       LLDB_LOG(GetLog(LLDBLog::OS), "OperatingSystemSwiftTasks: failed to find "
                                     "task address in thread local storage");
@@ -228,7 +240,7 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
   ThreadCollection::ThreadIterable locked_core_threads =
       core_thread_list.Threads();
   llvm::SmallVector<std::optional<addr_t>> task_addrs =
-      FindTaskAddresses(m_task_inspector, locked_core_threads);
+      FindTaskAddresses(*m_task_finder, locked_core_threads);
 
   assert(m_process != nullptr);
   llvm::SmallVector<std::optional<addr_t>> task_ids =

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -17,7 +17,9 @@
 namespace lldb_private {
 class OperatingSystemSwiftTasks : public OperatingSystem {
 public:
-  OperatingSystemSwiftTasks(Process &process);
+  OperatingSystemSwiftTasks(
+      Process &process,
+      std::optional<SwiftLanguageRuntime::CurrentTaskStorageKind>);
   ~OperatingSystemSwiftTasks() override;
 
   static OperatingSystem *CreateInstance(Process *process, bool force);
@@ -52,9 +54,7 @@ private:
   lldb::ThreadSP FindOrCreateSwiftThread(ThreadList &old_thread_list,
                                          uint64_t task_id);
 
-  /// A cache for task addr locations, which are expensive to compute but
-  /// immutable.
-  TaskInspector m_task_inspector;
+  std::unique_ptr<TaskFinder> m_task_finder;
 };
 } // namespace lldb_private
 


### PR DESCRIPTION
The first commit fixes a typo in the symbol used to detect whether we have a statically linked concurrency library.

The second/third commits change LLDB so that it reads from the concurrency runtime library itself how task pointers are stored, building on top of the work in https://github.com/swiftlang/swift/pull/90290.  This is still just NFC: helper functions and data structures are created, but no functionality changes.

The fourth commit creates an abstraction that can be extended for each of the different ways the current task pointer can be stored. It is in practice NFC, as no new way is supported.
