### PR TITLE
🍒 [stable/23.x][clang][APINotes] Remove redundant ProcessAPINotes calls for C++ members

### DIFF
--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -83,7 +83,6 @@ NamedDecl *Parser::ParseCXXInlineMethodDef(
                                            VS, ICIS_NoInit);
     if (FnD) {
       Actions.ProcessDeclAttributeList(getCurScope(), FnD, AccessAttrs);
-      Actions.ProcessAPINotes(FnD);
       if (PureSpecLoc.isValid())
         Actions.ActOnPureSpecifier(FnD, PureSpecLoc);
     }

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -3130,10 +3130,8 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclaration(
         // initialize it.
         ThisDecl = VT->getTemplatedDecl();
 
-      if (ThisDecl) {
+      if (ThisDecl)
         Actions.ProcessDeclAttributeList(getCurScope(), ThisDecl, AccessAttrs);
-        Actions.ProcessAPINotes(ThisDecl);
-      }
     }
 
     // Error recovery might have converted a non-static member into a static

--- a/clang/test/APINotes/boundssafety.cpp
+++ b/clang/test/APINotes/boundssafety.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s --check-prefixes=CHECK,CHECK-MEMBER
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf -DFREE_FUNCTIONS | FileCheck %s
 
 #ifdef FREE_FUNCTIONS
@@ -38,8 +38,6 @@
 
 // CHECK: asdf_counted_noescape 'void (int * __counted_by(len), int)'
 // CHECK: buf 'int * __counted_by(len)':'int *'
-// CHECK-MEMBER-NEXT: | |-SwiftVersionedAdditionAttr {{.*}} Implicit 0 IsReplacedByActive
-// CHECK-MEMBER-NEXT: | | `-NoEscapeAttr
 // CHECK-NEXT: | `-NoEscapeAttr
 
 // CHECK: asdf_counted_default_level 'void (int * __counted_by(len), int)'

--- a/clang/test/APINotes/lifetimebound.cpp
+++ b/clang/test/APINotes/lifetimebound.cpp
@@ -11,8 +11,6 @@
 
 // CHECK-METHOD: CXXMethodDecl {{.+}} methodToAnnotate 
 // CHECK-METHOD-NEXT: ParmVarDecl {{.+}} p
-// CHECK-METHOD-NEXT: SwiftVersionedAdditionAttr
-// CHECK-METHOD-NEXT: LifetimeBoundAttr
 // CHECK-METHOD-NEXT: LifetimeBoundAttr
 
 // CHECK-METHOD-THIS: CXXMethodDecl {{.+}} annotateThis 'int *() {{\[\[}}clang::lifetimebound{{\]\]}}'

--- a/clang/test/APINotes/where-parameters-sema.cpp
+++ b/clang/test/APINotes/where-parameters-sema.cpp
@@ -79,17 +79,11 @@
 
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void (int)'
 // CHECK-METHOD-OVERLOADS-NEXT: ParmVarDecl {{.+}} 'int'
-// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
-// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setIntValue(_:)"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setIntValue(_:)"
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void (double)'
 // CHECK-METHOD-OVERLOADS-NEXT: ParmVarDecl {{.+}} 'double'
-// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
-// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setDoubleValue(_:)"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setDoubleValue(_:)"
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void ()'
-// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
-// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "currentValue()"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "currentValue()"
 
 // CHECK-METHOD-BROAD: CXXMethodDecl {{.+}} broad 'void (int)'
@@ -136,11 +130,7 @@
 
 // CHECK-METHOD-OPERATOR: CXXMethodDecl {{.+}} operator+ 'SelectorWidget (int)'
 // CHECK-METHOD-OPERATOR-NEXT: ParmVarDecl {{.+}} 'int'
-// CHECK-METHOD-OPERATOR-NEXT: SwiftVersionedAdditionAttr
-// CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusInt(_:)"
 // CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusInt(_:)"
 // CHECK-METHOD-OPERATOR: CXXMethodDecl {{.+}} operator+ 'SelectorWidget (double)'
 // CHECK-METHOD-OPERATOR-NEXT: ParmVarDecl {{.+}} 'double'
-// CHECK-METHOD-OPERATOR-NEXT: SwiftVersionedAdditionAttr
-// CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusDouble(_:)"
 // CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusDouble(_:)"

--- a/clang/test/APINotes/where-parameters-sema.cpp
+++ b/clang/test/APINotes/where-parameters-sema.cpp
@@ -79,11 +79,17 @@
 
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void (int)'
 // CHECK-METHOD-OVERLOADS-NEXT: ParmVarDecl {{.+}} 'int'
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setIntValue(_:)"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setIntValue(_:)"
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void (double)'
 // CHECK-METHOD-OVERLOADS-NEXT: ParmVarDecl {{.+}} 'double'
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setDoubleValue(_:)"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "setDoubleValue(_:)"
 // CHECK-METHOD-OVERLOADS: CXXMethodDecl {{.+}} setValue 'void ()'
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "currentValue()"
 // CHECK-METHOD-OVERLOADS-NEXT: SwiftNameAttr {{.+}} "currentValue()"
 
 // CHECK-METHOD-BROAD: CXXMethodDecl {{.+}} broad 'void (int)'
@@ -130,7 +136,11 @@
 
 // CHECK-METHOD-OPERATOR: CXXMethodDecl {{.+}} operator+ 'SelectorWidget (int)'
 // CHECK-METHOD-OPERATOR-NEXT: ParmVarDecl {{.+}} 'int'
+// CHECK-METHOD-OPERATOR-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusInt(_:)"
 // CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusInt(_:)"
 // CHECK-METHOD-OPERATOR: CXXMethodDecl {{.+}} operator+ 'SelectorWidget (double)'
 // CHECK-METHOD-OPERATOR-NEXT: ParmVarDecl {{.+}} 'double'
+// CHECK-METHOD-OPERATOR-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusDouble(_:)"
 // CHECK-METHOD-OPERATOR-NEXT: SwiftNameAttr {{.+}} "plusDouble(_:)"


### PR DESCRIPTION
C++ member declarators were processed by ProcessAPINotes() twice: once via ProcessDeclAttributes() and again via explicit parser calls in ParseCXXClassMemberDeclarationWithPragmas / ParseCXXInlineMethodDef. The explicit calls are redundant and absent upstream, and they duplicated API-note attributes into a SwiftVersionedAdditionAttr + copy.

rdar://182117526
(cherry picked from commit f27d32ca26b2c51edddb5de5e50258f8bba8cf9b / https://github.com/swiftlang/llvm-project/pull/13407)