### PR TITLE
[lldb] Correct false case in SwiftOptionalSummaryProvider::DoesPrintChildren

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
@@ -45,7 +45,7 @@ lldb_private::formatters::swift::SwiftOptionalSummaryProvider::GetName() {
   return "Swift.Optional summary provider";
 }
 
-/// If this ValueObject is an Optional<T> with the Some(T) case selected,
+/// If this ValueObject is an Optional<T> with the some(T) case selected,
 /// retrieve the value of the Some case.
 ///
 /// Returns {} on error, nullptr on .none, and a ValueObject on .some.
@@ -262,7 +262,7 @@ bool lldb_private::formatters::swift::SwiftOptionalSummaryProvider::
 
   ValueObjectSP some = *maybe_some;
   if (!some)
-    return true;
+    return false;
 
   lldb_private::Flags some_flags(some->GetCompilerType().GetTypeInfo());
 


### PR DESCRIPTION
Return false from `DoesPrintChildren` for `.none` values.

From the docstring for `ExtractSomeIfAny`:

```cpp
/// Returns {} on error, nullptr on .none, and a ValueObject on .some.
```

This changes the case where nullptr is returned, indicating `.none`. In those cases, children should not be printed.

I have seen an issue in the wild where "nil" is printed as the summary, yet children are incorrectly printed. I have not yet figured out a reproduction. An example output is:

```
headKeyView = nil {
  NSResponder = <parent failed to evaluate: read memory from 0x0 failed (0 of 8 bytes read)>
  _frame = <parent failed to evaluate: read memory from 0x0 failed (0 of 8 bytes read)>
  _bounds = <parent failed to evaluate: read memory from 0x0 failed (0 of 8 bytes read)>
  _subviews = <parent failed to evaluate: read memory from 0x0 failed (0 of 8 bytes read)>
  ...
}
```