### PR TITLE
Handle the EmbeddedMismatch serialization failure

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1194,6 +1194,8 @@ static const char *getImportFailureString(swift::serialization::Status status) {
            "different version of the compiler.";
   case swift::serialization::Status::SDKMismatch:
     return "The module file was built with a different SDK version.";
+  case swift::serialization::Status::EmbeddedMismatch:
+    return "The module file was built with a different Embedded setting.";
   case swift::serialization::Status::ChannelIncompatible:
     return "The distribution channel doesn't match."
            " This version of LLDB is most likely from a different toolchain"


### PR DESCRIPTION
This was committed to a branch. Bring it to `next`, addressing rdar://174227939.