### PR TITLE
[clang][APINotes] Add duplicated attrs to where parameters test

### DIFF
--- a/clang/test/APINotes/where-parameters-sema.cpp
+++ b/clang/test/APINotes/where-parameters-sema.cpp
@@ -79,11 +79,17 @@
 
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void (int)'
 // CHECK-METHOD-OVERLOADS-NEXT: ParmVarDecl {{.+}} 'int'
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setIntValue(_:)"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setIntValue(_:)"
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void (double)'
 // CHECK-METHOD-OVERLOADS-NEXT: ParmVarDecl {{.+}} 'double'
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setDoubleValue(_:)"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setDoubleValue(_:)"
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void ()'
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "currentValue()"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "currentValue()"
 
 // CHECK-METHOD-BROAD: CXXMethodDecl {{.+}} broad 'void (int)'
@@ -130,7 +136,11 @@
 
 // CHECK-METHOD-OPERATOR: CXXMethodDecl {{.+}} operator+ 'SelectorWidget (int)'
 // CHECK-METHOD-OPERATOR-NEXT: ParmVarDecl {{.+}} 'int'
+// CHECK-METHOD-OPERATOR-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusInt(_:)"
 // CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusInt(_:)"
 // CHECK-METHOD-OPERATOR: CXXMethodDecl {{.+}} operator+ 'SelectorWidget (double)'
 // CHECK-METHOD-OPERATOR-NEXT: ParmVarDecl {{.+}} 'double'
+// CHECK-METHOD-OPERATOR-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusDouble(_:)"
 // CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusDouble(_:)"


### PR DESCRIPTION
On this fork, C++ member declarators are routed through Sema::ProcessAPINotes() twice for the same Decl (once via ProcessDeclAttributes() during HandleDeclarator, and again explicitly via Actions.ProcessAPINotes() in the member/inline-method handling).

Update the CHECK-METHOD-OVERLOADS and CHECK-METHOD-OPERATOR blocks to expect the SwiftVersionedAdditionAttr plus duplicated SwiftNameAttr, matching the pattern already established for CXXMethodDecl in lifetimebound.cpp and boundssafety.cpp.

Similar to https://github.com/swiftlang/llvm-project/pull/9653

rdar://182117526