### PR TITLE
[compiler-rt] Propagate LLVM_ENABLE_INDEX_STORE to the runtimes builds

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -419,6 +419,19 @@ macro(darwin_add_builtin_libraries)
 
   append_list_if(COMPILER_RT_HAS_ASM_LSE -DHAS_ASM_LSE CFLAGS)
 
+  # Add in the index store similar to how HandleLLVMOptions does.
+  # LLVM_ENABLE_INDEX_STORE won't be propagated for IDE generators, so that
+  # test can be skipped here.
+  if(LLVM_ENABLE_INDEX_STORE AND INDEX_DATA_STORE_PATH)
+    builtin_check_c_compiler_flag(
+      "-Werror -index-store-path ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/IndexStore"
+      COMPILER_RT_HAS_INDEX_STORE_FLAG)
+    if(COMPILER_RT_HAS_INDEX_STORE_FLAG)
+      list(APPEND CFLAGS "SHELL:-index-store-path \"${INDEX_DATA_STORE_PATH}\"")
+    endif()
+    # Note that builtins don't use CMAKE_CXX_FLAGS, but rather reuse CFLAGS for C++.
+  endif()
+
   set(PROFILE_SOURCES ../profile/InstrProfiling.c
                       ../profile/InstrProfilingBuffer.c
                       ../profile/InstrProfilingPlatformDarwin.c
@@ -548,6 +561,16 @@ macro(darwin_add_embedded_builtin_libraries)
     set(CMAKE_C_FLAGS "")
     set(CMAKE_CXX_FLAGS "")
     set(CMAKE_ASM_FLAGS "")
+
+    # Add in the index store like darwin_add_builtin_libraries above.
+    if(LLVM_ENABLE_INDEX_STORE AND INDEX_DATA_STORE_PATH)
+      builtin_check_c_compiler_flag(
+        "-Werror -index-store-path ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/IndexStore"
+        COMPILER_RT_HAS_INDEX_STORE_FLAG)
+      if(COMPILER_RT_HAS_INDEX_STORE_FLAG)
+        list(APPEND CFLAGS "SHELL:-index-store-path \"${INDEX_DATA_STORE_PATH}\"")
+      endif()
+    endif()
 
     set(SOFT_FLOAT_FLAG -mfloat-abi=soft)
     set(HARD_FLOAT_FLAG -mfloat-abi=hard)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -8,6 +8,18 @@ if(APPLE AND CMAKE_OSX_SYSROOT AND (LLVM_TARGET_TRIPLE STREQUAL LLVM_HOST_TRIPLE
   # Only propagate the host sysroot for native runtimes builds.
   list(APPEND RUNTIMES_CMAKE_ARGS "-DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}")
 endif()
+
+set(INDEX_STORE_CMAKE_ARGS "")
+if(LLVM_ENABLE_INDEX_STORE AND NOT XCODE AND NOT MSVC_IDE)
+  # Propagate the index store for non-IDE generators (same check as
+  # HandleLLVMOptions). Pass INDEX_DATA_STORE_PATH to share the same
+  # content-addressed index store as the top-level build instead of
+  # defaulting to a new one in the sub-build's directory.
+  list(APPEND INDEX_STORE_CMAKE_ARGS
+    "-DLLVM_ENABLE_INDEX_STORE=ON"
+    "-DINDEX_DATA_STORE_PATH=${INDEX_DATA_STORE_PATH}")
+endif()
+
 foreach(proj ${LLVM_ENABLE_RUNTIMES})
   string(TOUPPER "${proj}" canon_name)
   STRING(REGEX REPLACE "-" "_" canon_name ${canon_name})
@@ -153,6 +165,7 @@ function(builtin_default_target compiler_rt_path)
                                       -DCMAKE_CXX_COMPILER_WORKS=ON
                                       -DCMAKE_ASM_COMPILER_WORKS=ON
                                       ${COMMON_CMAKE_ARGS}
+                                      ${INDEX_STORE_CMAKE_ARGS}
                                       ${BUILTINS_CMAKE_ARGS}
                            PASSTHROUGH_PREFIXES COMPILER_RT
                                                 DARWIN
@@ -181,6 +194,7 @@ function(builtin_register_target compiler_rt_path name)
                                       -DCMAKE_ASM_COMPILER_WORKS=ON
                                       -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
                                       ${COMMON_CMAKE_ARGS}
+                                      ${INDEX_STORE_CMAKE_ARGS}
                                       ${${name}_extra_args}
                            USE_TOOLCHAIN
                            FOLDER "Compiler-RT"
@@ -349,6 +363,7 @@ function(runtime_default_target)
                                       -DCMAKE_Fortran_COMPILER_WORKS=ON
                                       -DCMAKE_ASM_COMPILER_WORKS=ON
                                       ${COMMON_CMAKE_ARGS}
+                                      ${INDEX_STORE_CMAKE_ARGS}
                                       ${RUNTIMES_CMAKE_ARGS}
                                       ${ARG_CMAKE_ARGS}
                            PASSTHROUGH_PREFIXES LLVM_ENABLE_RUNTIMES
@@ -472,6 +487,7 @@ function(runtime_register_target name)
                                       -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
                                       -DLLVM_RUNTIMES_TARGET=${name}
                                       ${COMMON_CMAKE_ARGS}
+                                      ${INDEX_STORE_CMAKE_ARGS}
                                       ${${name}_extra_args}
                            EXTRA_TARGETS ${${name}_extra_targets}
                                          ${${name}_test_targets}


### PR DESCRIPTION
The runtimes builds aren't using -index-store-path when the rest of the build is. Propagate that down.

Assisted-by: Claude Code