### PR TITLE
[BoundsSafety] Start migrating -fbounds-safety diagnostics to an implementation the upstream can use

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7261,8 +7261,11 @@ def err_count_attr_argument_not_integer : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' requires a non-boolean integer type argument">;
 def err_count_attr_only_support_simple_decl_reference : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument must be a simple declaration reference">;
+/* TO_UPSTREAM(BoundsSafety) ON */
+// `ended_by` in %select is downstream only
 def err_count_attr_in_union : Error<
-  "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' cannot be applied to a union member">;
+  "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null|ended_by}0' cannot be applied to a union member">;
+/* TO_UPSTREAM(BoundsSafety) OFF */
 def err_count_attr_refer_to_union : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument cannot refer to a union member">;
 def note_flexible_array_counted_by_attr_field : Note<
@@ -13479,8 +13482,6 @@ def err_attribute_invalid_argument_expression_for_pointer_bounds_attribute : Err
 def err_invalid_decl_kind_bounds_safety_dynamic_count : Error<
   "count expression %select{on struct field|in function declaration}0 may only "
   "reference %select{other fields of the same struct|parameters of that function}0">;
-def err_invalid_decl_kind_bounds_safety_union_count : Error<
-  "cannot use %0 on union fields">;
 def err_multiple_coupled_decls_in_bounds_safety_dynamic_count : Error<
   "multiple coupled declarations in a -fbounds-safety attribute are not supported yet">;
 def err_attribute_argument_type_for_bounds_safety_count : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7249,8 +7249,13 @@ def warn_superclass_variable_sized_type_not_at_end : Warning<
 
 def err_count_attr_param_not_in_same_struct : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1' field %0 isn't within the same struct as the annotated %select{pointer|flexible array}2">;
+/* TO_UPSTREAM(BoundsSafety) ON */
+// `ended_by` is downstream only.
+// FIXME: Stating `or C99 flexible array members` is only partially true.
+// In `-fbounds-safety` we also support it on arrays too.
 def err_count_attr_not_on_ptr_or_flexible_array_member : Error<
-  "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' only applies to pointers%select{ or C99 flexible array members|||}0%select{|; did you mean to use 'counted_by'?}1">;
+  "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null|ended_by}0' only applies to pointers%select{ or C99 flexible array members||||}0%select{|; did you mean to use 'counted_by'?}1">;
+/* TO_UPSTREAM(BoundsSafety) OFF */
 def err_counted_by_attr_on_array_not_flexible_array_member : Error<
   "'counted_by' on arrays only applies to C99 flexible array members">;
 def err_counted_by_attr_refer_to_itself : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7275,8 +7275,10 @@ def err_count_attr_refer_to_union : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument cannot refer to a union member">;
 def note_flexible_array_counted_by_attr_field : Note<
   "field %0 declared here">;
+/* TO_UPSTREAM(BoundsSafety) ON */
+// `ended_by` in %select is downstream only
 def err_counted_by_attr_pointee_unknown_size : Error<
-  "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{cannot|should not}3 be applied to %select{"
+  "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null|ended_by}4' %select{cannot|should not}3 be applied to %select{"
     "a pointer with pointee|" // pointer
     "an array with element}0" // array
   " of unknown size because %1 is %select{"
@@ -7288,6 +7290,7 @@ def err_counted_by_attr_pointee_unknown_size : Error<
     "%select{|. This will be an error in a future compiler version}3"
     ""
   "}2">;
+/* TO_UPSTREAM(BoundsSafety) OFF */
 def err_counted_by_on_incomplete_type_on_assign : Error <
   "cannot %select{"
     "assign to %select{object|'%1'}2 with|" // AA_Assigning,
@@ -13781,9 +13784,6 @@ def err_bounds_safety_flexible_array_member_record_pointer_arithmetic : Error<
   "member">;
 def err_bounds_safety_member_reference_null_base : Error<
   "base of member reference is a null pointer">;
-def err_bounds_safety_counted_by_without_size : Error<
-  "cannot apply '__counted_by%select{|_or_null}2' attribute to %0 because %1 has unknown size"
-  "%select{|; did you mean to use '__sized_by%select{|_or_null}2' instead?}3">;
 def err_bounds_safety_counted_by_on_incomplete_type_on_use : Error <
   "cannot %select{"
     "use '%1'|" // Generic expr

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7253,6 +7253,7 @@ def err_count_attr_param_not_in_same_struct : Error<
 // `ended_by` is downstream only.
 // FIXME: Stating `or C99 flexible array members` is only partially true.
 // In `-fbounds-safety` we also support it on arrays too.
+// Tracked by swiftlang/llvm-project#13416.
 def err_count_attr_not_on_ptr_or_flexible_array_member : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null|ended_by}0' only applies to pointers%select{ or C99 flexible array members||||}0%select{|; did you mean to use 'counted_by'?}1">;
 /* TO_UPSTREAM(BoundsSafety) OFF */

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2921,6 +2921,12 @@ public:
   };
   static BoundsAttrFlags getBoundsAttrFlags(AttributeCommonInfo::Kind K);
 
+  /// Validates that a pointer's pointee type is compatible with __counted_by.
+  /// If the pointee is incomplete/function/sizeless/FAM and CountInBytes is
+  /// false, emits a diagnostic and recovers by setting CountInBytes = true.
+  void DiagnoseCountedByPointeeType(QualType PointerTy, SourceLocation AttrLoc,
+                                    bool &CountInBytes, bool OrNull);
+
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2921,11 +2921,17 @@ public:
   };
   static BoundsAttrFlags getBoundsAttrFlags(AttributeCommonInfo::Kind K);
 
-  /// Validates that a pointer's pointee type is compatible with __counted_by.
-  /// If the pointee is incomplete/function/sizeless/FAM and CountInBytes is
-  /// false, emits a diagnostic and recovers by setting CountInBytes = true.
-  void DiagnoseCountedByPointeeType(QualType PointerTy, SourceLocation AttrLoc,
-                                    bool &CountInBytes, bool OrNull);
+  /// Validates that a type is eligible for a bounds-safety attribute
+  /// (counted_by/sized_by/ended_by). Checks type eligibility (must be pointer
+  /// or array) and pointee/element type validity.
+  /// Does NOT require a Decl — only the QualType and attribute metadata.
+  /// Callable from: ActOnLateParsedTypeAttr (placeholder insertion),
+  /// HandleCountedByAttrOnType, applyPtrCountedByEndedByAttr, and
+  /// CheckCountedByAttrOnFieldDecl.
+  /// \returns true if the type is valid, false on error.
+  bool ValidateBoundsAttrTypeShape(QualType Ty, SourceLocation AttrLoc,
+                                   SourceRange AttrRange,
+                                   BoundsAttrFlags &Flags);
 
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2920,6 +2920,8 @@ public:
     bool IsEndedBy = false;
   };
   static BoundsAttrFlags getBoundsAttrFlags(AttributeCommonInfo::Kind K);
+  static BoundsAttributedType::BoundsAttrKind
+  getBoundsAttrKind(const BoundsAttrFlags &);
 
   /// Validates that a type is eligible for a bounds-safety attribute
   /// (counted_by/sized_by/ended_by). Checks type eligibility (must be pointer

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2913,6 +2913,14 @@ public:
                                     SourceRange Range, StringRef DiagName,
                                     bool OriginatesInAPINotes = false,
                                     bool InInstantiatedTemplate = false);
+
+  struct BoundsAttrFlags {
+    bool CountInBytes = false;
+    bool OrNull = false;
+    bool IsEndedBy = false;
+  };
+  static BoundsAttrFlags getBoundsAttrFlags(AttributeCommonInfo::Kind K);
+
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 
 

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -54,6 +54,68 @@ Sema::BoundsAttrFlags Sema::getBoundsAttrFlags(AttributeCommonInfo::Kind K) {
   return Flags;
 }
 
