### PR TITLE
[BoundsSafety] add new AssignConvertTypes to switch

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12828,11 +12828,14 @@ bool Sema::isCompatibleBoundsUnsafeAssignment(AssignConvertType ConvTy) const {
   case AssignConvertType::PointerToInt:
   case AssignConvertType::IntToPointer:
   case AssignConvertType::Incompatible:
+  case AssignConvertType::IncompatiblePointerDiscardsOverflowBehavior:
+  case AssignConvertType::IncompatibleOBTKinds:
   // Not errors
   case AssignConvertType::CompatibleSingleToExplicitIndexablePointer:
   case AssignConvertType::CompatiblePointerDiscardsQualifiers:
   case AssignConvertType::CompatibleVoidPtrToNonVoidPtr:
   case AssignConvertType::Compatible:
+  case AssignConvertType::CompatibleOBTDiscards:
     return false;
   }
   llvm_unreachable("Unhandled AssignConvertType");


### PR DESCRIPTION
These were added in 7f631bb523a34d3b95a6614006468c609e60fcf5. This silences the -Wswitch warning and prevents control flow from reaching llvm_unreachable.