### PR TITLE
[lldb][Windows] XFAIL Swift REPL tests

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfWindows
 class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @skipEmbeddedSwift

--- a/lldb/test/Shell/SwiftREPL/Deadlock.test
+++ b/lldb/test/Shell/SwiftREPL/Deadlock.test
@@ -1,4 +1,5 @@
 // REQUIRES: swift
+// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/Dict.test
+++ b/lldb/test/Shell/SwiftREPL/Dict.test
@@ -1,5 +1,6 @@
 // Test that the dictionary data formatter works in the REPL.
 // REQUIRES: swift
+// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 

--- a/lldb/test/Shell/SwiftREPL/Generics.test
+++ b/lldb/test/Shell/SwiftREPL/Generics.test
@@ -1,5 +1,6 @@
 // Test that generics work in the REPL.
 // REQUIRES: swift
+// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/MetatypeRepl.test
+++ b/lldb/test/Shell/SwiftREPL/MetatypeRepl.test
@@ -1,4 +1,5 @@
 // REQUIRES: swift
+// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
+++ b/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
@@ -1,4 +1,5 @@
 // REQUIRES: swift
+// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -29,7 +29,6 @@ xfail lldb-shell :: SwiftREPL/SwiftInterface.test
 
 # https://github.com/swiftlang/llvm-project/issues/9539
 xfail lldb-shell :: SwiftREPL/ErrorReturn.test
-xfail lldb-shell :: SwiftREPL/GenericTypealias.test
 xfail lldb-shell :: SwiftREPL/Optional.test
 xfail lldb-shell :: SwiftREPL/RecursiveClass.test
 xfail lldb-shell :: SwiftREPL/Regex.test


### PR DESCRIPTION
The following tests are failing, XFAIL them.

```
********************
Failed Tests (5):
    lldb-shell :: SwiftREPL/Deadlock.test
    lldb-shell :: SwiftREPL/Dict.test
    lldb-shell :: SwiftREPL/Generics.test
    lldb-shell :: SwiftREPL/MetatypeRepl.test
    lldb-shell :: SwiftREPL/PropertyWrapperTopLevel.test

  ********************
  Unexpectedly Passed Tests (1):
    lldb-shell :: SwiftREPL/GenericTypealias.test
```