### PR TITLE
[stable/21.x][cmake] Preserve CMake file API queries when clearing an LLVM external project build directory

### DIFF
--- a/llvm/cmake/modules/ClearBuildDir.cmake
+++ b/llvm/cmake/modules/ClearBuildDir.cmake
@@ -1,0 +1,22 @@
+# CMake script that clears a project build directory
+# while preserving CMake file API queries.
+#
+# Input variables:
+#   BINARY_DIR  - The build directory to remove.
+
+set(API_QUERY_DIR "${BINARY_DIR}/.cmake/api/v1/query")
+
+if(IS_DIRECTORY "${API_QUERY_DIR}")
+  # BINARY_DIR usually ends with a slash, strip it to make
+  # the query backup directory name.
+  string(REGEX REPLACE "/+$" "" BINARY_DIR_BASE "${BINARY_DIR}")
+  set(QUERY_BACKUP "${BINARY_DIR_BASE}.api_query_backup")
+  file(RENAME "${API_QUERY_DIR}" "${QUERY_BACKUP}")
+endif()
+
+file(REMOVE_RECURSE "${BINARY_DIR}")
+
+if(DEFINED QUERY_BACKUP)
+  file(MAKE_DIRECTORY "${BINARY_DIR}/.cmake/api/v1")
+  file(RENAME "${QUERY_BACKUP}" "${API_QUERY_DIR}")
+endif()

--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -160,7 +160,8 @@ function(llvm_ExternalProject_Add name source_dir)
   set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${name}-bins/)
 
   add_custom_target(${name}-clear
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${BINARY_DIR}
+    COMMAND ${CMAKE_COMMAND} "-DBINARY_DIR=${BINARY_DIR}"
+                             -P "${LLVM_CMAKE_DIR}/ClearBuildDir.cmake"
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${STAMP_DIR}
     COMMENT "Clobbering ${name} build and stamp directories"
     USES_TERMINAL


### PR DESCRIPTION
Cherry pick of https://github.com/llvm/llvm-project/pull/206801