### PR TITLE
[lldb] Fix bug when calling stringForPrintObject(_:mangledTypeName:) with existentials

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1013,6 +1013,17 @@ static bool IsSwiftReferenceType(ValueObject &object) {
   return false;
 }
 
+static bool ContainsPrivateDeclName(swift::Demangle::NodePointer node) {
+  if (!node)
+    return false;
+  if (node->getKind() == swift::Demangle::Node::Kind::PrivateDeclName)
+    return true;
+  for (auto *child : *node)
+    if (ContainsPrivateDeclName(child))
+      return true;
+  return false;
+}
+
 llvm::Error
 SwiftLanguageRuntime::PrintObjectViaPointer(Stream &strm, ValueObject &object,
                                             Process &process) const {
@@ -1053,7 +1064,21 @@ SwiftLanguageRuntime::PrintObjectViaPointer(Stream &strm, ValueObject &object,
         return llvm::createStringError("no Objective-C runtime");
       return objc_runtime->GetObjectDescription(strm, *static_object);
     }
-    mangled_type_name = static_object->GetMangledTypeName();
+
+    // Use the static type only if the dynamic type contains a private
+    // discriminator, and only if the static type is not an existential.
+    swift::Demangle::Context ctx;
+    auto *node = ctx.demangleSymbolAsNode(object.GetMangledTypeName());
+    if (ContainsPrivateDeclName(node)) {
+      Flags static_flags(static_object->GetTypeInfo());
+      if (static_flags.Test(eTypeIsProtocol))
+        return llvm::createStringError("existential types are unsupported");
+      // Use non-private static type, because the dynamic type is private.
+      mangled_type_name = static_object->GetMangledTypeName();
+    } else {
+      // Use non-private dynamic type.
+      mangled_type_name = object.GetMangledTypeName();
+    }
   } else {
     mangled_type_name = object.GetMangledTypeName();
   }

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -135,3 +135,14 @@ class TestCase(TestBase):
         self.expect("po value", substrs=["DescribedEnum"])
         self._filecheck("DESC-ENUM")
         # CHECK-DESC-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a13DescribedEnumOD")
+
+    @swiftTest
+    @skipEmbeddedSwift
+    def test_class_only_protocol(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break class-only protocol", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["DescribedConformance"])
+        self._filecheck("CLASS-ONLY-PROTOCOL")
+        # CHECK-CLASS-ONLY-PROTOCOL: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a20DescribedConformanceCD")

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/main.swift
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/main.swift
@@ -47,6 +47,12 @@ enum DescribedEnum: CustomStringConvertible {
     var description: String { "DescribedEnum" }
 }
 
+protocol ClassOnlyProtocol: AnyObject {}
+
+class DescribedConformance: ClassOnlyProtocol, CustomStringConvertible {
+    var description: String { "DescribedConformance" }
+}
+
 @main struct Entry {
     static func main() {
         do {
@@ -92,6 +98,10 @@ enum DescribedEnum: CustomStringConvertible {
         do {
             let value = DescribedEnum.pair("Po", 50)
             print("break described enum")
+        }
+        do {
+            let value: ClassOnlyProtocol = DescribedConformance()
+            print("break class-only protocol")
         }
     }
 }


### PR DESCRIPTION
Improves the logic for deciding when to use the mangled name from the dynamic type or
the static type.

Previously, the static type was always being used. However this is incorrect when the
static type is a protocol, in that case, the dynamic type (class or otherwise) should be
used.

Now, the static type is only used when the demangled dynamic type contains a
`PrivateDeclName` node.

rdar://179501356

(cherry picked from commit 842b35cdeaab2b52ec3ffe9b23adebc006733270)
