### PR TITLE
[lldb][Windows] enable Swift parseable_interfaces/shared

### DIFF
--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part01.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part01.py
@@ -104,6 +104,12 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
         # Import C for the first time and check we can evaluate expressions
         # involving types from it
+        if self.getPlatform() == "windows":
+            # main does not reference CC, so unlike the Unix DT_NEEDED behavior
+            # CC.dll is not in main's import table and is never loaded into the
+            # inferior. Load it explicitly so the expression evaluator can
+            # resolve CC's symbols (this does not compile its .swiftinterface).
+            self.runCmd('process load "%s"' % self.getBuildArtifact("CC.dll"))
         self.runCmd("expr import CC")
         lldbutil.check_expression(
             self, self.frame(), "Baz.baz()", "23", use_summary=False)
@@ -129,7 +135,6 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""
         self.build()

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part02.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part02.py
@@ -104,6 +104,12 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
         # Import C for the first time and check we can evaluate expressions
         # involving types from it
+        if self.getPlatform() == "windows":
+            # main does not reference CC, so unlike the Unix DT_NEEDED behavior
+            # CC.dll is not in main's import table and is never loaded into the
+            # inferior. Load it explicitly so the expression evaluator can
+            # resolve CC's symbols (this does not compile its .swiftinterface).
+            self.runCmd('process load "%s"' % self.getBuildArtifact("CC.dll"))
         self.runCmd("expr import CC")
         lldbutil.check_expression(
             self, self.frame(), "Baz.baz()", "23", use_summary=False)
@@ -129,7 +135,6 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_swift_interface_fallback(self):
         """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""
         self.build()

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part03.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part03.py
@@ -135,7 +135,6 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     @skipUnlessPlatform(["macosx"])
     def test_prebuilt_cache_location(self):
         """Verify the prebuilt cache path is correct"""


### PR DESCRIPTION
Follow up to https://github.com/swiftlang/llvm-project/pull/13181 to enable more tests of the same category.