+void Sema::DiagnoseCountedByPointeeType(QualType PointerTy,
+                                        SourceLocation AttrLoc,
+                                        bool &CountInBytes, bool OrNull) {
+  // Check the pointee for counted_by has a size. One exception, we don't
+  // error for incomplete pointee types that might be later completed (e.g. a
+  // struct forward declaration). Instead for those completable-incomplete types
+  // we delay checking until the type is used see
+  // `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
+  // attribute to be used on code that prefers to keep its pointees incomplete
+  // until they need to be used.
+
+  const auto *PT = PointerTy->getAs<PointerType>();
+  if (!PT)
+    return;
+
+  if (CountInBytes)
+    return;
+
+  QualType PointeeTy = PT->getPointeeType();
+  if (!PointeeTy->isAlwaysIncompleteType() && !PointeeTy->isFunctionType() &&
+      !PointeeTy->isSizelessType() &&
+      !PointeeTy->isStructureTypeWithFlexibleArrayMember())
+    return;
+
+  // Use unspecified pointer attributes for diagnostic purposes.
+  QualType Unsp = Context.getBoundsSafetyPointerType(
+      QualType(PT, 0), BoundsSafetyPointerAttributes::unspecified());
+
+  auto PD = PDiag(diag::err_bounds_safety_counted_by_without_size);
+  PD << Unsp << Unsp->getPointeeType() << OrNull;
+
+  // Suggest `__sized_by` if the `__counted_by` macro was used.
+  // We intentionally don't suggest a fixit if the attribute is used
+  // directly (i.e. without the macro) because it is not expected that
+  // users will use it.
+  int SuggestFixIt = 0; // Default don't suggest __sized_by
+  if (AttrLoc.isMacroID()) {
+    // FIXME(dliew): Use `AL.MacroII` to get the name. Unfortunately
+    // `AL.MacroII` is not set so we can't simply check the macro name
+    // is what we expect. So instead we have the lexer tell us the
+    // contents of the token and check against that.
+    // rdar://100631458
+    auto MacroName = Lexer::getImmediateMacroName(AttrLoc, SourceMgr, LangOpts);
+    if (MacroName == "__counted_by") {
+      // Emit text to suggest __sized_by
+      SuggestFixIt = 1;
+      auto MacroLoc = SourceMgr.getExpansionLoc(AttrLoc);
+      PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by");
+    } else if (MacroName == "__counted_by_or_null") {
+      // Emit text to suggest __sized_by_or_null
+      SuggestFixIt = 1;
+      auto MacroLoc = SourceMgr.getExpansionLoc(AttrLoc);
+      PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by_or_null");
+    }
+  }
+  PD << SuggestFixIt;
+  Diag(AttrLoc, PD);
+
+  // Recover by assuming a byte count.
+  CountInBytes = true;
+}
+
 static const RecordDecl *GetEnclosingNamedOrTopAnonRecord(const FieldDecl *FD,
                                                   // TO_UPSTREAM(BoundsSafety)
                                                           Sema &S) {

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -176,6 +176,7 @@ bool Sema::ValidateBoundsAttrTypeShape(QualType Ty, SourceLocation AttrLoc,
   if (InvalidTypeKind != CountedByInvalidPointeeTypeKind::VALID) {
     // FIXME: We should suggest `__sized_by(_or_null)` and in the error
     // diagnostic case emit a FixIt.
+    // Tracked by swiftlang/llvm-project#13417.
     unsigned DiagID = ShouldWarn
                           ? diag::warn_counted_by_attr_elt_type_unknown_size
                           : diag::err_counted_by_attr_pointee_unknown_size;

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -62,49 +62,132 @@ enum class CountedByInvalidPointeeTypeKind {
   VALID,
 };
 
-void Sema::DiagnoseCountedByPointeeType(QualType PointerTy,
-                                        SourceLocation AttrLoc,
-                                        bool &CountInBytes, bool OrNull) {
-  // Check the pointee for counted_by has a size. One exception, we don't
-  // error for incomplete pointee types that might be later completed (e.g. a
-  // struct forward declaration). Instead for those completable-incomplete types
-  // we delay checking until the type is used see
-  // `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
-  // attribute to be used on code that prefers to keep its pointees incomplete
-  // until they need to be used.
+bool Sema::ValidateBoundsAttrTypeShape(QualType Ty, SourceLocation AttrLoc,
+                                       SourceRange AttrRange,
+                                       BoundsAttrFlags &Flags) {
+  unsigned Kind = Flags.IsEndedBy
+                      ? BoundsAttributedType::EndedBy
+                      : getCountAttrKind(Flags.CountInBytes, Flags.OrNull);
 
-  const auto *PT = PointerTy->getAs<PointerType>();
-  if (!PT)
-    return;
+  // ended_by only applies to pointers, not arrays.
+  if (Flags.IsEndedBy) {
+    if (!Ty->isPointerType()) {
+      Diag(AttrLoc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
+          << Kind << 0;
+      return false;
+    }
+    return true;
+  }
 
-  if (CountInBytes)
-    return;
+  // counted_by/sized_by: must be pointer or array.
+  if (!Ty->isPointerType() && !Ty->isArrayType()) {
+    Diag(AttrLoc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
+        << Kind << 0;
+    return false;
+  }
 
-  QualType PointeeTy = PT->getPointeeType();
+  // Arrays with sized_by or _or_null variants are not allowed.
+  if (Ty->isArrayType() && (Flags.CountInBytes || Flags.OrNull)) {
+    Diag(AttrLoc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
+        << Kind << /*suggest counted_by*/ 1;
+    return false;
+  }
 
-  CountedByInvalidPointeeTypeKind InvalidTypeKind;
-  if (PointeeTy->isAlwaysIncompleteType())
+  // Pointee/element type validation.
+  QualType PointeeTy;
+  int SelectPtrOrArr;
+  if (Ty->isPointerType()) {
+    PointeeTy = Ty->getPointeeType();
+    SelectPtrOrArr = 0;
+  } else {
+    const ArrayType *AT = getASTContext().getAsArrayType(Ty);
+    PointeeTy = AT->getElementType();
+    SelectPtrOrArr = 1;
+  }
+
+  auto InvalidTypeKind = CountedByInvalidPointeeTypeKind::VALID;
+  bool ShouldWarn = false;
+  if (!Flags.CountInBytes && PointeeTy->isAlwaysIncompleteType()) {
+    // In general using `counted_by` or `counted_by_or_null` on
+    // pointers where the pointee is an incomplete type are problematic. This
+    // is because it isn't possible to compute the pointer's bounds without
+    // knowing the pointee type size. At the same time it is common to forward
+    // declare types in header files.
+    //
+    // E.g.:
+    //
+    // struct Handle;
+    // struct Wrapper {
+    //   size_t count;
+    //   struct Handle* __counted_by(count) handles;
+    // }
+    //
+    // To allow the above code pattern but still prevent the pointee type from
+    // being incomplete in places where bounds checks are needed the following
+    // scheme is used:
+    //
+    // * When the pointee type might not always be an incomplete type (i.e.
+    // a type that is currently incomplete but might be completed later
+    // on in the translation unit) the attribute is allowed by this method
+    // but later uses of the FieldDecl are checked that the pointee type
+    // is complete see `BoundsSafetyCheckAssignmentToCountAttrPtr`,
+    // `BoundsSafetyCheckInitialization`, and
+    // `BoundsSafetyCheckUseOfCountAttrPtr`
+    //
+    // * When the pointee type is always an incomplete type (e.g.
+    // `void` in strict C mode) the attribute is disallowed by this method
+    // because we know the type can never be completed so there's no reason
+    // to allow it.
+    //
+    // Exception: void has an implicit size of 1 byte for pointer arithmetic
+    // (following GNU convention). Therefore, counted_by on void* is allowed
+    // and behaves equivalently to sized_by (treating the count as bytes).
+    if (PointeeTy->isVoidType() && !getLangOpts().hasBoundsSafetyAttributes()) {
+      // Emit a warning that this is a GNU extension.
+      Diag(AttrLoc, diag::ext_gnu_counted_by_void_ptr) << Kind;
+      Diag(AttrLoc, diag::note_gnu_counted_by_void_ptr_use_sized_by) << Kind;
+      Flags.CountInBytes = true;
+      return true;
+    }
     InvalidTypeKind = CountedByInvalidPointeeTypeKind::INCOMPLETE;
-  else if (PointeeTy->isSizelessType())
+  } else if (PointeeTy->isSizelessType()) {
     InvalidTypeKind = CountedByInvalidPointeeTypeKind::SIZELESS;
-  else if (PointeeTy->isFunctionType())
+  } else if (PointeeTy->isFunctionType()) {
     InvalidTypeKind = CountedByInvalidPointeeTypeKind::FUNCTION;
-  else if (PointeeTy->isStructureTypeWithFlexibleArrayMember())
+  } else if (!Flags.CountInBytes &&
+             PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
+    if (Ty->isArrayType() && !getLangOpts().BoundsSafety) {
+      // This is a workaround for the Linux kernel that has already adopted
+      // `counted_by` on a FAM where the pointee is a struct with a FAM. This
+      // should be an error because computing the bounds of the array cannot
+      // be done correctly without manually traversing every struct object in
+      // the array at runtime. To allow the code to be built this error is
+      // downgraded to a warning.
+      ShouldWarn = true;
+    }
     InvalidTypeKind = CountedByInvalidPointeeTypeKind::FLEXIBLE_ARRAY_MEMBER;
-  else
-    return;
+  }
 
-  unsigned Kind = OrNull ? BoundsAttributedType::CountedByOrNull
-                         : BoundsAttributedType::CountedBy;
-  Diag(AttrLoc, diag::err_counted_by_attr_pointee_unknown_size)
-      << /*pointer*/ 0 << PointeeTy << static_cast<int>(InvalidTypeKind)
-      << /*cannot*/ 0 << Kind;
+  if (InvalidTypeKind != CountedByInvalidPointeeTypeKind::VALID) {
+    // FIXME: We should suggest `__sized_by(_or_null)` and in the error
+    // diagnostic case emit a FixIt.
+    unsigned DiagID = ShouldWarn
+                          ? diag::warn_counted_by_attr_elt_type_unknown_size
+                          : diag::err_counted_by_attr_pointee_unknown_size;
+    Diag(AttrLoc, DiagID) << SelectPtrOrArr << PointeeTy << InvalidTypeKind
+                          << (ShouldWarn ? 1 : 0) << Kind << AttrRange;
+    if (ShouldWarn)
+      return true;
+    if (getLangOpts().hasBoundsSafetyAttributes()) {
+      // Under BoundsSafety, recover by switching to byte count so that
+      // type construction can proceed and emit follow-up diagnostics.
+      Flags.CountInBytes = true;
+      return true;
+    }
+    return false;
+  }
 
-  // FIXME: We should suggest `__sized_by(_or_null)` and in the error
-  // diagnostic case emit a FixIt.
-
-  // Recover by assuming a byte count.
-  CountInBytes = true;
+  return true;
 }
 
 static const RecordDecl *GetEnclosingNamedOrTopAnonRecord(const FieldDecl *FD,
@@ -172,8 +255,6 @@ static const RecordDecl *GetEnclosingNamedOrTopAnonRecord(const FieldDecl *FD,
 
 bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
                                      bool OrNull) {
-  // Check the context the attribute is used in
-
   unsigned Kind = getCountAttrKind(CountInBytes, OrNull);
 
   if (FD->getParent()->isUnion()) {
@@ -183,19 +264,16 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
   }
 
   const auto FieldTy = FD->getType();
-  if (FieldTy->isArrayType() && (CountInBytes || OrNull)) {
-    Diag(FD->getBeginLoc(),
-         diag::err_count_attr_not_on_ptr_or_flexible_array_member)
-        << Kind << FD->getLocation() << /* suggest counted_by */ 1;
-    return true;
-  }
-  if (!FieldTy->isArrayType() && !FieldTy->isPointerType()) {
-    Diag(FD->getBeginLoc(),
-         diag::err_count_attr_not_on_ptr_or_flexible_array_member)
-        << Kind << FD->getLocation() << /* do not suggest counted_by */ 0;
-    return true;
-  }
 
+  // Type shape validation (shared with BoundsSafety path).
+  BoundsAttrFlags Flags;
+  Flags.CountInBytes = CountInBytes;
+  Flags.OrNull = OrNull;
+  if (!ValidateBoundsAttrTypeShape(FieldTy, FD->getBeginLoc(),
+                                   FD->getSourceRange(), Flags))
+    return true;
+
+  // FAM check — needs Decl context (isFlexibleArrayMemberLike).
   LangOptions::StrictFlexArraysLevelKind StrictFlexArraysLevel =
       LangOptions::StrictFlexArraysLevelKind::IncompleteOnly;
   if (FieldTy->isArrayType() &&
@@ -204,96 +282,6 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
     Diag(FD->getBeginLoc(),
          diag::err_counted_by_attr_on_array_not_flexible_array_member)
         << Kind << FD->getLocation();
-    return true;
-  }
-
-  CountedByInvalidPointeeTypeKind InvalidTypeKind =
-      CountedByInvalidPointeeTypeKind::VALID;
-  QualType PointeeTy;
-  int SelectPtrOrArr = 0;
-  if (FieldTy->isPointerType()) {
-    PointeeTy = FieldTy->getPointeeType();
-    SelectPtrOrArr = 0;
-  } else {
-    assert(FieldTy->isArrayType());
-    const ArrayType *AT = getASTContext().getAsArrayType(FieldTy);
-    PointeeTy = AT->getElementType();
-    SelectPtrOrArr = 1;
-  }
-  // Note: The `Decl::isFlexibleArrayMemberLike` check earlier on means
-  // only `PointeeTy->isStructureTypeWithFlexibleArrayMember()` is reachable
-  // when `FieldTy->isArrayType()`.
-  bool ShouldWarn = false;
-  if (!CountInBytes && PointeeTy->isAlwaysIncompleteType()) {
-    // In general using `counted_by` or `counted_by_or_null` on
-    // pointers where the pointee is an incomplete type are problematic. This is
-    // because it isn't possible to compute the pointer's bounds without knowing
-    // the pointee type size. At the same time it is common to forward declare
-    // types in header files.
-    //
-    // E.g.:
-    //
-    // struct Handle;
-    // struct Wrapper {
-    //   size_t count;
-    //   struct Handle* __counted_by(count) handles;
-    // }
-    //
-    // To allow the above code pattern but still prevent the pointee type from
-    // being incomplete in places where bounds checks are needed the following
-    // scheme is used:
-    //
-    // * When the pointee type might not always be an incomplete type (i.e.
-    // a type that is currently incomplete but might be completed later
-    // on in the translation unit) the attribute is allowed by this method
-    // but later uses of the FieldDecl are checked that the pointee type
-    // is complete see `BoundsSafetyCheckAssignmentToCountAttrPtr`,
-    // `BoundsSafetyCheckInitialization`, and
-    // `BoundsSafetyCheckUseOfCountAttrPtr`
-    //
-    // * When the pointee type is always an incomplete type (e.g.
-    // `void` in strict C mode) the attribute is disallowed by this method
-    // because we know the type can never be completed so there's no reason
-    // to allow it.
-    //
-    // Exception: void has an implicit size of 1 byte for pointer arithmetic
-    // (following GNU convention). Therefore, counted_by on void* is allowed
-    // and behaves equivalently to sized_by (treating the count as bytes).
-    bool IsVoidPtr = PointeeTy->isVoidType();
-    if (IsVoidPtr) {
-      // Emit a warning that this is a GNU extension.
-      Diag(FD->getBeginLoc(), diag::ext_gnu_counted_by_void_ptr) << Kind;
-      Diag(FD->getBeginLoc(), diag::note_gnu_counted_by_void_ptr_use_sized_by)
-          << Kind;
-      assert(InvalidTypeKind == CountedByInvalidPointeeTypeKind::VALID);
-    } else {
-      InvalidTypeKind = CountedByInvalidPointeeTypeKind::INCOMPLETE;
-    }
-  } else if (PointeeTy->isSizelessType()) {
-    InvalidTypeKind = CountedByInvalidPointeeTypeKind::SIZELESS;
-  } else if (PointeeTy->isFunctionType()) {
-    InvalidTypeKind = CountedByInvalidPointeeTypeKind::FUNCTION;
-  } else if (!CountInBytes &&
-             PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
-    if (FieldTy->isArrayType() && !getLangOpts().BoundsSafety) {
-      // This is a workaround for the Linux kernel that has already adopted
-      // `counted_by` on a FAM where the pointee is a struct with a FAM. This
-      // should be an error because computing the bounds of the array cannot be
-      // done correctly without manually traversing every struct object in the
-      // array at runtime. To allow the code to be built this error is
-      // downgraded to a warning.
-      ShouldWarn = true;
-    }
-    InvalidTypeKind = CountedByInvalidPointeeTypeKind::FLEXIBLE_ARRAY_MEMBER;
-  }
-
-  if (InvalidTypeKind != CountedByInvalidPointeeTypeKind::VALID) {
-    unsigned DiagID = ShouldWarn
-                          ? diag::warn_counted_by_attr_elt_type_unknown_size
-                          : diag::err_counted_by_attr_pointee_unknown_size;
-    Diag(FD->getBeginLoc(), DiagID)
-        << SelectPtrOrArr << PointeeTy << (int)InvalidTypeKind
-        << (ShouldWarn ? 1 : 0) << Kind << FD->getSourceRange();
     return true;
   }
 

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -30,6 +30,30 @@ getCountAttrKind(bool CountInBytes, bool OrNull) {
                 : CountAttributedType::CountedBy;
 }
 
+Sema::BoundsAttrFlags Sema::getBoundsAttrFlags(AttributeCommonInfo::Kind K) {
+  BoundsAttrFlags Flags;
+  switch (K) {
+  case ParsedAttr::AT_SizedBy:
+    Flags.CountInBytes = true;
+    break;
+  case ParsedAttr::AT_SizedByOrNull:
+    Flags.CountInBytes = true;
+    Flags.OrNull = true;
+    break;
+  case ParsedAttr::AT_CountedBy:
+    break;
+  case ParsedAttr::AT_CountedByOrNull:
+    Flags.OrNull = true;
+    break;
+  case ParsedAttr::AT_PtrEndedBy:
+    Flags.IsEndedBy = true;
+    break;
+  default:
+    llvm_unreachable("unexpected bounds attribute kind");
+  }
+  return Flags;
+}
+
 static const RecordDecl *GetEnclosingNamedOrTopAnonRecord(const FieldDecl *FD,
                                                   // TO_UPSTREAM(BoundsSafety)
                                                           Sema &S) {

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -30,6 +30,13 @@ getCountAttrKind(bool CountInBytes, bool OrNull) {
                 : CountAttributedType::CountedBy;
 }
 
+BoundsAttributedType::BoundsAttrKind
+Sema::getBoundsAttrKind(const BoundsAttrFlags &Flags) {
+  if (Flags.IsEndedBy)
+    return BoundsAttributedType::EndedBy;
+  return getCountAttrKind(Flags.CountInBytes, Flags.OrNull);
+}
+
 Sema::BoundsAttrFlags Sema::getBoundsAttrFlags(AttributeCommonInfo::Kind K) {
   BoundsAttrFlags Flags;
   switch (K) {
@@ -65,9 +72,7 @@ enum class CountedByInvalidPointeeTypeKind {
 bool Sema::ValidateBoundsAttrTypeShape(QualType Ty, SourceLocation AttrLoc,
                                        SourceRange AttrRange,
                                        BoundsAttrFlags &Flags) {
-  unsigned Kind = Flags.IsEndedBy
-                      ? BoundsAttributedType::EndedBy
-                      : getCountAttrKind(Flags.CountInBytes, Flags.OrNull);
+  BoundsAttributedType::BoundsAttrKind Kind = getBoundsAttrKind(Flags);
 
   // ended_by only applies to pointers, not arrays.
   if (Flags.IsEndedBy) {

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -54,6 +54,14 @@ Sema::BoundsAttrFlags Sema::getBoundsAttrFlags(AttributeCommonInfo::Kind K) {
   return Flags;
 }
 
+enum class CountedByInvalidPointeeTypeKind {
+  INCOMPLETE,
+  SIZELESS,
+  FUNCTION,
+  FLEXIBLE_ARRAY_MEMBER,
+  VALID,
+};
+
 void Sema::DiagnoseCountedByPointeeType(QualType PointerTy,
                                         SourceLocation AttrLoc,
                                         bool &CountInBytes, bool OrNull) {
@@ -73,44 +81,27 @@ void Sema::DiagnoseCountedByPointeeType(QualType PointerTy,
     return;
 
   QualType PointeeTy = PT->getPointeeType();
-  if (!PointeeTy->isAlwaysIncompleteType() && !PointeeTy->isFunctionType() &&
-      !PointeeTy->isSizelessType() &&
-      !PointeeTy->isStructureTypeWithFlexibleArrayMember())
+
+  CountedByInvalidPointeeTypeKind InvalidTypeKind;
+  if (PointeeTy->isAlwaysIncompleteType())
+    InvalidTypeKind = CountedByInvalidPointeeTypeKind::INCOMPLETE;
+  else if (PointeeTy->isSizelessType())
+    InvalidTypeKind = CountedByInvalidPointeeTypeKind::SIZELESS;
+  else if (PointeeTy->isFunctionType())
+    InvalidTypeKind = CountedByInvalidPointeeTypeKind::FUNCTION;
+  else if (PointeeTy->isStructureTypeWithFlexibleArrayMember())
+    InvalidTypeKind = CountedByInvalidPointeeTypeKind::FLEXIBLE_ARRAY_MEMBER;
+  else
     return;
 
-  // Use unspecified pointer attributes for diagnostic purposes.
-  QualType Unsp = Context.getBoundsSafetyPointerType(
-      QualType(PT, 0), BoundsSafetyPointerAttributes::unspecified());
+  unsigned Kind = OrNull ? BoundsAttributedType::CountedByOrNull
+                         : BoundsAttributedType::CountedBy;
+  Diag(AttrLoc, diag::err_counted_by_attr_pointee_unknown_size)
+      << /*pointer*/ 0 << PointeeTy << static_cast<int>(InvalidTypeKind)
+      << /*cannot*/ 0 << Kind;
 
-  auto PD = PDiag(diag::err_bounds_safety_counted_by_without_size);
-  PD << Unsp << Unsp->getPointeeType() << OrNull;
-
-  // Suggest `__sized_by` if the `__counted_by` macro was used.
-  // We intentionally don't suggest a fixit if the attribute is used
-  // directly (i.e. without the macro) because it is not expected that
-  // users will use it.
-  int SuggestFixIt = 0; // Default don't suggest __sized_by
-  if (AttrLoc.isMacroID()) {
-    // FIXME(dliew): Use `AL.MacroII` to get the name. Unfortunately
-    // `AL.MacroII` is not set so we can't simply check the macro name
-    // is what we expect. So instead we have the lexer tell us the
-    // contents of the token and check against that.
-    // rdar://100631458
-    auto MacroName = Lexer::getImmediateMacroName(AttrLoc, SourceMgr, LangOpts);
-    if (MacroName == "__counted_by") {
-      // Emit text to suggest __sized_by
-      SuggestFixIt = 1;
-      auto MacroLoc = SourceMgr.getExpansionLoc(AttrLoc);
-      PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by");
-    } else if (MacroName == "__counted_by_or_null") {
-      // Emit text to suggest __sized_by_or_null
-      SuggestFixIt = 1;
-      auto MacroLoc = SourceMgr.getExpansionLoc(AttrLoc);
-      PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by_or_null");
-    }
-  }
-  PD << SuggestFixIt;
-  Diag(AttrLoc, PD);
+  // FIXME: We should suggest `__sized_by(_or_null)` and in the error
+  // diagnostic case emit a FixIt.
 
   // Recover by assuming a byte count.
   CountInBytes = true;
@@ -178,13 +169,6 @@ static const RecordDecl *GetEnclosingNamedOrTopAnonRecord(const FieldDecl *FD,
   return RD;
 }
 
-enum class CountedByInvalidPointeeTypeKind {
-  INCOMPLETE,
-  SIZELESS,
-  FUNCTION,
-  FLEXIBLE_ARRAY_MEMBER,
-  VALID,
-};
 
 bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
                                      bool OrNull) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7895,28 +7895,10 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     return;
   }
 
-  bool CountInBytes = false;
-  bool IsEndedBy = false;
-  bool OrNull = false;
-  switch (Kind) {
-  case ParsedAttr::AT_SizedBy:
-    CountInBytes = true;
-    break;
-  case ParsedAttr::AT_SizedByOrNull:
-    CountInBytes = true;
-    OrNull = true;
-    break;
-  case ParsedAttr::AT_CountedBy:
-    break;
-  case ParsedAttr::AT_CountedByOrNull:
-    OrNull = true;
-    break;
-  case ParsedAttr::AT_PtrEndedBy:
-    IsEndedBy = true;
-    break;
-  default:
-    llvm_unreachable("Invalid dynamic bound attribute");
-  }
+  auto Flags = getBoundsAttrFlags(Kind);
+  bool CountInBytes = Flags.CountInBytes;
+  bool IsEndedBy = Flags.IsEndedBy;
+  bool OrNull = Flags.OrNull;
 
   if (!IsEndedBy) {
     // Nullability as indicated by _Nonnull or _Nullable. Does not impact

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6511,7 +6511,7 @@ public:
   // into a function-prototype subwalk.
   //
   // Emits:
-  // - err_attribute_pointers_only
+  // - err_count_attr_not_on_ptr_or_flexible_array_member
   // - err_bounds_safety_atomic_unsupported_attribute
   // - err_bounds_safety_conflicting_pointer_attributes
   // - err_bounds_safety_conflicting_count_range_attributes
@@ -6663,15 +6663,21 @@ public:
           PT->getPointeeType(), CountInBytes, OrNull, AllowRedecl);
     }
 
-    // Fallback for pointers_only.
-    S.Diag(Loc, diag::err_attribute_pointers_only) << DiagName << 0;
+    // T isn't a pointer type.
+    unsigned DiagKind = CountInBytes
+                            ? (OrNull ? BoundsAttributedType::SizedByOrNull
+                                      : BoundsAttributedType::SizedBy)
+                            : (OrNull ? BoundsAttributedType::CountedByOrNull
+                                      : BoundsAttributedType::CountedBy);
+    S.Diag(Loc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
+        << DiagKind << 0;
     return false;
   }
 
   // Pre-check for ended-by.
   //
   // Emits:
-  // - err_attribute_pointers_only
+  // - err_count_attr_not_on_ptr_or_flexible_array_member
   // - err_bounds_safety_atomic_unsupported_attribute
   // - err_bounds_safety_conflicting_count_range_attributes
   // - err_bounds_safety_conflicting_pointer_attributes
@@ -6773,8 +6779,9 @@ public:
                                                   AllowRedecl);
     }
 
-    // Fallback for pointers_only.
-    S.Diag(Loc, diag::err_attribute_pointers_only) << DiagName << 0;
+    // T isn't a pointer type.
+    S.Diag(Loc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
+        << BoundsAttributedType::EndedBy << 0;
     return false;
   }
 };
@@ -7918,7 +7925,8 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     QualType TSITy = PVD->getTypeSourceInfo()->getType();
     if (IsEndedBy) {
       if (Level == 0 && TSITy->isArrayType()) {
-        Diag(Loc, diag::err_attribute_pointers_only) << DiagName << 0;
+        Diag(Loc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
+            << BoundsAttributedType::EndedBy << 0;
         return;
       }
     } else {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6654,7 +6654,13 @@ public:
         return false;
       }
       if (Level == 0) {
-        S.DiagnoseCountedByPointeeType(DeclTy, Loc, CountInBytes, OrNull);
+        Sema::BoundsAttrFlags Flags;
+        Flags.CountInBytes = CountInBytes;
+        Flags.OrNull = OrNull;
+        if (!S.ValidateBoundsAttrTypeShape(DeclTy, Loc, SourceRange(Loc),
+                                           Flags))
+          return false;
+        CountInBytes = Flags.CountInBytes;
         return true;
       }
       --Level;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6646,14 +6646,6 @@ public:
       return false;
     }
 
-    // Check the pointee for counted_by-without-size.
-    //
-    // NOTE: We don't error for incomplete types that might be later completed
-    // (e.g. a struct forward declaration). Instead for those
-    // completable-incomplete types we delay checking until the type is used
-    // see `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
-    // attribute to be used on code that prefers to keep its pointees
-    // incomplete until they need to be used.
     if (const auto *PT = dyn_cast<PointerType>(T)) {
       auto FAttr = PT->getPointerAttributes();
       if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
@@ -6662,48 +6654,7 @@ public:
         return false;
       }
       if (Level == 0) {
-        if (!CountInBytes) {
-          QualType PointeeTy = QualType(PT, 0)->getPointeeType();
-          if (PointeeTy->isAlwaysIncompleteType() ||
-              PointeeTy->isFunctionType() || PointeeTy->isSizelessType() ||
-              PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
-            // Use unspecified pointer attributes for diagnostic purposes.
-            QualType Unsp = S.Context.getBoundsSafetyPointerType(
-                QualType(PT, 0), BoundsSafetyPointerAttributes::unspecified());
-
-            auto PD = S.PDiag(diag::err_bounds_safety_counted_by_without_size);
-            PD << Unsp << Unsp->getPointeeType() << OrNull;
-            // Suggest `__sized_by` if the `__counted_by` macro was used.
-            // We intentionally don't suggest a fixit if the attribute is used
-            // directly (i.e. without the macro) because it is not expected that
-            // users will use it.
-            int SuggestFixIt = 0; // Default don't suggest __sized_by
-            if (Loc.isMacroID()) {
-              // FIXME(dliew): Use `AL.MacroII` to get the name. Unfortunately
-              // `AL.MacroII` is not set so we can't simply check the macro name
-              // is what we expect. So instead we have the lexer tell us the
-              // contents of the token and check against that.
-              // rdar://100631458
-              auto MacroName =
-                  Lexer::getImmediateMacroName(Loc, S.SourceMgr, S.LangOpts);
-              if (MacroName == "__counted_by") {
-                SuggestFixIt = 1; // Emit text to suggest __sized_by
-                auto MacroLoc = S.SourceMgr.getExpansionLoc(Loc);
-                PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by");
-              } else if (MacroName == "__counted_by_or_null") {
-                SuggestFixIt = 1; // Emit text to suggest __sized_by_or_null
-                auto MacroLoc = S.SourceMgr.getExpansionLoc(Loc);
-                PD << FixItHint::CreateReplacement(MacroLoc,
-                                                   "__sized_by_or_null");
-              }
-            }
-            PD << SuggestFixIt;
-            S.Diag(Loc, PD);
-
-            // Recover by assuming a byte count.
-            CountInBytes = true;
-          }
-        }
+        S.DiagnoseCountedByPointeeType(DeclTy, Loc, CountInBytes, OrNull);
         return true;
       }
       --Level;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7854,16 +7854,15 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     return;
   }
 
+  // This cannot be const because `diagnoseCountAttributedTypeShape` may modify
+  // Flags.CountInBytes.
   auto Flags = getBoundsAttrFlags(Kind);
-  bool CountInBytes = Flags.CountInBytes;
-  bool IsEndedBy = Flags.IsEndedBy;
-  bool OrNull = Flags.OrNull;
 
-  if (!IsEndedBy) {
+  if (!Flags.IsEndedBy) {
     // Nullability as indicated by _Nonnull or _Nullable. Does not impact
     // semantics, only warnings.
     NullabilityKindOrNone AttrNullability = Info.Ty->getNullability();
-    if (OrNull) {
+    if (Flags.OrNull) {
       // Function parameter/return value attribute that *does* impact semantics,
       // letting the compiler elide null checks. This could remove bounds safety
       // checks, so using it together with __counted_by_or_null is not safe.
@@ -7873,39 +7872,33 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
       if (auto NNAttr = D->getAttr<NonNullAttr>();
           NNAttr && isa<ParmVarDecl>(D)) {
         Diag(Loc, diag::err_bounds_safety_nullable_dynamic_count_nonnullable)
-            << CountInBytes << NNAttr << Range << NNAttr->getRange();
+            << Flags.CountInBytes << NNAttr << Range << NNAttr->getRange();
         return;
       }
       if (auto RNNAttr = D->getAttr<ReturnsNonNullAttr>()) {
         Diag(Loc, diag::err_bounds_safety_nullable_dynamic_count_nonnullable)
-            << CountInBytes << RNNAttr << Range << RNNAttr->getRange();
+            << Flags.CountInBytes << RNNAttr << Range << RNNAttr->getRange();
         return;
       }
 
       if (AttrNullability == NullabilityKind::NonNull) {
         Diag(Loc, diag::warn_bounds_safety_nullable_dynamic_count_nonnullable)
-            << CountInBytes << DiagName;
+            << Flags.CountInBytes << DiagName;
       }
     }
 
     if (auto CountArg = AttrArg->getIntegerConstantExpr(Context)) {
-      if (CountArg > 0 && !OrNull &&
+      if (CountArg > 0 && !Flags.OrNull &&
           AttrNullability == NullabilityKind::Nullable)
         Diag(AttrArg->getExprLoc(),
              diag::warn_bounds_safety_nonnullable_dynamic_count_nullable)
-            << CountInBytes << Range;
+            << Flags.CountInBytes << Range;
     }
   }
 
   const auto *FD = dyn_cast<FieldDecl>(D);
   if (FD && FD->getParent()->isUnion()) {
-    unsigned DiagKind =
-        IsEndedBy
-            ? BoundsAttributedType::EndedBy
-            : (CountInBytes ? (OrNull ? BoundsAttributedType::SizedByOrNull
-                                      : BoundsAttributedType::SizedBy)
-                            : (OrNull ? BoundsAttributedType::CountedByOrNull
-                                      : BoundsAttributedType::CountedBy));
+    BoundsAttributedType::BoundsAttrKind DiagKind = getBoundsAttrKind(Flags);
     Diag(Loc, diag::err_count_attr_in_union) << DiagKind;
     return;
   }
@@ -7924,7 +7917,7 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
   // instead.
   if (const auto *PVD = dyn_cast<ParmVarDecl>(D)) {
     QualType TSITy = PVD->getTypeSourceInfo()->getType();
-    if (IsEndedBy) {
+    if (Flags.IsEndedBy) {
       if (Level == 0 && TSITy->isArrayType()) {
         Diag(Loc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
             << BoundsAttributedType::EndedBy << 0;
@@ -7940,21 +7933,21 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     }
   }
 
-  if (Info.Ty->isArrayType() && OrNull &&
+  if (Info.Ty->isArrayType() && Flags.OrNull &&
       (FD || Info.EffectiveLevel > 0 ||
        (Info.Var && Info.Var->hasExternalStorage()))) {
     auto ErrDiag = Diag(Loc, diag::err_bounds_safety_nullable_fam);
     // Pointers to dynamic count types are only allowed for parameters, so any
     // FieldDecl containing a dynamic count type is a FAM. I.e. a struct field
     // with type 'int(*)[__counted_by(...)]' is not valid.
-    ErrDiag << CountInBytes << /*is FAM?*/ !!FD << DiagName;
+    ErrDiag << Flags.CountInBytes << /*is FAM?*/ !!FD << DiagName;
     assert(!FD || Info.EffectiveLevel == 0);
 
     SourceLocation FixItLoc = getSourceManager().getExpansionLoc(Loc);
     SourceLocation EndLoc =
         Lexer::getLocForEndOfToken(FixItLoc, /* Don't include '(' */ -1,
                                    getSourceManager(), getLangOpts());
-    std::string Attribute = CountInBytes ? "__sized_by" : "__counted_by";
+    std::string Attribute = Flags.CountInBytes ? "__sized_by" : "__counted_by";
     ErrDiag << FixItHint::CreateReplacement({FixItLoc, EndLoc}, Attribute);
 
     return;
@@ -7973,7 +7966,7 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
   const BoundsAttributedType *ConstructedType = nullptr;
 
   bool HadAtomicError = false;
-  if (IsEndedBy) {
+  if (Flags.IsEndedBy) {
     if (AttrArg && AttrArg->getType()->isAtomicType()) {
       Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
           << /*started_by*/ 8;
@@ -8023,12 +8016,12 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
     }
 
     if (!DiagCtx.diagnoseCountAttributedTypeShape(
-            Info.DeclTy, CountInBytes, OrNull,
+            Info.DeclTy, Flags.CountInBytes, Flags.OrNull,
             /*AllowRedecl=*/OriginatesInAPINotes))
       return;
 
     auto TypeConstructor = ConstructCountAttributedType(
-        *this, Level, DiagName, AttrArg, Loc, CountInBytes, OrNull,
+        *this, Level, DiagName, AttrArg, Loc, Flags.CountInBytes, Flags.OrNull,
         OriginatesInAPINotes, Info.ScopeCheck);
     NewDeclTy = TypeConstructor.Visit(Info.DeclTy);
     HadAtomicError = TypeConstructor.hadAtomicError();

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7891,8 +7891,14 @@ void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
 
   const auto *FD = dyn_cast<FieldDecl>(D);
   if (FD && FD->getParent()->isUnion()) {
-    Diag(Loc, diag::err_invalid_decl_kind_bounds_safety_union_count)
-        << DiagName;
+    unsigned DiagKind =
+        IsEndedBy
+            ? BoundsAttributedType::EndedBy
+            : (CountInBytes ? (OrNull ? BoundsAttributedType::SizedByOrNull
+                                      : BoundsAttributedType::SizedBy)
+                            : (OrNull ? BoundsAttributedType::CountedByOrNull
+                                      : BoundsAttributedType::CountedBy));
+    Diag(Loc, diag::err_count_attr_in_union) << DiagKind;
     return;
   }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6653,31 +6653,26 @@ public:
             << DiagName << (FAttr.hasLowerBound() ? 0 : 1);
         return false;
       }
-      if (Level == 0) {
-        Sema::BoundsAttrFlags Flags;
-        Flags.CountInBytes = CountInBytes;
-        Flags.OrNull = OrNull;
-        if (!S.ValidateBoundsAttrTypeShape(DeclTy, Loc, SourceRange(Loc),
-                                           Flags))
-          return false;
-        CountInBytes = Flags.CountInBytes;
-        return true;
+      if (Level != 0) {
+        --Level;
+        llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
+        return diagnoseCountAttributedTypeShape(
+            PT->getPointeeType(), CountInBytes, OrNull, AllowRedecl);
       }
-      --Level;
-      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
-      return diagnoseCountAttributedTypeShape(
-          PT->getPointeeType(), CountInBytes, OrNull, AllowRedecl);
     }
 
-    // T isn't a pointer type.
-    unsigned DiagKind = CountInBytes
-                            ? (OrNull ? BoundsAttributedType::SizedByOrNull
-                                      : BoundsAttributedType::SizedBy)
-                            : (OrNull ? BoundsAttributedType::CountedByOrNull
-                                      : BoundsAttributedType::CountedBy);
-    S.Diag(Loc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
-        << DiagKind << 0;
-    return false;
+    // T is a pointer type at Level == 0 or T is not a pointer type.
+    Sema::BoundsAttrFlags Flags;
+    Flags.CountInBytes = CountInBytes;
+    Flags.OrNull = OrNull;
+    // TODO: Change this function to use `BoundsAttrFlags` directly in its
+    // parameters then we can make `ValidateBoundsAttrTypeShape` a tail call.
+    if (!S.ValidateBoundsAttrTypeShape(DeclTy, Loc, SourceRange(Loc), Flags))
+      return false;
+    // For error recovery when __counted_by(_or_null) is used in error but
+    // __sized_by(_or_null) would be a correct replacement.
+    CountInBytes = Flags.CountInBytes;
+    return true;
   }
 
   // Pre-check for ended-by.
@@ -6777,18 +6772,18 @@ public:
             << DiagName << (FAttr.hasLowerBound() ? 0 : 1);
         return false;
       }
-      if (Level == 0)
-        return true;
-      --Level;
-      llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
-      return diagnoseDynamicRangePointerTypeShape(PT->getPointeeType(),
-                                                  AllowRedecl);
+      if (Level != 0) {
+        --Level;
+        llvm::SaveAndRestore<bool> Local(AutoPtrAttributed, false);
+        return diagnoseDynamicRangePointerTypeShape(PT->getPointeeType(),
+                                                    AllowRedecl);
+      }
     }
 
-    // T isn't a pointer type.
-    S.Diag(Loc, diag::err_count_attr_not_on_ptr_or_flexible_array_member)
-        << BoundsAttributedType::EndedBy << 0;
-    return false;
+    // T is a pointer type at Level == 0 or T is not a pointer type.
+    Sema::BoundsAttrFlags Flags;
+    Flags.IsEndedBy = true;
+    return S.ValidateBoundsAttrTypeShape(DeclTy, Loc, SourceRange(Loc), Flags);
   }
 };
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6518,7 +6518,7 @@ public:
   // - err_bounds_safety_complete_array_with_count
   // - err_bounds_safety_sized_by_array
   // - err_multiple_coupled_decls_in_bounds_safety_dynamic_count
-  // - err_bounds_safety_counted_by_without_size
+  // - err_counted_by_attr_pointee_unknown_size
   bool diagnoseCountAttributedTypeShape(QualType DeclTy, bool &CountInBytes,
                                         bool OrNull, bool AllowRedecl) {
     const Type *T = DeclTy.getTypePtr();

--- a/clang/test/APINotes/boundssafety-errors.c
+++ b/clang/test/APINotes/boundssafety-errors.c
@@ -70,13 +70,13 @@ Functions:
             Level: 0
             BoundedBy: apinote_end
 //--- SemaErrors.h
-// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: 'counted_by' only applies to pointers or C99 flexible array members
 // CHECK-NEXT: oob_level
 void oob_level(int * buf, int len);
-// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: 'counted_by' only applies to pointers or C99 flexible array members
 // CHECK-NEXT: off_by_1_level
 void off_by_1_level(int * buf, int len);
-// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: 'counted_by' only applies to pointers or C99 flexible array members
 // CHECK-NEXT: nonpointer_param
 void nonpointer_param(int buf, int len);
 // CHECK: <API Notes>:1:1: error: use of undeclared identifier 'len'; did you mean 'len2'?

--- a/clang/test/BoundsSafety/AST/typedef-pointer-attrs-late-parsed.c
+++ b/clang/test/BoundsSafety/AST/typedef-pointer-attrs-late-parsed.c
@@ -22,7 +22,7 @@ void test_fdecl2(unsigned size, cptr_t __sized_by(size));
 // CHECK: `-ParmVarDecl {{.*}} 'char *__single __sized_by(size)':'char *__single'
 
 void test_fdecl_err1(int64_t __counted_by(len), int len);
-// expected-error@-1{{'__counted_by' attribute only applies to pointer arguments}}
+// expected-error@-1{{'counted_by' only applies to pointers or C99 flexible array members}}
 
 int glen;
 void test_fdecl_err2(cptr_t __counted_by(glen));

--- a/clang/test/BoundsSafety/Sema/attributes_in_template_decls_attr_only_mode.cpp
+++ b/clang/test/BoundsSafety/Sema/attributes_in_template_decls_attr_only_mode.cpp
@@ -446,22 +446,22 @@ class RefParamMustBePtrExternallyCountedBad {
     public:
     int size;
     T end_ptr;
-    T __counted_by(size) cb; // expected-error 2{{'counted_by' attribute only applies to pointer arguments}}
-    T __counted_by_or_null(size) cbon; // expected-error 2{{'counted_by_or_null' attribute only applies to pointer arguments}}
-    T __sized_by(size) sb; // expected-error 2{{'sized_by' attribute only applies to pointer arguments}}
-    T __sized_by_or_null(size) sbon; // expected-error 2{{'sized_by_or_null' attribute only applies to pointer arguments}}
+    T __counted_by(size) cb; // expected-error 2{{'counted_by' only applies to pointers or C99 flexible array members}}
+    T __counted_by_or_null(size) cbon; // expected-error 2{{'counted_by_or_null' only applies to pointers}}
+    T __sized_by(size) sb; // expected-error 2{{'sized_by' only applies to pointers}}
+    T __sized_by_or_null(size) sbon; // expected-error 2{{'sized_by_or_null' only applies to pointers}}
     T __ended_by(end_ptr) eb; // expected-error 2{{'ended_by' attribute requires a pointer type argument}}
 
-    T __counted_by(size) ret_cb() { // expected-error 2{{'counted_by' attribute only applies to pointer arguments}}
+    T __counted_by(size) ret_cb() { // expected-error 2{{'counted_by' only applies to pointers or C99 flexible array members}}
         return cb;
     }
 
-    // expected-error@+1{{'__counted_by' attribute only applies to pointer arguments}}
+    // expected-error@+1{{'counted_by' only applies to pointers or C99 flexible array members}}
     void cb_param(T __counted_by(size) ptr, int size) {}
 
     void useT() {
         int size_local = size;
-        T __counted_by(size_local) tmp = cb; // expected-error{{'counted_by' attribute only applies to pointer arguments}}
+        T __counted_by(size_local) tmp = cb; // expected-error{{'counted_by' only applies to pointers or C99 flexible array members}}
     }
 };
 

--- a/clang/test/BoundsSafety/Sema/count-bound-attrs.c
+++ b/clang/test/BoundsSafety/Sema/count-bound-attrs.c
@@ -28,7 +28,7 @@ void Test(void) {
     int *__counted_by(len12) __unsafe_indexable countUnsafe;
 
     int len13;
-    void *__counted_by(len13) countVoid; // expected-error{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
+    void *__counted_by(len13) countVoid; // expected-error{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'void' is an incomplete type}}
     int len14;
     void *__sized_by(len14) byteCountVoid;
 }

--- a/clang/test/BoundsSafety/Sema/counted-by-or-null-array-fixit.c
+++ b/clang/test/BoundsSafety/Sema/counted-by-or-null-array-fixit.c
@@ -18,9 +18,8 @@ struct constant_sized_inner_arr_2d_struct {
     int fam[__counted_by_or_null(len)][10]; // expected-error{{flexible array members cannot be null; did you mean __counted_by instead?}}
 };
 
-// expected-error@+3{{'__counted_by_or_null' attribute on nested pointer type is only allowed on indirect parameters}}
-// expected-error@+2{{cannot apply '__counted_by_or_null' attribute to 'int (*)[][size]' because 'int[][size]' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
-// CHECK: fix-it:{{.*}}:{[[@LINE+1]]:52-[[@LINE+1]]:72}:"__sized_by_or_null"
+// expected-error@+2{{'__counted_by_or_null' attribute on nested pointer type is only allowed on indirect parameters}}
+// expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'int[][size]' is an incomplete type}}
 void counted_nested_unsized_array(int size, int (* __counted_by_or_null(size) param)[__counted_by_or_null(10)][size]);
 
 void local_array() {

--- a/clang/test/BoundsSafety/Sema/counted-by-or-null-array.c
+++ b/clang/test/BoundsSafety/Sema/counted-by-or-null-array.c
@@ -42,7 +42,7 @@ void pointers_to_array_params(int size, int (* __sized_by_or_null(size) param)[_
 void counted_unsized_array(int size, int (*param)[__counted_by_or_null(10)][__counted_by_or_null(size)]); // expected-error{{array has incomplete element type 'int[]'}}
 
 // expected-error@+2{{'__counted_by_or_null' attribute on nested pointer type is only allowed on indirect parameters}}
-// expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'int (*)[][size]' because 'int[][size]' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+// expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'int[][size]' is an incomplete type}}
 void counted_nested_unsized_array(int size, int (* __counted_by_or_null(size) param)[__counted_by_or_null(10)][size]);
 
 void counted_decayed_nested(int len, int arr[__counted_by_or_null(11)][__counted_by_or_null(len)]); // expected-error{{array has incomplete element type 'int[]'}}

--- a/clang/test/BoundsSafety/Sema/counted_by_type_incomplete_array.c
+++ b/clang/test/BoundsSafety/Sema/counted_by_type_incomplete_array.c
@@ -10,7 +10,7 @@
 
 
 extern int external_arr_len;
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
 extern char (* __counted_by(external_arr_len) incompleteArrayPtr)[]; // expected-note{{'incompleteArrayPtr' declared here}}
 void use_incompleteArrayPtr_when_incomplete(void) {
     // expected-error@+1{{subscript of pointer to incomplete type 'char[]'}}
@@ -34,9 +34,9 @@ char (* __counted_by(external_arr_len2) CompleteArrayPtr)[4]; // OK
 //==============================================================================
 
 int global_arr_len;
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
 char (* __counted_by(global_arr_len) GlobalCBIncompleteArrayPtr)[];
-// expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+// expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
 char (* __counted_by_or_null(global_arr_len) GlobalCBONIncompleteArrayPtr)[];
 
 char (* __counted_by(global_arr_len) GlobalCBCompleteArrayPtr)[2]; // OK
@@ -52,27 +52,27 @@ char (* __counted_by(1) GlobalCBCompleteArrayPtrOneCount)[2];
 
 void local_cb(void) {
   int size = 0;
-  // expected-error@+1{{cannot apply '__counted_by' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by' instead?}}
+  // expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
   char (* __counted_by(size) local_implicit_init)[];
 
   // expected-error@+1{{subscript of pointer to incomplete type 'char[]'}}
   local_implicit_init[0];
 
   int size2 = 0;
-  // expected-error@+1{{cannot apply '__counted_by' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by' instead?}}
+  // expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
   char (* __counted_by(size2) local_explicit_init)[] = 0x0;
 }
 
 void local_cbon(void) {
   int size = 0;
-  // expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+  // expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
   char (* __counted_by_or_null(size) local_implicit_init)[];
 
   // expected-error@+1{{subscript of pointer to incomplete type 'char[]'}}
   local_implicit_init[0];
 
   int size2 = 0;
-  // expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+  // expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
   char (* __counted_by_or_null(size2) local_explicit_init)[] = 0x0;
 }
 
@@ -80,12 +80,12 @@ void local_cbon(void) {
 // Parameters
 //==============================================================================
 
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
 void decl_param_cb(char (* __counted_by(size) p)[], int size) {}
-// expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+// expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
 void decl_param_cbon(char (* __counted_by_or_null(size) p)[], int size) {}
 
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
 void access_param_cb(char (* __counted_by(size) p)[], int size) {
   void* local = p;
 
@@ -101,7 +101,7 @@ void access_param_cb(char (* __counted_by(size) p)[], int size) {
   size = 0; // OK
 }
 
-// expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'char (*)[]' because 'char[]' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+// expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'char[]' is an incomplete type}}
 void access_param_cbon(char (* __counted_by_or_null(size) p)[], int size) {
   // This doesn't show up as an error because error recovery for treats `p` as
   // having type `char (*__single __sized_by_or_null(size))[]`

--- a/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size.c
+++ b/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size.c
@@ -1,8 +1,6 @@
 
 // RUN: %clang_cc1 -triple arm64-apple-macos -target-feature +sve -fsyntax-only -fbounds-safety -verify %s
-// RUN: not %clang_cc1 -triple arm64-apple-macos -target-feature +sve -fsyntax-only -fbounds-safety  -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -triple arm64-apple-macos -target-feature +sve -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
-// RUN: not %clang_cc1 -triple arm64-apple-macos -target-feature +sve -fsyntax-only -fbounds-safety  -x objective-c -fexperimental-bounds-safety-objc -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
 
 #include <ptrcheck.h>
 
@@ -11,12 +9,10 @@ int len;
 //------------------------------------------------------------------------------
 // void pointer
 //------------------------------------------------------------------------------
-// CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:7-[[@LINE+2]]:19}:"__sized_by"
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'void' is an incomplete type}}
 void *__counted_by(len) voidPtr;
 
-// CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:7-[[@LINE+2]]:27}:"__sized_by_or_null"
-// expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+// expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'void' is an incomplete type}}
 void *__counted_by_or_null(len) voidPtrOrNull;
 
 //------------------------------------------------------------------------------
@@ -24,12 +20,10 @@ void *__counted_by_or_null(len) voidPtrOrNull;
 //------------------------------------------------------------------------------
 typedef int (*fptr_t)(int*);
 
-// CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:8-[[@LINE+2]]:20}:"__sized_by"
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'int (*)(int *__single)' because 'int (int *__single)' has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'int (int *__single)' is a function type}}
 fptr_t __counted_by(len) fPtr;
 
-// CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:8-[[@LINE+2]]:28}:"__sized_by_or_null"
-// expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'int (*)(int *__single)' because 'int (int *__single)' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+// expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'int (int *__single)' is a function type}}
 fptr_t __counted_by_or_null(len) fPtrOrNull;
 
 
@@ -42,12 +36,10 @@ struct vla {
 };
 typedef struct vla vla_t;
 
-// CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:8-[[@LINE+2]]:20}:"__sized_by"
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'vla_t *' (aka 'struct vla *') because 'vla_t' (aka 'struct vla') has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'vla_t' (aka 'struct vla') is a struct type with a flexible array member}}
 vla_t* __counted_by(len) vlaPtr;
 
-// CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:13-[[@LINE+2]]:25}:"__sized_by"
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'struct vla *' because 'struct vla' has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'struct vla' is a struct type with a flexible array member}}
 struct vla* __counted_by(len) vlaPtr2;
 
 //------------------------------------------------------------------------------
@@ -55,6 +47,6 @@ struct vla* __counted_by(len) vlaPtr2;
 //------------------------------------------------------------------------------
 #ifdef  __aarch64__
     // CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:17-[[@LINE+2]]:29}:"__sized_by"
-    // expected-error@+1{{cannot apply '__counted_by' attribute to '__SVInt8_t *' because '__SVInt8_t' has unknown size; did you mean to use '__sized_by' instead?}}
+    // expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because '__SVInt8_t' is a sizeless type}}
     __SVInt8_t* __counted_by(len) countSVInt8;
 #endif

--- a/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size.c
+++ b/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size.c
@@ -2,6 +2,12 @@
 // RUN: %clang_cc1 -triple arm64-apple-macos -target-feature +sve -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -triple arm64-apple-macos -target-feature +sve -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
+// NOTE: This test previously checked `__sized_by` / `__sized_by_or_null` FixIt
+// suggestions. Those checks were removed when the diagnostic was migrated to
+// `err_counted_by_attr_pointee_unknown_size`, which does not emit the FixIt.
+// They should be restored once the FixIt is re-added; tracked by
+// swiftlang/llvm-project#13417.
+
 #include <ptrcheck.h>
 
 int len;

--- a/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size_no_fixit.c
+++ b/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size_no_fixit.c
@@ -9,11 +9,11 @@
 int len;
 
 // Using attribute directly should not suggest a fix-it.
-// expected-error-re@+1{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size{{$}}}}
+// expected-error-re@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'void' is an incomplete type{{$}}}}
 void *__attribute__((__counted_by__(len))) voidPtr;
 
 // Using a custom macro that wraps the attribute should not suggest a fix-it.
-// expected-error-re@+2{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size{{$}}}}
+// expected-error-re@+2{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'void' is an incomplete type{{$}}}}
 #define my_custom_counted_by(X) __attribute__((__counted_by__(X)))
 void * my_custom_counted_by(len) voidPtr2;
 

--- a/clang/test/BoundsSafety/Sema/disallow-union-count.c
+++ b/clang/test/BoundsSafety/Sema/disallow-union-count.c
@@ -9,13 +9,13 @@
 
 union S {
   int *p1 __counted_by(count);
-  // expected-error@-1 {{cannot use '__counted_by' on union fields}}
+  // expected-error@-1 {{'counted_by' cannot be applied to a union member}}
   int count;
   int *p2 __ended_by(end);
-  // expected-error@-1 {{cannot use '__ended_by' on union fields}}
+  // expected-error@-1 {{'ended_by' cannot be applied to a union member}}
   int *end;
   int *p3 __sized_by(size);
-  // expected-error@-1 {{cannot use '__sized_by' on union fields}}
+  // expected-error@-1 {{'sized_by' cannot be applied to a union member}}
   int size;
   struct
   {

--- a/clang/test/BoundsSafety/Sema/ended_by_decls.c
+++ b/clang/test/BoundsSafety/Sema/ended_by_decls.c
@@ -66,7 +66,7 @@ int *__ended_by(end) foo_ret_end(int *end);
 
 // expected-note@+3{{add a count attribute}}
 // expected-error@+2{{parameter of array type 'int[]' decays to a __single pointer}}
-// expected-error@+1{{'__ended_by' attribute only applies to pointer arguments}}
+// expected-error@+1{{'ended_by' only applies to pointers}}
 void foo_end_in_bracket(int buf[__ended_by(end)], int *end);
 
 // expected-error@+1{{invalid argument expression to bounds attribute}}

--- a/clang/test/BoundsSafety/Sema/flexible-array-member-restrictions.c
+++ b/clang/test/BoundsSafety/Sema/flexible-array-member-restrictions.c
@@ -63,7 +63,7 @@ flex_t *bar(flex_t *__bidi_indexable flex) {
     (void) (flex - 1); // expected-error{{-fbounds-safety forbids arithmetic on pointers to types with a flexible array member}}
 }
 
-void baz(flex_t *__counted_by(1) flex); // expected-error{{cannot apply '__counted_by' attribute to 'flex_t *' (aka 'struct flexible *') because 'flex_t' (aka 'struct flexible') has unknown size; did you mean to use '__sized_by' instead?}}
+void baz(flex_t *__counted_by(1) flex); // expected-error{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'flex_t' (aka 'struct flexible') is a struct type with a flexible array member}}
 void qux(flex_t *__sized_by(siz) flex, unsigned siz);
 
 void quux(flex_t *flex, char *__bidi_indexable buf) {

--- a/clang/test/BoundsSafety/Sema/fptr-count-return.c
+++ b/clang/test/BoundsSafety/Sema/fptr-count-return.c
@@ -6,7 +6,7 @@
 // CHECK: VarDecl {{.*}} fptr 'int *__single*__single __counted_by(len)(*__single)(int)'
 int **__counted_by(len) (*fptr)(int len);
 
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
+// expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'void' is an incomplete type}}
 void *__counted_by(len) (*fptr1)(int len);
 
 // expected-error@+1{{'__counted_by' attribute on nested pointer type is only allowed on indirect parameters}}

--- a/clang/test/Sema/attr-counted-by-void-ptr-gnu.c
+++ b/clang/test/Sema/attr-counted-by-void-ptr-gnu.c
@@ -18,7 +18,7 @@
 
 struct test_void_ptr_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
+  // expected-bounds-error@+3{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'void' is an incomplete type}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   void* buf __counted_by(count);
@@ -26,7 +26,7 @@ struct test_void_ptr_gnu {
 
 struct test_const_void_ptr_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'const void *' because 'const void' has unknown size; did you mean to use '__sized_by' instead?}}
+  // expected-bounds-error@+3{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'const void' is an incomplete type}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   const void* buf __counted_by(count);
@@ -34,7 +34,7 @@ struct test_const_void_ptr_gnu {
 
 struct test_volatile_void_ptr_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'volatile void *' because 'volatile void' has unknown size; did you mean to use '__sized_by' instead?}}
+  // expected-bounds-error@+3{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'volatile void' is an incomplete type}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   volatile void* buf __counted_by(count);
@@ -42,7 +42,7 @@ struct test_volatile_void_ptr_gnu {
 
 struct test_const_volatile_void_ptr_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'const volatile void *' because 'const volatile void' has unknown size; did you mean to use '__sized_by' instead?}}
+  // expected-bounds-error@+3{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'const volatile void' is an incomplete type}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   const volatile void* buf __counted_by(count);
@@ -60,7 +60,7 @@ struct test_sized_by_void_ptr {
 
 struct test_void_ptr_or_null_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by_or_null' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+  // expected-bounds-error@+3{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'void' is an incomplete type}}
   // expected-warn-warning@+2{{'counted_by_or_null' on a pointer to void is a GNU extension, treated as 'sized_by_or_null'}}
   // expected-warn-note@+1{{use '__sized_by_or_null' to suppress this warning}}
   void* buf __counted_by_or_null(count);
@@ -68,7 +68,7 @@ struct test_void_ptr_or_null_gnu {
 
 struct test_const_void_ptr_or_null_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by_or_null' attribute to 'const void *' because 'const void' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+  // expected-bounds-error@+3{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'const void' is an incomplete type}}
   // expected-warn-warning@+2{{'counted_by_or_null' on a pointer to void is a GNU extension, treated as 'sized_by_or_null'}}
   // expected-warn-note@+1{{use '__sized_by_or_null' to suppress this warning}}
   const void* buf __counted_by_or_null(count);


### PR DESCRIPTION
This PR contains multiple commits that starts moving us on to existing upstream diagnostics and refactors things so that both the non -fbounds-safety and -fbounds-safety code paths can start to share diagnostics. This work is also being done to support the late parsing refactor that's currently in progress.

To make this more reviewable please look at each commit in turn rather than the whole change.

Assisted-by: Claude Code
Co-authored-by: Yeoul Na <yeoul_na@apple.com>

## Summary

Consolidates bounds-attribute (`counted_by` / `sized_by` / `counted_by_or_null` /
`sized_by_or_null` / `ended_by`) **type-shape validation** into a single, `Decl`-free
leaf — `Sema::ValidateBoundsAttrTypeShape` — and migrates three downstream
`-fbounds-safety` diagnostics to their canonical **upstream** spellings.

Motivation:
- **Reduce downstream/upstream divergence.** Three `-fbounds-safety`-specific
  diagnostics are replaced by the roughly equivalent upstream diagnostics, so one wording
  serves both `-fbounds-safety` and plain-C `-fexperimental-late-parse-attributes`
  mode.
- **Single source of truth for type-shape checks.** Both eager walkers
  (`diagnoseCountAttributedTypeShape` and `diagnoseDynamicRangePointerTypeShape`)
  now route through `ValidateBoundsAttrTypeShape`, removing duplicated inline checks.
- **Foundation for the late-parsing migration.** The new leaf is `Decl`-free
  (operates on `QualType` + attribute metadata only), so the upcoming
  late-parsed-attribute mechanism can call the same validator.

## What's in this PR (7 commits)

**Refactors (NFC):**
1. `Add getBoundsAttrFlags helper` — extracts the repeated attribute-kind -> `{CountInBytes, OrNull, IsEndedBy}` switch.
2. `Extract incomplete __counted_by Sema checks into helper` — pulls the pointee-type validation into a Sema method.
6. `Introduce ValidateBoundsAttrTypeShape shared validation` — the shared, `Decl`-free type-shape leaf; the eager `counted_by`/upstream field paths now call it.
7. `Clean up calls to ValidateBoundsAttrTypeShape` — makes both eager walkers end with a single tail call to the leaf.

**Diagnostic migrations (semantically equivalent — canonical upstream wording):**
3. Union member: `err_invalid_decl_kind_bounds_safety_union_count` -> upstream `err_count_attr_in_union`.
4. Not a pointer/FAM: `err_attribute_pointers_only` -> upstream `err_count_attr_not_on_ptr_or_flexible_array_member`.
5. Pointee of unknown size: `err_bounds_safety_counted_by_without_size` -> upstream `err_counted_by_attr_pointee_unknown_size`.

The two upstream diagnostics `err_count_attr_in_union` and
`err_count_attr_not_on_ptr_or_flexible_array_member` are extended with an
`ended_by` `%select` option; this is a downstream-only divergence and is noted in
`DiagnosticSemaKinds.td`. The now-unused downstream diagnostics are removed.

## User-visible impact

`-fbounds-safety` diagnostics for these three cases now use the canonical upstream
text (same errors, different wording). Behavior is otherwise unchanged, including
that `__counted_by` on `void *` remains a GNU extension (allowed, warned under
`-Wpointer-arith`) in non-bounds-safety mode and an error under `-fbounds-safety`.

## Testing

- Minimum bounds-safety regression suite: **no regressions** (1081 pass / 0 fail / 13 XFail).
- `clang/test/BoundsSafety/Sema`: **256 / 0 / 2** preserved.
- Expected diagnostics updated to the new wording across the affected
  `BoundsSafety/*`, `Sema/attr-*`, `AST/*`, and `APINotes/*` tests.

