### PR TITLE
[Cherry-pick into next] [LLDB] Skip prebuilt cache check on toolchains that do not have one

### DIFF
--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part03.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part03.py
@@ -165,6 +165,9 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
         # Check the host toolchain has a prebuilt cache in the same subdirectory of its swift resource directory
         prebuilt_path = os.path.join(self.get_toolchain(), 'usr', 'lib', 'swift', expected_suffix)
+        # Not every toolchain ships a prebuilt module cache.
+        if not os.path.isdir(prebuilt_path):
+            self.skipTest('toolchain does not ship a prebuilt module cache')
         self.assertTrue(len(os.listdir(prebuilt_path)) > 0)
 
 OLD_TIMESTAMP = 1390550700 # 2014-01-24T08:05:00+00:00


### PR DESCRIPTION
```
commit 4acc00a7aadef6372a7ac0a6e23f66281b748eb2
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Jul 20 16:28:44 2026 -0700

    [LLDB] Skip prebuilt cache check on toolchains that do not have one
```
