### PR TITLE
[lldb][Windows] Re-enable cxx_interop backward stepping tests

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part01.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part01.py
@@ -34,28 +34,24 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_method_step_in_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_in(thread, 'testMethod', 'SwiftClass.swiftMethod')
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_method_step_over_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_over(thread, 'testMethod')
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_init_step_in_class(self):
         thread = self.setup('Break here for constructor - class')
         self.check_step_in(thread, 'testConstructor', 'SwiftClass.init')
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_init_step_over_class(self):
         thread = self.setup('Break here for constructor - class')
         self.check_step_over(thread, 'testConstructor')

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part03.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part03.py
@@ -34,14 +34,12 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_setter_step_in_class(self):
         thread = self.setup('Break here for setter - class')
         self.check_step_in(thread, 'testSetter', 'SwiftClass.swiftProperty.setter')
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_setter_step_over_class(self):
         thread = self.setup('Break here for setter - class')
         self.check_step_over(thread, 'testSetter')
@@ -49,14 +47,12 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_overriden_step_in_class(self):
         thread = self.setup('Break here for overridden - class')
         self.check_step_in(thread, 'testOverridenMethod', 'SwiftSubclass.overrideableMethod')
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_overriden_step_over_class(self):
         thread = self.setup('Break here for overridden')
         self.check_step_over(thread, 'testOverridenMethod')

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part01.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part01.py
@@ -35,28 +35,24 @@ class TestSwiftBackwardInteropSteppingStruct(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_method_step_in_struct(self):
         thread = self.setup("Break here for method - struct")
         self.check_step_in(thread, "testMethod", "SwiftStruct.swiftMethod")
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_method_step_over_struct(self):
         thread = self.setup("Break here for method - struct")
         self.check_step_over(thread, "testMethod")
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_init_step_in_struct(self):
         thread = self.setup("Break here for constructor - struct")
         self.check_step_in(thread, "testConstructor", "SwiftStruct.init")
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_init_step_over_struct(self):
         thread = self.setup("Break here for constructor - struct")
         self.check_step_over(thread, "testConstructor")

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part03.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part03.py
@@ -35,14 +35,12 @@ class TestSwiftBackwardInteropSteppingStruct(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_setter_step_in_struct(self):
         thread = self.setup("Break here for setter - struct")
         self.check_step_in(thread, "testSetter", "SwiftStruct.swiftProperty.setter")
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_setter_step_over_struct(self):
         thread = self.setup("Break here for setter - struct")
         self.check_step_over(thread, "testSetter")


### PR DESCRIPTION
Requires:
- https://github.com/swiftlang/llvm-project/pull/13178