### PR TITLE
[lldb][Windows] Enable cxx_interop backward stepping tests

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/Makefile
@@ -4,5 +4,9 @@ SWIFT_SOURCES := swift-types.swift
 CXX_SOURCES := main.cpp
 SWIFT_CXX_INTEROP := 1
 SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) -parse-as-library
+ifeq "$(OS)" "Windows_NT"
+CFLAGS_EXTRAS := -I. -gdwarf
+else
 CFLAGS = -I. -g
+endif
 include Makefile.rules

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part02.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part02.py
@@ -34,28 +34,24 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_static_method_step_in_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_in(thread, 'testStaticMethod', 'SwiftClass.swiftStaticMethod')
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_static_method_step_over_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_over(thread, 'testStaticMethod')
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_getter_step_in_class(self):
         thread = self.setup('Break here for getter - class')
         self.check_step_in(thread, 'testGetter', 'SwiftClass.swiftProperty.getter')
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_getter_step_over_class(self):
         thread = self.setup('Break here for getter - class')
         self.check_step_over(thread, 'testGetter')

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingFunc.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingFunc.py
@@ -35,14 +35,12 @@ class TestSwiftBackwardInteropSteppingFunc(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_func_step_in(self):
         thread = self.setup("Break here for func")
         self.check_step_in(thread, "testFunc", "swiftFunc")
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_func_step_over(self):
         thread = self.setup("Break here for func")
         self.check_step_over(thread, "testFunc")

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part02.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part02.py
@@ -35,28 +35,24 @@ class TestSwiftBackwardInteropSteppingStruct(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_static_method_step_in_struct(self):
         thread = self.setup("Break here for static method - struct")
         self.check_step_in(thread, "testStaticMethod", "SwiftStruct.swiftStaticMethod")
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_static_method_step_over_struct(self):
         thread = self.setup("Break here for static method - struct")
         self.check_step_over(thread, "testStaticMethod")
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_getter_step_in_struct(self):
         thread = self.setup("Break here for getter - struct")
         self.check_step_in(thread, "testGetter", "SwiftStruct.swiftProperty.getter")
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_getter_step_over_struct(self):
         thread = self.setup("Break here for getter - struct")
         self.check_step_over(thread, "testGetter")


### PR DESCRIPTION
The backward interop tests put `main()` in C++ (main.cpp) and set a source breakpoint there. Their Makefile assigned`CFLAGS = -I. -g`, which overrode `Makefile.rules`' `DEBUG_INFO_FLAG` default, so on Windows clang emitted CodeView for `main.cpp` while the Swift side used DWARF.
    
This patch moves `-I.` into `CFLAGS_EXTRAS` so the default debug flag `(-gdwarf on Windows)` applies to the C++ main as well.

rdar://179241795