### PR TITLE
[lldb] Change type in TestSwiftExplicitModules_part02 from URL to UUID

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
@@ -23,8 +23,6 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('expression URL(string: "https://lldb.llvm.org")',
-                    error=True)
+        self.expect('expression UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")', error=True)
         self.expect("expression import Foundation")
-        self.expect('expression URL(string: "https://lldb.llvm.org")',
-                    substrs=["https://lldb.llvm.org"])
+        self.expect('expression UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")',substrs=["E621E1F8-C36C-495A-93FC-0C247A3E6E5F"])


### PR DESCRIPTION
In TestSwiftExplicitModules_part02, URL is used as a convenient type to test that expression evaluation works after importing Foundation. URL uses a Mutex, whose reflection metadata is missing if the stdlib is compiled with a deployment target < macOS 27.0, which is the case when building locally.

Since the type doesn't really matter, replace it with UUID.