### PR TITLE
[asan][test] Fix asan/TestCases/str{n}cpy-overlap.cpp

### DIFF
--- a/compiler-rt/test/asan/TestCases/strcpy-overlap.cpp
+++ b/compiler-rt/test/asan/TestCases/strcpy-overlap.cpp
@@ -37,9 +37,10 @@ ATTRIBUTE_NOINLINE void bad_function() {
   char buffer[] = "hello";
   // CHECK: strcpy-param-overlap: memory ranges
   // CHECK: [{{0x.*,[ ]*0x.*}}) and [{{0x.*,[ ]*0x.*}}) overlap
-  // CHECK: {{#0 0x.* in .*strcpy}}
-  // CHECK: {{#1 0x.* in bad_function.*strcpy-overlap.cpp:}}[[@LINE+2]]
-  // CHECK: {{#2 0x.* in main .*strcpy-overlap.cpp:}}[[@LINE+5]]
+  // CHECK: {{#0 0x.* in .*strcpy.cold}}
+  // CHECK: {{#1 0x.* in .*strcpy}}
+  // CHECK: {{#2 0x.* in bad_function.*strcpy-overlap.cpp:}}[[@LINE+2]]
+  // CHECK: {{#3 0x.* in main .*strcpy-overlap.cpp:}}[[@LINE+5]]
   strcpy(buffer, buffer + 1); // BOOM
 }
 

--- a/compiler-rt/test/asan/TestCases/strncpy-overlap.cpp
+++ b/compiler-rt/test/asan/TestCases/strncpy-overlap.cpp
@@ -37,9 +37,10 @@ ATTRIBUTE_NOINLINE void bad_function() {
   char buffer[] = "hello";
   // CHECK: strncpy-param-overlap: memory ranges
   // CHECK: [{{0x.*,[ ]*0x.*}}) and [{{0x.*,[ ]*0x.*}}) overlap
-  // CHECK: {{#0 0x.* in .*strncpy}}
-  // CHECK: {{#1 0x.* in bad_function.*strncpy-overlap.cpp:}}[[@LINE+2]]
-  // CHECK: {{#2 0x.* in main .*strncpy-overlap.cpp:}}[[@LINE+5]]
+  // CHECK: {{#0 0x.* in .*strncpy.cold}}
+  // CHECK: {{#1 0x.* in .*strncpy}}
+  // CHECK: {{#2 0x.* in bad_function.*strncpy-overlap.cpp:}}[[@LINE+2]]
+  // CHECK: {{#3 0x.* in main .*strncpy-overlap.cpp:}}[[@LINE+5]]
   strncpy(buffer, buffer + 1, 5); // BOOM
 }
 


### PR DESCRIPTION
Commit 90897920de9094a497f83ab4456a362cb9aefcaa changed the apple/swiftlang fork to enable hot-cold splitting by default. Update the str{n}cpy-overlap.cpp tests to account for that.

Assisted-by: Claude Code

rdar://181829504