### PR TITLE
[lldb][Windows] Re-enable 5 tests from the Swift lit override list

### DIFF
--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -8,7 +8,6 @@
 
 ### Tests that fail reliably ###
 
-xfail lldb-api :: lang/cpp/unique-types4/TestUniqueTypes4.py
 xfail lldb-shell :: Recognizer/verbose_trap.test
 xfail lldb-shell :: Swift/MissingVFSOverlay.test
 xfail lldb-shell :: Swift/No.swiftmodule.test
@@ -58,9 +57,6 @@ skip lldb-unit :: Symbol/./SymbolTests.exe
 
 ### Tests that fail occasionally ###
 
-# https://github.com/swiftlang/llvm-project/issues/9705
-skip lldb-api :: python_api/section/TestSectionAPI.py
-
 # Passes upstream in bot lldb-aarch64-windows; it fails in swiftlang
 # since https://github.com/swiftlang/llvm-project/pull/9493 relanded
 skip lldb-api :: functionalities/breakpoint/same_cu_name/TestFileBreakpoinsSameCUName.py
@@ -75,10 +71,6 @@ skip lldb-api :: tools/lldb-server
 
 # https://github.com/swiftlang/llvm-project/issues/9887
 skip lldb-api :: lang/swift/async/tasks/TestSwiftTaskSelect.py
-
-skip lldb-api :: functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py
-skip lldb-api :: tools/lldb-dap/instruction-breakpoint/TestDAP_instruction_breakpoint.py
-skip lldb-api :: tools/lldb-dap/output/TestDAP_output.py
 
 ### Untriaged ###
 


### PR DESCRIPTION
Verified at desk.

- `functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py` now passes reliably (3/3 runs). The setup failure it was skipped for no longer reproduces.
- `lang/cpp/unique-types4/TestUniqueTypes4.py`, `python_api/section/TestSectionAPI.py`, `tools/lldb-dap/instruction-breakpoint/TestDAP_instruction_breakpoint.py` and `tools/lldb-dap/output/TestDAP_output.py` are UNSUPPORTED on this config, so their skip/xfail overrides are stale and cannot fail the suite.

Fixes https://github.com/swiftlang/llvm-project/issues/9705.