### PR TITLE
[lldb][Windows] Re-enable resolved tests

### DIFF
--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -106,12 +106,6 @@ skip lldb-api :: functionalities/breakpoint/same_cu_name/TestFileBreakpoinsSameC
 # https://github.com/swiftlang/llvm-project/issues/9101
 skip lldb-api :: tools/lldb-server
 
-### Tests that pass accidentally ###
-
-https://github.com/llvm/llvm-project/issues/116972
-skip lldb-api :: api/command-return-object/TestSBCommandReturnObject.py
-skip lldb-api :: api/multiple-targets/TestMultipleTargets.py
-
 ### Tests that fail during setup and thus show up as UNRESOLVED ***
 
 # https://github.com/swiftlang/llvm-project/issues/9887


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/116972 has been resolved and the changes are on `stable/21.x`. The tests genuinely pass.