### PR TITLE
[LLDB] Replace the execution context DenseMap with Frame/Type pairs

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1012,6 +1012,15 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       actual_type =
           swift_ast_ctx->GetTypeRefType(actual_type.GetOpaqueQualType());
 
+      // Hoist the type into the scratch typesystem.
+      if (lldb::StackFrameSP frame_sp = stack_frame_wp.lock())
+        if (auto *runtime =
+                SwiftLanguageRuntime::Get(frame_sp->CalculateProcess()))
+          if (auto rt = runtime->GetRuntimeType(actual_type,
+                                                ExecutionContext(frame_sp)))
+            if (rt->IsValid())
+              actual_type = *rt;
+
       offset = materializer.AddResultVariable(
           actual_type, false, true,
           is_result ? &user_expression.GetResultDelegate()

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -560,11 +560,8 @@ ReflectionContextInterface::GetCanonicalTypeRef(CompilerType type) {
   ExecutionContext exe_ctx;
   if (auto *expr_ts =
           llvm::dyn_cast<TypeSystemSwiftTypeRefForExpressions>(tr_ts.get()))
-    exe_ctx = expr_ts
-                  ->GetExecutionContextForType(
-                      expr_ts->GetTypeFromMangledTypename(mangled_name)
-                          .GetOpaqueQualType())
-                  .Lock(false);
+    exe_ctx =
+        expr_ts->GetExecutionContextForType(type.GetOpaqueQualType()).Lock(false);
   auto node_or_err = tr_ts->RemoveMarkerProtocols(dem, node, flavor, exe_ctx);
   if (!node_or_err)
     return node_or_err.takeError();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3625,7 +3625,9 @@ static CompilerType HoistToScratchTypeSystem(CompilerType type,
 std::optional<CompilerType>
 SwiftLanguageRuntime::GetRuntimeType(CompilerType base_type,
                                      ExecutionContextRef exe_ctx) {
-  // Hoist the type into a scratch typesystem.
+  // Hoist the type into a scratch typesystem. The resulting type is
+  // bound to exe_ctx, so subsequent queries resolve frame-dependent
+  // properties such as generic parameters.
   if (!base_type.GetTypeSystem().isa_and_nonnull<TypeSystemSwiftTypeRef>())
     return {};
   if (CompilerType run_type = HoistToScratchTypeSystem(base_type, exe_ctx))

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2708,10 +2708,58 @@ SwiftASTContextSP TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContextOrNull
   return {};
 }
 
+static constexpr uintptr_t g_frame_bound_tag = 1;
+
+static bool IsFrameBoundType(opaque_compiler_type_t type) {
+  return reinterpret_cast<uintptr_t>(type) & g_frame_bound_tag;
+}
+
+/// Decode the index stored in a frame-bound \p type.
+static uintptr_t GetFrameBoundIndex(opaque_compiler_type_t type) {
+  return reinterpret_cast<uintptr_t>(type) >> 1;
+}
+
 ExecutionContextRef
 TypeSystemSwiftTypeRefForExpressions::GetExecutionContextForType(
     lldb::opaque_compiler_type_t type) {
-  return m_exectx_sidetable.Lookup(AsMangledName(type));
+  if (IsFrameBoundType(type))
+    return GetFrameBoundExecutionContext(GetFrameBoundIndex(type));
+  return {};
+}
+
+CompilerType TypeSystemSwiftTypeRefForExpressions::MakeFrameBoundType(
+    ConstString mangled_name, lldb::StackFrameSP frame) {
+  uintptr_t index;
+  {
+    std::lock_guard<std::mutex> guard(m_frame_bound_types_mutex);
+    index = m_frame_bound_types.size();
+    m_frame_bound_types.push_back({frame, mangled_name});
+  }
+  // Construct the CompilerType outside the lock: its constructor calls Verify(),
+  // which resolves the frame-bound type back through this table.
+  auto opaque_type = reinterpret_cast<opaque_compiler_type_t>(
+      (index << 1) | g_frame_bound_tag);
+  return {weak_from_this(), opaque_type};
+}
+
+const char *
+TypeSystemSwiftTypeRefForExpressions::GetFrameBoundMangledName(
+    uintptr_t index) const {
+  std::lock_guard<std::mutex> guard(m_frame_bound_types_mutex);
+  if (index >= m_frame_bound_types.size())
+    return nullptr;
+  return m_frame_bound_types[index].mangled_name.AsCString(nullptr);
+}
+
+ExecutionContextRef
+TypeSystemSwiftTypeRefForExpressions::GetFrameBoundExecutionContext(
+    uintptr_t index) {
+  ExecutionContextRef exe_ctx;
+  std::lock_guard<std::mutex> guard(m_frame_bound_types_mutex);
+  if (index < m_frame_bound_types.size())
+    if (lldb::StackFrameSP frame = m_frame_bound_types[index].frame.lock())
+      exe_ctx.SetFrameSP(frame);
+  return exe_ctx;
 }
 
 CompilerType
@@ -2720,7 +2768,6 @@ TypeSystemSwiftTypeRefForExpressions::ImportType(CompilerType type,
   ConstString mangled_name = type.GetMangledTypeName();
   if (mangled_name.IsEmpty())
     return {};
-  m_exectx_sidetable.Insert(mangled_name.AsCString(nullptr), exe_ctx);
 
   // Copy the DWARF type cache entry from the source typesystem so
   // that queries like IsMarkerProtocol work on the scratch typesystem.
@@ -2729,7 +2776,9 @@ TypeSystemSwiftTypeRefForExpressions::ImportType(CompilerType type,
     if (auto type_sp = src_ts->GetCachedType(mangled_name))
       SetCachedType(mangled_name, type_sp);
 
-  return GetTypeFromMangledTypename(mangled_name);
+  // Remember the frame this type was observed in, so that a frame-dependent
+  // type (e.g. a bare generic parameter) can later be resolved unambiguously.
+  return MakeFrameBoundType(mangled_name, exe_ctx.GetFrameSP());
 }
 
 SwiftDWARFImporterForClangTypes &
@@ -2778,7 +2827,16 @@ void TypeSystemSwiftTypeRef::ClearModuleDependentCaches() {
   });
 }
 
-const char *TypeSystemSwiftTypeRef::AsMangledName(opaque_compiler_type_t type) {
+const char *
+TypeSystemSwiftTypeRef::AsMangledName(opaque_compiler_type_t type) const {
+  if (IsFrameBoundType(type)) {
+    // Only the expression type system mints frame-bound types, and such a type
+    // always travels with the type system that owns its backing store.
+    if (const auto *for_expr =
+            llvm::dyn_cast<TypeSystemSwiftTypeRefForExpressions>(this))
+      return for_expr->GetFrameBoundMangledName(GetFrameBoundIndex(type));
+    return nullptr;
+  }
   assert(type && *reinterpret_cast<const char *>(type) == '$' &&
          "wrong type system");
   return reinterpret_cast<const char *>(type);
@@ -2793,8 +2851,8 @@ TypeSystemSwiftTypeRef::GetMangledTypeName(opaque_compiler_type_t type) {
 void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type,
                                               const ExecutionContext *exe_ctx) {
   SymbolContext sc = GetSymbolContextForType(type, exe_ctx);
-  std::pair<const char *, const char *> key = {
-      DeriveKeyFor(sc), reinterpret_cast<const char *>(type)};
+  std::pair<const char *, const char *> key = {DeriveKeyFor(sc),
+                                               AsMangledName(type)};
 
   if (m_dangerous_types.count(key))
     return nullptr;
@@ -2839,8 +2897,10 @@ TypeSystemSwiftTypeRef::ReconstructType(CompilerType type,
 
 CompilerType TypeSystemSwiftTypeRef::GetTypeFromMangledTypename(
     ConstString mangled_typename) {
-  return {weak_from_this(),
-          (opaque_compiler_type_t)mangled_typename.AsCString(nullptr)};
+  const char *mangled = mangled_typename.AsCString(nullptr);
+  assert((reinterpret_cast<uintptr_t>(mangled) & g_frame_bound_tag) == 0 &&
+         "mangled name is not aligned; would collide with frame-bound tag");
+  return {weak_from_this(), (opaque_compiler_type_t)mangled};
 }
 
 TypeSP TypeSystemSwiftTypeRef::GetCachedType(ConstString mangled) {
@@ -3016,8 +3076,10 @@ bool TypeSystemSwiftTypeRef::Verify(opaque_compiler_type_t type) {
   if (!type)
     return true;
 
-  const char *str = reinterpret_cast<const char *>(type);
-  if (!SwiftLanguageRuntime::IsSwiftMangledName(str))
+  // Decode via AsMangledName so that frame-bound types (which encode an index
+  // rather than a mangled name pointer) are handled correctly.
+  const char *str = AsMangledName(type);
+  if (!str || !SwiftLanguageRuntime::IsSwiftMangledName(str))
     return false;
 
   // Finally, check that the mangled name is canonical.
@@ -4275,6 +4337,17 @@ llvm::Expected<uint64_t>
 TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
                                    ExecutionContextScope *exe_scope) {
   static constexpr const char *FUNC_NAME = __FUNCTION__;
+  // Assert that exe_scope i superflous and can be removed upstream.
+  exe_scope = nullptr;
+  // Recover exe_scope from frame-bound types.
+  ExecutionContext exe_ctx;
+  if (!exe_scope) {
+    exe_ctx = GetExecutionContextForType(type).Lock(false);
+    if (!exe_ctx.HasTargetScope())
+      if (TargetSP target_sp = GetTargetWP().lock())
+        target_sp->CalculateExecutionContext(exe_ctx);
+    exe_scope = exe_ctx.GetBestExecutionContextScope();
+  }
   auto impl = [&]() -> llvm::Expected<uint64_t> {
     auto get_static_size = [&](bool cached_only) -> std::optional<uint64_t> {
       if (IsMeaninglessWithoutDynamicResolution(type))
@@ -4320,10 +4393,20 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
       auto clang_size = clang_type.GetBitSize(exe_scope);
       return clang_size;
     }
-    if (!exe_scope)
+
+    // Without an execution context we can't ask the Swift runtime, but a
+    // concrete (non-generic) type may still have a static size recorded in
+    // the debug info. Try that before giving up. Generic types are excluded
+    // by get_static_size (IsMeaninglessWithoutDynamicResolution).
+    if (!exe_scope) {
+      if (auto cached_type_static_size = get_static_size(true))
+        return *cached_type_static_size;
+      if (auto static_size = get_static_size(false))
+        return *static_size;
       return llvm::createStringError(
           "Cannot compute size of type %s without an execution context.",
           AsMangledName(type));
+    }
     // The hot code path is to ask the Swift runtime for the size.
     if (auto runtime = GetRuntime()) {
       auto result_or_err =
@@ -4880,7 +4963,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
           llvm::dbgs() << "} != {";
           llvm::interleaveComma(ast_child_indexes, llvm::dbgs());
           llvm::dbgs() << "}\n";
-          llvm::dbgs() << "failing type was " << (const char *)type
+          llvm::dbgs() << "failing type was " << AsMangledName(type)
                        << ", member was " << name << "\n";
           assert(false &&
                  "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
@@ -5580,7 +5663,7 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
 /// Convenience LLVM-style dump method for use in the debugger only.
 LLVM_DUMP_METHOD void
 TypeSystemSwiftTypeRef::dump(opaque_compiler_type_t type) const {
-  llvm::dbgs() << reinterpret_cast<const char *>(type) << "\n";
+  llvm::dbgs() << AsMangledName(type) << "\n";
 }
 #endif
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -55,6 +55,19 @@ class SwiftDWARFImporterForClangTypes;
 class SwiftLanguageRuntime;
 class SwiftPersistentExpressionState;
 
+/// A type that is bound to a stack frame.
+///
+/// Generic types can only be resolved relative to a stack
+/// frame. FrameBoundTypes are produced by
+/// SwiftLanguageRuntime::GetRuntimeType(). Instances are owned by a
+/// TypeSystemSwiftTypeRefForExpressions and referred to by an index
+/// encoded into the lldb::opaque_compiler_type_t; see
+/// TypeSystemSwiftTypeRefForExpressions for the encoding.
+struct FrameBoundType {
+  lldb::StackFrameWP frame;
+  ConstString mangled_name;
+};
+
 /// A Swift TypeSystem that does not own a swift::ASTContext.
 class TypeSystemSwiftTypeRef : public TypeSystemSwift {
   /// LLVM RTTI support.
@@ -339,7 +352,7 @@ public:
                       CompilerType *original_type) override;
   /// Determine whether this is a builtin SIMD type.
   static bool IsSIMDType(CompilerType type);
-  static bool IsOptionalType(lldb::opaque_compiler_type_t type);
+  bool IsOptionalType(lldb::opaque_compiler_type_t type);
   /// Determine whether the mangled name refers to a protocol composition
   /// (i.e., a ProtocolList with more than one Type child in its TypeList).
   static bool IsProtocolComposition(llvm::StringRef mangled_name);
@@ -468,7 +481,7 @@ public:
                            llvm::StringRef mangled_name);
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
-  static std::string GetBaseName(lldb::opaque_compiler_type_t type);
+  std::string GetBaseName(lldb::opaque_compiler_type_t type);
 
   /// Given a mangled name that mangles a "type metadata for Type", return a
   /// CompilerType with that Type.
@@ -559,8 +572,8 @@ protected:
                         const ExecutionContext *exe_ctx = nullptr);
   void *ReconstructType(lldb::opaque_compiler_type_t type,
                         ExecutionContextScope *exe_scope);
-  /// Cast \p opaque_type as a mangled name.
-  static const char *AsMangledName(lldb::opaque_compiler_type_t type);
+  /// Return the mangled name of \p opaque_type.
+  const char *AsMangledName(lldb::opaque_compiler_type_t type) const;
 
   /// Demangle the mangled name of the canonical type of \p type and
   /// drill into the Global(TypeMangling(Type())).
@@ -787,13 +800,31 @@ protected:
   /// Map ConstString Clang type identifiers and the concatenation of the
   /// compiler context used to find them to Clang types.
   ThreadSafeStringMap<lldb::TypeSP> m_clang_type_cache;
-  /// In order to do a SwiftASTContext fallback, we need to have a
-  /// precise ExecutionContext to initialize the matching
-  /// SwiftASTContext. This information isn't part of CompilerType, so
-  /// this table keeps track of all types we imported into this
-  /// typesystem.
-  /// This can be removed when the fallback is removed.
-  ThreadSafeDenseMap<const char *, ExecutionContextRef> m_exectx_sidetable;
+
+  /// Backing store for frame-bound types produced by hoisting into this type
+  /// system (see SwiftLanguageRuntime::GetRuntimeType() / ImportType()).
+  ///
+  /// Encoding: the opaque type is (index << 1) | 1 for a frame-bound type. An
+  /// ordinary Swift opaque type is a pointer to a ConstString's mangled name,
+  /// which is always at least 8-byte aligned (see AsMangledName), so its low
+  /// bit is 0 and never collides with the frame-bound tag.
+  std::vector<FrameBoundType> m_frame_bound_types;
+  mutable std::mutex m_frame_bound_types_mutex;
+
+  /// Create a frame-bound type for \p mangled_name observed in \p frame and
+  /// return its (tagged) CompilerType. Frame-bound types are produced by
+  /// hoisting via SwiftLanguageRuntime::GetRuntimeType(), which calls
+  /// ImportType(); see m_frame_bound_types.
+  CompilerType MakeFrameBoundType(ConstString mangled_name,
+                                  lldb::StackFrameSP frame);
+
+public:
+  /// Return the mangled name of the frame-bound type at \p index, or nullptr.
+  const char *GetFrameBoundMangledName(uintptr_t index) const;
+
+  /// Return the execution context of the frame-bound type at \p index. The
+  /// context is empty if the index is stale or the frame has gone away.
+  ExecutionContextRef GetFrameBoundExecutionContext(uintptr_t index);
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
When attempting to remove the ExecutionContextScope parameter from GetBitSize() I realizes that the name-based lookup mechanism does not work for generic types, because they are ... generic. This patch replaces the name-based lookups with a new kind of CompilerType:

SwiftLanguageRuntime::GetRuntimeType() now conceptually returns a pair of CompilerType and ExecutionContext. This allows later type queries to bind generic parameters and consult the runtime about type properties. The frame-bound CompilerTypes can be distinguished from normal TypeRef types via a tag in the mangled name ConstrString pointer. If the tag is present, the value is an index into the list of FrameBoundTypes.

This is the last patch needed befer we can remove the ExecutionContextScope parameter from GetBitSize().