### PR TITLE
[stable/21.x][clang][test][darwin] Driver/clang-offload-bundler-zstd.c fails on macOS

### DIFF
--- a/clang/test/Driver/clang-offload-bundler-zstd.c
+++ b/clang/test/Driver/clang-offload-bundler-zstd.c
@@ -1,5 +1,5 @@
 // REQUIRES: zstd
-// UNSUPPORTED: target={{.*}}-darwin{{.*}}, target={{.*}}-aix{{.*}}, target={{.*}}-zos{{.*}}
+// UNSUPPORTED: target={{.*}}-macosx{{.*}}, target={{.*}}-darwin{{.*}}, target={{.*}}-aix{{.*}}, target={{.*}}-zos{{.*}}
 
 //
 // Generate the host binary to be bundled.


### PR DESCRIPTION
Cherry pick of https://github.com/llvm/llvm-project/pull/207876