### PR TITLE
Move the error about DIE not having an address range to the Verbose channel (#208593)

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.cpp
@@ -51,8 +51,8 @@ void DWARFCompileUnit::BuildAddressRangeTable(
       if (!ranges->empty())
         return;
     } else {
-      LLDB_LOG_ERROR(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
-                     "{1:x}: {0}", cu_offset);
+      LLDB_LOG_ERRORV(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
+                      "DIE({1:x}): {0}", cu_offset);
     }
   }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -195,8 +195,8 @@ DWARFDIE::LookupDeepestBlock(lldb::addr_t address) const {
       }
       check_children = addr_in_range;
     } else {
-      LLDB_LOG_ERROR(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
-                     "DIE({1:x}): {0}", GetID());
+      LLDB_LOG_ERRORV(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
+                      "DIE({1:x}): {0}", GetID());
     }
   }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -630,7 +630,8 @@ void DWARFDebugInfoEntry::BuildFunctionAddressRangeTable(
         for (const auto &r : *ranges)
           debug_aranges->AppendRange(GetOffset(), r.LowPC, r.HighPC);
       } else {
-        LLDB_LOG_ERROR(log, ranges.takeError(), "DIE({1:x}): {0}", GetOffset());
+        LLDB_LOG_ERRORV(log, ranges.takeError(), "DIE({1:x}): {0}",
+                        GetOffset());
       }
     }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -937,7 +937,8 @@ Function *SymbolFileDWARF::ParseFunction(CompileUnit &comp_unit,
         ranges.emplace_back(std::move(base_addr), range.HighPC - range.LowPC);
     }
   } else {
-    LLDB_LOG_ERROR(log, die_ranges.takeError(), "DIE({1:x}): {0}", die.GetID());
+    LLDB_LOG_ERRORV(log, die_ranges.takeError(), "DIE({1:x}): {0}",
+                    die.GetID());
   }
   if (ranges.empty())
     return nullptr;
@@ -3489,8 +3490,8 @@ size_t SymbolFileDWARF::ParseBlocksRecursive(Function &func) {
         ParseBlocksRecursive(*comp_unit, &func.GetBlock(false),
                              function_die.GetFirstChild(), function_file_addr);
     } else {
-      LLDB_LOG_ERROR(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
-                     "{1:x}: {0}", dwarf_cu->GetOffset());
+      LLDB_LOG_ERRORV(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
+                      "{1:x}: {0}", dwarf_cu->GetOffset());
     }
   }
 
@@ -3526,8 +3527,8 @@ size_t SymbolFileDWARF::ParseVariablesForContext(const SymbolContext &sc) {
         if (!ranges->empty())
           func_lo_pc = ranges->begin()->LowPC;
       } else {
-        LLDB_LOG_ERROR(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
-                       "DIE({1:x}): {0}", function_die.GetID());
+        LLDB_LOG_ERRORV(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
+                        "DIE({1:x}): {0}", function_die.GetID());
       }
       if (func_lo_pc != LLDB_INVALID_ADDRESS) {
         const size_t num_variables =


### PR DESCRIPTION
This particular error, when it comes tends to come over and over and over and swamps all the other logging output.

It's clearly a candidate for the verbose log channel. Since this was emitted with LLDB_LOG_ERROR that also meant it went to the always on log, where again it was swamping the other output and making logs quite difficult to read. I asked around and nobody felt the need to have this always on.

(cherry picked from commit 98e5f18078ca87ff59bb6e6b07e341a77d599f81)