### PR TITLE
[lldb][Windows] make lldb-server.exe the default plugin

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -754,7 +754,7 @@ def _usingLLDBServerOnWindows():
     variable: unset/off selects the default in-process plugin, on selects
     the gdb-remote path through ``lldb-server``.
     """
-    return os.environ.get("LLDB_USE_LLDB_SERVER", "").lower() in (
+    return os.environ.get("LLDB_USE_LLDB_SERVER", "on").lower() in (
         "on",
         "yes",
         "1",

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -98,10 +98,10 @@ ProcessSP ProcessWindows::CreateInstance(lldb::TargetSP target_sp,
 
 static bool ShouldUseLLDBServer() {
   llvm::StringRef use_lldb_server = ::getenv("LLDB_USE_LLDB_SERVER");
-  return use_lldb_server.equals_insensitive("on") ||
-         use_lldb_server.equals_insensitive("yes") ||
-         use_lldb_server.equals_insensitive("1") ||
-         use_lldb_server.equals_insensitive("true");
+  return !(use_lldb_server.equals_insensitive("off") ||
+           use_lldb_server.equals_insensitive("no") ||
+           use_lldb_server.equals_insensitive("0") ||
+           use_lldb_server.equals_insensitive("false"));
 }
 
 void ProcessWindows::Initialize() {

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -458,7 +458,7 @@ if platform.system() == "Windows":
         if v in os.environ:
             config.environment[v] = os.environ[v]
 
-    if getattr(config, "lldb_use_lldb_server", False):
+    if getattr(config, "lldb_use_lldb_server", True):
         config.environment["LLDB_USE_LLDB_SERVER"] = "1"
 
     # Use anonymous pipes instead of ConPTY for all tests. ConPTY injects VT

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -195,7 +195,7 @@ if config.have_dia_sdk:
     config.available_features.add("diasdk")
 
 if platform.system() == "Windows":
-    if getattr(config, "lldb_use_lldb_server", False):
+    if getattr(config, "lldb_use_lldb_server", True):
         config.environment["LLDB_USE_LLDB_SERVER"] = "1"
     # Use anonymous pipes instead of ConPTY for all tests. ConPTY injects VT
     # escape sequences into the output stream, which breaks tests that check


### PR DESCRIPTION
This makes lldb-server.exe the default plugin in lldb on Windows.