### PR TITLE
[lldb][Windows] Re-enable override tests that pass on stable/21.x

### DIFF
--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -139,31 +139,14 @@ skip lldb-api :: tools/lldb-dap/output/TestDAP_output.py
 
 ### Untriaged ###
 
-skip lldb-api :: commands/statistics/basic/TestStats.py
-skip lldb-api :: lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers.py
-skip lldb-api :: lang/BoundsSafety/out_of_bounds_pointer/TestOutOfBoundsPointer.py
 skip lldb-shell :: Commands/command-expr-diagnostics.test
 skip lldb-unit :: Host/./HostTests.exe
 
-# https://github.com/llvm/llvm-project/issues/62983
-skip lldb-api :: functionalities/var_path/TestVarPath.py
-
 # https://github.com/swiftlang/llvm-project/issues/9073
 skip lldb-api :: lang/c/trampoline_stepping/TestTrampolineStepping.py
-
-# https://github.com/swiftlang/llvm-project/issues/9072
-skip lldb-api :: lang/cpp/bitfields/TestCppBitfields.py
-
-skip lldb-shell :: Swift/astcontext_error.test
-skip lldb-shell :: Swift/cond-breakpoint.test
-
-skip lldb-api :: functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
-skip lldb-api :: lang/cpp/frame-var-depth-and-elem-count/TestFrameVarDepthAndElemCount.py
-skip lldb-api :: functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
 
 # Untriaged: new in stable/21.x
 skip lldb-api :: commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILQualifiedId.py
 skip lldb-api :: functionalities/dead-strip/TestDeadStrip.py
 skip lldb-api :: functionalities/memory/holes/TestMemoryHoles.py
 skip lldb-api :: lang/cpp/forward/TestCPPForwardDeclaration.py
-skip lldb-api :: functionalities/thread/state/TestThreadStates.py


### PR DESCRIPTION
These were skipped in the Windows lit override file. They now pass reliably at desk (6-8 repeated single-test runs each). Remove their skip entries from windows-swift-llvm-lit-test-overrides.txt.

Re-enabled (the two Swift shell tests also PASS in-suite via build.ps1):
  - `Swift/astcontext_error.test`
  - `Swift/cond-breakpoint.test`
  - `functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py`
  - `lang/cpp/frame-var-depth-and-elem-count/TestFrameVarDepthAndElemCount.py`
  - `functionalities/thread/state/TestThreadStates.py`
  - `commands/statistics/basic/TestStats.py`
  - `lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers.py`
  - `lang/BoundsSafety/out_of_bounds_pointer/TestOutOfBoundsPointer.py`
  - `lang/cpp/bitfields/TestCppBitfields.py` (https://github.com/swiftlang/llvm-project/issues/9072 no longer reproduces)
  - `functionalities/var_path/TestVarPath.py` (https://github.com/llvm/llvm-project/issues/62983 no longer reproduces)
  - `functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py`