### PR TITLE
[LLDB] Limit dynamic Swift types to the scratch typesystem

### DIFF
--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -17,6 +17,7 @@
 #include "lldb/Core/Value.h"
 #include "lldb/Expression/LLVMUserExpression.h"
 #include "lldb/Symbol/DeclVendor.h"
+#include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/ExecutionContextScope.h"
 #include "lldb/Target/Runtime.h"
 #include "lldb/ValueObject/ValueObject.h"
@@ -206,7 +207,8 @@ public:
   /// from the user interface.
   virtual bool IsAllowedRuntimeValue(ConstString name) { return false; }
 
-  virtual std::optional<CompilerType> GetRuntimeType(CompilerType base_type) {
+  virtual std::optional<CompilerType>
+  GetRuntimeType(CompilerType base_type, ExecutionContextRef exe_ctx) {
     return std::nullopt;
   }
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -12,8 +12,10 @@
 
 #include "SwiftExpressionParser.h"
 
-#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "Plugins/Language/Swift/LogChannelSwift.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "SwiftASTManipulator.h"
 #include "SwiftDiagnostic.h"
 #include "SwiftExpressionSourceCode.h"
@@ -56,6 +58,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TargetSelect.h"
@@ -457,7 +460,7 @@ public:
 /// Returns the Swift type for a ValueObject representing a variable.
 /// An invalid CompilerType is returned on error.
 static CompilerType GetSwiftTypeForVariableValueObject(
-    lldb::ValueObjectSP valobj_sp, lldb::StackFrameSP &stack_frame_sp,
+    lldb::ValueObjectSP valobj_sp, lldb_private::StackFrame &stack_frame,
     SwiftLanguageRuntime *runtime, lldb::BindGenericTypes bind_generic_types) {
   // Check that the passed ValueObject is valid.
   if (!valobj_sp)
@@ -467,10 +470,16 @@ static CompilerType GetSwiftTypeForVariableValueObject(
     return {};
   if (SwiftASTManipulator::ShouldBindGenericTypes(bind_generic_types))
     result = llvm::expectedToOptional(
-                 runtime->BindGenericTypeParameters(*stack_frame_sp, result))
+                 runtime->BindGenericTypeParameters(stack_frame, result))
                  .value_or(CompilerType());
   if (!result)
     return {};
+  if (runtime)
+    if (auto rt =
+            runtime->GetRuntimeType(result, ExecutionContext(stack_frame)))
+      if (rt->IsValid())
+        result = *rt;
+
   if (!result.GetTypeSystem()->SupportsLanguage(lldb::eLanguageTypeSwift))
     return {};
   return result;
@@ -483,16 +492,15 @@ static CompilerType GetSwiftTypeForVariableValueObject(
 /// SwiftASTContext cannot see because there is no header file that
 /// would declare them.
 CompilerType SwiftExpressionParser::ResolveVariable(
-    lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
+    lldb::VariableSP variable_sp, lldb_private::StackFrame &stack_frame,
     SwiftLanguageRuntime *runtime, lldb::DynamicValueType use_dynamic,
     lldb::BindGenericTypes bind_generic_types) {
-  lldb::ValueObjectSP valobj_sp =
-      stack_frame_sp->GetValueObjectForFrameVariable(variable_sp,
-                                                     lldb::eNoDynamicValues);
+  lldb::ValueObjectSP valobj_sp = stack_frame.GetValueObjectForFrameVariable(
+      variable_sp, lldb::eNoDynamicValues);
   const bool use_dynamic_value = use_dynamic > lldb::eNoDynamicValues;
 
   CompilerType var_type = GetSwiftTypeForVariableValueObject(
-      valobj_sp, stack_frame_sp, runtime, bind_generic_types);
+      valobj_sp, stack_frame, runtime, bind_generic_types);
 
   if (!var_type.IsValid())
     return {};
@@ -510,7 +518,7 @@ CompilerType SwiftExpressionParser::ResolveVariable(
       SwiftASTManipulator::ShouldBindGenericTypes(bind_generic_types) &&
       use_dynamic_value) {
     var_type = GetSwiftTypeForVariableValueObject(
-        valobj_sp->GetDynamicValue(use_dynamic), stack_frame_sp, runtime,
+        valobj_sp->GetDynamicValue(use_dynamic), stack_frame, runtime,
         bind_generic_types);
     if (!var_type.IsValid())
       return {};
@@ -545,7 +553,7 @@ lldb::VariableSP SwiftExpressionParser::FindSelfVariable(Block *block) {
 /// successfully. If the method returns an error status, it contains a string
 /// that explain the failure.
 static llvm::Error
-AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
+AddRequiredAliases(Block *block, lldb_private::StackFrame &stack_frame,
                    SwiftASTContextForExpressions &swift_ast_context,
                    SwiftASTManipulator &manipulator,
                    lldb::DynamicValueType use_dynamic,
@@ -574,10 +582,9 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     return llvm::Error::success();
 
   auto *swift_runtime =
-      SwiftLanguageRuntime::Get(stack_frame_sp->GetThread()->GetProcess());
+      SwiftLanguageRuntime::Get(stack_frame.GetThread()->GetProcess());
   CompilerType self_type = SwiftExpressionParser::ResolveVariable(
-      self_var_sp, stack_frame_sp, swift_runtime, use_dynamic,
-      bind_generic_types);
+      self_var_sp, stack_frame, swift_runtime, use_dynamic, bind_generic_types);
 
   if (!self_type.IsValid()) {
     if (Type *type = self_var_sp->GetType()) {
@@ -601,10 +608,9 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
         "Unable to add the aliases the expression needs because the "
         "self type from an import isn't valid.");
 
-  auto *stack_frame = stack_frame_sp.get();
   if (SwiftASTManipulator::ShouldBindGenericTypes(bind_generic_types)) {
     auto bound_type_or_err = swift_runtime->BindGenericTypeParameters(
-        *stack_frame, imported_self_type);
+        stack_frame, imported_self_type);
     if (!bound_type_or_err)
       return llvm::joinErrors(
           llvm::createStringError(
@@ -646,7 +652,7 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     // If we are extending a generic class it's going to be a metatype,
     // and we have to grab the instance type:
     imported_self_type = swift_type_system->GetInstanceType(
-        imported_self_type.GetOpaqueQualType(), stack_frame_sp.get());
+        imported_self_type.GetOpaqueQualType(), &stack_frame);
     if (!imported_self_type)
       return llvm::createStringError(
           "Unable to add the aliases the expression needs because the Swift "
@@ -1447,6 +1453,8 @@ SwiftExpressionParser::ParseAndImport(
 
   if (!playground && !repl) {
     lldb::StackFrameSP stack_frame_sp = m_stack_frame_wp.lock();
+    if (!stack_frame_sp)
+      return llvm::createStringError("no stack frame");
 
     bool local_context_is_swift = true;
 
@@ -1459,7 +1467,7 @@ SwiftExpressionParser::ParseAndImport(
     if (!m_options.GetUseContextFreeSwiftPrintObject()) {
       if (local_context_is_swift) {
         llvm::Error error = AddRequiredAliases(
-            m_sc.block, stack_frame_sp, m_swift_ast_ctx, *code_manipulator,
+            m_sc.block, *stack_frame_sp, m_swift_ast_ctx, *code_manipulator,
             m_options.GetUseDynamic(), m_options.GetSwiftBindGenericTypes());
         if (error)
           return error;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -157,7 +157,7 @@ public:
   bool RewriteExpression(DiagnosticManager &diagnostic_manager) override;
 
   static CompilerType ResolveVariable(
-      lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
+      lldb::VariableSP variable_sp, lldb_private::StackFrame &stack_frame,
       SwiftLanguageRuntime *runtime, lldb::DynamicValueType use_dynamic,
       lldb::BindGenericTypes bind_generic_types);
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -366,7 +366,7 @@ static llvm::Error AddVariableInfo(
     target_type = variable_sp->GetType()->GetForwardCompilerType();
   else {
     CompilerType var_type = SwiftExpressionParser::ResolveVariable(
-        variable_sp, stack_frame_sp, runtime, use_dynamic, bind_generic_types);
+        variable_sp, *stack_frame_sp, runtime, use_dynamic, bind_generic_types);
 
     // IsMeaninglessWithoutDynamicResolution basically only checks if
     // it is an unspecialized generic type.

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -96,7 +96,13 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
   if (opt_size)
     m_element_size = *opt_size;
   auto opt_stride = elem_type.GetByteStride(process_sp.get());
+  // The Objective-C bridged array path (_ContiguousArrayStorage) uses a Clang
+  // 'id' element type, whose type system does not implement GetByteStride.
+  assert((opt_stride ||
+          !elem_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>()) &&
+         "Swift Array element type has no stride");
   m_element_stride = opt_stride.value_or(m_element_size);
+  assert(m_element_stride > 0 && "Swift array element stride must be positive");
   size_t ptr_size = process_sp->GetAddressByteSize();
   Status error;
   lldb::addr_t next_read = native_ptr;
@@ -465,6 +471,8 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &static_valobj) {
     if (!nonsynth_sp)
       return nullptr;
     ValueObjectSP storage_sp(nonsynth_sp->GetChildMemberWithName(g__storage));
+    if (!storage_sp)
+      return nullptr;
 
     lldb::addr_t storage_location =
         storage_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -493,19 +493,30 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
 
   m_ptr_size = m_process->GetAddressByteSize();
 
-  auto count_sp = m_storage->GetChildAtNamePath({g__count, g__value});
+  // Embedded Swift can resolve the static, but not the dynamic value.
+  ValueObject *storage_for_children = m_storage;
+  if (m_is_embedded_swift) {
+    lldb::ValueObjectSP static_storage = m_storage->GetStaticValue();
+    if (!static_storage)
+      return;
+    storage_for_children = static_storage.get();
+  }
+  auto count_sp =
+      storage_for_children->GetChildAtNamePath({g__count, g__value});
   if (!count_sp)
     return;
   m_count = count_sp->GetValueAsUnsigned(0);
 
-  auto scale_sp = m_storage->GetChildAtNamePath({g__scale, g__value});
+  auto scale_sp =
+      storage_for_children->GetChildAtNamePath({g__scale, g__value});
   if (!scale_sp)
     return;
   auto scale = scale_sp->GetValueAsUnsigned(0);
   m_scale = scale;
 
   auto keys_ivar = value_type ? g__rawKeys : g__rawElements;
-  auto keys_sp = m_storage->GetChildAtNamePath({keys_ivar, g__rawValue});
+  auto keys_sp =
+      storage_for_children->GetChildAtNamePath({keys_ivar, g__rawValue});
   if (!keys_sp)
     return;
   m_keys_ptr = keys_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
@@ -513,7 +524,8 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
   lldb::addr_t last_field_ptr = keys_sp->GetAddressOf().address;
 
   if (value_type) {
-    auto values_sp = m_storage->GetChildAtNamePath({g__rawValues, g__rawValue});
+    auto values_sp =
+        storage_for_children->GetChildAtNamePath({g__rawValues, g__rawValue});
     if (!values_sp)
       return;
     m_values_ptr = values_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -667,11 +667,11 @@ lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::Update() {
   if (m_unsafe_ptr->Update() == ChildCacheState::eRefetch)
     return ChildCacheState::eRefetch;
 
-  const uint32_t num_children = CalculateNumChildrenIgnoringErrors();
   m_children = ::ExtractChildrenFromSwiftPointerValueObject(valobj_sp,
                                                           *m_unsafe_ptr.get());
-  return m_children.size() == num_children ? ChildCacheState::eReuse
-                                           : ChildCacheState::eRefetch;
+  // The children are freshly-rebuilt memory snapshots, so the caller must drop
+  // any cached wrapper children rather than reuse stale ones from a prior stop.
+  return ChildCacheState::eRefetch;
 }
 
 bool lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
@@ -468,7 +468,8 @@ CompilerType ObjCLanguageRuntime::LookupInRuntime(ConstString class_name) {
 }
 
 std::optional<CompilerType>
-ObjCLanguageRuntime::GetRuntimeType(CompilerType base_type) {
+ObjCLanguageRuntime::GetRuntimeType(CompilerType base_type,
+                                    ExecutionContextRef exe_ctx) {
   CompilerType class_type;
   bool is_pointer_type = false;
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -281,7 +281,8 @@ public:
 
   lldb::TypeSP LookupInCompleteClassCache(ConstString &name);
 
-  std::optional<CompilerType> GetRuntimeType(CompilerType base_type) override;
+  std::optional<CompilerType>
+  GetRuntimeType(CompilerType base_type, ExecutionContextRef exe_ctx) override;
 
   virtual llvm::Expected<std::unique_ptr<UtilityFunction>>
   CreateObjectChecker(std::string name, ExecutionContext &exe_ctx) = 0;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -567,7 +567,15 @@ ReflectionContextInterface::GetCanonicalTypeRef(CompilerType type) {
 
   auto flavor =
       SwiftLanguageRuntime::GetManglingFlavor(mangled_name.GetStringRef());
-  auto node_or_err = tr_ts->RemoveMarkerProtocols(dem, node, flavor);
+  ExecutionContext exe_ctx;
+  if (auto *expr_ts =
+          llvm::dyn_cast<TypeSystemSwiftTypeRefForExpressions>(tr_ts.get()))
+    exe_ctx = expr_ts
+                  ->GetExecutionContextForType(
+                      expr_ts->GetTypeFromMangledTypename(mangled_name)
+                          .GetOpaqueQualType())
+                  .Lock(false);
+  auto node_or_err = tr_ts->RemoveMarkerProtocols(dem, node, flavor, exe_ctx);
   if (!node_or_err)
     return node_or_err.takeError();
   return GetTypeRef(dem, *node_or_err);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -308,6 +308,20 @@ public:
   };
   /// \}
 
+  /// Import a Swift type into a scratch typesystem
+  /// (TypeSystemSwiftTypeRefForExpressions). This works with all
+  /// types, but only makes sense for types in the per-module
+  /// TypeSystemSwiftTypeRef. In contrast to the per-module
+  /// (lldb_private::Module) typesystems the scratch typesystem is
+  /// bound to a process and can therefore answer queries that need
+  /// runtime information.
+  static llvm::Expected<CompilerType>
+  GetScratchTypeSystemType(CompilerType module_type,
+                           ExecutionContextRef exe_ctx_ref);
+
+  std::optional<CompilerType>
+  GetRuntimeType(CompilerType base_type, ExecutionContextRef exe_ctx) override;
+
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
@@ -490,7 +504,8 @@ public:
                                       ExecutionContextScope *exe_scope);
 
   /// Ask Remote mirrors for the stride of a Swift type.
-  std::optional<uint64_t> GetByteStride(CompilerType type);
+  std::optional<uint64_t>
+  GetByteStride(CompilerType type, ExecutionContextScope *exe_scope = nullptr);
 
   /// Ask Remote mirrors for the alignment of a Swift type.
   std::optional<size_t> GetBitAlignment(CompilerType type,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -38,6 +38,7 @@
 #include "llvm/Support/Error.h"
 
 #include "lldb/lldb-enumerations.h"
+#include "lldb/lldb-forward.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTWalker.h"
@@ -48,6 +49,7 @@
 #include "swift/RemoteInspection/TypeRefBuilder.h"
 #include "swift/Strings.h"
 
+#include <memory>
 #include <sstream>
 
 #define HEALTH_LOG(FMT, ...)                                                   \
@@ -1035,8 +1037,30 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
   const swift::reflection::TypeRef *tr = nullptr;
   auto ti_or_err = m_runtime.GetSwiftRuntimeTypeInfo(
       m_type, m_exe_ctx.GetBestExecutionContextScope(), &tr);
-  if (!ti_or_err)
-    return ti_or_err.takeError();
+  if (!ti_or_err) {
+    // For class types with no field descriptor (e.g., forward
+    // declarations in embedded Swift), fall back to reading the class
+    // instance layout from the instance pointer in memory.
+    if (m_valobj &&
+        Flags(m_type.GetTypeInfo()).AllSet(eTypeIsClass | eTypeIsSwift)) {
+      lldb::addr_t instance = ::MaskMaybeBridgedPointer(
+          m_runtime.GetProcess(), m_valobj->GetPointerValue().address);
+      if (instance != LLDB_INVALID_ADDRESS) {
+        auto *desc_finder =
+            ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope());
+        LLDBTypeInfoProvider tip(m_runtime, ts);
+        ThreadSafeReflectionContext reflection_ctx =
+            m_runtime.GetReflectionContext();
+        if (reflection_ctx) {
+          llvm::consumeError(ti_or_err.takeError());
+          ti_or_err = reflection_ctx->GetTypeInfoFromInstance(instance, &tip,
+                                                              desc_finder);
+        }
+      }
+    }
+    if (!ti_or_err)
+      return ti_or_err.takeError();
+  }
   auto *ti = &*ti_or_err;
 
   // Structs and Tuples.
@@ -1284,7 +1308,8 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
 
       LLDBTypeInfoProvider tip(m_runtime, ts);
       auto cti_or_err = reflection_ctx->GetClassInstanceTypeInfo(
-          *tr, &tip, ts.GetDescriptorFinder());
+          *tr, &tip,
+          ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope()));
       if (!cti_or_err)
         return cti_or_err.takeError();
       if (auto *rti = llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(
@@ -1296,14 +1321,18 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
         if (count_only) {
           // The superclass, if any, is an extra child.
           if (!m_hide_superclass &&
-              reflection_ctx->LookupSuperclass(*tr, ts.GetDescriptorFinder()))
+              reflection_ctx->LookupSuperclass(
+                  *tr, ts.GetDescriptorFinder(
+                           m_exe_ctx.GetBestExecutionContextScope())))
             return rti->getNumFields() + 1;
           return rti->getNumFields();
         }
         if (m_visit_superclass) {
           unsigned depth = 0;
           reflection_ctx->ForEachSuperClassType(
-              &tip, ts.GetDescriptorFinder(), tr, [&](SuperClassType sc) {
+              &tip,
+              ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope()),
+              tr, [&](SuperClassType sc) {
                 auto *tr = sc.get_typeref();
                 if (!tr || llvm::isa<swift::reflection::ObjCClassTypeRef>(tr))
                   return true;
@@ -1312,7 +1341,8 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
                   return true;
 
                 if (auto *super_tr = reflection_ctx->LookupSuperclass(
-                        *tr, ts.GetDescriptorFinder()))
+                        *tr, ts.GetDescriptorFinder(
+                                 m_exe_ctx.GetBestExecutionContextScope())))
                   if (auto error = visit_callback(
                           GetTypeFromTypeRef(ts, super_tr, m_flavor), depth,
                           []() -> std::string { return "<base class>"; },
@@ -1342,7 +1372,8 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
           return success;
         }
         if (auto *super_tr = reflection_ctx->LookupSuperclass(
-                *tr, ts.GetDescriptorFinder())) {
+                *tr, ts.GetDescriptorFinder(
+                         m_exe_ctx.GetBestExecutionContextScope()))) {
           auto get_name = []() -> std::string { return "<base class>"; };
           auto get_info = []() -> llvm::Expected<ChildInfo> {
             return ChildInfo();
@@ -1402,16 +1433,19 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
     lldb::addr_t instance = ::MaskMaybeBridgedPointer(
         m_runtime.GetProcess(), m_valobj->GetPointerValue().address);
 
+    auto *desc_finder =
+        ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope());
+
     // Try out the instance pointer based super class traversal first, as its
     // usually faster.
-    reflection_ctx->ForEachSuperClassType(&tip, ts.GetDescriptorFinder(),
-                                          instance, superclass_finder);
+    reflection_ctx->ForEachSuperClassType(&tip, desc_finder, instance,
+                                          superclass_finder);
 
     if (supers.empty())
       // If the pointer based super class traversal failed (this may happen
       // when metadata is not present in the binary, for example: embedded
       // Swift), try the typeref based one next.
-      reflection_ctx->ForEachSuperClassType(&tip, ts.GetDescriptorFinder(), tr,
+      reflection_ctx->ForEachSuperClassType(&tip, desc_finder, tr,
                                             superclass_finder);
 
     if (supers.empty() && tr) {
@@ -1419,8 +1453,8 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
                "Couldn't find the type metadata for {0} in instance",
                m_type.GetTypeName());
 
-      auto cti_or_err = reflection_ctx->GetClassInstanceTypeInfo(
-          *tr, &tip, ts.GetDescriptorFinder());
+      auto cti_or_err =
+          reflection_ctx->GetClassInstanceTypeInfo(*tr, &tip, desc_finder);
       const swift::reflection::TypeInfo *cti = nullptr;
       if (cti_or_err)
         cti = &*cti_or_err;
@@ -1665,20 +1699,21 @@ llvm::Expected<std::string> SwiftLanguageRuntime::GetEnumCaseName(
 
 llvm::Expected<ValueObjectSP>
 SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
-  TypeSystemSwiftTypeRefSP ts_sp;
-  if (auto target_sp = valobj.GetTargetSP()) {
-    auto type_system_or_err =
-        target_sp->GetScratchTypeSystemForLanguage(lldb::eLanguageTypeSwift);
-    if (!type_system_or_err)
-      return type_system_or_err.takeError();
-    auto ts_ptr = type_system_or_err->get();
-    ts_sp = llvm::cast<TypeSystemSwift>(ts_ptr)->GetTypeSystemSwiftTypeRef();
-  }
-  if (!ts_sp)
-    return llvm::createStringError("no target");
-  auto &ts = *ts_sp;
   auto exe_ctx = valobj.GetExecutionContextRef().Lock(true);
   CompilerType enum_type = valobj.GetCompilerType();
+
+  // The enum may live in either the per-module typesystem (e.g. a static
+  // ValueObject, or an Embedded Swift type) or the scratch typesystem (a
+  // hoisted dynamic value). Either one works here: everything below only
+  // needs a TypeSystemSwiftTypeRef to build payload types and to reach the
+  // descriptor finder.
+  auto ts_sp = enum_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!ts_sp)
+    return llvm::createStringError("not a Swift type");
+  auto tr_ts_sp = ts_sp->GetTypeSystemSwiftTypeRef();
+  if (!tr_ts_sp)
+    return llvm::createStringError("no Swift typeref typesystem");
+  auto &ts = *tr_ts_sp;
 
   auto ti_or_err = GetSwiftRuntimeTypeInfo(
       enum_type, exe_ctx.GetBestExecutionContextScope());
@@ -2555,6 +2590,26 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
       swift::Demangle::Demangler dem;
       swift::Demangle::NodePointer node = typeref->getDemangling(dem);
       dynamic_type = ts->RemangleAsType(dem, node, flavor);
+
+      // FIXME: The metadata type of an expression-defined class type
+      // contains an anonymous context that cannot be resolved. Keep
+      // the static type.
+      auto is_anonymous_expr_context = [](swift::Demangle::NodePointer n) {
+        using namespace swift::Demangle;
+        return swift_demangle::FindIf(n, [](NodePointer child) {
+          return child->getKind() == Node::Kind::AnonymousContext;
+        });
+      };
+      if (dynamic_type && is_anonymous_expr_context(node)) {
+        swift::Demangle::Demangler static_dem;
+        swift::Demangle::NodePointer static_node = static_dem.demangleSymbol(
+            class_type.GetMangledTypeName().GetStringRef());
+        CompilerType static_type =
+            ts->GetTypeFromMangledTypename(class_type.GetMangledTypeName());
+        if (!is_anonymous_expr_context(static_node) &&
+            ts->IsExpressionEvaluatorDefined(static_type.GetOpaqueQualType()))
+          dynamic_type = class_type;
+      }
     } else {
       dynamic_type =
           GetDynamicTypeAndAddress_EmbeddedClass(instance_ptr, class_type);
@@ -2877,8 +2932,20 @@ SwiftLanguageRuntime::GetTypeMetadataForTypeNameAndFrame(StringRef mdvar_name,
 
   ValueObjectSP metadata_ptr_var_sp(
       frame.GetValueObjectForFrameVariable(var_sp, lldb::eNoDynamicValues));
-  if (!metadata_ptr_var_sp ||
-      metadata_ptr_var_sp->UpdateValueIfNeeded() == false)
+  if (!metadata_ptr_var_sp)
+    return {};
+  ExecutionContext exe_ctx(frame);
+  auto scratch_type =
+      llvm::expectedToOptional(SwiftLanguageRuntime::GetScratchTypeSystemType(
+          metadata_ptr_var_sp->GetCompilerType(), exe_ctx));
+  if (!scratch_type)
+    return {};
+  metadata_ptr_var_sp = ValueObjectCast::Create(
+      *metadata_ptr_var_sp, ConstString(mdvar_name), *scratch_type);
+  if (!metadata_ptr_var_sp)
+    return {};
+
+  if (!metadata_ptr_var_sp->UpdateValueIfNeeded())
     return {};
 
   lldb::addr_t metadata_location(metadata_ptr_var_sp->GetValueAsUnsigned(0));
@@ -3099,6 +3166,11 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
     bound_type = *bound_type_or_err;
   }
 
+  ExecutionContext exe_ctx(stack_frame);
+  if (std::optional<CompilerType> runtime_type =
+          GetRuntimeType(bound_type, exe_ctx))
+    return *runtime_type;
+
   return bound_type;
 }
 
@@ -3130,7 +3202,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
     Address &address, Value::ValueType &value_type,
     llvm::ArrayRef<uint8_t> &local_buffer) {
-  auto static_type = in_value.GetCompilerType();
+  CompilerType static_type = in_value.GetCompilerType();
   value_type = Value::ValueType::Invalid;
   class_type_or_name.SetCompilerType(bound_type);
 
@@ -3455,6 +3527,50 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_ClangType(
   return true;
 }
 
+llvm::Expected<CompilerType> SwiftLanguageRuntime::GetScratchTypeSystemType(
+    CompilerType module_type, ExecutionContextRef exe_ctx_ref) {
+  // Hoist the type into the scratch typesystem (which knows about Process).
+  TypeSystemSwiftTypeRefForExpressionsSP ts;
+  TargetSP target_sp = exe_ctx_ref.GetTargetSP();
+  if (!target_sp)
+    return llvm::createStringError("no target");
+  auto type_system_or_err =
+      target_sp->GetScratchTypeSystemForLanguage(lldb::eLanguageTypeSwift);
+  if (!type_system_or_err)
+    return type_system_or_err.takeError();
+  auto ts_sp = *type_system_or_err;
+  if (!llvm::isa_and_nonnull<TypeSystemSwiftTypeRefForExpressions>(ts_sp.get()))
+    return llvm::createStringError("unexpected typesystem");
+
+  ts = std::static_pointer_cast<TypeSystemSwiftTypeRefForExpressions>(ts_sp);
+  return ts->ImportType(module_type, exe_ctx_ref);
+}
+
+/// Import \p type into the scratch typesystem. On failure, log the error and
+/// return an invalid CompilerType.
+static CompilerType HoistToScratchTypeSystem(CompilerType type,
+                                             ExecutionContextRef exe_ctx_ref) {
+  llvm::Expected<CompilerType> scratch_type =
+      SwiftLanguageRuntime::GetScratchTypeSystemType(type, exe_ctx_ref);
+  if (!scratch_type) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), scratch_type.takeError(),
+                   "cannot import type into scratch typesystem: {0}");
+    return CompilerType();
+  }
+  return *scratch_type;
+}
+
+std::optional<CompilerType>
+SwiftLanguageRuntime::GetRuntimeType(CompilerType base_type,
+                                     ExecutionContextRef exe_ctx) {
+  // Hoist the type into a scratch typesystem.
+  if (!base_type.GetTypeSystem().isa_and_nonnull<TypeSystemSwiftTypeRef>())
+    return {};
+  if (CompilerType run_type = HoistToScratchTypeSystem(base_type, exe_ctx))
+    return run_type;
+  return {};
+}
+
 static bool CouldHaveDynamicValue(ValueObject &in_value) {
   CompilerType var_type(in_value.GetCompilerType());
   Flags var_type_flags(var_type.GetTypeInfo());
@@ -3465,6 +3581,8 @@ static bool CouldHaveDynamicValue(ValueObject &in_value) {
     // disable it.
     return !in_value.IsBaseClass();
   }
+  if (var_type_flags.AllSet(eTypeIsSwift | lldb::eTypeIsGenericTypeParam))
+    return true;
   return var_type.IsPossibleDynamicType(nullptr, false, false);
 }
 
@@ -3475,7 +3593,32 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
   class_type_or_name.Clear();
   if (use_dynamic == lldb::eNoDynamicValues)
     return false;
-  CompilerType val_type(in_value.GetCompilerType());
+
+  auto hoist_type = [&](CompilerType type) {
+    if (!type.GetTypeSystem().isa_and_nonnull<TypeSystemSwiftTypeRef>())
+      return CompilerType();
+    // Embedded Swift types have no runtime reflection metadata, so
+    // hoisting them to the scratch typesystem is counterproductive.
+    if (SwiftLanguageRuntime::GetManglingFlavor(type.GetMangledTypeName()) ==
+        swift::Mangle::ManglingFlavor::Embedded)
+      return type;
+    if (type.GetTypeSystem()
+            .isa_and_nonnull<TypeSystemSwiftTypeRefForExpressions>())
+      return type;
+    return HoistToScratchTypeSystem(type, in_value.GetExecutionContextRef());
+  };
+
+  // Hoist the type into a scratch typesystem.
+  auto hoist_result_type = [&](TypeAndOrName &class_type_or_name) {
+    CompilerType type = class_type_or_name.GetCompilerType();
+    if (!type)
+      return;
+    CompilerType scratch_type = hoist_type(type);
+    if (!scratch_type)
+      return;
+    class_type_or_name.SetCompilerType(scratch_type);
+  };
+
   Value::ValueType static_value_type = Value::ValueType::Invalid;
 
   // Try to import a Clang type into Swift.
@@ -3484,12 +3627,20 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
                                            class_type_or_name, address,
                                            value_type, local_buffer))
       return true;
-    return GetDynamicTypeAndAddress_Class(in_value, val_type, use_dynamic,
-                                          class_type_or_name, address,
-                                          static_value_type, local_buffer);
+    if (GetDynamicTypeAndAddress_Class(in_value, in_value.GetCompilerType(),
+                                       use_dynamic, class_type_or_name, address,
+                                       static_value_type, local_buffer)) {
+      hoist_result_type(class_type_or_name);
+      return true;
+    }
+    return false;
   }
 
   if (!CouldHaveDynamicValue(in_value))
+    return false;
+
+  CompilerType val_type = hoist_type(in_value.GetCompilerType());
+  if (!val_type)
     return false;
 
   Flags type_info(val_type.GetTypeInfo());
@@ -3508,7 +3659,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
                                              static_value_type, local_buffer);
   else if (type_info.AllSet(eTypeIsMetatype | eTypeIsProtocol)) {
     success = GetDynamicTypeAndAddress_ExistentialMetatype(
-        in_value, val_type, use_dynamic, class_type_or_name, address, static_value_type);
+        in_value, val_type, use_dynamic, class_type_or_name, address,
+        static_value_type);
   } else if (type_info.AnySet(eTypeIsProtocol)) {
     if (type_info.AnySet(eTypeIsObjC))
       success = GetDynamicTypeAndAddress_Class(in_value, val_type, use_dynamic,
@@ -3550,6 +3702,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
   }
 
   if (success) {
+    hoist_result_type(class_type_or_name);
+
     // If we haven't found a better static value type, use the value object's
     // one.
     if (static_value_type == Value::ValueType::Invalid)
@@ -3843,7 +3997,8 @@ SwiftLanguageRuntime::GetSwiftRuntimeTypeInfo(
                                                         : g_reflection,
       &GetProcess().GetTarget().GetDebugger(), *GetMemoryReader());
   LLDBTypeInfoProvider provider(*this, ts);
-  return reflection_ctx->GetTypeInfo(type, &provider, ts.GetDescriptorFinder());
+  return reflection_ctx->GetTypeInfo(type, &provider,
+                                     ts.GetDescriptorFinder(exe_scope));
 }
 
 bool SwiftLanguageRuntime::IsStoredInlineInBuffer(CompilerType type) {
@@ -3998,8 +4153,10 @@ SwiftLanguageRuntime::GetBitSize(CompilerType type,
   return type_info_or_err->getSize() * 8;
 }
 
-std::optional<uint64_t> SwiftLanguageRuntime::GetByteStride(CompilerType type) {
-  auto type_info_or_err = GetSwiftRuntimeTypeInfo(type, nullptr);
+std::optional<uint64_t>
+SwiftLanguageRuntime::GetByteStride(CompilerType type,
+                                    ExecutionContextScope *exe_scope) {
+  auto type_info_or_err = GetSwiftRuntimeTypeInfo(type, exe_scope);
   if (!type_info_or_err) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Types), type_info_or_err.takeError(), "{0}");
     return {};

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -26,9 +26,10 @@
 #include "swift/RemoteInspection/DescriptorFinder.h"
 #include "swift/RemoteInspection/TypeLowering.h"
 
+#include "lldb/Target/Target.h"
+#include "lldb/Utility/Flags.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
-#include "lldb/Target/Target.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -151,6 +152,18 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
               const swift::reflection::TypeRef *TR) {
   swift::Demangle::Demangler dem;
   swift::Demangle::NodePointer node = TR->getDemangling(dem);
+  // FIXME: Use Transform instead.  TypeRefs use a normalized
+  // representation where bare protocols are wrapped in a
+  // ProtocolList.
+  if (node && node->getKind() == swift::Demangle::Node::Kind::Protocol) {
+    auto type_node = dem.createNode(swift::Demangle::Node::Kind::Type);
+    type_node->addChild(node, dem);
+    auto type_list = dem.createNode(swift::Demangle::Node::Kind::TypeList);
+    type_list->addChild(type_node, dem);
+    auto proto_list = dem.createNode(swift::Demangle::Node::Kind::ProtocolList);
+    proto_list->addChild(type_list, dem);
+    node = proto_list;
+  }
   // TODO: mangling flavor should come from the TypeRef.
   auto type =
       ts.RemangleAsType(dem, node, swift::Mangle::ManglingFlavor::Embedded);
@@ -207,6 +220,8 @@ getFieldDescriptorKindForDie(CompilerType type) {
   case lldb::eTypeClassUnion:
     return swift::reflection::FieldDescriptorKind::Enum;
   default:
+    if (Flags(type.GetTypeInfo()).AnySet(lldb::eTypeIsProtocol))
+      return swift::reflection::FieldDescriptorKind::Protocol;
     LLDB_LOG(GetLog(LLDBLog::Types),
              "Could not determine file descriptor kind for type: {0}",
              type.GetMangledTypeName());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5337,7 +5337,7 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
   assert(!found_type || &found_type->getASTContext() == *ast_ctx);
 
   // This type might have been been found in reflection and annotated with
-  // @_originallyDefinedIn. The compiler emits a typelias for these type
+  // @_originallyDefinedIn. The compiler emits a typealias for these type
   // pointing them back to the types with the real module name.
   if (!found_type) {
     auto adjusted =
@@ -6250,19 +6250,28 @@ bool SwiftASTContext::IsArrayType(opaque_compiler_type_t type,
     swift::StructDecl *struct_decl = struct_type->getDecl();
     llvm::StringRef name = struct_decl->getName().get();
     // This is sketchy, but it matches the behavior of GetArrayElementType().
-    if (name != "Array" && name != "ContiguousArray" && name != "ArraySlice")
+    if (name != "Array" && name != "ContiguousArray" && name != "InlineArray" &&
+        name != "ArraySlice")
       return false;
     if (!struct_decl->getModuleContext()->isStdlibModule())
       return false;
     const llvm::ArrayRef<swift::Type> &args = struct_type->getGenericArgs();
-    if (args.size() != 1)
-      return false;
+    if (name == "InlineArray") {
+      if (args.size() != 2)
+        return false;
+      // In an inline array args[0] is the array length.
+      if (element_type_ptr)
+        *element_type_ptr = ToCompilerType(args[1].getPointer());
+    } else {
+      if (args.size() != 1)
+        return false;
+      if (element_type_ptr)
+        *element_type_ptr = ToCompilerType(args[0].getPointer());
+    }
     if (is_incomplete)
       *is_incomplete = true;
     if (size)
       *size = 0;
-    if (element_type_ptr)
-      *element_type_ptr = ToCompilerType(args[0].getPointer());
     return true;
   }
 
@@ -6727,9 +6736,12 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
         eTypeIsBuiltIn | eTypeIsPointer | eTypeIsScalar | eTypeHasValue;
     break;
   case swift::TypeKind::BuiltinFixedArray:
-    return eTypeIsBuiltIn | eTypeHasChildren;
+    swift_flags |= eTypeIsBuiltIn | eTypeHasChildren;
+    // Don't recurse into the array *element* type.
+    return swift_flags;
   case swift::TypeKind::BuiltinBorrow:
-    return eTypeIsBuiltIn;
+    swift_flags |= eTypeIsBuiltIn;
+    return swift_flags;
   case swift::TypeKind::BuiltinVector:
     // TODO: OR in eTypeIsFloat or eTypeIsInteger as needed
     return eTypeIsBuiltIn | eTypeHasChildren | eTypeIsVector;
@@ -7303,7 +7315,7 @@ SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
   if (!exe_scope)
     return {};
   if (auto *runtime = SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-    return runtime->GetByteStride({weak_from_this(), type});
+    return runtime->GetByteStride({weak_from_this(), type}, exe_scope);
   return {};
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -313,6 +313,31 @@ inline bool IsFloat(swift::Demangle::NodePointer node) {
   return false;
 }
 
+/// Determine whether \p kind denotes a nominal type: a class, struct, enum,
+/// protocol, type alias, or one of their symbolic-reference forms (and the
+/// builtin tuple type). This mirrors the demangler's own
+/// swift::Demangle::isAnyGeneric(), which is file-local (not exported), so it
+/// cannot be called from here; keep the two in sync. To also accept the
+/// specialized BoundGeneric* forms, normalize with
+/// swift::Demangle::isSpecialized()/getUnspecialized() first.
+inline bool IsAnyGeneric(Node::Kind kind) {
+  switch (kind) {
+  case Node::Kind::Structure:
+  case Node::Kind::Class:
+  case Node::Kind::Enum:
+  case Node::Kind::Protocol:
+  case Node::Kind::ProtocolSymbolicReference:
+  case Node::Kind::ObjectiveCProtocolSymbolicReference:
+  case Node::Kind::OtherNominalType:
+  case Node::Kind::TypeAlias:
+  case Node::Kind::TypeSymbolicReference:
+  case Node::Kind::BuiltinTupleType:
+    return true;
+  default:
+    return false;
+  }
+}
+
 } // namespace swift_demangle
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -96,9 +96,34 @@ private:
 ///
 /// Memory management:
 ///
-/// A per-module TypeSystemSwiftTypeRef owns a lazily initialized SwiftASTContext.
-/// A SwiftASTContextForExpressions owns a  TypeSystemSwiftTypeRef.
+/// A per-module TypeSystemSwiftTypeRef owns a lazily initialized
+/// SwiftASTContext. A SwiftASTContextForExpressions owns a
+/// TypeSystemSwiftTypeRef.
 ///
+/// \endverbatim
+///
+/// Static vs. runtime types:
+///
+/// Static Swift types generally don't know their own size or memory
+/// layout, because the layout can depend on runtime information
+/// (e.g., resilient library types, generics, ...)  Similar to the
+/// Objective-C runtime, SwiftLanguageRuntime can return the *runtime
+/// type* of a static type.  Because runtime types are bound to a
+/// process, they can use the SwiftLanguageRuntime to answer size and
+/// layout queries. Runtime types are created in a target's scratch
+/// typesystem, never in a per-module typesystem.
+///
+/// \verbatim
+///   static type            (per-module TypeSystemSwiftTypeRef)
+///     - mangled name
+///     - no size or layout information
+///                  │
+///                  │   SwiftLanguageRuntime::GetRuntimeType()
+///                  │
+///                  ↓
+///   runtime type           (scratch TypeSystemSwiftTypeRefForExpressions)
+///     - bound to a process / runtime
+///     - answers size and layout queries via process' SwiftLanguageRuntime
 /// \endverbatim
 class TypeSystemSwift : public TypeSystem {
   /// LLVM RTTI support.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -42,6 +42,7 @@
 #include "lldb/Utility/Timer.h"
 
 #include "lldb/lldb-enumerations.h"
+#include "lldb/lldb-forward.h"
 #include "lldb/lldb-types.h"
 #include "swift/../../lib/ClangImporter/ClangAdapter.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -267,10 +268,6 @@ std::string TypeSystemSwiftTypeRef::AdjustTypeForOriginallyDefinedInModule(
     if (node->getKind() != Node::Kind::Type)
       return true;
 
-    auto compiler_type = RemangleAsType(dem, node, flavor);
-    if (!compiler_type)
-      return true;
-
     // Find the node that contains the module and identifier nodes.
     NodePointer node_with_module_and_name =
         FindTypeWithModuleAndIdentifierNode(node);
@@ -285,6 +282,10 @@ std::string TypeSystemSwiftTypeRef::AdjustTypeForOriginallyDefinedInModule(
     // If we already processed this node there's nothing to do (this can happen
     // because nodes are shared in the tree).
     if (type_to_renamed_type_nodes.contains(node_with_module_and_name))
+      return true;
+
+    auto compiler_type = RemangleAsType(dem, node, flavor);
+    if (!compiler_type)
       return true;
 
     // Look for the imported declarations that indicate the type has moved
@@ -1208,8 +1209,22 @@ TypeSystemSwiftTypeRef::GetParentType(lldb::opaque_compiler_type_t type) {
               mangled_typename);
     return {};
   }
-  if (parent_node->getKind() == Node::Kind::Module)
+  // A nested type has a parent type only when its enclosing context
+  // is itself a nominal type. Normalize a specialized enclosing
+  // generic to its unbound nominal so the check doesn't have to
+  // enumerate every BoundGeneric* kind, then let the demangler tell
+  // us whether it is a nominal type.
+  NodePointer nominal = parent_node;
+  if (swift::Demangle::isSpecialized(nominal)) {
+    auto unspec = swift::Demangle::getUnspecialized(nominal, dem);
+    if (!unspec.isSuccess())
+      return {};
+    nominal = unspec.result();
+  }
+  if (!swift_demangle::IsAnyGeneric(nominal->getKind()))
     return {};
+  // Remangle the original parent_node so the parent type keeps its generic
+  // arguments.
   NodePointer type_node = dem.createNode(Node::Kind::Type);
   type_node->addChild(parent_node, dem);
   return RemangleAsType(dem, type_node, flavor);
@@ -2170,9 +2185,13 @@ uint32_t TypeSystemSwiftTypeRef::CollectTypeInfo(
     swift_flags |= eTypeIsPointer | eTypeHasValue;
     return swift_flags;
   case Node::Kind::BoundGenericFunction:
+  case Node::Kind::ThinFunctionType:
   case Node::Kind::NoEscapeFunctionType:
   case Node::Kind::FunctionType:
     swift_flags |= eTypeIsPointer | eTypeHasValue;
+    break;
+  case Node::Kind::BuiltinFixedArray:
+    swift_flags |= eTypeIsBuiltIn | eTypeHasChildren;
     break;
   case Node::Kind::BuiltinTypeName:
     swift_flags |= eTypeIsBuiltIn | eTypeHasValue;
@@ -2493,6 +2512,18 @@ const char *TypeSystemSwiftTypeRef::DeriveKeyFor(const SymbolContext &sc) {
   return nullptr;
 }
 
+TypeSystemSwiftTypeRef::SwiftLanguageRuntimeHolder
+TypeSystemSwiftTypeRef::GetRuntime(ExecutionContextScope *exe_scope) {
+  ProcessSP process_sp;
+  if (TargetSP target_sp = GetTargetWP().lock())
+    process_sp = target_sp->GetProcessSP();
+  // Per-module typesystems aren't bound to a target, so fall back to the
+  // process from the execution context when one is available.
+  if (!process_sp && exe_scope)
+    process_sp = exe_scope->CalculateProcess();
+  return {process_sp, SwiftLanguageRuntime::Get(process_sp.get())};
+}
+
 SymbolContext TypeSystemSwiftTypeRef::GetSymbolContext(
     ExecutionContextScope *exe_scope) const {
   if (!exe_scope)
@@ -2517,6 +2548,34 @@ SymbolContext TypeSystemSwiftTypeRef::GetSymbolContext(
       sc = SymbolContext(target_sp, target_sp->GetExecutableModule());
 
   return sc;
+}
+
+SymbolContext TypeSystemSwiftTypeRef::GetSymbolContextForType(
+    opaque_compiler_type_t type, const ExecutionContext *exe_ctx) {
+  SymbolContext sc = GetSymbolContext(exe_ctx);
+  if (sc.comp_unit && sc.comp_unit->GetLanguage() == eLanguageTypeSwift)
+    return sc;
+
+  // Frame-less query for an expression-defined type: recover the precise
+  // ExecutionContext the type was imported with (side table).
+  if (IsExpressionEvaluatorDefined(type)) {
+    ExecutionContext type_exe_ctx =
+        GetExecutionContextForType(type).Lock(false);
+    if (type_exe_ctx.HasTargetScope()) {
+      SymbolContext type_sc = GetSymbolContext(&type_exe_ctx);
+      if (type_sc.comp_unit)
+        return type_sc;
+    }
+  }
+  return sc;
+}
+
+SymbolContext TypeSystemSwiftTypeRef::GetSymbolContextForType(
+    opaque_compiler_type_t type, ExecutionContextScope *exe_scope) {
+  ExecutionContext exe_ctx;
+  if (exe_scope)
+    exe_scope->CalculateExecutionContext(exe_ctx);
+  return GetSymbolContextForType(type, &exe_ctx);
 }
 
 SwiftASTContextSP
@@ -2648,6 +2707,30 @@ SwiftASTContextSP TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContextOrNull
   return {};
 }
 
+ExecutionContextRef
+TypeSystemSwiftTypeRefForExpressions::GetExecutionContextForType(
+    lldb::opaque_compiler_type_t type) {
+  return m_exectx_sidetable.Lookup(AsMangledName(type));
+}
+
+CompilerType
+TypeSystemSwiftTypeRefForExpressions::ImportType(CompilerType type,
+                                                 ExecutionContextRef exe_ctx) {
+  ConstString mangled_name = type.GetMangledTypeName();
+  if (mangled_name.IsEmpty())
+    return {};
+  m_exectx_sidetable.Insert(mangled_name.AsCString(nullptr), exe_ctx);
+
+  // Copy the DWARF type cache entry from the source typesystem so
+  // that queries like IsMarkerProtocol work on the scratch typesystem.
+  if (auto src_ts =
+          type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwiftTypeRef>())
+    if (auto type_sp = src_ts->GetCachedType(mangled_name))
+      SetCachedType(mangled_name, type_sp);
+
+  return GetTypeFromMangledTypename(mangled_name);
+}
+
 SwiftDWARFImporterForClangTypes &
 TypeSystemSwiftTypeRef::GetSwiftDWARFImporterForClangTypes() {
   if (!m_dwarf_importer_for_clang_types_up)
@@ -2708,9 +2791,9 @@ TypeSystemSwiftTypeRef::GetMangledTypeName(opaque_compiler_type_t type) {
 
 void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type,
                                               const ExecutionContext *exe_ctx) {
+  SymbolContext sc = GetSymbolContextForType(type, exe_ctx);
   std::pair<const char *, const char *> key = {
-      DeriveKeyFor(GetSymbolContext(exe_ctx)),
-      reinterpret_cast<const char *>(type)};
+      DeriveKeyFor(sc), reinterpret_cast<const char *>(type)};
 
   if (m_dangerous_types.count(key))
     return nullptr;
@@ -2719,7 +2802,7 @@ void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type,
   if (swift_demangle::ContainsError(AsMangledName(type)))
     return nullptr;
 
-  auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx));
+  auto swift_ast_context = GetSwiftASTContext(sc);
   if (!swift_ast_context || swift_ast_context->HasFatalErrors())
     return nullptr;
   void *result = llvm::expectedToStdOptional(swift_ast_context->ReconstructType(
@@ -2744,7 +2827,8 @@ void *TypeSystemSwiftTypeRef::ReconstructType(
 CompilerType
 TypeSystemSwiftTypeRef::ReconstructType(CompilerType type,
                                         const ExecutionContext *exe_ctx) {
-  if (auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+  if (auto swift_ast_context = GetSwiftASTContext(
+          GetSymbolContextForType(type.GetOpaqueQualType(), exe_ctx)))
     if (auto ts =
             type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwiftTypeRef>())
       return {{swift_ast_context->weak_from_this()},
@@ -2782,10 +2866,31 @@ bool TypeSystemSwiftTypeRef::IsMarkerProtocol(ConstString mangled_name) {
 llvm::Expected<swift::Demangle::NodePointer>
 TypeSystemSwiftTypeRef::RemoveMarkerProtocols(
     swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
-    swift::Mangle::ManglingFlavor flavor) {
+    swift::Mangle::ManglingFlavor flavor, ExecutionContext &exe_ctx) {
   using namespace swift::Demangle;
   if (!node)
     return node;
+
+  // Find the per-module typesystem for marker protocol lookups, since
+  // the scratch typesystem has no DWARF type cache.
+  TypeSystemSwiftTypeRef *lookup_ts = this;
+  if (!GetModule()) {
+    if (auto *frame = exe_ctx.GetFramePtr()) {
+      SymbolContext sc = frame->GetSymbolContext(eSymbolContextModule);
+      if (sc.module_sp) {
+        auto ts_or_err =
+            sc.module_sp->GetTypeSystemForLanguage(eLanguageTypeSwift);
+        if (ts_or_err) {
+          if (auto *module_ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
+                  ts_or_err->get()))
+            lookup_ts = module_ts;
+        } else
+          LLDB_LOG_ERRORV(
+              GetLog(LLDBLog::Types), ts_or_err.takeError(),
+              "Could not get Swift typesystem for marker protocol lookup: {0}");
+      }
+    }
+  }
 
   // Strip marker protocols from every ProtocolList > TypeList in the tree.
   swift_demangle::NodeBuilder b(dem);
@@ -2809,7 +2914,7 @@ TypeSystemSwiftTypeRef::RemoveMarkerProtocols(
                 return llvm::createStringError(
                     "failed to mangle protocol in type: " +
                     nodeToString(current));
-              if (IsMarkerProtocol(ConstString(mangling.result())))
+              if (lookup_ts->IsMarkerProtocol(ConstString(mangling.result())))
                 to_remove.push_back(i);
             }
             for (size_t i : llvm::reverse(to_remove))
@@ -2846,10 +2951,9 @@ npdb::PdbAstBuilder *TypeSystemSwiftTypeRef::GetNativePDBParser() {
 }
 
 TypeSP
-TypeSystemSwiftTypeRef::FindTypeInModule(std::vector<CompilerContext> context) {
-  auto *M = GetModule();
-  if (!M)
-    return {};
+TypeSystemSwiftTypeRef::FindTypeInModule(std::vector<CompilerContext> context,
+                                         lldb_private::Module *M,
+                                         swift::Mangle::ManglingFlavor flavor) {
   // DW_AT_linkage_name is not part of the accelerator table, so
   // we need to search by decl context.
   auto options =
@@ -2865,7 +2969,9 @@ TypeSystemSwiftTypeRef::FindTypeInModule(std::vector<CompilerContext> context) {
   query.SetLanguages(TypeSystemSwift::GetSupportedLanguagesForTypes());
 
   TypeResults results;
-  M->FindTypes(query, results);
+  if (M)
+    M->FindTypes(query, results);
+
   if (results.Done(query))
     return results.GetFirstType();
   return {};
@@ -2873,14 +2979,24 @@ TypeSystemSwiftTypeRef::FindTypeInModule(std::vector<CompilerContext> context) {
 
 TypeSP
 TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
+  Module *M = GetModule();
+  if (!M) {
+    ExecutionContext exe_ctx = GetExecutionContextForType(opaque_type);
+    if (StackFrameSP frame_sp = exe_ctx.GetFrameSP()) {
+      SymbolContext sc = frame_sp->GetSymbolContext(eSymbolContextModule);
+      M = sc.module_sp.get();
+    }
+  }
 
   swift::Demangle::Demangler dem;
   auto maybe_context = BuildDeclContext(AsMangledName(opaque_type), dem);
   if (!maybe_context || maybe_context->empty())
     return {};
 
+  swift::Mangle::ManglingFlavor flavor =
+      SwiftLanguageRuntime::GetManglingFlavor(AsMangledName(opaque_type));
   auto context = *maybe_context;
-  if (auto result = FindTypeInModule(context))
+  if (auto result = FindTypeInModule(context, M, flavor))
     return result;
 
   // Types with "Swift" as their module might actually belong to the
@@ -2889,7 +3005,7 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
       context[0].kind != CompilerContextKind::Module)
     return {};
   context[0].name = ConstString("_Concurrency");
-  return FindTypeInModule(context);
+  return FindTypeInModule(context, M, flavor);
 }
 
 // Tests
@@ -3199,9 +3315,10 @@ template <typename T> bool Equivalent(std::optional<T> l, T r) {
 } // namespace
 #endif
 
-#ifndef NDEBUG
+// Used both by the VALIDATE_AND_RETURN validation macros (asserts-only) and by
+// real code paths below (e.g. GetTypeInfo), so it must be defined regardless of
+// NDEBUG.
 constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
-#endif
 
 #ifndef NDEBUG
 // Due to the lack of a symbol context, this only does the validation
@@ -3232,7 +3349,8 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
     ExecutionContext _exe_ctx(EXE_CTX);                                        \
-    if (!GetSwiftASTContext(GetSymbolContext(&_exe_ctx)))                      \
+    auto swift_ast_ctx = GetSwiftASTContext(GetSymbolContext(&_exe_ctx));      \
+    if (!swift_ast_ctx || swift_ast_ctx->HasFatalErrors())                     \
       return result;                                                           \
     if (ShouldSkipValidation(TYPE))                                            \
       return result;                                                           \
@@ -3243,11 +3361,8 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
       if (frame->GetSymbolContext(eSymbolContextFunction).GetFunctionName() == \
           SwiftLanguageRuntime::GetErrorBackstopName())                        \
         return result;                                                         \
-    bool equivalent =                                                          \
-        !ReconstructType(TYPE) /* missing .swiftmodule */ ||                   \
-        (COMPARISON(                                                           \
-            result,                                                            \
-            GetSwiftASTContext(GetSymbolContext(&_exe_ctx))->REFERENCE ARGS)); \
+    bool equivalent = !ReconstructType(TYPE) /* missing .swiftmodule */ ||     \
+                      (COMPARISON(result, swift_ast_ctx->REFERENCE ARGS));     \
     if (!equivalent)                                                           \
       llvm::dbgs() << "failing type was " << (const char *)TYPE << "\n";       \
     assert(equivalent &&                                                       \
@@ -3265,7 +3380,8 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
     ExecutionContext _exe_ctx(EXE_CTX);                                        \
-    if (!GetSwiftASTContext(GetSymbolContext(&_exe_ctx)))                      \
+    auto swift_ast_ctx = GetSwiftASTContext(GetSymbolContext(&_exe_ctx));      \
+    if (!swift_ast_ctx || swift_ast_ctx->HasFatalErrors())                     \
       return result;                                                           \
     if (ShouldSkipValidation(TYPE))                                            \
       return result;                                                           \
@@ -3277,12 +3393,10 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
           SwiftLanguageRuntime::GetErrorBackstopName())                        \
         return result;                                                         \
     bool equivalent = true;                                                    \
-    if (ReconstructType(TYPE)) {                                               \
-      equivalent =                                                             \
-          (Equivalent(llvm::expectedToStdOptional(std::move(result)),          \
-                      llvm::expectedToStdOptional(                             \
-                          GetSwiftASTContext(GetSymbolContext(&_exe_ctx))      \
-                              ->REFERENCE ARGS)));                             \
+    if (ReconstructType(TYPE) && !swift_ast_ctx->HasFatalErrors()) {           \
+      equivalent = (Equivalent(                                                \
+          llvm::expectedToStdOptional(std::move(result)),                      \
+          llvm::expectedToStdOptional(swift_ast_ctx->REFERENCE ARGS)));        \
     } else { /* missing .swiftmodule */                                        \
       if (!result)                                                             \
         llvm::consumeError(result.takeError());                                \
@@ -3568,6 +3682,7 @@ size_t TypeSystemSwiftTypeRef::GetNumberOfFunctionArguments(
     Demangler dem;
     NodePointer node = DemangleCanonicalOutermostType(dem, type);
     if (!node || (node->getKind() != Node::Kind::FunctionType &&
+                  node->getKind() != Node::Kind::ThinFunctionType &&
                   node->getKind() != Node::Kind::NoEscapeFunctionType &&
                   node->getKind() != Node::Kind::ImplFunctionType))
       return 0;
@@ -3832,8 +3947,8 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     uint32_t flags = CollectTypeInfo(dem, node, flavor, unresolved_typealias);
     if (unresolved_typealias)
       if (auto target_sp = GetTargetWP().lock())
-        if (auto swift_ast_ctx = GetSwiftASTContext(
-                SymbolContext(target_sp, target_sp->GetExecutableModule())))
+        if (auto swift_ast_ctx =
+                GetSwiftASTContext(GetSymbolContextForType(type, g_no_exe_ctx)))
           // If this is a typealias defined in the expression evaluator,
           // then we don't have debug info to resolve it from.
           return swift_ast_ctx->GetTypeInfo(ReconstructType(type),
@@ -4194,12 +4309,13 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
     if (IsSILPackType({weak_from_this(), type}))
       return GetPointerByteSize() * 8;
 
+    // Swift doesn't know pointers: return the size of the object
+    // pointer instead of the underlying object.
+    if (Flags(GetTypeInfo(type, nullptr)).AllSet(eTypeIsClass))
+      return GetPointerByteSize() * 8;
+
     // Clang types can be resolved even without a process.
     if (CompilerType clang_type = GetAsClangTypeOrNull(type)) {
-      // Swift doesn't know pointers: return the size of the object
-      // pointer instead of the underlying object.
-      if (Flags(clang_type.GetTypeInfo()).AllSet(eTypeIsObjC | eTypeIsClass))
-        return GetPointerByteSize() * 8;
       auto clang_size = clang_type.GetBitSize(exe_scope);
       return clang_size;
     }
@@ -4208,8 +4324,7 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
           "Cannot compute size of type %s without an execution context.",
           AsMangledName(type));
     // The hot code path is to ask the Swift runtime for the size.
-    if (auto *runtime =
-            SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
+    if (auto runtime = GetRuntime()) {
       auto result_or_err =
           runtime->GetBitSize({weak_from_this(), type}, exe_scope);
       if (result_or_err)
@@ -4222,7 +4337,7 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
       // Runtime failed, fallback to SwiftASTContext.
       if (UseSwiftASTContextFallback(FUNC_NAME, type)) {
         if (auto swift_ast_context =
-                GetSwiftASTContext(GetSymbolContext(exe_scope))) {
+                GetSwiftASTContext(GetSymbolContextForType(type, exe_scope))) {
           auto result = swift_ast_context->GetBitSize(
               ReconstructType(type, exe_scope), exe_scope);
           if (result)
@@ -4247,6 +4362,7 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
     // static type in the debug info.
     if (auto static_size = get_static_size(false))
       return *static_size;
+
     return llvm::createStringError(
         "Cannot compute size of type %s using static debug info.",
         AsMangledName(type));
@@ -4263,16 +4379,21 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
                                       ExecutionContextScope *exe_scope) {
   static constexpr const char *FUNC_NAME = __FUNCTION__;
   auto impl = [&]() -> std::optional<uint64_t> {
-    if (auto *runtime =
-            SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
-      if (auto stride =
-              runtime->GetByteStride(GetCanonicalType(type, exe_scope)))
+    if (auto runtime = GetRuntime()) {
+      ExecutionContext exe_ctx = GetExecutionContextForType(type).Lock(false);
+      if (!exe_ctx.HasTargetScope())
+        if (TargetSP target_sp = GetTargetWP().lock())
+          target_sp->CalculateExecutionContext(exe_ctx);
+
+      if (auto stride = runtime->GetByteStride(
+              GetCanonicalType(type, exe_ctx.GetBestExecutionContextScope()),
+              exe_ctx.GetBestExecutionContextScope()))
         return stride;
     }
     // Runtime failed, fallback to SwiftASTContext.
     if (UseSwiftASTContextFallback(FUNC_NAME, type)) {
       if (auto swift_ast_context =
-              GetSwiftASTContext(GetSymbolContext(exe_scope))) {
+              GetSwiftASTContext(GetSymbolContextForType(type, exe_scope))) {
         auto result =
             swift_ast_context->GetByteStride(ReconstructType(type), exe_scope);
         if (result)
@@ -4383,7 +4504,8 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
   }
   // Runtime failed, fallback to SwiftASTContext.
   if (UseSwiftASTContextFallback(__FUNCTION__, type)) {
-    if (auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+    if (auto swift_ast_context =
+            GetSwiftASTContext(GetSymbolContextForType(type, exe_ctx)))
       if (auto n =
               llvm::expectedToStdOptional(swift_ast_context->GetNumChildren(
                   ReconstructType(type, exe_ctx), omit_empty_base_classes,
@@ -4450,7 +4572,7 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
   // Runtime failed, fallback to SwiftASTContext.
   if (UseSwiftASTContextFallback(__FUNCTION__, type))
     if (auto swift_ast_context =
-            GetSwiftASTContext(GetSymbolContext(exe_ctx))) {
+            GetSwiftASTContext(GetSymbolContextForType(type, exe_ctx))) {
       auto result = swift_ast_context->GetNumFields(
           ReconstructType(type, exe_ctx), exe_ctx);
       if (result)
@@ -4475,7 +4597,41 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
 }
 
 swift::reflection::DescriptorFinder *
-TypeSystemSwiftTypeRef::GetDescriptorFinder() {
+TypeSystemSwiftTypeRef::GetDescriptorFinder(ExecutionContextScope *exe_scope) {
+  if (!GetSymbolFile()) {
+    // Find the per-module typesystem which has the SymbolFileDWARF.
+    auto get_module_descriptor_finder =
+        [](ModuleSP module_sp) -> swift::reflection::DescriptorFinder * {
+      if (!module_sp)
+        return nullptr;
+      auto ts_or_err = module_sp->GetTypeSystemForLanguage(eLanguageTypeSwift);
+      if (!ts_or_err) {
+        LLDB_LOG_ERRORV(
+            GetLog(LLDBLog::Types), ts_or_err.takeError(),
+            "Could not get Swift typesystem for descriptor finder: {0}");
+        return nullptr;
+      }
+      if (auto *module_ts =
+              llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(ts_or_err->get()))
+        return module_ts->GetDescriptorFinder();
+      return nullptr;
+    };
+
+    if (exe_scope) {
+      if (auto *frame = exe_scope->CalculateStackFrame().get()) {
+        SymbolContext sc = frame->GetSymbolContext(eSymbolContextModule);
+        if (auto *df = get_module_descriptor_finder(sc.module_sp))
+          return df;
+      }
+    }
+    if (TargetSP target_sp = GetTargetWP().lock()) {
+      auto &images = target_sp->GetImages();
+      for (size_t i = 0; i < images.GetSize(); ++i) {
+        if (auto *df = get_module_descriptor_finder(images.GetModuleAtIndex(i)))
+          return df;
+      }
+    }
+  }
   return llvm::cast<DWARFASTParserSwift>(GetDWARFParser());
 }
 
@@ -4532,7 +4688,7 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
              "Had to engage SwiftASTContext fallback for type {0}, field #{1}.",
              AsMangledName(type), idx);
     if (auto swift_ast_context =
-            GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+            GetSwiftASTContext(GetSymbolContextForType(type, exe_ctx)))
       return swift_ast_context->GetChildCompilerTypeAtIndex(
           ReconstructType(type, exe_ctx), exe_ctx, idx, transparent_pointers,
           omit_empty_base_classes, ignore_array_bounds, child_name,
@@ -4546,7 +4702,7 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     if (ast_num_children)
       return *ast_num_children;
     if (auto swift_ast_context =
-            GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+            GetSwiftASTContext(GetSymbolContextForType(type, exe_ctx)))
       ast_num_children = llvm::expectedToStdOptional(
           swift_ast_context->GetNumChildren(ReconstructType(type, exe_ctx),
                                             omit_empty_base_classes, exe_ctx));
@@ -4701,14 +4857,14 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
         if (!ModuleList::GetGlobalModuleListProperties()
                  .GetSwiftValidateTypeSystem())
           return index_size;
-        if (!GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+        if (!GetSwiftASTContext(GetSymbolContextForType(type, exe_ctx)))
           return index_size;
         auto ast_type = ReconstructType(type, exe_ctx);
         if (!ast_type)
           return index_size;
         std::vector<uint32_t> ast_child_indexes;
         auto ast_index_size =
-            GetSwiftASTContext(GetSymbolContext(exe_ctx))
+            GetSwiftASTContext(GetSymbolContextForType(type, exe_ctx))
                 ->GetIndexOfChildMemberWithName(ast_type, name, exe_ctx,
                                                 omit_empty_base_classes,
                                                 ast_child_indexes);
@@ -4750,7 +4906,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
   // Runtime failed, fallback to SwiftASTContext.
   if (UseSwiftASTContextFallback(__FUNCTION__, type))
     if (auto swift_ast_context =
-            GetSwiftASTContext(GetSymbolContext(exe_ctx))) {
+            GetSwiftASTContext(GetSymbolContextForType(type, exe_ctx))) {
       auto result = swift_ast_context->GetIndexOfChildMemberWithName(
           ReconstructType(type, exe_ctx), name, exe_ctx,
           omit_empty_base_classes, child_indexes);
@@ -5154,7 +5310,7 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type,
       // Runtime failed, fallback to SwiftASTContext.
       if (UseSwiftASTContextFallback(FUNC_NAME, type))
         if (auto swift_ast_context =
-                GetSwiftASTContext(GetSymbolContext(exe_scope))) {
+                GetSwiftASTContext(GetSymbolContextForType(type, exe_scope))) {
           auto result = swift_ast_context->GetInstanceType(
               ReconstructType(type, exe_scope), exe_scope);
           if (result)
@@ -5410,7 +5566,7 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
   // Also dump the swift ast context info, as this functions should not be in
   // any critical path.
   if (auto swift_ast_context =
-          GetSwiftASTContext(GetSymbolContext(exe_scope))) {
+          GetSwiftASTContext(GetSymbolContextForType(type, exe_scope))) {
     s->PutCString("Source code info:\n");
     swift_ast_context->DumpTypeDescription(
         ReconstructType(type, exe_scope), s, print_help_if_available,
@@ -5566,24 +5722,26 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::Enum:
     case Node::Kind::BoundGenericEnum: {
       std::string error;
-      if (exe_scope)
-        if (auto runtime =
-                SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
-          ExecutionContext exe_ctx;
+      if (auto runtime = GetRuntime(exe_scope)) {
+        ExecutionContext exe_ctx;
+        if (exe_scope)
           exe_scope->CalculateExecutionContext(exe_ctx);
-          auto case_name = runtime->GetEnumCaseName({weak_from_this(), type},
-                                                    data, &exe_ctx);
-          if (case_name && !case_name->empty()) {
-            // The syntactic sugar for `.none` is `nil`.
-            if (*case_name == "none" && IsOptionalType(type))
-              s << "nil";
-            else
-              s << *case_name;
-            return true;
-          }
-          if (!case_name)
-            error = toString(case_name.takeError());
+        else if (TargetSP target_sp = GetTargetWP().lock())
+          target_sp->CalculateExecutionContext(exe_ctx);
+
+        auto case_name =
+            runtime->GetEnumCaseName({weak_from_this(), type}, data, &exe_ctx);
+        if (case_name && !case_name->empty()) {
+          // The syntactic sugar for `.none` is `nil`.
+          if (*case_name == "none" && IsOptionalType(type))
+            s << "nil";
+          else
+            s << *case_name;
+          return true;
         }
+        if (!case_name)
+          error = toString(case_name.takeError());
+      }
 
       s << error;
       return false;
@@ -5595,7 +5753,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       // typedefs such as CFString in the REPL. More investigation is
       // needed.
       if (auto swift_ast_context =
-              GetSwiftASTContext(GetSymbolContext(exe_scope))) {
+              GetSwiftASTContext(GetSymbolContextForType(type, exe_scope))) {
         if (swift_ast_context->DumpTypeValue(
                 ReconstructType(type, exe_scope), s, format, data, data_offset,
                 data_byte_size, bitfield_bit_size, bitfield_bit_offset,
@@ -5610,6 +5768,8 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::ProtocolList:
       return false;
     default:
+      if (!llvm::isa<TypeSystemSwiftTypeRefForExpressions>(this))
+        return false;
       assert(false && "Unhandled node kind");
       LLDB_LOGF(GetLog(LLDBLog::Types),
                 "DumpTypeValue: Unhandled node kind for type %s",
@@ -5632,7 +5792,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     CollectTypeInfo(dem, node, flavor, unresolved_typealias);
     if (!node || unresolved_typealias) {
       if (auto swift_ast_ctx =
-              GetSwiftASTContext(GetSymbolContext(exe_scope))) {
+              GetSwiftASTContext(GetSymbolContextForType(type, exe_scope))) {
         if (swift_ast_ctx->DumpTypeValue(
                 ReconstructType(type, exe_scope), s, format, data, data_offset,
                 data_byte_size, bitfield_bit_size, bitfield_bit_offset,
@@ -5654,13 +5814,15 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
   });
 #endif
 
-  auto better_or_equal = [](bool a, bool b) -> bool {
+  auto better_or_equal = [&](bool a, bool b) -> bool {
     if (a || a == b)
       return true;
 
     llvm::dbgs() << "TypeSystemSwiftTypeRef: " << a << " SwiftASTContext: " << b
                  << "\n";
-    return false;
+
+    // Not expected to work without a Process.
+    return !llvm::isa<TypeSystemSwiftTypeRefForExpressions>(this);
   };
   VALIDATE_AND_RETURN_CUSTOM(
       impl, DumpTypeValue, type, better_or_equal, exe_scope,
@@ -5857,9 +6019,17 @@ bool TypeSystemSwiftTypeRef::IsTypedefType(opaque_compiler_type_t type) {
     NodePointer node = GetDemangledType(dem, AsMangledName(type));
     if (IsAnyObjectTypeAlias(node))
       return impl();
+    // SwiftASTContext resolves type aliases, so it may disagree
+    // with TypeSystemSwiftTypeRef for AnyObject and ObjC-imported
+    // type aliases.
+    if (node && node->getKind() == Node::Kind::TypeAlias &&
+        node->getNumChildren() > 0 &&
+        node->getFirstChild()->getKind() == Node::Kind::Module &&
+        node->getFirstChild()->hasText() &&
+        node->getFirstChild()->getText() == swift::MANGLING_MODULE_OBJC)
+      return impl();
   }
 #endif
-
   VALIDATE_AND_RETURN(impl, IsTypedefType, type, g_no_exe_ctx,
                       (ReconstructType(type)));
 }
@@ -6033,6 +6203,10 @@ TypeSystemSwiftTypeRef::GetDependentGenericParamListForType(
 #ifndef NDEBUG
 bool TypeSystemSwiftTypeRef::ShouldSkipValidation(opaque_compiler_type_t type) {
   auto mangled_name = GetMangledTypeName(type);
+  // Expression-defined types only reconstruct in their per-expression
+  // SwiftASTContext, so the cross-context validation comparison is moot.
+  if (IsExpressionEvaluatorDefined(type))
+    return true;
   // NSNotificationName is a typedef to a NSString in clang type, but it's a
   // struct in SwiftASTContext. Skip validation in this case.
   if (mangled_name == "$sSo18NSNotificationNameaD")

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -52,6 +52,7 @@ class ClangNameImporter;
 class SwiftASTContext;
 class SwiftASTContextForExpressions;
 class SwiftDWARFImporterForClangTypes;
+class SwiftLanguageRuntime;
 class SwiftPersistentExpressionState;
 
 /// A Swift TypeSystem that does not own a swift::ASTContext.
@@ -80,6 +81,12 @@ public:
   /// Convenience helpers.
   SymbolContext GetSymbolContext(ExecutionContextScope *exe_scope) const;
   SymbolContext GetSymbolContext(const ExecutionContext *exe_ctx) const;
+  /// Like GetSymbolContext(exe_ctx), but for an expression-defined type with no
+  /// Swift frame, recover the context the type was imported with (side table).
+  SymbolContext GetSymbolContextForType(lldb::opaque_compiler_type_t type,
+                                        const ExecutionContext *exe_ctx);
+  SymbolContext GetSymbolContextForType(lldb::opaque_compiler_type_t type,
+                                        ExecutionContextScope *exe_scope);
   /// Return SwiftASTContext, iff one has already been created.
   virtual SwiftASTContextSP
   GetSwiftASTContextOrNull(const SymbolContext &sc) const;
@@ -325,10 +332,9 @@ public:
   /// Marker protocols are compile-time concepts only and the reflection
   /// context does not expect them as input. Note: this mutates \p node
   /// in place.
-  llvm::Expected<swift::Demangle::NodePointer>
-  RemoveMarkerProtocols(swift::Demangle::Demangler &dem,
-                        swift::Demangle::NodePointer node,
-                        swift::Mangle::ManglingFlavor flavor);
+  llvm::Expected<swift::Demangle::NodePointer> RemoveMarkerProtocols(
+      swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+      swift::Mangle::ManglingFlavor flavor, ExecutionContext &exe_ctx);
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
   /// Determine whether this is a builtin SIMD type.
@@ -501,8 +507,11 @@ public:
                               swift::Mangle::ManglingFlavor flavor) override;
 
   /// Gets the descriptor finder belonging to this instance's
-  /// module.
-  swift::reflection::DescriptorFinder *GetDescriptorFinder();
+  /// module. If exe_scope is provided and this is a scratch
+  /// typesystem, returns the per-module descriptor finder instead
+  /// (which has access to the SymbolFileDWARF).
+  swift::reflection::DescriptorFinder *
+  GetDescriptorFinder(ExecutionContextScope *exe_scope = nullptr);
 
   /// Lookup a type in the debug info.
   lldb::TypeSP FindTypeInModule(lldb::opaque_compiler_type_t type);
@@ -511,7 +520,24 @@ public:
   /// their types in the debug info.
   CompilerType Canonicalize(CompilerType type);
 
+  /// Determine if this type contains a type from a module that looks
+  /// like it was JIT-compiled by LLDB.
+  bool IsExpressionEvaluatorDefined(lldb::opaque_compiler_type_t type);
+
 protected:
+  /// A temporary object that keeps the process alive.
+  struct SwiftLanguageRuntimeHolder {
+    lldb::ProcessSP process_sp;
+    SwiftLanguageRuntime *runtime;
+
+    explicit operator bool() const { return runtime; }
+    SwiftLanguageRuntime *operator->() { return runtime; }
+  };
+  /// Get the SwiftLanguageRuntime. For per-module typesystems (which aren't
+  /// bound to a target) the process is taken from \p exe_scope when provided.
+  SwiftLanguageRuntimeHolder
+  GetRuntime(ExecutionContextScope *exe_scope = nullptr);
+
   /// Determine whether the fallback is enabled via setting.
   bool UseSwiftASTContextFallback(const char *func_name,
                                   lldb::opaque_compiler_type_t type);
@@ -520,7 +546,9 @@ protected:
                                        lldb::opaque_compiler_type_t type);
 
   /// Looks for the type using the provided compiler context.
-  lldb::TypeSP FindTypeInModule(std::vector<CompilerContext> context);
+  lldb::TypeSP FindTypeInModule(std::vector<CompilerContext> context,
+                                lldb_private::Module *M,
+                                swift::Mangle::ManglingFlavor flavor);
 
   /// Helper that creates an AST type from \p type.
   ///
@@ -624,9 +652,10 @@ protected:
   GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
                        CompilerType clang_type);
 
-  /// Determine if this type contains a type from a module that looks
-  /// like it was JIT-compiled by LLDB.
-  bool IsExpressionEvaluatorDefined(lldb::opaque_compiler_type_t type);
+  virtual ExecutionContextRef
+  GetExecutionContextForType(lldb::opaque_compiler_type_t type) {
+    return {};
+  }
 
 #ifndef NDEBUG
   /// Check whether the type being dealt with is tricky to validate due to
@@ -729,8 +758,15 @@ public:
                                llvm::ArrayRef<CompilerContext> decl_context,
                                bool ignore_modules,
                                SymbolContext sc = {}) override;
+  /// Import type into this typesystem and register it in the fallback
+  /// sidetable.
+  CompilerType ImportType(CompilerType type, ExecutionContextRef exe_ctx);
+
+  ExecutionContextRef
+  GetExecutionContextForType(lldb::opaque_compiler_type_t type) override;
 
   friend class SwiftASTContextForExpressions;
+
 protected:
   lldb::TargetWP m_target_wp;
   unsigned m_generation = 0;
@@ -751,6 +787,13 @@ protected:
   /// Map ConstString Clang type identifiers and the concatenation of the
   /// compiler context used to find them to Clang types.
   ThreadSafeStringMap<lldb::TypeSP> m_clang_type_cache;
+  /// In order to do a SwiftASTContext fallback, we need to have a
+  /// precise ExecutionContext to initialize the matching
+  /// SwiftASTContext. This information isn't part of CompilerType, so
+  /// this table keeps track of all types we imported into this
+  /// typesystem.
+  /// This can be removed when the fallback is removed.
+  ThreadSafeDenseMap<const char *, ExecutionContextRef> m_exectx_sidetable;
 };
 
 } // namespace lldb_private

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -18,6 +18,7 @@
 #include "lldb/ValueObject/ValueObject.h"
 #include "lldb/ValueObject/ValueObjectRegister.h"
 #include "lldb/ValueObject/ValueObjectVariable.h"
+#include "lldb/lldb-enumerations.h"
 #include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/FormatAdapters.h"
 #include <memory>
@@ -52,6 +53,14 @@ static llvm::Expected<lldb::TypeSystemSP> GetTypeSystemFromCU(StackFrame &ctx) {
                                     ctx.GetFunctionName());
 
   lldb::LanguageType language = symbol_context.comp_unit->GetLanguage();
+  // BEGIN SWIFT
+  if (language == lldb::eLanguageTypeSwift) {
+    lldb::TargetSP target_sp = ctx.CalculateTarget();
+    if (!target_sp)
+      return llvm::createStringError("no target in this context");
+    return target_sp->GetScratchTypeSystemForLanguage(language);
+  }
+  // END SWIFT
   symbol_context = ctx.GetSymbolContext(lldb::eSymbolContextModule);
   return symbol_context.module_sp->GetTypeSystemForLanguage(language);
 }

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -279,8 +279,8 @@ CompilerType ValueObject::GetCompilerType() {
 
   if (auto *runtime =
           process_sp->GetLanguageRuntime(GetObjectRuntimeLanguage())) {
-    if (std::optional<CompilerType> complete_type =
-            runtime->GetRuntimeType(compiler_type)) {
+    if (std::optional<CompilerType> complete_type = runtime->GetRuntimeType(
+            compiler_type, GetUpdatePoint().GetExecutionContextRef())) {
       m_override_type = *complete_type;
       if (m_override_type.IsValid())
         return m_override_type;

--- a/lldb/source/ValueObject/ValueObjectVariable.cpp
+++ b/lldb/source/ValueObject/ValueObjectVariable.cpp
@@ -31,6 +31,7 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-private-enumerations.h"
 #include "lldb/lldb-types.h"
+#include "llvm/Support/Error.h"
 
 #if defined(LLDB_ENABLE_SWIFT)
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
@@ -139,8 +140,9 @@ bool ValueObjectVariable::UpdateValue() {
   // Check if the type has size 0. If so, there is nothing to update,
   // unless the type is C++ where even empty structs have a non-zero
   // size.
-  CompilerType var_type(GetCompilerTypeImpl());
-  if (var_type.IsValid() && var_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
+  CompilerType var_type(GetCompilerType());
+  if (var_type.IsValid() &&
+      var_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
     ExecutionContext exe_ctx(GetExecutionContextRef());
     auto size_or_err =
         var_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -42,7 +42,6 @@ class TestSwiftProgressReporting(TestBase):
             "Setting up Swift reflection",
             "Importing dependencies for main.swift",
             "Importing dependencies for main.swift: Foundation",
-            "Importing Swift standard library",
             "Loading reflection metadata",
         ]
 

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -49,7 +49,3 @@ class TestSwiftDedupMacros(TestBase):
 #       CHECK: SwiftASTContextForExpressions{{.*}}-DSPACE
 #       CHECK-NOT: {{ SPACE}}
 #       CHECK: SwiftASTContextForExpressions{{.*}}-UNDEBUG
-#       CHECK: SwiftASTContext(module: "Dylib{{.*}}-DDEBUG=1
-#       CHECK: SwiftASTContext(module: "Dylib{{.*}}-DSPACE
-#       CHECK-NOT: {{ SPACE}}
-#       CHECK: SwiftASTContext(module: "Dylib{{.*}}-UNDEBUG

--- a/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
+++ b/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
@@ -14,7 +14,7 @@ class TestSwiftDifferentABIName(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
 
-        self.expect("frame variable s", 
+        self.expect("frame variable -d no-run-target s",
                     substrs=["Struct", "s = ", "field = 42"])
         self.expect("expr s", substrs=["Struct", "field = 42"])
         self.expect("expr -O -- s", substrs=["Struct", "- field : 42"])

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -90,10 +90,10 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         lldbutil.check_variable(self, b, False, value="123456")
 
         nonPayload1 = frame.FindVariable("nonPayload1")
-        lldbutil.check_variable(self, nonPayload1, False, value="one")
+        lldbutil.check_variable(self, nonPayload1, True, value="one")
 
         nonPayload2 = frame.FindVariable("nonPayload2")
-        lldbutil.check_variable(self, nonPayload2, False, value="two")
+        lldbutil.check_variable(self, nonPayload2, True, value="two")
 
         singlePayload = frame.FindVariable("singlePayload")
         payload = singlePayload.GetChildMemberWithName("payload")
@@ -103,7 +103,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         lldbutil.check_variable(self, b, False, value="123456")
 
         emptySinglePayload = frame.FindVariable("emptySinglePayload")
-        lldbutil.check_variable(self, emptySinglePayload, False, value="nonPayloadTwo")
+        lldbutil.check_variable(self, emptySinglePayload, True, value="nonPayloadTwo")
 
         smallMultipayloadEnum1 = frame.FindVariable("smallMultipayloadEnum1")
         one = smallMultipayloadEnum1.GetChildMemberWithName("one")

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
@@ -26,9 +26,8 @@ class TestSwiftLateSwiftDylibClangDeps(TestBase):
 
         self.expect("v fromClang", substrs=['42'])
         self.expect("frame select 1")
-        # Note that in earlier versions the lookup was a global one and
-        # thus re-evaluating the variable after adding dylib would
-        # have produced a different result. Currently these lookups
-        # are per-module so this expectedly still fails.
-        self.expect("v fromClang",
-                    substrs=["missing debug info", "FromClang"])
+        # After the dylib is loaded, its reflection metadata for FromClang
+        # becomes available in the (process-global) reflection context, so
+        # re-evaluating the variable in the loader frame now resolves its
+        # layout.
+        self.expect("v fromClang", substrs=["x = 23"])

--- a/lldb/test/API/lang/swift/multi_optionals/main.swift
+++ b/lldb/test/API/lang/swift/multi_optionals/main.swift
@@ -11,7 +11,7 @@
 // -----------------------------------------------------------------------------
 func main() {
   var foo: String????? = "foo"
-  print(foo) //% lldbutil.check_variable(self, self.frame().FindVariable("foo"), use_dynamic=False,use_synthetic=True,summary='"foo"')
+  print(foo) //% lldbutil.check_variable(self, self.frame().FindVariable("foo"), use_dynamic=True,use_synthetic=True,summary='"foo"')
 }
 
 main()

--- a/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -28,7 +28,7 @@ class TestSwiftMultipayloadEnum(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
 
-        self.expect("frame variable one", substrs=['One', '1234'])
+        self.expect("frame variable -d no-run-target one", substrs=['One', '1234'])
         self.expect("frame variable two", substrs=['TheOther', '"some value"'])
 
         self.expect("expression one", substrs=['One', '1234'])

--- a/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -27,10 +27,10 @@ class TestSwiftRangeType(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(
                 self, 'Set breakpoint here', lldb.SBFileSpec("main.swift"))
-        self.expect("frame variable a", substrs=[
+        self.expect("frame variable -d no-run-target a", substrs=[
                     '(ClosedRange<Int>) a = 1...100'])
-        self.expect("frame variable b", substrs=['(Range<Int>) b = 1..<100'])
-        self.expect("frame variable c", substrs=[
+        self.expect("frame variable -d no-run-target b", substrs=['(Range<Int>) b = 1..<100'])
+        self.expect("frame variable -d no-run-target c", substrs=[
                     '(ClosedRange<Int>) c = 1...100'])
-        self.expect("frame variable d", substrs=[
+        self.expect("frame variable -d no-run-target d", substrs=[
                     '(Range<Int>) d = 1..<100'])

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -66,39 +66,39 @@ class TestSwiftOptionalType(TestBase):
         lldbutil.check_variable(
             self,
             optS_Some,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=2)
         uoptS_Some = self.frame().FindVariable("uoptS_Some")
         lldbutil.check_variable(
             self,
             uoptS_Some,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=2)
 
         optString_None = self.frame().FindVariable("optString_None")
         lldbutil.check_variable(
             self,
             optString_None,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=0)
         uoptString_None = self.frame().FindVariable("uoptString_None")
         lldbutil.check_variable(
             self,
             uoptString_None,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=0)
 
         optString_Some = self.frame().FindVariable("optString_Some")
         lldbutil.check_variable(
             self,
             optString_Some,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=0)
         uoptString_Some = self.frame().FindVariable("uoptString_Some")
         lldbutil.check_variable(
             self,
             uoptString_Some,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=0)
         uoptString_Some.GetChildAtIndex(99)
 
@@ -106,7 +106,7 @@ class TestSwiftOptionalType(TestBase):
         lldbutil.check_variable(
             self,
             optTrue,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=0,
             summary='true')
 
@@ -114,7 +114,7 @@ class TestSwiftOptionalType(TestBase):
         lldbutil.check_variable(
             self,
             optFalse,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=0,
             summary='false')
 
@@ -122,7 +122,7 @@ class TestSwiftOptionalType(TestBase):
         lldbutil.check_variable(
             self,
             optNil,
-            use_dynamic=False,
+            use_dynamic=True,
             num_children=0,
             summary='nil')
 

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -286,6 +286,9 @@ TEST_F(ClangArgs, DoubleDash) {
   EXPECT_EQ(dest, std::vector<std::string>({"-v"}));
 }
 
+#ifndef NDEBUG
+// These tests rely on SwiftASTContextTester's default constructor, which is
+// only available in assert builds (see SwiftASTContext::SwiftASTContext()).
 TEST_F(TestSwiftASTContext, IVFS) {
   const auto *Info = testing::UnitTest::GetInstance()->current_test_info();
   llvm::SmallString<128> name;
@@ -336,3 +339,4 @@ TEST_F(TestSwiftASTContext, GetTypeNameFatalError) {
   EXPECT_EQ(context->GetTypeName(nullptr, false),
             ConstString("<invalid Swift context>"));
 }
+#endif // NDEBUG


### PR DESCRIPTION
... in SwiftLanguageRuntime::GetDynamicTypeAndAddress

This change will allow us to remove all the ExecutionContext* parameters from CompilerType APIs that were added only for the Swift plugin. That is a nice cleanup. But more importantly this will make Swift types work properly in the SBAPI, which is by design unable to pass a valid ExecutionContext into any of these function calls.

The idea behind the commit is that static Swift types for the most part do not know about their size and layout. Once we ask the SwiftLanguageRuntime for the RuntimeType of a type (a concept borrowed from the Objective-C type system) we get a dynamic type back that is tied to a process/runtime, which can answer questions about its layout and size.

rdar://169806360

Assisted-by: claude
(cherry picked from commit 366003fdd98c7509056f48623276d678796c753c)