### PR TITLE
[6.4] wasm-ld: Preserve segment linking flags in --relocatable output

### DIFF
--- a/lld/test/wasm/relocatable-segment-flags.s
+++ b/lld/test/wasm/relocatable-segment-flags.s
@@ -1,0 +1,39 @@
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj --triple=wasm32-unknown-unknown -o %t/main.o %t/main.s
+# RUN: llvm-mc -filetype=obj --triple=wasm32-unknown-unknown -o %t/extra.o %t/extra.s
+# RUN: wasm-ld --relocatable -o %t/reloc.o %t/main.o %t/extra.o
+# RUN: obj2yaml %t/reloc.o | FileCheck %s
+
+# --relocatable must preserve per-segment linking flags (RETAIN, STRINGS). The plain
+# "retained" chunk in extra.s coalesces with the retained one in main.o, so RETAIN must
+# survive the flag union rather than be overwritten by the flag-less chunk.
+
+#--- main.s
+  .globl  _start
+_start:
+  .functype _start () -> ()
+  end_function
+
+  .section retained,"R",@
+  .asciz  "keep"
+
+  .section .rodata.str,"S",@
+  .asciz  "merge"
+
+  .section plain,"",@
+  .asciz  "drop"
+
+#--- extra.s
+  .section retained,"",@
+  .asciz  "more"
+
+# CHECK:      SegmentInfo:
+# CHECK:          Name:            .rodata.str
+# CHECK-NEXT:     Alignment:       0
+# CHECK-NEXT:     Flags:           [ STRINGS ]
+# CHECK:          Name:            retained
+# CHECK-NEXT:     Alignment:       0
+# CHECK-NEXT:     Flags:           [ RETAIN ]
+# CHECK:          Name:            plain
+# CHECK-NEXT:     Alignment:       0
+# CHECK-NEXT:     Flags:           [ ]

--- a/lld/wasm/OutputSegment.cpp
+++ b/lld/wasm/OutputSegment.cpp
@@ -19,6 +19,10 @@ namespace lld::wasm {
 
 void OutputSegment::addInputSegment(InputChunk *inSeg) {
   alignment = std::max(alignment, inSeg->alignment);
+  // Carry input flags (RETAIN, STRINGS) into the relocatable SegmentInfo
+  // output; otherwise a relocatable link drops them and the downstream link
+  // loses RETAIN (segment GC'd) and STRINGS (string merge disabled).
+  linkingFlags |= inSeg->flags;
   inputSegments.push_back(inSeg);
   size = llvm::alignTo(size, 1ULL << inSeg->alignment);
   LLVM_DEBUG(dbgs() << "addInputSegment: " << inSeg->name << " oname=" << name


### PR DESCRIPTION
Cherry-pick of #13431, merged upstream as https://github.com/llvm/llvm-project/pull/210747 

**Explanation**: `OutputSegment::addInputSegment` copied each input chunk's alignment but never its flags, so a relocatable link serialized `flags=0` for every data segment and dropped `RETAIN` and `STRINGS`. Losing `RETAIN` let the final default `--gc-sections` link discard runtime-registered sections such as Swift's `swift5_*` metadata, corrupting the program. This unions each input segment's flags into the output segment's `linkingFlags` and adds a `lld/test/wasm` test covering `RETAIN`, `STRINGS`, and flag accumulation across coalesced segments.
**Scope**: Isolated to `wasm-ld`. One line in `wasm-ld`'s `--relocatable` path, no effect for non-Wasm `lld` codepaths.
**Risk**:  Low due to isolated scope.
**Testing**: New lit test `lld/test/wasm/relocatable-segment-flags.s`.
**Issue**: Resolves https://github.com/swiftlang/swift-package-manager/issues/10314, rdar://182650701
**Reviewed by**: @kateinoigakukun and upstream `wasm-ld` maintainers.
