### PR TITLE
[LLDB] Plumb isSourceCanInput through canImportModule in LLDB

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
@@ -109,16 +109,19 @@ std::error_code LLDBExplicitSwiftModuleLoader::findModuleFilesInDirectory(
 }
 bool LLDBExplicitSwiftModuleLoader::canImportModule(
     swift::ImportPath::Module named, swift::SourceLoc loc,
-    ModuleVersionInfo *versionInfo, bool isTestableImport) {
+    ModuleVersionInfo *versionInfo, bool isTestableImport,
+    bool isSourceCanImport) {
   if (!enabled())
     return false;
 
   if (m_casml &&
       llvm::cast<swift::SerializedModuleLoaderBase>(m_casml.get())
-          ->canImportModule(named, loc, versionInfo, isTestableImport))
+          ->canImportModule(named, loc, versionInfo, isTestableImport,
+                            isSourceCanImport))
     return true;
   return llvm::cast<swift::SerializedModuleLoaderBase>(m_esml.get())
-      ->canImportModule(named, loc, versionInfo, isTestableImport);
+      ->canImportModule(named, loc, versionInfo, isTestableImport,
+                        isSourceCanImport);
 }
 
 swift::ModuleDecl *

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h
@@ -63,7 +63,8 @@ public:
 
   bool canImportModule(swift::ImportPath::Module named, swift::SourceLoc loc,
                        ModuleVersionInfo *versionInfo,
-                       bool isTestableImport = false) override;
+                       bool isTestableImport,
+                       bool isSourceCanImport) override;
 
   swift::ModuleDecl *loadModule(swift::SourceLoc importLoc,
                                 swift::ImportPath::Module path,

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.cpp
@@ -83,7 +83,8 @@ bool LLDBImplicitSwiftModuleLoader::findModule(
     std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
     std::string *CacheKey, bool isCanImportLookup,
-    bool isTestableDependencyLookup, bool &isFramework, bool &isSystemModule) {
+    bool isTestableDependencyLookup, bool &isFramework, bool &isSystemModule,
+    bool isSourceCanImport) {
   assert(false && "pass-through not implemented");
   // This is a protected member and probably also not useful.
   return false;
@@ -103,10 +104,12 @@ std::error_code LLDBImplicitSwiftModuleLoader::findModuleFilesInDirectory(
 }
 bool LLDBImplicitSwiftModuleLoader::canImportModule(
     swift::ImportPath::Module named, swift::SourceLoc loc,
-    ModuleVersionInfo *versionInfo, bool isTestableImport) {
+    ModuleVersionInfo *versionInfo, bool isTestableImport,
+    bool isSourceCanImport) {
   if (enabled() || isSDKOverlay(named))
     return llvm::cast<swift::SerializedModuleLoaderBase>(m_isml.get())
-        ->canImportModule(named, loc, versionInfo, isTestableImport);
+        ->canImportModule(named, loc, versionInfo, isTestableImport,
+                          isSourceCanImport);
   return false;
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.h
@@ -45,7 +45,7 @@ public:
                   std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
                   std::string *CacheKey, bool isCanImportLookup,
                   bool isTestableDependencyLookup, bool &isFramework,
-                  bool &isSystemModule) override;
+                  bool &isSystemModule, bool isSourceCanImport) override;
   std::error_code findModuleFilesInDirectory(
       swift::ImportPath::Element ModuleID,
       const swift::SerializedModuleBaseName &BaseName,
@@ -60,7 +60,8 @@ public:
   bool isSDKOverlay(swift::ImportPath::Module named) const;
   bool canImportModule(swift::ImportPath::Module named, swift::SourceLoc loc,
                        ModuleVersionInfo *versionInfo,
-                       bool isTestableImport = false) override;
+                       bool isTestableImport,
+                       bool isSourceCanImport) override;
 
   swift::ModuleDecl *loadModule(swift::SourceLoc importLoc,
                                 swift::ImportPath::Module path,


### PR DESCRIPTION
Paired with 7380bf039af80eb5d5f93e13e84c6f0700eecd9a (https://github.com/swiftlang/swift/pull/90109) in swift to plumb this 'no side effects please' variable through import checking, needed to update these virtual methods

Resolves rdar://175566663