### PR TITLE
[lldb] Fix incorrect optional check in `language swift task info`

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2950,8 +2950,8 @@ private:
       std::optional<lldb::addr_t> maybe_task_addr =
           task_inspector.GetTaskAddrFromThreadLocalStorage(
               m_exe_ctx.GetThreadRef());
-      if (!task_addr) {
-        result.AppendError("could find the task address");
+      if (!maybe_task_addr) {
+        result.AppendError("could not find the task address");
         return;
       }
 


### PR DESCRIPTION
## Summary

`language swift task info` checked the wrong variable when looking up the current task's address from thread-local storage, so the error path for a missing task address was never taken.

Fixes swiftlang/llvm-project#13330

## Changes

- Check `maybe_task_addr` instead of `task_addr` before dereferencing it.
- Fix a typo in the resulting error message ("could find" -> "could not find").