### PR TITLE
[MCCAS] Fix warning for unhandled FT_PrefAlign

### DIFF
--- a/llvm/include/llvm/MCCAS/MCCASObjectV1.def
+++ b/llvm/include/llvm/MCCAS/MCCASObjectV1.def
@@ -80,6 +80,7 @@ MCFRAGMENT_NODE_REF(MCLEBFragment, FT_LEB, mc:leb)
 MCFRAGMENT_NODE_REF(MCNopsFragment, FT_Nops, mc:nops)
 MCFRAGMENT_NODE_REF(MCOrgFragment, FT_Org, mc:org)
 MCFRAGMENT_NODE_REF(MCSymbolIdFragment, FT_SymbolId, mc:symbol_id)
+MCFRAGMENT_NODE_REF(MCPrefAlignFragment, FT_PrefAlign, mc:pref_align)
 #endif /* MCFRAGMENT_ENCODED_FRAGMENT_ONLY */
 #undef MCFRAGMENT_ENCODED_FRAGMENT_ONLY
 

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -1802,6 +1802,38 @@ MCSymbolIdFragmentRef::materialize(MCCASReader &Reader,
   return sizeof(uint32_t);
 }
 
+Expected<MCPrefAlignFragmentRef>
+MCPrefAlignFragmentRef::create(MCCASBuilder &MB, const MCFragment &F,
+                               unsigned FragmentSize,
+                               ArrayRef<char> FragmentContents) {
+  Expected<Builder> B = Builder::startNode(MB.Schema, KindString);
+  if (!B)
+    return B.takeError();
+
+  B->Data.append(FragmentContents.begin(), FragmentContents.end());
+  uint64_t PadSize = FragmentSize - FragmentContents.size();
+  if (F.getPrefAlignEmitNops()) {
+    if (!MB.Asm.getBackend().writeNopData(MB.FragmentOS, PadSize,
+                                          F.getSubtargetInfo()))
+      reportFatalInternalError("unable to write nop sequence of " +
+                               Twine(PadSize) + " bytes");
+  } else if (F.getPrefAlignFill() == 0) {
+    MB.FragmentOS.write_zeros(PadSize);
+  } else {
+    char B = char(F.getPrefAlignFill());
+    for (uint64_t I = 0; I < PadSize; ++I)
+      MB.FragmentOS << B;
+  }
+  return get(B->build());
+}
+
+Expected<uint64_t>
+MCPrefAlignFragmentRef::materialize(MCCASReader &Reader,
+                                    raw_ostream *Stream) const {
+  *Stream << getData();
+  return getData().size();
+}
+
 #define MCFRAGMENT_NODE_REF(MCFragmentName, MCEnumName, MCEnumIdentifier)      \
   Expected<MCFragmentName##Ref> MCFragmentName##Ref::create(                   \
       MCCASBuilder &MB, const MCFragment &F, unsigned FragmentSize,            \


### PR DESCRIPTION
Add support for FT_PrefAlign to fix the warning for unhandled switch case. Note this MCFragment type is ELF only so it is not used inside Macho currently so the current implementation for it lacks testing.

Fix: https://github.com/swiftlang/llvm-project/issues/13395