### PR TITLE
[lldb][Windows] reuse preloaded exe module on launch

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -705,25 +705,23 @@ void ProcessWindows::OnDebuggerConnected(lldb::addr_t image_base) {
   LLDB_LOG(log, "Debugger connected to process {0}.  Image base = {1:x}",
            debugger->GetProcess().GetProcessId(), image_base);
 
-  ModuleSP module;
-  // During attach, we won't have the executable module, so find it now.
-  const DWORD pid = debugger->GetProcess().GetProcessId();
-  const std::string file_name = GetProcessExecutableName(pid);
-  if (file_name.empty()) {
-    return;
-  }
-
-  FileSpec executable_file(file_name);
-  FileSystem::Instance().Resolve(executable_file);
-  ModuleSpec module_spec(executable_file);
-  Status error;
-  module =
-      GetTarget().GetOrCreateModule(module_spec, true /* notify */, &error);
+  ModuleSP module = GetTarget().GetExecutableModule();
   if (!module) {
-    return;
-  }
+    const DWORD pid = debugger->GetProcess().GetProcessId();
+    const std::string file_name = GetProcessExecutableName(pid);
+    if (file_name.empty())
+      return;
 
-  GetTarget().SetExecutableModule(module, eLoadDependentsNo);
+    FileSpec executable_file(file_name);
+    FileSystem::Instance().Resolve(executable_file);
+    ModuleSpec module_spec(executable_file);
+    Status error;
+    module =
+        GetTarget().GetOrCreateModule(module_spec, /*notify=*/true, &error);
+    if (!module)
+      return;
+    GetTarget().SetExecutableModule(module, eLoadDependentsNo);
+  }
 
   if (auto dyld = GetDynamicLoader())
     dyld->OnLoadModule(module, ModuleSpec(), image_base);

--- a/lldb/test/API/functionalities/breakpoint/move_nearest/TestMoveNearest.py
+++ b/lldb/test/API/functionalities/breakpoint/move_nearest/TestMoveNearest.py
@@ -1,4 +1,5 @@
 import lldb
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
@@ -16,6 +17,7 @@ class TestMoveNearest(TestBase):
         print("BR_Between found at", self.line_between)
         self.line_main = line_number("main.cpp", "// !BR_main")
 
+    @expectedFailureWindows  # https://github.com/swiftlang/llvm-project/issues/13444
     def test(self):
         """Test target.move-to-nearest logic"""
 

