### PR TITLE
[NFC] Temporarily reinstate some code to avoid swift rebranch change

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1104,6 +1104,10 @@ public:
       RawCommentLookupKey Key, const SourceLocation RepresentativeLoc,
       const std::map<unsigned, RawComment *> &CommentsInFile) const;
 
+  /// Return the documentation comment attached to a given declaration,
+  /// without looking into cache.
+  RawComment *getRawCommentForDeclNoCache(const Decl *D) const;
+
   /// Return the documentation comment attached to a given declaration or
   /// macro, without looking into cache.
   RawComment *getRawCommentNoCache(RawCommentLookupKey Key) const;

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -877,6 +877,9 @@ public:
                                 llvm::opt::ArgStringList &CmdArgs) const {}
 
   /// Return sanitizers which are available in this toolchain.
+  SanitizerMask getSupportedSanitizers() const;
+
+  /// Return sanitizers which are available in this toolchain.
   virtual SanitizerMask
   getSupportedSanitizers(StringRef BoundArch,
                          Action::OffloadKind DeviceOffloadKind) const;

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -328,6 +328,10 @@ RawComment *ASTContext::getRawCommentNoCacheImpl(
   return CommentBeforeDecl;
 }
 
+RawComment *ASTContext::getRawCommentForDeclNoCache(const Decl *D) const {
+  return getRawCommentNoCache(D);
+}
+
 RawComment *ASTContext::getRawCommentNoCache(RawCommentLookupKey Key) const {
   const auto Locs = getLocsForCommentSearch(Key, SourceMgr);
 

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1831,6 +1831,11 @@ ToolChain::getSystemGPUArchs(const llvm::opt::ArgList &Args) const {
   return SmallVector<std::string>();
 }
 
+SanitizerMask ToolChain::getSupportedSanitizers() const {
+  return getSupportedSanitizers(
+      /*BoundArch=*/"", clang::driver::Action::OFK_None);
+}
+
 SanitizerMask
 ToolChain::getSupportedSanitizers(StringRef BoundArch,
                                   Action::OffloadKind DeviceOffloadKind) const {


### PR DESCRIPTION
Once rebranch is complete, we should revert this.