### PR TITLE
[lldb] Replace BitCastInst with BitOrPointerCast

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/InjectPointerSigningFixups.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/InjectPointerSigningFixups.cpp
@@ -166,8 +166,8 @@ struct PerGlobalUtils {
           }
       } else {
         auto *OriginalLoad = getPtrLoadFor(F, *PtrForInsts->getType());
-        auto *Cast = new BitCastInst(OriginalLoad, &T, "",
-                                     &*std::next(OriginalLoad->getIterator()));
+        auto *Cast = CastInst::CreateBitOrPointerCast(
+            OriginalLoad, &T, "", &*std::next(OriginalLoad->getIterator()));
         LI = LoadsForCaller.insert(std::make_pair(Key, Cast)).first;
       }
     }


### PR DESCRIPTION
BitCastInst is appropriate when casting from one pointer type to another but not for casting from a pointer to an integer. PerGlobalUtils::getPtrLoadFor may need to convert between pointers and integers in both directions, so BitCastInst isn't always appropriate. Switch to using `CastInst::CreateBitOrPointerCast` to always choose the appropriate CastInst.