### PR TITLE
[Cherry-pick into next] [LLDB] Fix LLDB tests using URL on macOS 27

### DIFF
--- a/lldb/test/API/lang/swift/array_tuple_resilient/main.swift
+++ b/lldb/test/API/lang/swift/array_tuple_resilient/main.swift
@@ -3,15 +3,14 @@
 
 import Foundation
 
-var patatino : [(URL, Int64)] = [(URL(string: "https://github.com")!, 1001)]
-var tinky : [(URL, URL)] = [(URL(string: "https://github.com")!,
-                            URL(string: "https://github.com")!)]
+var patatino : [(Data, Int64)] = [(Data([1, 2, 3]), 1001)]
+var tinky : [(Data, Data)] = [(Data([1, 2, 3]), Data([9]))]
 print(patatino) //%self.expect('frame variable -d run -- patatino',
-                //%             substrs=['[0] = (0 = "https://github.com", 1 = 1001)'])
+                //%             substrs=['0 = 3 bytes', '1 = 1001'])
                 //%self.expect('expr -d run -- patatino',
-                //%             substrs=['[0] = (0 = "https://github.com", 1 = 1001)'])
+                //%             substrs=['0 = 3 bytes', '1 = 1001'])
 
 print(tinky)    //%self.expect('frame variable -d run -- tinky',
-                //%             substrs=['[0] = (0 = "https://github.com", 1 = "https://github.com")'])
+                //%             substrs=['0 = 3 bytes', '1 = 1 byte'])
                 //%self.expect('expr -d run -- tinky',
-                //%             substrs=['[0] = (0 = "https://github.com", 1 = "https://github.com")'])
+                //%             substrs=['0 = 3 bytes', '1 = 1 byte'])

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
@@ -23,8 +23,8 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('expression URL(string: "https://lldb.llvm.org")',
+        self.expect('expression Data([1, 2, 3])',
                     error=True)
         self.expect("expression import Foundation")
-        self.expect('expression URL(string: "https://lldb.llvm.org")',
-                    substrs=["https://lldb.llvm.org"])
+        self.expect('expression Data([1, 2, 3])',
+                    substrs=["3 bytes"])

--- a/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -32,9 +32,27 @@ class TestCase(TestBase):
 
         foundation = "Foundation" if sys.platform == "darwin" else "FoundationEssentials"
 
-        lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.swift")
+        # Foundation's URL stores its NSURL in a Synchronization.Mutex
+        # whose reflection metadata is missing if the stdlib is
+        # compiled with a deployment target < macOS 27.0, which is the
+        # case when building locally. Debug against the system
+        # Foundation / Swift stdlib (whose deployment target matches
+        # the OS) by dropping the library-path variables the test
+        # harness injects into the inferior environment (via
+        # --inferior-env) before launching.
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+        for var in [
+            "DYLD_LIBRARY_PATH",
+            "LD_LIBRARY_PATH",
+            "SIMCTL_CHILD_DYLD_LIBRARY_PATH",
+        ]:
+            self.runCmd(f"settings remove target.env-vars {var}", check=False)
+        bkpt = target.BreakpointCreateBySourceRegex(
+            "break here", lldb.SBFileSpec("main.swift")
         )
+        self.assertGreater(bkpt.GetNumLocations(), 0)
+        lldbutil.run_to_breakpoint_do_run(self, target, bkpt)
 
         self.expect(
             "frame var url",

--- a/lldb/test/Shell/SwiftREPL/ResilientArray.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientArray.test
@@ -3,10 +3,14 @@
 
 // RUN: %lldb --repl < %s | FileCheck %s
 
+// This exercises the Array data formatter with a *resilient* (non-@frozen)
+// Foundation value element type, whose layout is only known at runtime. Data
+// is used as a representative resilient Foundation value type.
+
 import Foundation
 
-let x : [URL] = [URL(string: "https://github.com")!, URL(string: "https://apple.com")!]
-// CHECK: {{x}}: [Foundation.URL] = 2 values {
-// CHECK-NEXT:  [0] = "https://github.com"
-// CHECK-NEXT:  [1] = "https://apple.com"
+let x : [Data] = [Data([1, 2, 3]), Data([9])]
+// CHECK: {{x}}: [Foundation.Data] = 2 values {
+// CHECK-NEXT:  [0] = 3 bytes
+// CHECK-NEXT:  [1] = 1 byte
 // CHECK-NEXT: }

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -5,19 +5,23 @@
 
 // The dictionary order isn't deterministic, so print the dictionary
 // once per element.
+//
+// This exercises the Dictionary data formatter with a *resilient*
+// (non-@frozen) Foundation value key type. Data is used as a representative
+// resilient Foundation value type.
 
 import Foundation
 
-let x : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
-// DICT-LABEL: {{x}}: [Foundation.URL : Int] = 2 key/value pairs {
+let x : [Data:Int] = [Data([1, 2, 3]): 40, Data([9]): 230]
+// DICT-LABEL: {{x}}: [Foundation.Data : Int] = 2 key/value pairs {
 // DICT:      [{{[0-1]}}] = {
-// DICT:         key = "https://apple.com"
-// DICT-NEXT:    value = 23
+// DICT:         key = 3 bytes
+// DICT-NEXT:    value = 40
 // DICT-NEXT:  }
 
-let y : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
-// DICT-LABEL: {{y}}: [Foundation.URL : Int] = 2 key/value pairs {
+let y : [Data:Int] = [Data([1, 2, 3]): 40, Data([9]): 230]
+// DICT-LABEL: {{y}}: [Foundation.Data : Int] = 2 key/value pairs {
 // DICT:       [{{[0-1]}}] = {
-// DICT:          key = "https://github.com"
-// DICT-NEXT:     value = 4
+// DICT:          key = 1 byte
+// DICT-NEXT:     value = 230
 // DICT-NEXT:  }


### PR DESCRIPTION
```
commit be56906a4e1298091b5c3a03c6bad4750308abb0
Author: Adrian Prantl <aprantl@apple.com>
Date:   Sat Jul 18 17:50:02 2026 -0700

    [LLDB] Fix LLDB tests using URL on macOS 27
    
    In macOS 27 Foundation.URL stores its NSURL in a Synchronization.Mutex
    whose reflection metadata is missing if the stdlib is compiled with a
    deployment target < macOS 27.0, which is the case when building
    locally. We fix this in the URL test by debugging against the system
    Foundation / Swift stdlib (whose deployment target matches the
    OS). Other tests that use a URL as a standin for a resilient
    Foundation value type have been changed to use other Foundation types,
    such as UUID.
```
