### PR TITLE
[llvm/CAS] Make sure we can ingest a path to a broken symlink

### DIFF
--- a/llvm/include/llvm/CAS/FileSystemCache.h
+++ b/llvm/include/llvm/CAS/FileSystemCache.h
@@ -127,14 +127,16 @@ public:
     /// Request a directory entry. The first parameter is the parent to look
     /// under, the second is the name of the entry.
     virtual Expected<DirectoryEntry *>
-    requestDirectoryEntry(DirectoryEntry &Parent, StringRef Name) = 0;
+    requestDirectoryEntry(DirectoryEntry &Parent, StringRef Name,
+                          bool FollowSymlinks) = 0;
 
     /// Request target of (lazy) symlink be filled in.
     virtual Error requestSymlinkTarget(DirectoryEntry &Symlink) = 0;
 
     /// Request a real path. The discovery instance should ensure this does
     /// minimal work if called multiple times during a single lookup.
-    virtual Error preloadRealPath(DirectoryEntry &Parent, StringRef Remaining) {
+    virtual Error preloadRealPath(DirectoryEntry &Parent, StringRef Remaining,
+                                  bool FollowSymlinks) {
       return Error::success();
     }
 
@@ -217,7 +219,8 @@ public:
   /// Look up a directory entry in the CAS, navigating through real paths but
   /// returning early on a symlink.
   Expected<LookupPathState> lookupRealPathPrefixFrom(DiscoveryInstance &DI,
-                                                     LookupPathState State);
+                                                     LookupPathState State,
+                                                     bool FollowSymlinks);
 
   /// Lookup \p Path, knowing that \a sys::fs::real_path() was called and
   /// failed.

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -386,8 +386,9 @@ public:
 private:
   using DirectoryEntry = FileSystemCache::DirectoryEntry;
 
