### PR TITLE
add new variants of lifetime_capture_by_* to lifetimebound.h

### DIFF
--- a/clang/lib/Headers/lifetimebound.h
+++ b/clang/lib/Headers/lifetimebound.h
@@ -28,6 +28,24 @@
 #define __lifetime_capture_by(X) __attribute__((lifetime_capture_by(X)))
 #endif
 
+#if __use_cpp_spelling(clang::lifetime_capture_by_this)
+#define __lifetime_capture_by_this [[clang::lifetime_capture_by_this]]
+#else
+#define __lifetime_capture_by_this __attribute__((lifetime_capture_by_this))
+#endif
+
+#if __use_cpp_spelling(clang::lifetime_capture_by_global)
+#define __lifetime_capture_by_global [[clang::lifetime_capture_by_global]]
+#else
+#define __lifetime_capture_by_global __attribute__((lifetime_capture_by_global))
+#endif
+
+#if __use_cpp_spelling(clang::lifetime_capture_by_unknown)
+#define __lifetime_capture_by_unknown [[clang::lifetime_capture_by_unknown]]
+#else
+#define __lifetime_capture_by_unknown __attribute__((lifetime_capture_by_unknown))
+#endif
+
 #if __use_cpp_spelling(clang::noescape)
 #define __noescape [[clang::noescape]]
 #else

--- a/clang/test/Headers/lifetimebound.cpp
+++ b/clang/test/Headers/lifetimebound.cpp
@@ -10,8 +10,10 @@ struct has_lifetimebound_method {
 };
 
 struct has_lifetime_capture_by_method {
-  void take_ptr(char* ptr __lifetime_capture_by(this));
+  void take_ptr(char* ptr __lifetime_capture_by_this);
   void take_ptr(has_lifetimebound_method a, char* ptr __lifetime_capture_by(a));
+  void take_ptr(short* ptr __lifetime_capture_by_global);
+  void take_ptr(int* ptr __lifetime_capture_by_unknown);
 };
 
 struct has_noescape_method {


### PR DESCRIPTION
`lifetime_capture_by(X)` is now deprecated for `this`, `global` and `unknown`, and instead have separate attributes. Add these to the lifetimebound header.

rdar://181878085