### PR TITLE
[lldb][Windows] Re-enable SwiftREPL BreakpointSimple and OpenClass

### DIFF
--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -15,12 +15,10 @@ xfail lldb-shell :: Swift/No.swiftmodule.test
 xfail lldb-shell :: Swift/ToolchainMismatch.test
 xfail lldb-shell :: Swift/global.test
 xfail lldb-shell :: Swift/runtime-initialization.test
-xfail lldb-shell :: SwiftREPL/BreakpointSimple.test
 xfail lldb-shell :: SwiftREPL/ClosureScope.test
 xfail lldb-shell :: SwiftREPL/ExistentialTypes.test
 xfail lldb-shell :: SwiftREPL/LookupAfterImport.test
 xfail lldb-shell :: SwiftREPL/LookupWithAttributedImport.test
-xfail lldb-shell :: SwiftREPL/OpenClass.test
 xfail lldb-shell :: SwiftREPL/OptionalUnowned.test
 xfail lldb-shell :: SwiftREPL/RedirectInputUnreadable.test
 xfail lldb-shell :: SwiftREPL/SwiftInterface.test

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFX86_64.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFX86_64.h
@@ -266,6 +266,12 @@ public:
       break;
     }
 
+    case COFF::IMAGE_REL_AMD64_SECREL: {
+      uint8_t *Displacement = (uint8_t *)ObjTarget;
+      Addend = readBytesUnaligned(Displacement, 4);
+      break;
+    }
+
     default:
       break;
     }

--- a/llvm/test/ExecutionEngine/RuntimeDyld/X86/COFF_x86_64_SECREL.s
+++ b/llvm/test/ExecutionEngine/RuntimeDyld/X86/COFF_x86_64_SECREL.s
@@ -1,0 +1,25 @@
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc -triple=x86_64-pc-win32 -filetype=obj -o %t/COFF_x86_64_SECREL.o %s
+# RUN: llvm-rtdyld -triple=x86_64-pc-win32 -verify -check=%s %t/COFF_x86_64_SECREL.o
+
+	.section	.rdata,"dr"
+sec_base:                               # section-relative offset 0
+	.zero	0x10
+target:                                 # section-relative offset 0x10
+	.long	0
+
+	.data
+	.globl	relocations
+relocations:
+
+sr_symoff:
+	.secrel32	target
+# rtdyld-check: *{4}sr_symoff = 0x10
+
+sr_addend:
+	.secrel32	sec_base+0x2a
+# rtdyld-check: *{4}sr_addend = 0x2a
+
+sr_both:
+	.secrel32	target+0x2a
+# rtdyld-check: *{4}sr_both = 0x3a


### PR DESCRIPTION
Requires:
- https://github.com/llvm/llvm-project/pull/211015