### PR TITLE
[NFC] Reinstate several `DenseMapInfo::{getEmptyKey,getTombstoneKey}` to avoid swift rebranch change

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -569,6 +569,15 @@ template <typename T> struct DenseMapInfo<ArrayRef<T>, void> {
   }
 
   static bool isEqual(ArrayRef<T> LHS, ArrayRef<T> RHS) { return LHS == RHS; }
+
+  static inline ArrayRef<T> getEmptyKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
+  static inline ArrayRef<T> getTombstoneKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -61,6 +61,15 @@ template <typename T> struct DenseMapInfo<T *> {
   }
 
   static bool isEqual(const T *LHS, const T *RHS) { return LHS == RHS; }
+
+  static inline T *getEmptyKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
+  static inline T *getTombstoneKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
 };
 
 // Provide DenseMapInfo for all integral types.
@@ -75,6 +84,15 @@ struct DenseMapInfo<T, std::enable_if_t<std::is_integral_v<T>>> {
   }
 
   static bool isEqual(const T &LHS, const T &RHS) { return LHS == RHS; }
+
+  static inline T getEmptyKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
+  static inline T getTombstoneKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
 };
 
 // Provide DenseMapInfo for all pairs whose members have info.

--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -433,6 +433,15 @@ template <typename... PTs> struct DenseMapInfo<PointerUnion<PTs...>> {
   static bool isEqual(const Union &LHS, const Union &RHS) {
     return LHS == RHS;
   }
+
+  static inline Union getEmptyKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
+  static inline Union getTombstoneKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -960,6 +960,15 @@ template <> struct DenseMapInfo<StringRef, void> {
   LLVM_ABI static unsigned getHashValue(StringRef Val);
 
   static bool isEqual(StringRef LHS, StringRef RHS) { return LHS == RHS; }
+
+  static inline StringRef getEmptyKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
+  static inline StringRef getTombstoneKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -532,6 +532,15 @@ template <> struct DenseMapInfo<AttributeSet, void> {
   }
 
   static bool isEqual(AttributeSet LHS, AttributeSet RHS) { return LHS == RHS; }
+
+  static inline AttributeSet getEmptyKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
+  static inline AttributeSet getTombstoneKey() {
+    assert(false && "Obsoleted");
+    abort();
+  }
 };
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Once rebranch is complete, we should revert this.

See:
- https://github.com/llvm/llvm-project/commit/836bf567e622a2e083a0c850b861b450fc97b915 (https://github.com/llvm/llvm-project/pull/200959).
- https://github.com/llvm/llvm-project/commit/11496fa35dfdf9a84c82d2c6181e54caf7288fce (https://github.com/llvm/llvm-project/pull/201998).