### PR TITLE
[lldb][Windows] Enable RedirectInputUnreadable.test

### DIFF
--- a/lldb/test/Shell/SwiftREPL/RedirectInputUnreadablePOSIX.test
+++ b/lldb/test/Shell/SwiftREPL/RedirectInputUnreadablePOSIX.test
@@ -1,5 +1,7 @@
 // Test that input can't be redirected from unreadable A.swift
+// See RedirectInputUnreadableWindows.test for the Windows version
 // REQUIRES: swift
+// UNSUPPORTED: system-windows
 
 // RUN: mkdir -p %t
 // RUN: cp %S/Inputs/A.swift %t/A.swift

--- a/lldb/test/Shell/SwiftREPL/RedirectInputUnreadableWindows.test
+++ b/lldb/test/Shell/SwiftREPL/RedirectInputUnreadableWindows.test
@@ -1,0 +1,17 @@
+// Test that input can't be redirected from unreadable A.swift
+// See RedirectInputUnreadablePOSIX.test for the POSIX version
+// REQUIRES: swift
+// REQUIRES: system-windows
+
+// RUN: mkdir -p %t
+// RUN: cp %S/Inputs/A.swift %t/A.swift
+// icalcs is Windows' CLI to modify file permissions.
+// RUN: icacls %t/A.swift /deny "*S-1-1-0:(R)"
+// RUN: cd %t
+// RUN: %lldb --repl < %s 2>&1 | FileCheck %s --check-prefix=LLDB
+
+< A.swift
+// LLDB: could not create buffer for file at path 'A.swift'
+
+// RUN: icacls %t/A.swift /reset
+// RUN: rm -f %t/A.swift

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -17,7 +17,6 @@ xfail lldb-shell :: Swift/runtime-initialization.test
 xfail lldb-shell :: SwiftREPL/ClosureScope.test
 xfail lldb-shell :: SwiftREPL/ExistentialTypes.test
 xfail lldb-shell :: SwiftREPL/OptionalUnowned.test
-xfail lldb-shell :: SwiftREPL/RedirectInputUnreadable.test
 
 ### Tests that pass locally, but fail in CI reliably ###
 
@@ -25,7 +24,6 @@ xfail lldb-shell :: SwiftREPL/RedirectInputUnreadable.test
 xfail lldb-shell :: SwiftREPL/ErrorReturn.test
 xfail lldb-shell :: SwiftREPL/Optional.test
 xfail lldb-shell :: SwiftREPL/RecursiveClass.test
-xfail lldb-shell :: SwiftREPL/Regex.test
 xfail lldb-shell :: SwiftREPL/SimpleExpressions.test
 xfail lldb-shell :: SwiftREPL/enum-singlecase.test
 


### PR DESCRIPTION
`RedirectInputUnreadable.test` was relying on chmod which is POSIX only: use the Windows equivalent

`Regex.test` is gated on rdar://168153424, remove it from the overrides list.