-  Expected<DirectoryEntry *> requestDirectoryEntry(DirectoryEntry &Parent,
-                                                   StringRef Name) override {
+  Expected<DirectoryEntry *>
+  requestDirectoryEntry(DirectoryEntry &Parent, StringRef Name,
+                        bool FollowSymlinks) override {
     if (Parent.asDirectory().isComplete())
       return errorCodeToError(
           std::make_error_code(std::errc::no_such_file_or_directory));

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -83,7 +83,8 @@ public:
   ///          cannot be accessed, or nullptr if the path was accessed but there
   ///          was a subsequent filesystem modification.
   Expected<FileSystemCache::DirectoryEntry *>
-  preloadRealPath(DirectoryEntry &From, StringRef Remaining);
+  preloadRealPath(DirectoryEntry &From, StringRef Remaining,
+                  bool FollowSymlinks);
 
   ErrorOr<vfs::Status> statusAndFileID(const Twine &Path,
                                        std::optional<CASID> &FileID,
@@ -197,10 +198,12 @@ public:
   ~DiscoveryInstanceImpl();
 
 private:
-  Expected<DirectoryEntry *> requestDirectoryEntry(DirectoryEntry &Parent,
-                                                   StringRef Name) override;
+  Expected<DirectoryEntry *>
+  requestDirectoryEntry(DirectoryEntry &Parent, StringRef Name,
+                        bool FollowSymlinks) override;
   Error requestSymlinkTarget(DirectoryEntry &Symlink) override;
-  Error preloadRealPath(DirectoryEntry &Parent, StringRef Remaining) override;
+  Error preloadRealPath(DirectoryEntry &Parent, StringRef Remaining,
+                        bool FollowSymlinks) override;
   void trackNonRealPathEntry(DirectoryEntry &Entry) override;
 
 private:
@@ -548,7 +551,8 @@ CachingOnDiskFileSystemImpl::getDirectoryIterator(const Twine &Path) {
 
 Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
-                                             StringRef Remaining) {
+                                             StringRef Remaining,
+                                             bool FollowSymlinks) {
   auto BypassSandbox = sys::sandbox::scopedDisable();
 
   PathStorage RemainingStorage(Remaining);
@@ -562,11 +566,12 @@ CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
   // on Darwin when running clang-scan-deps (looks like allocation traffic in
   // ::open on stat failures). This may be platform- or even
   // OS-version-dependent though.
+  sys::fs::file_status ExpectedRealPathStatus;
   {
-    sys::fs::file_status Status;
-    if (std::error_code EC = sys::fs::status(ExpectedRealPath, Status))
+    if (std::error_code EC = sys::fs::status(
+            ExpectedRealPath, ExpectedRealPathStatus, FollowSymlinks))
       return errorCodeToError(EC);
-    if (!sys::fs::exists(Status))
+    if (!sys::fs::exists(ExpectedRealPathStatus))
       return errorCodeToError(
           std::make_error_code(std::errc::no_such_file_or_directory));
 
@@ -575,8 +580,13 @@ CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
 
   SmallString<256> RealPath;
   if (std::error_code EC = sys::fs::real_path(ExpectedRealPath, RealPath,
-      /* expand_tilde */false))
-    return errorCodeToError(EC);
+                                              /* expand_tilde */ false)) {
+    if (ExpectedRealPathStatus.type() == sys::fs::file_type::symlink_file) {
+      RealPath = ExpectedRealPath;
+    } else {
+      return errorCodeToError(EC);
+    }
+  }
 
   SmallString<256> RealTreePath = StringRef(llvm::cas::getTreePath(RealPath,
       Cache->getPathStyle()));
@@ -786,7 +796,8 @@ DiscoveryInstanceImpl::~DiscoveryInstanceImpl() {}
 
 Expected<FileSystemCache::DirectoryEntry *>
 DiscoveryInstanceImpl::requestDirectoryEntry(DirectoryEntry &Parent,
-                                             StringRef Name) {
+                                             StringRef Name,
+                                             bool FollowSymlinks) {
   if (!LookupOnDisk)
     return nullptr;
 
@@ -809,7 +820,7 @@ DiscoveryInstanceImpl::requestDirectoryEntry(DirectoryEntry &Parent,
     // that we hit F_GETPATH non-determinism for a hard link on Darwin. We need
     // to get the realpath of Parent + Name, which may be different from the
     // realpath of the path that's ultimately being looked up.
-    auto RP = FS.preloadRealPath(Parent, Name);
+    auto RP = FS.preloadRealPath(Parent, Name, FollowSymlinks);
     if (!RP)
       return RP.takeError();
     if (*RP)
@@ -846,10 +857,11 @@ Error DiscoveryInstanceImpl::requestSymlinkTarget(DirectoryEntry &Symlink) {
 }
 
 Error DiscoveryInstanceImpl::preloadRealPath(DirectoryEntry &Parent,
-                                             StringRef Remaining) {
+                                             StringRef Remaining,
+                                             bool FollowSymlinks) {
   if (LookupOnDisk && !ComputedRealPath) {
     ComputedRealPath = true;
-    auto Entry = FS.preloadRealPath(Parent, Remaining);
+    auto Entry = FS.preloadRealPath(Parent, Remaining, FollowSymlinks);
     if (Entry)
       RealPath = *Entry;
     return Entry.takeError();

--- a/llvm/lib/CAS/FileSystemCache.cpp
+++ b/llvm/lib/CAS/FileSystemCache.cpp
@@ -286,8 +286,9 @@ FileSystemCache::lookupPath(DiscoveryInstance &DI, StringRef Path,
   while (!Worklist.empty()) {
     assert(Current);
     auto Work = Worklist.pop_back_val();
-    Expected<LookupPathState> Found = lookupRealPathPrefixFrom(DI,
-        LookupPathState(PathStyle, *Current, Work.Remaining));
+    Expected<LookupPathState> Found = lookupRealPathPrefixFrom(
+        DI, LookupPathState(PathStyle, *Current, Work.Remaining),
+        FollowSymlinks);
     if (!Found)
       return createFileError(Path, Found.takeError());
     Current = Found->Entry;
@@ -379,7 +380,8 @@ FileSystemCache::lookupRealPathPrefixFromCached(
 
 Expected<FileSystemCache::LookupPathState>
 FileSystemCache::lookupRealPathPrefixFrom(DiscoveryInstance &DI,
-                                          LookupPathState State) {
+                                          LookupPathState State,
+                                          bool FollowSymlinks) {
   assert(State.Entry);
   bool LoadedRealPath = false;
   while (true) {
@@ -399,7 +401,8 @@ FileSystemCache::lookupRealPathPrefixFrom(DiscoveryInstance &DI,
     // Cache the real path to avoid unnecessary component-by-component stat
     // calls.
     if (!LoadedRealPath) {
-      if (Error E = DI.preloadRealPath(*State.Entry, State.Remaining))
+      if (Error E =
+              DI.preloadRealPath(*State.Entry, State.Remaining, FollowSymlinks))
         return std::move(E);
       LoadedRealPath = true;
       continue;
@@ -407,7 +410,7 @@ FileSystemCache::lookupRealPathPrefixFrom(DiscoveryInstance &DI,
 
     // Read the next component from disk.
     Expected<DirectoryEntry *> Next =
-        DI.requestDirectoryEntry(*State.Entry, State.Name);
+        DI.requestDirectoryEntry(*State.Entry, State.Name, FollowSymlinks);
     if (!Next)
       return Next.takeError();
 

--- a/llvm/test/tools/llvm-cas/ingest.test
+++ b/llvm/test/tools/llvm-cas/ingest.test
@@ -42,3 +42,7 @@ CHECK-NODE-REFS: llvmcas://
 // Test exporting the entire tree.
 RUN: llvm-cas --cas %t/new-cas --fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext --upstream-cas %t/cas --import @%t/cas.id > %t/plugin.id
 RUN: llvm-cas --cas %t/new-cas --fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext --ls-tree-recursive @%t/plugin.id | FileCheck %s
+
+RUN: llvm-cas --cas %t/cas --ingest %S/Inputs/broken_symlink > %t/cas-symlink.id
+RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/cas.id | FileCheck %s --check-prefix=CHECK-SYMLINK
+CHECK-SYMLINK: broken_symlink -> missing

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -584,7 +584,7 @@ static Error checkCASIngestPath(StringRef CASPath, StringRef DataPath) {
   if (std::error_code EC = sys::fs::real_path(StringRef(CASPath), RealCAS))
     return createFileError(CASPath, EC);
   if (std::error_code EC = sys::fs::real_path(StringRef(DataPath), RealData))
-    return createFileError(DataPath, EC);
+    return Error::success(); // can error later if important.
   if (RealCAS.starts_with(RealData) &&
       (RealCAS.size() == RealData.size() ||
        sys::path::is_separator(RealCAS[RealData.size()])))


### PR DESCRIPTION
If we are not following symlinks then a broken symlink should not trigger an error when ingesting it for CASFS purposes.