### PR TITLE
[BoundsSafety] Fix attribute dropping in attribute only mode

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6940,10 +6940,10 @@ public:
     return S.Context.getMacroQualifiedType(NewTy, T->getMacroIdentifier());
   }
 
+  // FIXME: Would like to apply AttributedType(attr::CountedBy/SizedBy[OrNull])
+  // but this may trigger additional needed fixes.
   QualType VisitTypedefType(const TypedefType *T) {
-    if (S.getLangOpts().isBoundsSafetyAttributeOnlyMode())
-      return Visit(T->desugar());
-    return VisitType(T);
+    return Visit(T->desugar());
   }
 
   QualType VisitArrayType(const ArrayType *T) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6940,6 +6940,12 @@ public:
     return S.Context.getMacroQualifiedType(NewTy, T->getMacroIdentifier());
   }
 
+  QualType VisitTypedefType(const TypedefType *T) {
+    if (S.getLangOpts().isBoundsSafetyAttributeOnlyMode())
+      return Visit(T->desugar());
+    return VisitType(T);
+  }
+
   QualType VisitArrayType(const ArrayType *T) {
     return VisitType(T);
   }

--- a/clang/test/BoundsSafety/AST/nonnull-attribute.c
+++ b/clang/test/BoundsSafety/AST/nonnull-attribute.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -ast-dump -ast-dump-filter bar -fbounds-safety %s | FileCheck %s --check-prefix=FBOUNDS
+// RUN: %clang_cc1 -ast-dump -ast-dump-filter bar -fexperimental-bounds-safety-attributes %s | FileCheck %s --check-prefix=FATTR_ONLY
+
+#include <ptrcheck.h>
+
+typedef int * _Nonnull foo_t;
+
+void bar(int len, foo_t __counted_by(len) p);
+
+// FBOUNDS:      FunctionDecl {{.*}} bar 'void (int, int *__single __counted_by(len) _Nonnull)'
+// FBOUNDS-NEXT: ParmVarDecl {{.*}} len 'int'
+// FBOUNDS-NEXT: DependerDeclsAttr
+// FBOUNDS-NEXT: ParmVarDecl {{.*}} p 'int *__single __counted_by(len) _Nonnull':'int *__single'
+
+// FATTR_ONLY:      FunctionDecl {{.*}} bar 'void (int, int * __counted_by(len))'
+// FATTR_ONLY-NEXT: ParmVarDecl {{.*}} len 'int'
+// FATTR_ONLY-NEXT: DependerDeclsAttr
+// FATTR_ONLY-NEXT: ParmVarDecl {{.*}} p 'int * __counted_by(len)':'int *'

--- a/clang/test/BoundsSafety/AST/nonnull-attribute.c
+++ b/clang/test/BoundsSafety/AST/nonnull-attribute.c
@@ -12,7 +12,7 @@ void bar(int len, foo_t __counted_by(len) p);
 // FBOUNDS-NEXT: DependerDeclsAttr
 // FBOUNDS-NEXT: ParmVarDecl {{.*}} p 'int *__single __counted_by(len) _Nonnull':'int *__single'
 
-// FATTR_ONLY:      FunctionDecl {{.*}} bar 'void (int, int * __counted_by(len))'
+// FATTR_ONLY:      FunctionDecl {{.*}} bar 'void (int, int * __counted_by(len) _Nonnull)'
 // FATTR_ONLY-NEXT: ParmVarDecl {{.*}} len 'int'
 // FATTR_ONLY-NEXT: DependerDeclsAttr
-// FATTR_ONLY-NEXT: ParmVarDecl {{.*}} p 'int * __counted_by(len)':'int *'
+// FATTR_ONLY-NEXT: ParmVarDecl {{.*}} p 'int * __counted_by(len) _Nonnull':'int *'

--- a/clang/test/BoundsSafety/AST/typedef-function-desugar.c
+++ b/clang/test/BoundsSafety/AST/typedef-function-desugar.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -ast-dump -ast-dump-filter bar -fbounds-safety %s | FileCheck %s --check-prefix=FBOUNDS
+// RUN: %clang_cc1 -ast-dump -ast-dump-filter bar -fexperimental-bounds-safety-attributes %s | FileCheck %s --check-prefix=FATTR_ONLY
+
+#include <ptrcheck.h>
+
+typedef int * __single _Nonnull baz_t;
+
+void bar(int len, baz_t __counted_by(len) p);
+
+// FBOUNDS:      FunctionDecl {{.*}} bar 'void (int, int *__single __counted_by(len))'
+// FBOUNDS-NEXT: ParmVarDecl {{.*}} len 'int'
+// FBOUNDS-NEXT: DependerDeclsAttr
+// FBOUNDS-NEXT: ParmVarDecl {{.*}} p 'int *__single __counted_by(len)':'int *__single'
+
+// FATTR_ONLY:      FunctionDecl {{.*}} bar 'void (int, int * __counted_by(len))'
+// FATTR_ONLY-NEXT: ParmVarDecl {{.*}} len 'int'
+// FATTR_ONLY-NEXT: DependerDeclsAttr
+// FATTR_ONLY-NEXT: ParmVarDecl {{.*}} p 'int * __counted_by(len)':'int *'

--- a/clang/test/BoundsSafety/AST/typedef-function-desugar.c
+++ b/clang/test/BoundsSafety/AST/typedef-function-desugar.c
@@ -7,12 +7,12 @@ typedef int * __single _Nonnull baz_t;
 
 void bar(int len, baz_t __counted_by(len) p);
 
-// FBOUNDS:      FunctionDecl {{.*}} bar 'void (int, int *__single __counted_by(len))'
+// FBOUNDS:      FunctionDecl {{.*}} bar 'void (int, int *__single __counted_by(len) _Nonnull)'
 // FBOUNDS-NEXT: ParmVarDecl {{.*}} len 'int'
 // FBOUNDS-NEXT: DependerDeclsAttr
-// FBOUNDS-NEXT: ParmVarDecl {{.*}} p 'int *__single __counted_by(len)':'int *__single'
+// FBOUNDS-NEXT: ParmVarDecl {{.*}} p 'int *__single __counted_by(len) _Nonnull':'int *__single'
 
-// FATTR_ONLY:      FunctionDecl {{.*}} bar 'void (int, int * __counted_by(len))'
+// FATTR_ONLY:      FunctionDecl {{.*}} bar 'void (int, int * __counted_by(len) _Nonnull__single)'
 // FATTR_ONLY-NEXT: ParmVarDecl {{.*}} len 'int'
 // FATTR_ONLY-NEXT: DependerDeclsAttr
-// FATTR_ONLY-NEXT: ParmVarDecl {{.*}} p 'int * __counted_by(len)':'int *'
+// FATTR_ONLY-NEXT: ParmVarDecl {{.*}} p 'int * __counted_by(len) _Nonnull__single':'int *'


### PR DESCRIPTION
Add visitors for TypedefType and ElaboratedType to fix attribute dropping in
-fexperimental-bounds-safety-attributes mode.  
Passes all regression tests in check-clang.

fixes: #13277