### PR TITLE
[lldb] Make OperatingSystemSwift return null StopReason for non-backed threads

### DIFF
--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -264,9 +264,4 @@ RegisterContextSP OperatingSystemSwiftTasks::CreateRegisterContextForThread(
   return thread->GetRegisterContext();
 }
 
-StopInfoSP OperatingSystemSwiftTasks::CreateThreadStopReason(
-    lldb_private::Thread *thread) {
-  return thread->GetStopInfo();
-}
-
 #endif // #if LLDB_ENABLE_SWIFT

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -42,7 +42,9 @@ public:
   CreateRegisterContextForThread(Thread *thread,
                                  lldb::addr_t reg_data_addr) override;
 
-  lldb::StopInfoSP CreateThreadStopReason(Thread *thread) override;
+  lldb::StopInfoSP CreateThreadStopReason(Thread *thread) override {
+    return nullptr;
+  }
 
   bool DoesPluginReportAllThreads() override { return false; }
 


### PR DESCRIPTION

    The CreateStopReason method for OS plugins is meant to create, if
    possible, a stop reason for MemoryThreads without a backing thread. As
    such, the current implementation is just wrong: it loops indefinitely.

rdar://181763783