### PR TITLE
[lldb][Windows] Re-enable cxx_interop forward/stepping tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -740,42 +740,13 @@ class Base(unittest.TestCase):
         """Create the test-specific working directory, deleting any previous
         contents."""
         bdir = self.getBuildDir()
-        if sys.platform == "win32" and len(bdir) > 256:
-            import warnings
-
-            warnings.warn(
-                "Test build directory path exceeds 256 characters (Windows "
-                "MAX_PATH limit): {}".format(bdir)
-            )
         if os.path.isdir(bdir):
-            # Tolerate files vanishing mid-walk. Clang's implicit module
-            # build leaves behind `*.pcm.lock` lockfiles whose lifetime is
-            # tied to the holding process; a concurrent or just-exited
-            # clang can unlink one between rmtree's scandir and unlink,
-            # raising ENOENT. The dir is going away anyway, so treat
-            # already-gone entries as success.
-            def _ignore_enoent(func, path, exc_info):
-                if (
-                    isinstance(exc_info[1], OSError)
-                    and exc_info[1].errno == errno.ENOENT
-                ):
-                    return
-                raise exc_info[1]
-
-            shutil.rmtree(bdir, onerror=_ignore_enoent)
+            lldbutil.remove_tree(bdir)
         lldbutil.mkdir_p(bdir)
 
     def getBuildArtifact(self, name="a.out"):
         """Return absolute path to an artifact in the test's build directory."""
-        artifact_path = os.path.join(self.getBuildDir(), name)
-        if sys.platform == "win32" and len(artifact_path) > 256:
-            import warnings
-
-            warnings.warn(
-                "Test artifact path exceeds 256 characters (Windows "
-                "MAX_PATH limit): {}".format(artifact_path)
-            )
-        return artifact_path
+        return os.path.join(self.getBuildDir(), name)
 
     def getSourcePath(self, name):
         """Return absolute path to a file in the test's source directory."""
@@ -2237,7 +2208,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
         with open(src, "w") as f:
             f.write(new_content)
 
-        self.addTearDownHook(lambda: os.remove(src))
+        self.addTearDownHook(lambda: os.remove(lldbutil.get_extended_windows_path(src)))
 
     def setUp(self):
         # Works with the test driver to conditionally skip tests via
@@ -3092,7 +3063,7 @@ FileCheck output:
 def remove_file(file, num_retries=1, sleep_duration=0.5):
     for i in range(num_retries + 1):
         try:
-            os.remove(file)
+            os.remove(lldbutil.get_extended_windows_path(file))
             return True
         except:
             time.sleep(sleep_duration)

--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -10,6 +10,7 @@ import io
 import json
 import os
 import re
+import shutil
 import sys
 import subprocess
 from typing import Dict
@@ -55,6 +56,113 @@ def mkdir_p(path):
             raise
     if not os.path.isdir(path):
         raise OSError(errno.ENOTDIR, "%s is not a directory" % path)
