### PR TITLE
[Cherry-pick into next] [lldb] Only apply forced triple override to main binary

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3406,11 +3406,12 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
 
     if (computed_triple.getOS() == llvm::Triple::MacOSX) {
       // Handle the case where an apparent macOS binary has been
-      // force-loaded as a macCatalyst process. The Xcode test
-      // runner works this way.
+      // force-loaded as a macCatalyst process. The Xcode test runner
+      // works this way.
       llvm::Triple exe_triple = get_executable_triple();
       if (exe_triple.getOS() == llvm::Triple::IOS &&
-          exe_triple.getEnvironment() == llvm::Triple::MacABI) {
+          exe_triple.getEnvironment() == llvm::Triple::MacABI &&
+          sc.module_sp == exe_module_sp) {
         LOG_PRINTF(GetLog(LLDBLog::Types), "Adjusting triple to macCatalyst.");
         computed_triple.setOSAndEnvironmentName(
             exe_triple.getOSAndEnvironmentName());

--- a/lldb/test/API/lang/swift/macCatalystFramework/Framework.swift
+++ b/lldb/test/API/lang/swift/macCatalystFramework/Framework.swift
@@ -1,0 +1,5 @@
+@_cdecl("entry")
+public func entry() {
+  let x = "hello"
+  print(x) // break here
+}

--- a/lldb/test/API/lang/swift/macCatalystFramework/Makefile
+++ b/lldb/test/API/lang/swift/macCatalystFramework/Makefile
@@ -1,0 +1,24 @@
+# A macCatalyst (arm64-apple-ios-macabi) executable, loading a plain
+# macOS (arm64-apple-macosx) Swift framework.
+C_SOURCES := main.c
+LD_EXTRAS := -F. -framework Framework
+CFLAGS_EXTRAS = -target $(ARCH)-apple-ios26.0-macabi
+
+all: Framework.framework/Versions/A/Framework a.out
+
+include Makefile.rules
+
+# The framework is built for plain macOS -- note the macosx -target.
+Framework.framework/Versions/A/Framework: $(SRCDIR)/Framework.swift
+	touch Framework.h
+	"$(MAKE)" -f $(MAKEFILE_RULES) \
+	    MAKE_DSYM=YES \
+		DYLIB_ONLY=YES \
+		DYLIB_SWIFT_SOURCES=Framework.swift \
+		MODULENAME=Framework \
+		FRAMEWORK=Framework \
+		FRAMEWORK_MODULES=Framework.swiftinterface \
+		FRAMEWORK_HEADERS=Framework.h \
+		SWIFTFLAGS_EXTRAS="-target $(ARCH)-apple-macosx26.0"
+	$(call RM_F,$(BUILDDIR)/Framework.swiftmodule $(BUILDDIR)/Framework.swiftinterface)
+	$(call RM_F,Framework.o Framework.h Framework.partial.swiftmodule)

--- a/lldb/test/API/lang/swift/macCatalystFramework/TestSwiftMacCatalystFramework.py
+++ b/lldb/test/API/lang/swift/macCatalystFramework/TestSwiftMacCatalystFramework.py
@@ -1,0 +1,37 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftMacCatalystFramework(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipEmbeddedSwift
+    @swiftTest
+    @skipIf(macos_version=["<", "26"])
+    @skipUnlessDarwin
+    @skipIfDarwinEmbedded
+    def test(self):
+        """A macCatalyst (arm64-apple-ios-macabi) executable that loads a plain
+           macOS (arm64-apple-macosx) Swift framework. When stopped in the
+           framework's Swift code, LLDB must build the framework's
+           SwiftASTContextForExpressions with the framework's *macOS* triple,
+           not the executable's macCatalyst triple.
+        """
+        self.build()
+        types_log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % types_log)
+
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("Framework.swift"),
+            extra_images=["Framework.framework/Framework"])
+
+        arch = self.getArchitecture()
+        self.expect("image list -t -b",
+                    patterns=[arch + r".*-apple-ios.*-macabi a\.out"])
+
+        self.expect("expression -- x", substrs=['"hello"'])
+        self.filecheck_log(types_log, __file__)
+#       CHECK: SwiftASTContextForExpressions(module: "Framework", cu: "Framework.swift")::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx

--- a/lldb/test/API/lang/swift/macCatalystFramework/categories
+++ b/lldb/test/API/lang/swift/macCatalystFramework/categories
@@ -1,0 +1,1 @@
+swiftmaccatalyst

--- a/lldb/test/API/lang/swift/macCatalystFramework/main.c
+++ b/lldb/test/API/lang/swift/macCatalystFramework/main.c
@@ -1,0 +1,8 @@
+// The main executable is a macCatalyst (arm64-apple-ios-macabi) binary that
+// calls into a plain macOS Swift framework via a C entry point.
+extern void entry(void);
+
+int main() {
+  entry();
+  return 0;
+}


### PR DESCRIPTION
```
commit 35f7b260da841011e3fcd973cd897e4bb6f92233
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Jul 15 16:40:38 2026 -0700

    [lldb] Only apply forced triple override to main binary
    
    When debugging a macOS framework linked against a Mac Catalyst binary,
    the heuristic that detects the DYLD override that Xcode applies to the
    xctest runner is misfiring, causing the macOS framework to be clamped
    to the incompatible ios-macabi triple of the main binary. The
    heuristic should only be applied to the main binary, and LLDB should
    trust the load commands in frameworks.
    
    rdar://182139188
    
    Assisted-by: claude
```
