### PR TITLE
[lldb][Windows] Re-enable clangimporter anonymous-clang-types and fmodule_flags

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/TestSwiftAnonymousClangTypes.py
+++ b/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/TestSwiftAnonymousClangTypes.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftAnonymousClangTypes(lldbtest.TestBase):
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/Makefile
@@ -1,4 +1,12 @@
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS = -parse-stdlib -Xcc -DMARKER1 -Xcc -fno-implicit-modules -Xcc -fno-implicit-module-maps -Xcc -DMARKER2
 
+# -parse-stdlib tells the Swift driver not to autolink the runtime, but the
+# emitted object still references swift_addNewDSOImage.
+# On Windows lld-link leaves that dllimport unresolved, so link swiftCore
+# explicitly.
+ifeq "$(OS)" "Windows_NT"
+LD_EXTRAS = -lswiftCore
+endif
+
 include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
@@ -9,7 +9,7 @@ class TestSwiftFModuleFlags(TestBase):
     @skipIfDarwinEmbedded
     @swiftTest
     @skipEmbeddedSwiftOnLinux # Failed to load SwiftCore.so
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows # module 'Swift' cannot be imported in embedded mode
     def test(self):
         """Test that -fmodule flags get stripped out"""
         self.build()


### PR DESCRIPTION
This patch fixes 2 tests:

- `anonymous-clang-types`: the tests pass now.
- `fmodule_flags`: Link `swiftCore` explicitly on Windows to fix `lld-link: undefined symbol: swift_addNewDSOImage`.