### PR TITLE
Fix Bazel build for clang and llvm

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -49,6 +49,7 @@ gentbl_cc_library(
     tbl_outs = dict([out for c in [
         "AST",
         "Analysis",
+        "CAS",
         "Comment",
         "Common",
         "CrossTU",
@@ -705,6 +706,7 @@ cc_library(
         "include/clang/Basic/BuiltinTemplates.inc",
         "include/clang/Basic/DiagnosticASTKinds.inc",
         "include/clang/Basic/DiagnosticAnalysisKinds.inc",
+        "include/clang/Basic/DiagnosticCASKinds.inc",
         "include/clang/Basic/DiagnosticCommentKinds.inc",
         "include/clang/Basic/DiagnosticCommonKinds.inc",
         "include/clang/Basic/DiagnosticCrossTUKinds.inc",
@@ -802,6 +804,22 @@ cc_library(
         ":support",
         "//llvm:Support",
         "//llvm:TargetParser",
+    ],
+)
+
+cc_library(
+    name = "cas",
+    srcs = glob([
+        "lib/CAS/*.cpp",
+    ]),
+    hdrs = glob([
+        "include/clang/CAS/*.h",
+    ]),
+    includes = ["include"],
+    deps = [
+        ":basic",
+        ":config",
+        "//llvm:Support",
     ],
 )
 
@@ -1016,6 +1034,8 @@ cc_library(
     hdrs = glob([
         "include/clang/Index/*.h",
         "include/clang-c/*.h",
+        "include/indexstore/*.h",
+        "lib/Index/*.h",
     ]),
     includes = ["include"],
     deps = [
@@ -1028,7 +1048,23 @@ cc_library(
         ":sema",
         ":serialization",
         ":unified_symbol_resolution",
+        "//llvm:BitstreamReader",
+        "//llvm:BitstreamWriter",
         "//llvm:Core",
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "index_headers",
+    hdrs = glob([
+        "include/clang/Index/*.h",
+    ]),
+    includes = ["include"],
+    deps = [
+        ":ast",
+        ":basic",
+        ":lex",
         "//llvm:Support",
     ],
 )
@@ -1305,6 +1341,7 @@ cc_library(
         ":ast",
         ":ast_matchers",
         ":basic",
+        ":cas",
         ":dependency_scanning",
         ":driver",
         ":format",
@@ -1358,7 +1395,35 @@ cc_library(
         ":rewrite",
         ":tooling",
         ":tooling_core",
+        ":tooling_syntax",
         ":unified_symbol_resolution",
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "tooling_refactor",
+    srcs = glob([
+        "lib/Tooling/Refactor/*.cpp",
+        "lib/Tooling/Refactor/*.h",
+    ]),
+    hdrs = glob(["include/clang/Tooling/Refactor/*.h"]),
+    textual_hdrs = glob(["include/clang/Tooling/Refactor/*.def"]),
+    deps = [
+        ":ast",
+        ":ast_matchers",
+        ":basic",
+        ":edit",
+        ":frontend",
+        ":index",
+        ":lex",
+        ":rewrite",
+        ":sema",
+        ":tooling_core",
+        ":tooling_refactoring",
+        ":tooling_syntax",
+        ":unified_symbol_resolution",
+        "//llvm:FrontendOpenMP",
         "//llvm:Support",
     ],
 )
@@ -1401,7 +1466,9 @@ cc_library(
     ]),
     hdrs = glob(["include/clang/DependencyScanning/**/*.h"]),
     deps = [
+        ":apinotes",
         ":basic",
+        ":cas",
         ":frontend",
         ":lex",
         ":serialization",
@@ -1816,9 +1883,11 @@ cc_library(
         ":apinotes",
         ":ast",
         ":basic",
+        ":cas",
         ":config",
         ":driver_options_inc_gen",
         ":edit",
+        ":index_headers",
         ":lex",
         ":options",
         ":parse",
@@ -1834,10 +1903,12 @@ cc_library(
         "//llvm:FrontendDebug",
         "//llvm:Linker",
         "//llvm:MC",
+        "//llvm:MCCAS",
         "//llvm:Option",
         "//llvm:Plugins",
         "//llvm:ProfileData",
         "//llvm:Remarks",
+        "//llvm:RemoteCachingService",
         "//llvm:Support",
         "//llvm:Target",
         "//llvm:TargetParser",
@@ -1926,6 +1997,7 @@ cc_library(
         "include",
         "lib/CodeGen",
     ],
+    textual_hdrs = glob(["lib/CodeGen/*.def"]),
     deps = [
         ":analysis",
         ":ast",
@@ -1936,6 +2008,7 @@ cc_library(
         ":basic_riscv_andes_vector_builtin_cg_gen",
         ":basic_riscv_sifive_vector_builtin_cg_gen",
         ":basic_riscv_vector_builtin_cg_gen",
+        ":cas",
         ":driver",
         ":frontend",
         ":lex",
@@ -2061,6 +2134,36 @@ cc_library(
 )
 
 cc_library(
+    name = "index_data_store",
+    srcs = glob(["lib/IndexDataStore/*.cpp"]),
+    hdrs = glob(["include/clang/Index/IndexDataStore.h"]),
+    deps = [
+        ":basic",
+        ":directory_watcher",
+        ":index",
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "index_store",
+    srcs = ["tools/IndexStore/IndexStore.cpp"],
+    hdrs = glob(["include/indexstore/*.h"]),
+    includes = ["include"],
+    linkopts = select({
+        "@platforms//os:macos": ["-Wl,-framework,CoreServices"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":basic",
+        ":directory_watcher",
+        ":index",
+        ":index_data_store",
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "install_api",
     srcs = glob([
         "lib/InstallAPI/*.cpp",
@@ -2132,6 +2235,7 @@ cc_library(
         ":extract_api",
         ":frontend",
         ":frontend_rewrite",
+        ":index_headers",
         ":options",
         ":scalable_static_analysis_core",
         ":scalable_static_analysis_frontend",
@@ -2153,8 +2257,10 @@ cc_library(
     deps = [
         ":ast",
         ":basic",
+        ":cas",
         ":codegen",
         ":config",
+        ":dependency_scanning",
         ":driver",
         ":extract_api",
         ":frontend",
@@ -2165,10 +2271,13 @@ cc_library(
         ":sema",
         ":serialization",
         ":tooling",
+        ":tooling_refactor",
         ":unified_symbol_resolution",
         "//llvm:BitstreamReader",
         "//llvm:FrontendOpenMP",
+        "//llvm:Option",
         "//llvm:Support",
+        "//llvm:TargetParser",
         "//llvm:config",
     ],
 )
@@ -2188,8 +2297,10 @@ cc_plugin_library(
     deps = [
         ":ast",
         ":basic",
+        ":cas",
         ":codegen",
         ":config",
+        ":dependency_scanning",
         ":driver",
         ":extract_api",
         ":frontend",
@@ -2200,10 +2311,13 @@ cc_plugin_library(
         ":sema",
         ":serialization",
         ":tooling",
+        ":tooling_refactor",
         ":unified_symbol_resolution",
         "//llvm:BitstreamReader",
         "//llvm:FrontendOpenMP",
+        "//llvm:Option",
         "//llvm:Support",
+        "//llvm:TargetParser",
         "//llvm:config",
     ],
 )
@@ -2229,6 +2343,8 @@ cc_binary(
     srcs = [
         "tools/c-index-test/c-index-test.c",
         "tools/c-index-test/core_main.cpp",
+        "tools/c-index-test/JSONAggregation.cpp",
+        "tools/c-index-test/JSONAggregation.h",
     ],
     copts = [
         "-Wno-uninitialized",
@@ -2239,9 +2355,11 @@ cc_binary(
         ":basic",
         ":codegen",
         ":config",
+        ":directory_watcher",
         ":driver",
         ":frontend",
         ":index",
+        ":index_store",
         ":lex",
         ":libclang",
         ":serialization",
@@ -2302,7 +2420,10 @@ cc_binary(
 
 cc_library(
     name = "clang-driver",
-    srcs = glob(["tools/driver/*.cpp"]),
+    srcs = glob([
+        "tools/driver/*.cpp",
+        "tools/driver/*.h",
+    ]),
     copts = [
         # Disable stack frame size checks in the driver because
         # clang::ensureStackAddressSpace allocates a large array on the stack.
@@ -2312,8 +2433,10 @@ cc_library(
         ":analysis",
         ":ast",
         ":basic",
+        ":cas",
         ":codegen",
         ":config",
+        ":dependency_scanning",
         ":driver",
         ":frontend",
         ":frontend_rewrite",
@@ -2324,6 +2447,7 @@ cc_library(
         ":sema",
         ":serialization",
         ":static_analyzer_frontend",
+        ":tooling",
         "//llvm:AllTargetsAsmParsers",
         "//llvm:AllTargetsCodeGens",
         "//llvm:BitReader",
@@ -2334,6 +2458,7 @@ cc_library(
         "//llvm:MC",
         "//llvm:MCParser",
         "//llvm:Option",
+        "//llvm:RemoteCachingService",
         "//llvm:Support",
         "//llvm:Target",
         "//llvm:TargetParser",
@@ -2603,6 +2728,7 @@ cc_library(
     srcs = glob(["tools/clang-scan-deps/*.cpp"]),
     deps = [
         ":ScanDepsTableGen",
+        ":cas",
         ":dependency_scanning",
         ":driver",
         ":frontend",

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -359,6 +359,9 @@ cc_library(
         "lib/Support/*.h",
         "lib/Support/*.inc",
         "lib/Support/LSP/*.cpp",
+        "lib/CAS/*.cpp",
+        "lib/CAS/*.h",
+        "lib/CASUtil/*.cpp",
         # To avoid a dependency cycle.
         "include/llvm/Option/*.h",
     ]) + select({
@@ -386,6 +389,10 @@ cc_library(
     hdrs = glob([
         "include/llvm/Support/**/*.h",
         "include/llvm/ADT/*.h",
+        "include/llvm/CAS/**/*.h",
+        "include/llvm-c/CAS/*.h",
+        "include/llvm/CASUtil/*.h",
+        "include/llvm/CASObjectFormats/*.h",
     ]) + [
         "include/llvm-c/Core.h",
         "include/llvm-c/DataTypes.h",
@@ -398,11 +405,12 @@ cc_library(
         "include/llvm-c/Types.h",
         "include/llvm-c/Visibility.h",
         "include/llvm-c/blake3.h",
+        "include/llvm/BinaryFormat/Magic.h",
         "include/llvm/ExecutionEngine/JITSymbol.h",
         "include/llvm/Support/Extension.def",
         "include/llvm/Support/VCSRevision.h",
     ],
-    copts = llvm_copts,
+    copts = llvm_copts + ["-DLLVM_ENABLE_ONDISK_CAS=1"],
     defines = select({
         "@platforms//cpu:aarch64": [
         ],
@@ -462,6 +470,7 @@ cc_library(
     }),
     textual_hdrs = glob([
         "include/llvm/Support/*.def",
+        "lib/CAS/*.def",
     ]),
     deps = [
         ":config",
@@ -1127,7 +1136,10 @@ cc_library(
             "lib/Remarks/*.cpp",
             "lib/Remarks/*.h",
         ],
-        exclude = ["lib/Remarks/RemarkLinker.cpp"],
+        exclude = [
+            "lib/Remarks/RemarkLinker.cpp",
+            "lib/Remarks/ExtraOptRemarks.cpp",
+        ],
     ),
     hdrs = glob(
         [
@@ -1137,7 +1149,9 @@ cc_library(
     ) + [
         "include/llvm-c/Remarks.h",
     ],
+    textual_hdrs = glob(["include/llvm/Remarks/*.def"]),
     copts = llvm_copts,
+    features = ["-parse_headers"],
     deps = [
         ":BitstreamReader",
         ":BitstreamWriter",
@@ -1433,7 +1447,9 @@ cc_library(
     name = "Analysis",
     srcs = glob(
         ["lib/Analysis/*.cpp"],
-    ),
+    ) + [
+        "lib/Remarks/ExtraOptRemarks.cpp",
+    ],
     hdrs = glob(
         [
             "include/llvm/Analysis/*.h",
@@ -1452,6 +1468,7 @@ cc_library(
         ":MC",
         ":Object",
         ":ProfileData",
+        ":Remarks",
         ":Support",
         ":TargetParser",
         ":config",
@@ -1835,9 +1852,11 @@ cc_library(
         ":AggressiveInstCombine",
         ":Analysis",
         ":BinaryFormat",
+        ":BitWriter",
         ":Core",
         ":InstCombine",
         ":ProfileData",
+        ":Remarks",
         ":Support",
         ":Target",
         ":TransformUtils",
@@ -2290,6 +2309,24 @@ cc_library(
 )
 
 cc_library(
+    name = "MCCAS",
+    srcs = glob(["lib/MCCAS/*.cpp"]),
+    hdrs = glob(["include/llvm/MCCAS/*.h"]),
+    copts = llvm_copts,
+    features = ["-parse_headers"],
+    textual_hdrs = glob(["include/llvm/MCCAS/*.def"]),
+    deps = [
+        ":BinaryFormat",
+        ":DebugInfoCodeView",
+        ":DebugInfoDWARF",
+        ":MC",
+        ":Support",
+        ":TargetParser",
+        ":config",
+    ],
+)
+
+cc_library(
     name = "CodeGen",
     srcs = glob(
         [
@@ -2329,6 +2366,7 @@ cc_library(
         ":IRPrinter",
         ":Instrumentation",
         ":MC",
+        ":MCCAS",
         ":MCParser",
         ":ObjCARC",
         ":Object",
@@ -4208,6 +4246,20 @@ cc_library(
 )
 
 cc_library(
+    name = "RemoteCachingService",
+    srcs = [
+        "lib/RemoteCachingService/NullService/NullService.cpp",
+        "lib/RemoteCachingService/RemoteCachingService.cpp",
+    ],
+    hdrs = glob(["include/llvm/RemoteCachingService/*.h"]),
+    copts = llvm_copts,
+    deps = [
+        ":Support",
+        ":config",
+    ],
+)
+
+cc_library(
     name = "LTO",
     srcs = glob([
         "lib/LTO/*.cpp",
@@ -4238,6 +4290,7 @@ cc_library(
         ":Passes",
         ":Plugins",
         ":Remarks",
+        ":RemoteCachingService",
         ":Scalar",
         ":Support",
         ":Target",
@@ -4901,6 +4954,7 @@ cc_binary(
         ":IRPrinter",
         ":IRReader",
         ":MC",
+        ":MCCAS",
         ":Passes",
         ":Plugins",
         ":Remarks",
@@ -5685,6 +5739,7 @@ cc_binary(
         ":AllTargetsDisassemblers",
         ":DWARFCFIChecker",
         ":MC",
+        ":MCCAS",
         ":MCDisassembler",
         ":MCParser",
         ":Object",


### PR DESCRIPTION
Updates the Bazel build configuration with libraries only present on this fork of LLVM.