### PR TITLE
[6.4][CAS] Prefer pluginCAS for distributed caching

### DIFF
--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -34,12 +34,14 @@
 // SPECIFIC-DAEMON-NOT: "-fdepscan-share-identifier"
 // SPECIFIC-DAEMON: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-daemon=[[PREFIX]]/scand"
 
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_PLUGIN_PATH=%t/plugin LLVM_CACHE_PLUGIN_OPTIONS=some-opt=value:opt2=val2 \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_PLUGIN_PATH=%t/plugin LLVM_CACHE_PLUGIN_OPTIONS=some-opt=value:opt2=val2 LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote \
 // RUN:   %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=PLUGIN -DPREFIX=%t
 // PLUGIN: "-fcas-path" "[[PREFIX]]/cas"
 // PLUGIN: "-fcas-plugin-path" "[[PREFIX]]/plugin"
 // PLUGIN: "-fcas-plugin-option" "some-opt=value"
 // PLUGIN: "-fcas-plugin-option" "opt2=val2"
+// PLUGIN: "-fcas-plugin-option" "remote-service-path=[[PREFIX]]/ccremote"
+// PLUGIN-NOT: "-fcompilation-caching-service-path"
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
 // RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS -DPREFIX=%t

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -214,8 +214,12 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
   const char *ServicePath = ::getenv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH");
 
   if (ServicePath) {
-    AppendArgs({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
-        ServicePath});
+    if (llvm::sys::Process::GetEnv("LLVM_CACHE_PLUGIN_PATH"))
+      AppendArgs({"-Xclang", "-fcas-plugin-option", "-Xclang",
+                  std::string("remote-service-path=") + ServicePath});
+    else
+      AppendArgs({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
+                  ServicePath});
   }
   if (IsCOFF) {
     // Suppress timestamp non-determism in COFF object files.

--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -162,15 +162,21 @@ public:
 
   struct CachingOptions {
     std::string Path;                    // Path to the cache, empty to disable.
+    std::string PluginPath;
+    std::vector<std::pair<std::string, std::string>> PluginOpts;
     CachePruningPolicy Policy;
     enum class CacheType {
       CacheDirectory,
       CAS,
+      PluginCAS,
       RemoteService,
     } Type;
-    std::unique_ptr<cas::ObjectStore> CAS;
-    std::unique_ptr<cas::ActionCache> Cache;
+    std::shared_ptr<cas::ObjectStore> CAS;
+    std::shared_ptr<cas::ActionCache> Cache;
     std::optional<cas::remote::ClientServices> Service;
+
+    // Init the CAS and Cache
+    Error startCache();
   };
 
   /// Provide a path to a directory where to store the cached files for
@@ -247,9 +253,7 @@ public:
 
   /// Set the path to a directory where to save temporaries from the remote
   /// service.
-  void setRemoteServiceTempsDir(std::string Path) {
-    RemoteServiceTempsDir = std::move(Path);
-  }
+  void setRemoteServiceTempsDir(std::string Path);
 
   /// Set the path to a directory where to save generated object files. This
   /// path can be used by a linker to request on-disk files instead of in-memory

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -13,6 +13,7 @@
 
 #include "llvm/LTO/legacy/ThinLTOCodeGenerator.h"
 #include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/RemoteCachingService/Client.h"
 #include "llvm/Support/CommandLine.h"
@@ -1038,23 +1039,21 @@ Error ThinLTOCodeGenerator::setCacheDir(std::string Path) {
   // The environment overwrites the option parameter.
   if (PathStr.consume_front("cas:")) {
     CacheOptions.Type = CachingOptions::CacheType::CAS;
-    // Create ObjectStore and ActionCache.
-    auto MaybeCAS = cas::createOnDiskCAS(PathStr);
-    if (!MaybeCAS)
-      return MaybeCAS.takeError();
-    CacheOptions.CAS = std::move(*MaybeCAS);
-    auto MaybeCache = cas::createOnDiskActionCache(PathStr);
-    if (!MaybeCache)
-      return MaybeCache.takeError();
-    CacheOptions.Cache = std::move(*MaybeCache);
     CacheOptions.Path = PathStr.str();
+  } else if (PathStr.consume_front("plugin:")) {
+    CacheOptions.Type = CachingOptions::CacheType::PluginCAS;
+    auto [PluginPath, Remain] = PathStr.split(':');
+    auto [OnDiskPath, Options] = Remain.split('?');
+    while (!Options.empty()) {
+      auto [Pair, OptRemain] = Options.split(':');
+      auto [Name, Val] = StringRef(Pair).split('=');
+      CacheOptions.PluginOpts.push_back({std::string(Name), std::string(Val)});
+      Options = OptRemain;
+    }
+    CacheOptions.Path = OnDiskPath;
+    CacheOptions.PluginPath = PluginPath.str();
   } else if (PathStr.consume_front("grpc:")) {
     CacheOptions.Type = CachingOptions::CacheType::RemoteService;
-    auto MaybeService =
-        cas::remote::createCompilationCachingRemoteClient(PathStr);
-    if (!MaybeService)
-      return MaybeService.takeError();
-    CacheOptions.Service = std::move(*MaybeService);
     CacheOptions.Path = PathStr.str();
   } else {
     CacheOptions.Type = CachingOptions::CacheType::CacheDirectory;
@@ -1062,6 +1061,47 @@ Error ThinLTOCodeGenerator::setCacheDir(std::string Path) {
   }
 
   return Error::success();
+}
+
+Error ThinLTOCodeGenerator::CachingOptions::startCache() {
+  if (Type == CacheType::CacheDirectory)
+    return Error::success();
+
+  if (Type == CacheType::PluginCAS) {
+    if (Path.empty()) {
+      auto DefaultPath = cas::getDefaultOnDiskCASPath();
+      if (DefaultPath.empty())
+        return createStringError("CAS Path is not specified for plugin CAS");
+      Path = DefaultPath;
+    }
+    auto MaybeCAS = cas::createPluginCASDatabases(PluginPath, Path, PluginOpts);
+    if (!MaybeCAS)
+      return MaybeCAS.takeError();
+    CAS = std::move(MaybeCAS->first);
+    Cache = std::move(MaybeCAS->second);
+  } else if (Type == CacheType::CAS)  {
+    auto MaybeCAS = cas::createOnDiskUnifiedCASDatabases(Path);
+    if (!MaybeCAS)
+      return MaybeCAS.takeError();
+    CAS = std::move(MaybeCAS->first);
+    Cache = std::move(MaybeCAS->second);
+  } else if (Type == CacheType::RemoteService) {
+    auto MaybeService = cas::remote::createCompilationCachingRemoteClient(Path);
+    if (!MaybeService)
+      return MaybeService.takeError();
+    Service = std::move(*MaybeService);
+  }
+
+  return Error::success();
+}
+
+void ThinLTOCodeGenerator::setRemoteServiceTempsDir(std::string Path) {
+  RemoteServiceTempsDir = std::move(Path);
+
+  // If plugin CAS do not have a on disk path, use remote service path.
+  if (CacheOptions.Type == CachingOptions::CacheType::PluginCAS &&
+      CacheOptions.Path.empty())
+    CacheOptions.Path = RemoteServiceTempsDir;
 }
 
 std::unique_ptr<ModuleCacheEntry> ThinLTOCodeGenerator::createModuleCacheEntry(
@@ -1104,6 +1144,7 @@ static std::unique_ptr<AsyncModuleCacheEntry> createAsyncModuleCacheEntry(
 
   switch (CacheOptions.Type) {
   case ThinLTOCodeGenerator::CachingOptions::CacheType::CAS:
+  case ThinLTOCodeGenerator::CachingOptions::CacheType::PluginCAS:
     return std::make_unique<CASModuleCacheEntry>(
         *CacheOptions.CAS, *CacheOptions.Cache, std::move(*Key),
         std::move(Logger));
@@ -1576,6 +1617,11 @@ void ThinLTOCodeGenerator::run() {
   // Prepare the resulting object vector
   assert(ProducedBinaries.empty() && "The generator should not be reused");
 
+  // Start the cache before using.
+  auto Err = CacheOptions.startCache();
+  if (Err)
+    report_fatal_error(std::move(Err));
+
   // When using RemoteService caching, we will always create a saved object
   // directory for remote service to pass back the cached object file.
   // First, we need to remember whether the caller requests buffer API or file
@@ -1759,6 +1805,7 @@ void ThinLTOCodeGenerator::run() {
 
   // We can try running cache queries asynchronously.
   if (CacheOptions.Type == CachingOptions::CacheType::CAS ||
+      CacheOptions.Type == CachingOptions::CacheType::PluginCAS ||
       CacheOptions.Type == CachingOptions::CacheType::RemoteService) {
     enum ModuleState {
       // Initial state, no guarantees.

--- a/llvm/tools/lto/lto.cpp
+++ b/llvm/tools/lto/lto.cpp
@@ -547,10 +547,21 @@ thinlto_code_gen_t thinlto_create_codegen(void) {
   if (sys::Process::GetEnv("LLVM_THINLTO_USE_REMOTE_CACHE")) {
     if (auto CacheSocket =
             sys::Process::GetEnv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH")) {
-      std::string Path = std::string("grpc:") + *CacheSocket;
+      std::string Path;
+      // Prefer using plugin CAS to do remote caching before falling back to
+      // using gRPC remote CAS.
+      if (auto PluginPath = sys::Process::GetEnv("LLVM_CACHE_PLUGIN_PATH")) {
+        Path = std::string("plugin:") + *PluginPath + ":" +
+               "?remote-service-path=" + *CacheSocket;
+        if (auto PluginOpts = sys::Process::GetEnv("LLVM_CACHE_PLUGIN_OPTIONS"))
+          Path += ":" + *PluginOpts;
+      } else
+        Path = std::string("grpc:") + *CacheSocket;
+
       auto Err = CodeGen->setCacheDir(Path);
       if (Err)
         report_fatal_error(std::move(Err));
+      return wrap(CodeGen);
     }
   }
   return wrap(CodeGen);


### PR DESCRIPTION
- **Explanation**: For both ThinLTO and clang-cache configured to build with distributed caching via `LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH` environment, prefer using pluginCAS if `LLVM_CACHE_PLUGIN_PATH` is also set, rather than using the builtin gRPC remote cas (if supported).

  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: ThinLTO distributed compilation caching only change.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://180448889
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low. Limited scope. Backwards compatible to gRPC implementation if configured.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: End to end test locally.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->