--- a/lldb/test/API/lang/swift/breakpoint_perf/TestSwiftBreakpointPerf.py
+++ b/lldb/test/API/lang/swift/breakpoint_perf/TestSwiftBreakpointPerf.py
@@ -6,8 +6,8 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftReflectionLoading(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipIfWindows  # https://github.com/swiftlang/llvm-project/issues/13443
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that no SwiftASTContext is initialized just to stop at a breakpoint"""
         self.build()

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExplicitModulePrivateTypeGeneric(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @expectedFailureWindows  # https://github.com/swiftlang/llvm-project/issues/13444
     @skipEmbeddedSwift
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
+++ b/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftGenericFunction(lldbtest.TestBase):
+    @expectedFailureWindows  # https://github.com/swiftlang/llvm-project/issues/13444
     @skipEmbeddedSwift
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -21,6 +21,7 @@ import shutil
 
 
 class TestSwiftStructChangeRerun(TestBase):
+    @expectedFailureWindows  # https://github.com/swiftlang/llvm-project/issues/13444
     @skipEmbeddedSwift
     @swiftTest
     @skipIf(

--- a/lldb/test/Shell/Target/dependent-modules-nodupe-windows.test
+++ b/lldb/test/Shell/Target/dependent-modules-nodupe-windows.test
@@ -1,4 +1,6 @@
 # REQUIRES: target-windows
+# https://github.com/swiftlang/llvm-project/issues/13444
+# XFAIL: target-windows
 
 # Checks that dependent modules preloaded by LLDB are not duplicated when the
 # process actually loads the DLL.

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -35,45 +35,10 @@ xfail lldb-shell :: SwiftREPL/Regex.test
 xfail lldb-shell :: SwiftREPL/SimpleExpressions.test
 xfail lldb-shell :: SwiftREPL/enum-singlecase.test
 
-xfail lldb-api :: commands/apropos/with-process/TestAproposWithProcess.py
-xfail lldb-api :: commands/command/nested_alias/TestNestedAlias.py
-xfail lldb-api :: commands/expression/entry-bp/TestExprEntryBP.py
-xfail lldb-api :: commands/memory/write/TestMemoryWrite.py
-xfail lldb-api :: functionalities/breakpoint/address_breakpoints/TestAddressBreakpoints.py
-xfail lldb-api :: functionalities/breakpoint/auto_continue/TestBreakpointAutoContinue.py
-xfail lldb-api :: functionalities/breakpoint/breakpoint_conditions/TestBreakpointConditions.py
-xfail lldb-api :: functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
-xfail lldb-api :: functionalities/breakpoint/step_over_breakpoint/TestStepOverBreakpoint.py
-xfail lldb-api :: functionalities/conditional_break/TestConditionalBreak.py
-xfail lldb-api :: functionalities/memory/find/TestMemoryFind.py
-xfail lldb-api :: lang/c/anonymous/TestAnonymous.py
-xfail lldb-api :: lang/c/array_types/TestArrayTypes.py
-xfail lldb-api :: lang/c/enum_types/TestEnumTypes.py
-xfail lldb-api :: lang/c/forward/TestForwardDeclaration.py
-xfail lldb-api :: lang/c/function_types/TestFunctionTypes.py
-xfail lldb-api :: lang/c/register_variables/TestRegisterVariables.py
-xfail lldb-api :: lang/c/set_values/TestSetValues.py
-xfail lldb-api :: lang/c/shared_lib/TestSharedLib.py
-xfail lldb-api :: lang/cpp/class_types/TestClassTypes.py
-xfail lldb-api :: lang/cpp/inlines/TestInlines.py
-xfail lldb-api :: python_api/compile_unit/TestCompileUnitAPI.py
-xfail lldb-api :: python_api/thread/TestThreadAPI.py
 xfail lldb-api :: source-manager/TestSourceManager.py
-xfail lldb-shell :: Driver/TestConvenienceVariables.test
 
 # https://github.com/swiftlang/llvm-project/issues/9620
 xfail lldb-shell :: Swift/expression-diagnostics.test
-
-# https://github.com/swiftlang/llvm-project/issues/9540
-xfail lldb-shell :: SymbolFile/NativePDB/local-variables.cpp
-xfail lldb-shell :: SymbolFile/NativePDB/stack_unwinding01.cpp
-xfail lldb-api :: lang/c/local_variables/TestLocalVariables.py
-
-# https://github.com/swiftlang/llvm-project/issues/9637
-xfail lldb-api :: python_api/address_range/TestAddressRange.py
-
-# https://github.com/swiftlang/llvm-project/issues/9643
-xfail lldb-shell :: Commands/command-process-launch-user-entry.test
 
 # Skip SymbolTests because we cannot xfail unittests by name. We would need to
 # specify their indexes, but these are subject to change. Right now, failures
@@ -138,6 +103,4 @@ skip lldb-api :: lang/c/trampoline_stepping/TestTrampolineStepping.py
 
 # Untriaged: new in stable/21.x
 skip lldb-api :: commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILQualifiedId.py
-skip lldb-api :: functionalities/dead-strip/TestDeadStrip.py
-skip lldb-api :: functionalities/memory/holes/TestMemoryHoles.py
 skip lldb-api :: lang/cpp/forward/TestCPPForwardDeclaration.py


### PR DESCRIPTION
Enable the 29 overriden tests unblocked by:
- https://github.com/llvm/llvm-project/pull/210010.

Fixes:
- fix https://github.com/swiftlang/llvm-project/issues/9637
- fix https://github.com/swiftlang/llvm-project/issues/9540
- fix https://github.com/swiftlang/llvm-project/issues/9643