### PR TITLE
[swift][lldb] Migrate uses of obsoleted `StringSwitch::Cases`

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -10103,7 +10103,7 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
       // imported as "CxxStdlib", which should also be imported.
       if (module.path.size() &&
           llvm::StringSwitch<bool>(module.path.front().GetStringRef())
-              .Cases("SwiftShims", "Builtin", "std", true)
+              .Cases({"SwiftShims", "Builtin", "std"}, true)
               .Default(false))
         continue;
 


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/commit/f441746a7b3986d2fcb1f973745b53e33e6c68e4 (https://github.com/llvm/llvm-project/pull/185191).