### PR TITLE
[lldb][Windows] Re-enable clangimporter/extra_clang_flags

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExtraClangFlags(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=["windows"])
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_sanity(self):
         self.build()
@@ -17,7 +17,7 @@ class TestSwiftExtraClangFlags(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=["windows"])
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_extra_clang_flags(self):
         """
@@ -61,7 +61,7 @@ class TestSwiftExtraClangFlags(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=["windows"])
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_invalid_extra_clang_flags(self):
         """

--- a/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/bridging-header.h
+++ b/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/bridging-header.h
@@ -1,1 +1,1 @@
-#import <nonmodular/a.h>
+#include <nonmodular/a.h>


### PR DESCRIPTION
`#import` does not work on Windows as it treats it as a COM type library import. Switching to `#include` fixes the build on all platforms and allows to re-enable 3 tests.