+
+
+def get_extended_windows_path(path):
+    r"""Return ``path`` in the Windows extended-length ``\\?\`` form so it can be
+    handed to the Win32 API (and therefore to ``os``/``shutil``) even when it is
+    longer than MAX_PATH (260 characters). On non-Windows platforms ``path`` is
+    returned unchanged.
+
+    The ``\\?\`` prefix disables all path normalization normally performed by
+    Win32, so the path must be fully qualified, use backslash separators and
+    contain no ``.``/``..`` components. ``os.path.abspath`` guarantees all three.
+    """
+    if sys.platform != "win32":
+        return path
+    if path.startswith("\\\\?\\"):
+        return path
+    assert os.path.isabs(path), (
+        "cannot form a \\\\?\\ extended-length path from relative path: %s" % path
+    )
+    abs_path = os.path.abspath(path)
+    # UNC shares (\\server\share) use the \\?\UNC\ spelling.
+    if abs_path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + abs_path[2:]
+    return "\\\\?\\" + abs_path
+
+
+def remove_tree(path):
+    """Recursively delete the directory tree rooted at ``path``.
+
+    On Windows this drives the shell ``SHFileOperationW`` API directly rather
+    than ``shutil.rmtree``. It deletes the whole tree in a single native call,
+    which also clears read-only files.
+
+    This mirrors lit's builtin ``rm`` (see
+    ``llvm/utils/lit/lit/InprocBuiltins.py``).
+
+    On non-Windows platforms this is ``shutil.rmtree`` with a handler that
+    tolerates entries vanishing mid-walk (``FileNotFoundError``). clang's
+    implicit-module ``*.pcm.lock`` files, whose lifetime is tied to a concurrent
+    or just-exited clang process.
+    """
+    if sys.platform != "win32":
+
+        def _ignore_missing(func, failed_path, exc):
+            # `shutil.rmtree` passes the error as an instance on the `onexc` API
+            # (3.12+) or a `sys.exc_info()` tuple on the legacy `onerror` API.
+            if isinstance(exc, tuple):
+                exc = exc[1]
+            if isinstance(exc, FileNotFoundError):
+                return
+            raise exc
+
+        if sys.version_info >= (3, 12):
+            shutil.rmtree(path, onexc=_ignore_missing)
+        else:
+            shutil.rmtree(path, onerror=_ignore_missing)
+        return
+
+    # NOTE: use ctypes to access `SHFileOperationW` on Windows so we can delete
+    # trees using the wide-character Win32 API, which reaches long file paths
+    # that cannot be removed otherwise.
+    from ctypes import (
+        POINTER,
+        Structure,
+        WinError,
+        addressof,
+        byref,
+        c_void_p,
+        create_unicode_buffer,
+        windll,
+    )
+    from ctypes.wintypes import BOOL, HWND, LPCWSTR, UINT, WORD
+
+    class SHFILEOPSTRUCTW(Structure):
+        _fields_ = [
+            ("hWnd", HWND),
+            ("wFunc", UINT),
+            ("pFrom", LPCWSTR),
+            ("pTo", LPCWSTR),
+            ("fFlags", WORD),
+            ("fAnyOperationsAborted", BOOL),
+            ("hNameMappings", c_void_p),
+            ("lpszProgressTitle", LPCWSTR),
+        ]
+
+    FO_DELETE = 3
+
+    FOF_SILENT = 4
+    FOF_NOCONFIRMATION = 16
+    FOF_NOCONFIRMMKDIR = 512
+    FOF_NOERRORUI = 1024
+    FOF_NO_UI = FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_NOCONFIRMMKDIR
+
+    SHFileOperationW = windll.shell32.SHFileOperationW
+    SHFileOperationW.argtypes = [POINTER(SHFILEOPSTRUCTW)]
+
+    path = os.path.abspath(path)
+    pFrom = create_unicode_buffer(path, len(path) + 2)
+    pFrom[len(path)] = pFrom[len(path) + 1] = "\0"
+    operation = SHFILEOPSTRUCTW(
+        wFunc=UINT(FO_DELETE),
+        pFrom=LPCWSTR(addressof(pFrom)),
+        fFlags=FOF_NO_UI,
+    )
+    result = SHFileOperationW(byref(operation))
+    if result:
+        raise WinError(result)
 
 
 # ============================

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping_part01.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping_part01.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropStepping(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_function(self):
         """ Test that stepping into a simple C++ function works"""
         self.build()
@@ -27,7 +27,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testFunction', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_function(self):
         """ Test that stepping over a simple C++ function works"""
         self.build()
@@ -43,7 +43,7 @@ class TestSwiftForwardInteropStepping(TestBase):
 
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_method(self):
         """ Test that stepping into a C++ method works"""
         self.build()
@@ -61,7 +61,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testMethod', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_method(self):
         """ Test that stepping over a C++ method works"""
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping_part02.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping_part02.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropStepping(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_constructor(self):
         """ Test that stepping into a simple C++ constructor works"""
         self.build()
@@ -30,7 +30,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testContructor', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_constructor(self):
         """ Test that stepping over a simple C++ constructor works"""
         self.build()
@@ -49,7 +49,7 @@ class TestSwiftForwardInteropStepping(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_extension(self):
         """ Test that stepping into a C++ function defined in an extension works"""
         self.build()
@@ -67,7 +67,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testClassWithExtension', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_extension(self):
         """ Test that stepping over a C++ function defined in an extension works"""
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping_part03.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping_part03.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropStepping(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_call_operator(self):
         """ Test that stepping into a C++ call operator works"""
         self.build()
@@ -21,13 +21,13 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testCallOperator', name)
         thread.StepInto()
         name = thread.frames[0].GetFunctionName()
-        self.assertIn('ClassWithCallOperator::operator()()', name)
+        self.assertIn('ClassWithCallOperator::operator()', name)
         thread.StepOut()
         name = thread.frames[0].GetFunctionName()
         self.assertIn('testCallOperator', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_call_operator(self):
         """ Test that stepping over a C++ call operator works"""
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly_part01.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly_part01.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_function(self):
         """ Test that stepping into a simple C++ function works"""
         self.build()
@@ -27,7 +27,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testFunction', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_function(self):
         """ Test that stepping over a simple C++ function works"""
         self.build()
@@ -43,7 +43,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
 
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_method(self):
         """ Test that stepping into a C++ method works"""
         self.build()
@@ -61,7 +61,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testMethod', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_method(self):
         """ Test that stepping over a C++ method works"""
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly_part02.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly_part02.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_constructor(self):
         """ Test that stepping into a simple C++ constructor works"""
         self.build()
@@ -30,7 +30,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testContructor', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_constructor(self):
         """ Test that stepping over a simple C++ constructor works"""
         self.build()
@@ -49,7 +49,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_extension(self):
         """ Test that stepping into a C++ function defined in an extension works"""
         self.build()
@@ -67,7 +67,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testClassWithExtension', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_extension(self):
         """ Test that stepping over a C++ function defined in an extension works"""
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly_part03.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly_part03.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_into_call_operator(self):
         """ Test that stepping into a C++ call operator works"""
         self.build()
@@ -21,13 +21,13 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testCallOperator', name)
         thread.StepInto()
         name = thread.frames[0].GetFunctionName()
-        self.assertIn('ClassWithCallOperator::operator()()', name)
+        self.assertIn('ClassWithCallOperator::operator()', name)
         thread.StepOut()
         name = thread.frames[0].GetFunctionName()
         self.assertIn('testCallOperator', name)
 
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     def test_step_over_call_operator(self):
         """ Test that stepping over a C++ call operator works"""
         self.build()

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -55,13 +55,6 @@ class ShTestLldb(ShTest):
         super().__init__(execute_external, extra_substitutions, preamble_commands)
 
     def execute(self, test, litConfig):
-        exec_path = test.getExecPath()
-        if platform.system() == "Windows" and len(exec_path) > 256:
-            litConfig.warning(
-                "Test path exceeds 256 characters (Windows MAX_PATH limit): "
-                + exec_path
-            )
-
         # Run each Shell test in a separate directory (on remote).
 
         # Find directory change command in %lldb substitution.


### PR DESCRIPTION
Stepping into the C++ call operator lands in the right frame, but Windows demangles it as `int ClassWithCallOperator::operator()(void)` rather than `ClassWithCallOperator::operator()()`. This patch relaxes the substring check to `ClassWithCallOperator::operator()` to enable the tests.

Cherry-picks:
- https://github.com/llvm/llvm-project/pull/209409