### PR TITLE
[lldb] Match module by basename instead of full path

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -164,7 +164,8 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
   }
 
   FileSpecList containingModules;
-  containingModules.Append(exe_module_sp->GetFileSpec());
+  containingModules.Append(
+      FileSpec(exe_module_sp->GetFileSpec().GetFilename().GetStringRef()));
 
   BreakpointSP main_bp_sp = target_sp->CreateBreakpoint(
       &containingModules,    // Limit to these modules

--- a/lldb/test/Shell/SwiftREPL/DiagnosticCaret.test
+++ b/lldb/test/Shell/SwiftREPL/DiagnosticCaret.test
@@ -1,7 +1,6 @@
 // Test that the caret for a single-character operator is correctly underlined.
 
 // REQUIRES: swift
-// XFAIL: system-windows
 
 // RUN: env LANG=C %lldb --repl 2>&1 < %s | FileCheck %s
 

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -28,35 +28,13 @@ xfail lldb-shell :: SwiftREPL/SwiftInterface.test
 ### Tests that pass locally, but fail in CI reliably ###
 
 # https://github.com/swiftlang/llvm-project/issues/9539
-xfail lldb-shell :: SwiftREPL/Basic.test
-xfail lldb-shell :: SwiftREPL/Class.test
-xfail lldb-shell :: SwiftREPL/ComputedProperties.test
-xfail lldb-shell :: SwiftREPL/Deadlock.test
-xfail lldb-shell :: SwiftREPL/DiagnosticOptions.test
-xfail lldb-shell :: SwiftREPL/Dict.test
 xfail lldb-shell :: SwiftREPL/ErrorReturn.test
-xfail lldb-shell :: SwiftREPL/ExclusivityREPL.test
 xfail lldb-shell :: SwiftREPL/GenericTypealias.test
-xfail lldb-shell :: SwiftREPL/Generics.test
-xfail lldb-shell :: SwiftREPL/ImportError.test
-xfail lldb-shell :: SwiftREPL/MetatypeRepl.test
 xfail lldb-shell :: SwiftREPL/Optional.test
-xfail lldb-shell :: SwiftREPL/PropertyWrapperTopLevel.test
 xfail lldb-shell :: SwiftREPL/RecursiveClass.test
-xfail lldb-shell :: SwiftREPL/Redefinition.test
-xfail lldb-shell :: SwiftREPL/RedirectInput.test
-xfail lldb-shell :: SwiftREPL/RedirectInputNoSuchFile.test
 xfail lldb-shell :: SwiftREPL/Regex.test
 xfail lldb-shell :: SwiftREPL/SimpleExpressions.test
-xfail lldb-shell :: SwiftREPL/Struct.test
-xfail lldb-shell :: SwiftREPL/Subclassing.test
-xfail lldb-shell :: SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
-xfail lldb-shell :: SwiftREPL/SwiftTypeLookup.test
-xfail lldb-shell :: SwiftREPL/SyntaxError.test
-xfail lldb-shell :: SwiftREPL/UninitVariables.test
-xfail lldb-shell :: SwiftREPL/ZeroSizeStruct.test
 xfail lldb-shell :: SwiftREPL/enum-singlecase.test
-xfail lldb-shell :: SwiftREPL/one-char-string.test
 
 xfail lldb-api :: commands/apropos/with-process/TestAproposWithProcess.py
 xfail lldb-api :: commands/command/nested_alias/TestNestedAlias.py


### PR DESCRIPTION
On the Windows CI, we use subst drives (`S:` mapped to `C:\S`) which causes a path comparison to fail in `SwiftREPL.cpp` even though we are comparing similar paths.

This patch matches the executable module by basename instead of full path. This is robust to subst drives, symlinks, and path-case differences, and is safe elsewhere since the REPL module name is unique.

This re-enables 23 SwiftREPL lldb-shell tests on Windows.