### PR TITLE
[lldb] Diagnose unresolved generic 'self' instead of emitting an invalid wrapper

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -182,6 +182,15 @@ findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
 
   if (!info.type.IsValid())
     return {};
+
+  // If `self`'s static type is meaningless without dynamic type resolution
+  // there's nothing we can do with it. This does not apply to metatypes (i.e.
+  // `self` in a static method): the expression evaluator can still bind their
+  // generic parameters directly, without relying on dynamic type resolution of
+  // an instance's metadata.
+  if (!info.is_metatype && info.type.IsMeaninglessWithoutDynamicResolution())
+    return {};
+
   return info;
 }
 

--- a/lldb/test/API/lang/swift/invalid_self_type/Makefile
+++ b/lldb/test/API/lang/swift/invalid_self_type/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/invalid_self_type/TestSwiftInvalidSelfType.py
+++ b/lldb/test/API/lang/swift/invalid_self_type/TestSwiftInvalidSelfType.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftInvalidSelfType(TestBase):
+    @swiftTest
+    @skipEmbeddedSwift
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+        frame = thread.frames[0]
+
+        # `self`'s static type is the archetype, but dynamic resolution
+        # normally rescues it. Force that resolution to fail.
+        self_val = frame.FindVariable("self", lldb.eNoDynamicValues)
+        slot = self_val.GetLoadAddress()
+        self.assertNotEqual(slot, lldb.LLDB_INVALID_ADDRESS,
+                            "could not locate self's slot")
+        err = lldb.SBError()
+        instance = process.ReadPointerFromMemory(slot, err)
+        self.assertSuccess(err, "could not read self's instance pointer")
+        process.WriteMemory(instance, (0xdeadbeef0).to_bytes(8, "little"), err)
+        self.assertSuccess(err, "failed to clobber isa")
+
+        # Sanity check: with the isa clobbered, dynamic-type resolution can no
+        # longer concretize `self`, so its raw type stays the archetype.
+        self.expect("frame variable --raw -- self", substrs=["τ_0_0"])
+
+        value = frame.EvaluateExpression("self.number")
+        self.assertFalse(value.GetError().Success())
+        error = value.GetError().GetCString()
+        # We should not surface the misleading wrapper error ...
+        self.assertNotIn("'mutating' is not valid on instance methods in classes",
+                         error)
+        # ... instead 'self' is treated as not in scope.
+        self.assertIn("cannot find 'self' in scope", error)

--- a/lldb/test/API/lang/swift/invalid_self_type/main.swift
+++ b/lldb/test/API/lang/swift/invalid_self_type/main.swift
@@ -1,0 +1,19 @@
+// A class-bound protocol. Inside its extension methods the static type of
+// `self` is the generic archetype `τ_0_0`, not a concrete class.
+protocol P: AnyObject {
+    func payload() -> Int
+}
+
+class C: P {
+    let number = 42
+    func payload() -> Int { number }
+}
+
+extension P {
+    func useSelf() {
+        return // break here
+    }
+}
+
+let c: P = C()
+c.useSelf()


### PR DESCRIPTION
When stopped in a class-bound protocol extension, the static type of `self` is the generic archetype (τ_0_0). LLDB normally upgrades it to the concrete class via dynamic-type resolution, but when that fails the archetype was kept as `self`'s type.

This causes an invalid expression to be generated, with the confusing error message:

    'mutating' is not valid on instance methods in classes

rdar://179294326

Assisted-by: claude