### PR TITLE
[clang] Regenerate BoundsSafety -O2 CodeGen checks after InstCombine …

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/dynamic-range-init-list-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/dynamic-range-init-list-O2.c
@@ -23,9 +23,9 @@ void TestOK(void) {
 }
 
 // CHECK-LABEL: define dso_local void @TestRangeFail1(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR3:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR2:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR5:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3:[0-9]+]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail1(void) {
@@ -34,9 +34,9 @@ void TestRangeFail1(void) {
 }
 
 // CHECK-LABEL: define dso_local void @TestRangeFail2(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR3]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail2(void) {
@@ -45,9 +45,9 @@ void TestRangeFail2(void) {
 }
 
 // CHECK-LABEL: define dso_local void @TestStartFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR3]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestStartFail(void) {
@@ -56,22 +56,10 @@ void TestStartFail(void) {
 }
 
 // CHECK-LABEL: define dso_local void @TestIterFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6:[0-9]+]]
-// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
-// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[ARR]], i64 44
-// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[CMP34_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP34_NOT]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT86:.*]], {{!annotation ![0-9]+}}
-// CHECK:       [[TRAP]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
-// CHECK:       [[CONT86]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
-// CHECK-NEXT:    ret void
 //
 void TestIterFail(void) {
   int arr[10];
@@ -79,22 +67,10 @@ void TestIterFail(void) {
 }
 
 // CHECK-LABEL: define dso_local void @TestEndFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
-// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[ARR]], i64 44
-// CHECK-NEXT:    [[UPPER3:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
-// CHECK-NEXT:    [[CMP28_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER3]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[CMP43_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP28_NOT]], [[CMP43_NOT]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT55:.*]], {{!annotation ![0-9]+}}
-// CHECK:       [[TRAP]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
-// CHECK:       [[CONT55]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
-// CHECK-NEXT:    ret void
 //
 void TestEndFail(void) {
   int arr[10];

--- a/clang/test/BoundsSafety/CodeGen/dynamic-range-init-list-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/dynamic-range-init-list-O2.c
@@ -12,8 +12,23 @@ struct RangePtrs {
   void *end;
 };
 
+__attribute__((noinline))
+__attribute__((optnone))
+__attribute__((pure))
+// CHECK-LABEL: define dso_local i32 @opaque(
+// CHECK-SAME: i32 noundef [[X:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[X_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32 [[X]], ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    ret i32 [[TMP0]]
+//
+int opaque(int x) {
+  return x;
+}
+
 // CHECK-LABEL: define dso_local void @TestOK(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret void
 //
@@ -22,10 +37,35 @@ void TestOK(void) {
   struct RangePtrs rptrs = { arr, arr, arr + 10 };
 }
 
-// CHECK-LABEL: define dso_local void @TestRangeFail1(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR2:[0-9]+]] {
+// CHECK-LABEL: define dso_local void @TestOKOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6:[0-9]+]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR7:[0-9]+]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[UPPER3:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CMP28_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP43_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP28_NOT]], [[CMP43_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT55:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR8:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT55]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    ret void
+//
+void TestOKOpaque(void) {
+  int arr[10];
+  struct RangePtrs rptrs = { arr, arr, arr + opaque(10) };
+}
+
+// CHECK-LABEL: define dso_local void @TestRangeFail1(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail1(void) {
@@ -33,10 +73,47 @@ void TestRangeFail1(void) {
   struct RangePtrs rptrs = { arr + 2, arr + 1, arr + 10 };
 }
 
-// CHECK-LABEL: define dso_local void @TestRangeFail2(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR2]] {
+// CHECK-LABEL: define dso_local void @TestRangeFail1Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 2) #[[ATTR7]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CALL3:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR7]]
+// CHECK-NEXT:    [[IDXPROM7:%.*]] = sext i32 [[CALL3]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH8:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM7]]
+// CHECK-NEXT:    [[CALL10:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR7]]
+// CHECK-NEXT:    [[IDXPROM14:%.*]] = sext i32 [[CALL10]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH15:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM14]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH8]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP40_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[BOUND_PTR_ARITH8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP51_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[CMP51_NOT]], [[CMP40_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND115:%.*]] = select i1 [[CMP_NOT]], i1 true, i1 [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP62_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH15]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP78_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH8]], [[BOUND_PTR_ARITH15]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP1:%.*]] = or i1 [[CMP62_NOT]], [[CMP78_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND117:%.*]] = select i1 [[OR_COND115]], i1 true, i1 [[TMP1]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND117]], label %[[TRAP:.*]], label %[[CONT92:.*]], !prof [[PROF8:![0-9]+]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT92]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    ret void
+//
+void TestRangeFail1Opaque(void) {
+  int arr[10];
+  struct RangePtrs rptrs = { arr + opaque(2), arr + opaque(1), arr + opaque(10) };
+}
+
+// CHECK-LABEL: define dso_local void @TestRangeFail2(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail2(void) {
@@ -44,10 +121,42 @@ void TestRangeFail2(void) {
   struct RangePtrs rptrs = { arr, arr + 2, arr + 1 };
 }
 
-// CHECK-LABEL: define dso_local void @TestStartFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR2]] {
+// CHECK-LABEL: define dso_local void @TestRangeFail2Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 2) #[[ATTR7]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CALL6:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR7]]
+// CHECK-NEXT:    [[IDXPROM10:%.*]] = sext i32 [[CALL6]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH11:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM10]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP36_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP36_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP58_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH11]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP74_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[BOUND_PTR_ARITH11]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[CMP58_NOT]], [[CMP74_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND112:%.*]] = select i1 [[OR_COND]], i1 true, i1 [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND112]], label %[[TRAP:.*]], label %[[CONT88:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT88]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    ret void
+//
+void TestRangeFail2Opaque(void) {
+  int arr[10];
+  struct RangePtrs rptrs = { arr, arr + opaque(2), arr + opaque(1) };
+}
+
+// CHECK-LABEL: define dso_local void @TestStartFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestStartFail(void) {
@@ -55,10 +164,38 @@ void TestStartFail(void) {
   struct RangePtrs rptrs = { arr - 1, arr, arr + 10 };
 }
 
-// CHECK-LABEL: define dso_local void @TestIterFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR2]] {
+// CHECK-LABEL: define dso_local void @TestStartFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR7]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL6:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR7]]
+// CHECK-NEXT:    [[IDXPROM10:%.*]] = sext i32 [[CALL6]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH11:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM10]]
+// CHECK-NEXT:    [[OR_COND:%.*]] = icmp ne i32 [[CALL]], 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP58_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH11]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP74_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH11]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[CMP58_NOT]], [[CMP74_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND112:%.*]] = select i1 [[OR_COND]], i1 true, i1 [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND112]], label %[[TRAP:.*]], label %[[CONT88:.*]], !prof [[PROF9:![0-9]+]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT88]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    ret void
+//
+void TestStartFailOpaque(void) {
+  int arr[10];
+  struct RangePtrs rptrs = { arr - opaque(1), arr, arr + opaque(10) };
+}
+
+// CHECK-LABEL: define dso_local void @TestIterFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestIterFail(void) {
@@ -66,13 +203,67 @@ void TestIterFail(void) {
   struct RangePtrs rptrs = { arr, arr + 11, arr + 11 };
 }
 
-// CHECK-LABEL: define dso_local void @TestEndFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR2]] {
+// CHECK-LABEL: define dso_local void @TestIterFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 11) #[[ATTR7]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP36_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP36_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT88:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT88]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    ret void
+//
+void TestIterFailOpaque(void) {
+  int arr[10];
+  struct RangePtrs rptrs = { arr, arr + opaque(11), arr + opaque(11) };
+}
+
+// CHECK-LABEL: define dso_local void @TestEndFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestEndFail(void) {
   int arr[10];
   struct RangePtrs rptrs = { arr, arr, arr + 11 };
 }
+
+// CHECK-LABEL: define dso_local void @TestEndFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 11) #[[ATTR7]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[UPPER3:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CMP28_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP43_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP28_NOT]], [[CMP43_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT55:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT55]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    ret void
+//
+void TestEndFailOpaque(void) {
+  int arr[10];
+  struct RangePtrs rptrs = { arr, arr, arr + opaque(11) };
+}
+//.
+// CHECK: [[PROF8]] = !{!"branch_weights", i32 -536869889, i32 536869888}
+// CHECK: [[PROF9]] = !{!"branch_weights", i32 7340033, i32 1048575}
+//.

--- a/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks-O2.c
@@ -9,8 +9,23 @@ struct S {
     int *end;
 };
 
+__attribute__((noinline))
+__attribute__((optnone))
+__attribute__((pure))
+// CHECK-LABEL: define dso_local i32 @opaque(
+// CHECK-SAME: i32 noundef [[X:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[X_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32 [[X]], ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    ret i32 [[TMP0]]
+//
+int opaque(int x) {
+  return x;
+}
+
 // CHECK-LABEL: define dso_local noundef i32 @TestOK(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret i32 0
 //
@@ -22,11 +37,39 @@ int TestOK() {
   return 0;
 }
 
-// CHECK-LABEL: define dso_local noundef i32 @TestStartFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR3:[0-9]+]] {
+// CHECK-LABEL: define dso_local noundef i32 @TestOKOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR5:[0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR7:[0-9]+]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR8:[0-9]+]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP22_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP22_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR9:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
+// CHECK-NEXT:    ret i32 0
+//
+int TestOKOpaque() {
+  int arr[10];
+  struct S s;
+  s.start = arr;
+  s.end = arr + opaque(10);
+  return 0;
+}
+
+// CHECK-LABEL: define dso_local noundef i32 @TestStartFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
 // CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[ARR]], i64 -4
 // CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
 // CHECK-NEXT:    [[CMP24_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
@@ -34,10 +77,10 @@ int TestOK() {
 // CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP24_NOT]], [[CMP35_NOT]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[TRAP]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR6:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR5]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
 // CHECK-NEXT:    ret i32 0
 //
 int TestStartFail() {
@@ -48,10 +91,44 @@ int TestStartFail() {
     return 0;
 }
 
-// CHECK-LABEL: define dso_local noundef i32 @TestEndFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-LABEL: define dso_local noundef i32 @TestStartFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR8]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[IDX_NEG:%.*]] = sub nsw i64 0, [[IDXPROM]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDX_NEG]]
+// CHECK-NEXT:    [[CALL2:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR8]]
+// CHECK-NEXT:    [[IDXPROM6:%.*]] = sext i32 [[CALL2]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH7:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM6]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH7]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP26_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[BOUND_PTR_ARITH7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP37_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[CMP37_NOT]], [[CMP26_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND54:%.*]] = select i1 [[CMP_NOT]], i1 true, i1 [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND54]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
+// CHECK-NEXT:    ret i32 0
+//
+int TestStartFailOpaque() {
+    int arr[10];
+    struct S s;
+    s.start = arr - opaque(1);
+    s.end = arr + opaque(10);
+    return 0;
+}
+
+// CHECK-LABEL: define dso_local noundef i32 @TestEndFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR6:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 int TestEndFail() {
@@ -62,16 +139,64 @@ int TestEndFail() {
   return 0;
 }
 
-// CHECK-LABEL: define dso_local noundef i32 @TestRangeFail(
+// CHECK-LABEL: define dso_local noundef i32 @TestEndFailOpaque(
 // CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 11) #[[ATTR8]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP22_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP22_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
+// CHECK-NEXT:    ret i32 0
+//
+int TestEndFailOpaque() {
+  int arr[10];
+  struct S s;
+  s.start = arr;
+  s.end = arr + opaque(11);
+  return 0;
+}
+
+// CHECK-LABEL: define dso_local noundef i32 @TestRangeFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR6]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 int TestRangeFail() {
   int arr[10];
   struct S s;
   s.start = arr + 1;
+  s.end = arr;
+  return 0;
+}
+
+// CHECK-LABEL: define dso_local noundef i32 @TestRangeFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR8]]
+// CHECK-NEXT:    [[OR_COND_NOT:%.*]] = icmp eq i32 [[CALL]], 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND_NOT]], label %[[CONT:.*]], label %[[TRAP:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT]]:
+// CHECK-NEXT:    ret i32 0
+//
+int TestRangeFailOpaque() {
+  int arr[10];
+  struct S s;
+  s.start = arr + opaque(1);
   s.end = arr;
   return 0;
 }

--- a/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks-O2.c
@@ -49,22 +49,10 @@ int TestStartFail() {
 }
 
 // CHECK-LABEL: define dso_local noundef i32 @TestEndFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR3]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR5]]
-// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
-// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[ARR]], i64 44
-// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[CMP22_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP22_NOT]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!annotation ![0-9]+}}
-// CHECK:       [[TRAP]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
-// CHECK:       [[CONT]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR5]]
-// CHECK-NEXT:    ret i32 0
 //
 int TestEndFail() {
   int arr[10];
@@ -75,7 +63,7 @@ int TestEndFail() {
 }
 
 // CHECK-LABEL: define dso_local noundef i32 @TestRangeFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}

--- a/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks_parms-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks_parms-O2.c
@@ -4,6 +4,21 @@
 
 #include <ptrcheck.h>
 
+__attribute__((noinline))
+__attribute__((optnone))
+__attribute__((pure))
+// CHECK-LABEL: define dso_local i32 @opaque(
+// CHECK-SAME: i32 noundef [[X:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[X_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32 [[X]], ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    ret i32 [[TMP0]]
+//
+int opaque(int x) {
+  return x;
+}
+
 static inline void TestOKImpl(int *__ended_by(*out_end) *out_start,
                               int **out_end) {
   int arr[10];
@@ -12,7 +27,7 @@ static inline void TestOKImpl(int *__ended_by(*out_end) *out_start,
 }
 
 // CHECK-LABEL: define dso_local void @TestOK(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret void
 //
@@ -20,6 +35,39 @@ void TestOK() {
   int *end;
   int *__ended_by(end) start;
   TestOKImpl(&start, &end);
+}
+
+static inline void TestOKOpaqueImpl(int *__ended_by(*out_end) *out_start,
+                                    int **out_end) {
+  int arr[10];
+  *out_start = arr;
+  *out_end = arr + opaque(10);
+}
+
+// CHECK-LABEL: define dso_local void @TestOKOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[ARR_I:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR_I]]) #[[ATTR7:[0-9]+]]
+// CHECK-NEXT:    [[UPPER_I:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR_I]], i64 40
+// CHECK-NEXT:    [[CALL_I:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR8:[0-9]+]]
+// CHECK-NEXT:    [[IDXPROM_I:%.*]] = sext i32 [[CALL_I]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH_I:%.*]] = getelementptr [4 x i8], ptr [[ARR_I]], i64 [[IDXPROM_I]]
+// CHECK-NEXT:    [[CMP_NOT_I:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH_I]], [[UPPER_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP22_NOT_I:%.*]] = icmp ugt ptr [[ARR_I]], [[BOUND_PTR_ARITH_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND_I:%.*]] = or i1 [[CMP_NOT_I]], [[CMP22_NOT_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND_I]], label %[[TRAP_I:.*]], label %[[TESTOKOPAQUEIMPL_EXIT:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP_I]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR9:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[TESTOKOPAQUEIMPL_EXIT]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR_I]]) #[[ATTR7]]
+// CHECK-NEXT:    ret void
+//
+void TestOKOpaque() {
+  int *end;
+  int *__ended_by(end) start;
+  TestOKOpaqueImpl(&start, &end);
 }
 
 static inline void TestStartFailImpl(int *__ended_by(*out_end) *out_start,
@@ -30,10 +78,10 @@ static inline void TestStartFailImpl(int *__ended_by(*out_end) *out_start,
 }
 
 // CHECK-LABEL: define dso_local void @TestStartFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR3:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[ARR_I:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR_I]]) #[[ATTR5:[0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR_I]]) #[[ATTR7]]
 // CHECK-NEXT:    [[UPPER_I:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR_I]], i64 40
 // CHECK-NEXT:    [[BOUND_PTR_ARITH_I:%.*]] = getelementptr i8, ptr [[ARR_I]], i64 -4
 // CHECK-NEXT:    [[CMP24_NOT_I:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH_I]], [[UPPER_I]], {{!annotation ![0-9]+}}
@@ -41,16 +89,55 @@ static inline void TestStartFailImpl(int *__ended_by(*out_end) *out_start,
 // CHECK-NEXT:    [[OR_COND_I:%.*]] = or i1 [[CMP24_NOT_I]], [[CMP35_NOT_I]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND_I]], label %[[TRAP_I:.*]], label %[[TESTSTARTFAILIMPL_EXIT:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[TRAP_I]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR6:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 // CHECK:       [[TESTSTARTFAILIMPL_EXIT]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR_I]]) #[[ATTR5]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR_I]]) #[[ATTR7]]
 // CHECK-NEXT:    ret void
 //
 void TestStartFail() {
   int *end;
   int *__ended_by(end) start;
   TestStartFailImpl(&start, &end);
+}
+
+static inline void TestStartFailOpaqueImpl(int *__ended_by(*out_end) *out_start,
+                                           int **out_end) {
+  int arr[10];
+  *out_start = arr - opaque(1);
+  *out_end = arr + opaque(10);
+}
+
+// CHECK-LABEL: define dso_local void @TestStartFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[ARR_I:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR_I]]) #[[ATTR7]]
+// CHECK-NEXT:    [[CALL_I:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR8]]
+// CHECK-NEXT:    [[UPPER_I:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR_I]], i64 40
+// CHECK-NEXT:    [[IDXPROM_I:%.*]] = sext i32 [[CALL_I]] to i64
+// CHECK-NEXT:    [[IDX_NEG_I:%.*]] = sub nsw i64 0, [[IDXPROM_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[BOUND_PTR_ARITH_I:%.*]] = getelementptr [4 x i8], ptr [[ARR_I]], i64 [[IDX_NEG_I]]
+// CHECK-NEXT:    [[CALL2_I:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR8]]
+// CHECK-NEXT:    [[IDXPROM6_I:%.*]] = sext i32 [[CALL2_I]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH7_I:%.*]] = getelementptr [4 x i8], ptr [[ARR_I]], i64 [[IDXPROM6_I]]
+// CHECK-NEXT:    [[CMP_NOT_I:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH7_I]], [[UPPER_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP26_NOT_I:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH_I]], [[BOUND_PTR_ARITH7_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP37_NOT_I:%.*]] = icmp ugt ptr [[ARR_I]], [[BOUND_PTR_ARITH_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[CMP37_NOT_I]], [[CMP26_NOT_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND52_I:%.*]] = select i1 [[CMP_NOT_I]], i1 true, i1 [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND52_I]], label %[[TRAP_I:.*]], label %[[TESTSTARTFAILOPAQUEIMPL_EXIT:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP_I]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[TESTSTARTFAILOPAQUEIMPL_EXIT]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR_I]]) #[[ATTR7]]
+// CHECK-NEXT:    ret void
+//
+void TestStartFailOpaque() {
+  int *end;
+  int *__ended_by(end) start;
+  TestStartFailOpaqueImpl(&start, &end);
 }
 
 static inline void TestEndFailImpl(int *__ended_by(*out_end) *out_start,
@@ -61,15 +148,48 @@ static inline void TestEndFailImpl(int *__ended_by(*out_end) *out_start,
 }
 
 // CHECK-LABEL: define dso_local void @TestEndFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR6:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestEndFail() {
   int *end;
   int *__ended_by(end) start;
   TestEndFailImpl(&start, &end);
+}
+
+static inline void TestEndFailOpaqueImpl(int *__ended_by(*out_end) *out_start,
+                                         int **out_end) {
+  int arr[10];
+  *out_start = arr;
+  *out_end = arr + opaque(11);
+}
+
+// CHECK-LABEL: define dso_local void @TestEndFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[ARR_I:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR_I]]) #[[ATTR7]]
+// CHECK-NEXT:    [[UPPER_I:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR_I]], i64 40
+// CHECK-NEXT:    [[CALL_I:%.*]] = tail call i32 @opaque(i32 noundef 11) #[[ATTR8]]
+// CHECK-NEXT:    [[IDXPROM_I:%.*]] = sext i32 [[CALL_I]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH_I:%.*]] = getelementptr [4 x i8], ptr [[ARR_I]], i64 [[IDXPROM_I]]
+// CHECK-NEXT:    [[CMP_NOT_I:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH_I]], [[UPPER_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP22_NOT_I:%.*]] = icmp ugt ptr [[ARR_I]], [[BOUND_PTR_ARITH_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND_I:%.*]] = or i1 [[CMP_NOT_I]], [[CMP22_NOT_I]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND_I]], label %[[TRAP_I:.*]], label %[[TESTENDFAILOPAQUEIMPL_EXIT:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP_I]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[TESTENDFAILOPAQUEIMPL_EXIT]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR_I]]) #[[ATTR7]]
+// CHECK-NEXT:    ret void
+//
+void TestEndFailOpaque() {
+  int *end;
+  int *__ended_by(end) start;
+  TestEndFailOpaqueImpl(&start, &end);
 }
 
 static inline void TestRangeFailImpl(int *__ended_by(*out_end) *out_start,
@@ -80,13 +200,38 @@ static inline void TestRangeFailImpl(int *__ended_by(*out_end) *out_start,
 }
 
 // CHECK-LABEL: define dso_local void @TestRangeFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR6]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail() {
   int *end;
   int *__ended_by(end) start;
   TestRangeFailImpl(&start, &end);
+}
+
+static inline void TestRangeFailOpaqueImpl(int *__ended_by(*out_end) *out_start,
+                                           int **out_end) {
+  int arr[10];
+  *out_start = arr + opaque(1);
+  *out_end = arr;
+}
+
+// CHECK-LABEL: define dso_local void @TestRangeFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CALL_I:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR8]]
+// CHECK-NEXT:    [[OR_COND_NOT_I:%.*]] = icmp eq i32 [[CALL_I]], 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND_NOT_I]], label %[[TESTRANGEFAILOPAQUEIMPL_EXIT:.*]], label %[[TRAP_I:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP_I]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR9]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[TESTRANGEFAILOPAQUEIMPL_EXIT]]:
+// CHECK-NEXT:    ret void
+//
+void TestRangeFailOpaque() {
+  int *end;
+  int *__ended_by(end) start;
+  TestRangeFailOpaqueImpl(&start, &end);
 }

--- a/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks_parms-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks_parms-O2.c
@@ -61,22 +61,10 @@ static inline void TestEndFailImpl(int *__ended_by(*out_end) *out_start,
 }
 
 // CHECK-LABEL: define dso_local void @TestEndFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR3]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[ARR_I:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR_I]]) #[[ATTR5]]
-// CHECK-NEXT:    [[UPPER_I:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR_I]], i64 40
-// CHECK-NEXT:    [[BOUND_PTR_ARITH_I:%.*]] = getelementptr i8, ptr [[ARR_I]], i64 44
-// CHECK-NEXT:    [[CMP_NOT_I:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH_I]], [[UPPER_I]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[CMP22_NOT_I:%.*]] = icmp ugt ptr [[ARR_I]], [[BOUND_PTR_ARITH_I]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_I:%.*]] = or i1 [[CMP_NOT_I]], [[CMP22_NOT_I]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_I]], label %[[TRAP_I:.*]], label %[[TESTENDFAILIMPL_EXIT:.*]], {{!annotation ![0-9]+}}
-// CHECK:       [[TRAP_I]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
-// CHECK:       [[TESTENDFAILIMPL_EXIT]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR_I]]) #[[ATTR5]]
-// CHECK-NEXT:    ret void
 //
 void TestEndFail() {
   int *end;
@@ -92,7 +80,7 @@ static inline void TestRangeFailImpl(int *__ended_by(*out_end) *out_start,
 }
 
 // CHECK-LABEL: define dso_local void @TestRangeFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR6]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}

--- a/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks_seq-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks_seq-O2.c
@@ -67,19 +67,19 @@ void TestRangeOK4(void) {
 // CHECK-SAME: ) local_unnamed_addr #[[ATTR3:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR7:[0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6:[0-9]+]]
 // CHECK-NEXT:    [[BOUND_PTR_ARITH8:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
-// CHECK-NEXT:    tail call void @foo() #[[ATTR7]]
+// CHECK-NEXT:    tail call void @foo() #[[ATTR6]]
 // CHECK-NEXT:    [[BOUND_PTR_ARITH58:%.*]] = getelementptr i8, ptr [[ARR]], i64 -4
 // CHECK-NEXT:    [[CMP77_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH58]], [[BOUND_PTR_ARITH8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[CMP92_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH58]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP77_NOT]], [[CMP92_NOT]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT93:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[TRAP]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR8:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR7:[0-9]+]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT93]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
 // CHECK-NEXT:    ret void
 //
 void TestIterFail(void) {
@@ -94,11 +94,10 @@ void TestIterFail(void) {
     s.end = s.end;
 }
 
-// XXX: Why this can be optimized when the next case can't?
 // CHECK-LABEL: define dso_local void @TestStartFail(
 // CHECK-SAME: ) local_unnamed_addr #[[ATTR5:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestStartFail(void) {
@@ -110,22 +109,10 @@ void TestStartFail(void) {
 }
 
 // CHECK-LABEL: define dso_local void @TestEndFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR6:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
-// CHECK-NEXT:    [[UPPER3:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
-// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[ARR]], i64 44
-// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER3]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[CMP25_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP25_NOT]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT48:.*]], {{!annotation ![0-9]+}}
-// CHECK:       [[TRAP]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
-// CHECK:       [[CONT48]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR7]]
-// CHECK-NEXT:    ret void
 //
 void TestEndFail(void) {
   int arr[10];
@@ -138,7 +125,7 @@ void TestEndFail(void) {
 // CHECK-LABEL: define dso_local void @TestRangeFail1(
 // CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail1(void) {
@@ -152,7 +139,7 @@ void TestRangeFail1(void) {
 // CHECK-LABEL: define dso_local void @TestRangeFail2(
 // CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail2(void) {
@@ -166,7 +153,7 @@ void TestRangeFail2(void) {
 // CHECK-LABEL: define dso_local void @TestRangeFail3(
 // CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail3(void) {
@@ -180,7 +167,7 @@ void TestRangeFail3(void) {
 // CHECK-LABEL: define dso_local void @TestRangeFail4(
 // CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail4(void) {

--- a/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks_seq-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/ended_by_assign_checks_seq-O2.c
@@ -11,8 +11,23 @@ struct S {
 
 void foo(void);
 
+__attribute__((noinline))
+__attribute__((optnone))
+__attribute__((pure))
+// CHECK-LABEL: define dso_local i32 @opaque(
+// CHECK-SAME: i32 noundef [[X:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[X_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32 [[X]], ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    ret i32 [[TMP0]]
+//
+int opaque(int x) {
+  return x;
+}
+
 // CHECK-LABEL: define dso_local void @TestRangeOK1(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret void
 //
@@ -24,8 +39,36 @@ void TestRangeOK1(void) {
   s.end = arr + 1;
 }
 
+// CHECK-LABEL: define dso_local void @TestRangeOK1Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR8:[0-9]+]]
+// CHECK-NEXT:    [[UPPER3:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR9:[0-9]+]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP25_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP25_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT48:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR10:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT48]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    ret void
+//
+void TestRangeOK1Opaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = arr;
+  s.iter = arr;
+  s.end = arr + opaque(1);
+}
+
 // CHECK-LABEL: define dso_local void @TestRangeOK2(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret void
 //
@@ -38,7 +81,7 @@ void TestRangeOK2(void) {
 }
 
 // CHECK-LABEL: define dso_local void @TestRangeOK3(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret void
 //
@@ -50,8 +93,36 @@ void TestRangeOK3(void) {
   s.end = arr + 10;
 }
 
+// CHECK-LABEL: define dso_local void @TestRangeOK3Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR9]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP40_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP40_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT81:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT81]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    ret void
+//
+void TestRangeOK3Opaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = arr;
+  s.iter = arr + opaque(10);
+  s.end = arr + opaque(10);
+}
+
 // CHECK-LABEL: define dso_local void @TestRangeOK4(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret void
 //
@@ -63,23 +134,51 @@ void TestRangeOK4(void) {
   s.end = arr + 10;
 }
 
-// CHECK-LABEL: define dso_local void @TestIterFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR3:[0-9]+]] {
+// CHECK-LABEL: define dso_local void @TestRangeOK4Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR6:[0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR9]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP44_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP44_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT85:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT85]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    ret void
+//
+void TestRangeOK4Opaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = arr + opaque(10);
+  s.iter = arr + opaque(10);
+  s.end = arr + opaque(10);
+}
+
+// CHECK-LABEL: define dso_local void @TestIterFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
 // CHECK-NEXT:    [[BOUND_PTR_ARITH8:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
-// CHECK-NEXT:    tail call void @foo() #[[ATTR6]]
+// CHECK-NEXT:    tail call void @foo() #[[ATTR8]]
 // CHECK-NEXT:    [[BOUND_PTR_ARITH58:%.*]] = getelementptr i8, ptr [[ARR]], i64 -4
 // CHECK-NEXT:    [[CMP77_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH58]], [[BOUND_PTR_ARITH8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[CMP92_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH58]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP77_NOT]], [[CMP92_NOT]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT93:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[TRAP]]:
-// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR7:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT93]]:
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR6]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
 // CHECK-NEXT:    ret void
 //
 void TestIterFail(void) {
@@ -94,10 +193,59 @@ void TestIterFail(void) {
     s.end = s.end;
 }
 
-// CHECK-LABEL: define dso_local void @TestStartFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR5:[0-9]+]] {
+// CHECK-LABEL: define dso_local void @TestIterFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 2) #[[ATTR9]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CALL5:%.*]] = tail call i32 @opaque(i32 noundef 10) #[[ATTR9]]
+// CHECK-NEXT:    [[IDXPROM9:%.*]] = sext i32 [[CALL5]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH10:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM9]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH10]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP29_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[BOUND_PTR_ARITH10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP40_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[CMP40_NOT]], [[CMP29_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP51_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP1:%.*]] = or i1 [[CMP51_NOT]], [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND188:%.*]] = select i1 [[CMP_NOT]], i1 true, i1 [[TMP1]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND188]], label %[[TRAP:.*]], label %[[CONT81:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT81]]:
+// CHECK-NEXT:    call void @foo() #[[ATTR8]]
+// CHECK-NEXT:    [[CALL111:%.*]] = call i32 @opaque(i32 noundef 3) #[[ATTR9]]
+// CHECK-NEXT:    [[IDXPROM116:%.*]] = sext i32 [[CALL111]] to i64
+// CHECK-NEXT:    [[IDX_NEG:%.*]] = sub nsw i64 0, [[IDXPROM116]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[BOUND_PTR_ARITH117:%.*]] = getelementptr [4 x i8], ptr [[BOUND_PTR_ARITH]], i64 [[IDX_NEG]]
+// CHECK-NEXT:    [[CMP136_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH117]], [[BOUND_PTR_ARITH10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP152_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH117]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND189:%.*]] = or i1 [[CMP136_NOT]], [[CMP152_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND189]], label %[[TRAP]], label %[[CONT154:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT154]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    ret void
+//
+void TestIterFailOpaque(void) {
+    int arr[10];
+    struct S s;
+    s.start = arr;
+    s.iter = arr + opaque(2);
+    s.end = arr + opaque(10);
+    foo();
+    s.start = s.start;
+    s.iter = s.iter - opaque(3); // is prevented since s.iter - 3 < s.start
+    s.end = s.end;
+}
+
+// CHECK-LABEL: define dso_local void @TestStartFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR7:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestStartFail(void) {
@@ -108,10 +256,30 @@ void TestStartFail(void) {
   s.end = arr + 1;
 }
 
-// CHECK-LABEL: define dso_local void @TestEndFail(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-LABEL: define dso_local void @TestStartFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR9]]
+// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i32 [[CALL]], 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[DOTNOT]], label %[[CONT81:.*]], label %[[TRAP:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT81]]:
+// CHECK-NEXT:    ret void
+//
+void TestStartFailOpaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = arr - opaque(1);
+  s.iter = arr;
+  s.end = arr + opaque(1);
+}
+
+// CHECK-LABEL: define dso_local void @TestEndFail(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR7]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestEndFail(void) {
@@ -122,10 +290,38 @@ void TestEndFail(void) {
   s.end = arr + 11;
 }
 
-// CHECK-LABEL: define dso_local void @TestRangeFail1(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-LABEL: define dso_local void @TestEndFailOpaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    [[UPPER3:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 11) #[[ATTR9]]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP25_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[CMP25_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT48:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT48]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    ret void
+//
+void TestEndFailOpaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = arr;
+  s.iter = arr;
+  s.end = arr + opaque(11);
+}
+
+// CHECK-LABEL: define dso_local void @TestRangeFail1(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR7]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail1(void) {
@@ -136,10 +332,39 @@ void TestRangeFail1(void) {
   s.end = arr + 1;
 }
 
-// CHECK-LABEL: define dso_local void @TestRangeFail2(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-LABEL: define dso_local void @TestRangeFail1Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR9]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH_IDX:%.*]] = shl nsw i64 [[IDXPROM]], 2, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[ARR]], i64 [[BOUND_PTR_ARITH_IDX]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = icmp ne i32 [[CALL]], 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND107:%.*]] = or i1 [[TMP0]], [[CMP_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND107]], label %[[TRAP:.*]], label %[[CONT81:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT81]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    ret void
+//
+void TestRangeFail1Opaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = arr + opaque(1);
+  s.iter = arr;
+  s.end = arr + opaque(1);
+}
+
+// CHECK-LABEL: define dso_local void @TestRangeFail2(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR7]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail2(void) {
@@ -150,10 +375,47 @@ void TestRangeFail2(void) {
   s.end = arr + 1;
 }
 
-// CHECK-LABEL: define dso_local void @TestRangeFail3(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-LABEL: define dso_local void @TestRangeFail2Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[ARR:%.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR9]]
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARR]], i64 40
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[CALL]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[CALL2:%.*]] = tail call i32 @opaque(i32 noundef 2) #[[ATTR9]]
+// CHECK-NEXT:    [[IDXPROM6:%.*]] = sext i32 [[CALL2]] to i64
+// CHECK-NEXT:    [[BOUND_PTR_ARITH7:%.*]] = getelementptr [4 x i8], ptr [[ARR]], i64 [[IDXPROM6]]
+// CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP33_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH7]], [[BOUND_PTR_ARITH]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP44_NOT:%.*]] = icmp ugt ptr [[ARR]], [[BOUND_PTR_ARITH7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[CMP33_NOT]], [[CMP44_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP55_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH7]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP1:%.*]] = or i1 [[CMP55_NOT]], [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP71_NOT:%.*]] = icmp ugt ptr [[BOUND_PTR_ARITH]], [[BOUND_PTR_ARITH7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP2:%.*]] = or i1 [[CMP71_NOT]], [[TMP1]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND113:%.*]] = select i1 [[CMP_NOT]], i1 true, i1 [[TMP2]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND113]], label %[[TRAP:.*]], label %[[CONT85:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT85]]:
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ARR]]) #[[ATTR8]]
+// CHECK-NEXT:    ret void
+//
+void TestRangeFail2Opaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = arr + opaque(1);
+  s.iter = arr + opaque(2);
+  s.end = arr + opaque(1);
+}
+
+// CHECK-LABEL: define dso_local void @TestRangeFail3(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR7]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail3(void) {
@@ -164,10 +426,24 @@ void TestRangeFail3(void) {
   s.end = s.end;
 }
 
-// CHECK-LABEL: define dso_local void @TestRangeFail4(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR5]] {
+// CHECK-LABEL: define dso_local void @TestRangeFail3Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR7]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+//
+void TestRangeFail3Opaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = arr - opaque(1);
+  s.iter = s.iter;
+  s.end = s.end;
+}
+
+// CHECK-LABEL: define dso_local void @TestRangeFail4(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR7]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestRangeFail4(void) {
@@ -176,4 +452,24 @@ void TestRangeFail4(void) {
   s.start = s.start;
   s.iter = s.iter;
   s.end = s.end + 1;
+}
+
+// CHECK-LABEL: define dso_local void @TestRangeFail4Opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 1) #[[ATTR9]]
+// CHECK-NEXT:    [[CMP_NOT_NOT:%.*]] = icmp eq i32 [[CALL]], 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[CMP_NOT_NOT]], label %[[CONT:.*]], label %[[TRAP:.*]], {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT]]:
+// CHECK-NEXT:    ret void
+//
+void TestRangeFail4Opaque(void) {
+  int arr[10];
+  struct S s;
+  s.start = s.start;
+  s.iter = s.iter;
+  s.end = s.end + opaque(1);
 }

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations-constexpr-geps.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations-constexpr-geps.c
@@ -31,25 +31,11 @@ int read_from_global_array_can_remove_checks() {
   return res;
 }
 
-// CHECK-LABEL: define dso_local i32 @read_from_global_array_trap_last_iter(
+// CHECK-LABEL: define dso_local noundef i32 @read_from_global_array_trap_last_iter(
 // CHECK-SAME: ) local_unnamed_addr #[[ATTR2:[0-9]+]] {
-// CHECK-NEXT:  [[CONT3_3:.*:]]
-// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr getelementptr (i8, ptr @a, i64 20), getelementptr inbounds nuw (i8, ptr @a, i64 16), {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[DOTNOT]], label %[[TRAP:.*]], label %[[CONT3_4:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
-// CHECK:       [[TRAP]]:
+// CHECK-NEXT:  [[TRAP:.*:]]
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
-// CHECK:       [[CONT3_4]]:
-// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr getelementptr inbounds nuw (i8, ptr @a, i64 12), align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr getelementptr inbounds nuw (i8, ptr @a, i64 8), align 8, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr getelementptr inbounds nuw (i8, ptr @a, i64 4), align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr @a, align 16, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ADD_1:%.*]] = add nsw i32 [[TMP2]], [[TMP3]]
-// CHECK-NEXT:    [[ADD_2:%.*]] = add nsw i32 [[TMP1]], [[ADD_1]]
-// CHECK-NEXT:    [[ADD_3:%.*]] = add nsw i32 [[TMP0]], [[ADD_2]]
-// CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr getelementptr inbounds nuw (i8, ptr @a, i64 16), align 16, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ADD_4:%.*]] = add nsw i32 [[TMP4]], [[ADD_3]]
-// CHECK-NEXT:    ret i32 [[ADD_4]]
 //
 int read_from_global_array_trap_last_iter() {
     int res = 0;
@@ -60,7 +46,7 @@ int read_from_global_array_trap_last_iter() {
 }
 
 // CHECK-LABEL: define dso_local i32 @read_from_global_array_cannot_rename(
-// CHECK-SAME: i32 noundef [[N:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-SAME: i32 noundef [[N:%.*]]) local_unnamed_addr #[[ATTR3:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*]]:
 // CHECK-NEXT:    [[CMP9_NOT:%.*]] = icmp eq i32 [[N]], 0
 // CHECK-NEXT:    br i1 [[CMP9_NOT]], label %[[FOR_COND_CLEANUP:.*]], label %[[FOR_BODY:.*]]

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations-constexpr-geps.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations-constexpr-geps.c
@@ -11,8 +11,23 @@ int b[4];
 int c[4];
 int d[4];
 
+__attribute__((noinline))
+__attribute__((optnone))
+__attribute__((pure))
+// CHECK-LABEL: define dso_local i32 @opaque(
+// CHECK-SAME: i32 noundef [[X:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[X_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32 [[X]], ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[X_ADDR]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    ret i32 [[TMP0]]
+//
+int opaque(int x) {
+  return x;
+}
+
 // CHECK-LABEL: define dso_local i32 @read_from_global_array_can_remove_checks(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr @a, align 16, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr getelementptr inbounds nuw (i8, ptr @a, i64 4), align 4, {{!tbaa ![0-9]+}}
@@ -31,8 +46,48 @@ int read_from_global_array_can_remove_checks() {
   return res;
 }
 
+// CHECK-LABEL: define dso_local i32 @read_from_global_array_can_remove_checks_opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR3:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*]]:
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 4) {{#[0-9]+}}
+// CHECK-NEXT:    [[CMP9:%.*]] = icmp sgt i32 [[CALL]], 0
+// CHECK-NEXT:    br i1 [[CMP9]], label %[[FOR_BODY:.*]], label %[[FOR_COND_CLEANUP:.*]]
+// CHECK:       [[FOR_COND_CLEANUP]]:
+// CHECK-NEXT:    [[RES_0_LCSSA:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[ADD:%.*]], %[[CONT3:.*]] ]
+// CHECK-NEXT:    ret i32 [[RES_0_LCSSA]]
+// CHECK:       [[FOR_BODY]]:
+// CHECK-NEXT:    [[I_011:%.*]] = phi i8 [ [[INC:%.*]], %[[CONT3]] ], [ 0, %[[ENTRY]] ]
+// CHECK-NEXT:    [[RES_010:%.*]] = phi i32 [ [[ADD]], %[[CONT3]] ], [ 0, %[[ENTRY]] ]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = zext i8 [[I_011]] to i64
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr [4 x i8], ptr @a, i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[ARRAYIDX]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP1:%.*]] = icmp ule ptr [[TMP0]], getelementptr inbounds nuw (i8, ptr @a, i64 16), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP2:%.*]] = icmp ule ptr [[ARRAYIDX]], [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = and i1 [[TMP1]], [[TMP2]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP3:%.*]] = icmp uge ptr [[ARRAYIDX]], @a, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND4:%.*]] = and i1 [[TMP3]], [[OR_COND]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND4]], label %[[CONT3]], label %[[TRAP:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT3]]:
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr [[ARRAYIDX]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ADD]] = add nsw i32 [[TMP4]], [[RES_010]]
+// CHECK-NEXT:    [[INC]] = add i8 [[I_011]], 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CONV:%.*]] = zext i8 [[INC]] to i32
+// CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ugt i32 [[CALL]], [[CONV]]
+// CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY]], label %[[FOR_COND_CLEANUP]], {{!llvm.loop ![0-9]+}}
+//
+int read_from_global_array_can_remove_checks_opaque() {
+    int res = 0;
+  for (unsigned char i = 0; i < opaque(4); i++) {
+    res += a[i];
+  }
+  return res;
+}
+
 // CHECK-LABEL: define dso_local noundef i32 @read_from_global_array_trap_last_iter(
-// CHECK-SAME: ) local_unnamed_addr #[[ATTR2:[0-9]+]] {
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR4:[0-9]+]] {
 // CHECK-NEXT:  [[TRAP:.*:]]
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
@@ -45,8 +100,48 @@ int read_from_global_array_trap_last_iter() {
   return res;
 }
 
+// CHECK-LABEL: define dso_local i32 @read_from_global_array_trap_last_iter_opaque(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR3]] {
+// CHECK-NEXT:  [[ENTRY:.*]]:
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 5) {{#[0-9]+}}
+// CHECK-NEXT:    [[CMP9:%.*]] = icmp sgt i32 [[CALL]], 0
+// CHECK-NEXT:    br i1 [[CMP9]], label %[[FOR_BODY:.*]], label %[[FOR_COND_CLEANUP:.*]]
+// CHECK:       [[FOR_COND_CLEANUP]]:
+// CHECK-NEXT:    [[RES_0_LCSSA:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[ADD:%.*]], %[[CONT3:.*]] ]
+// CHECK-NEXT:    ret i32 [[RES_0_LCSSA]]
+// CHECK:       [[FOR_BODY]]:
+// CHECK-NEXT:    [[I_011:%.*]] = phi i8 [ [[INC:%.*]], %[[CONT3]] ], [ 0, %[[ENTRY]] ]
+// CHECK-NEXT:    [[RES_010:%.*]] = phi i32 [ [[ADD]], %[[CONT3]] ], [ 0, %[[ENTRY]] ]
+// CHECK-NEXT:    [[IDXPROM:%.*]] = zext i8 [[I_011]] to i64
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr [4 x i8], ptr @a, i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[ARRAYIDX]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP1:%.*]] = icmp ule ptr [[TMP0]], getelementptr inbounds nuw (i8, ptr @a, i64 16), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP2:%.*]] = icmp ule ptr [[ARRAYIDX]], [[TMP0]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND:%.*]] = and i1 [[TMP1]], [[TMP2]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP3:%.*]] = icmp uge ptr [[ARRAYIDX]], @a, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND4:%.*]] = and i1 [[TMP3]], [[OR_COND]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND4]], label %[[CONT3]], label %[[TRAP:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT3]]:
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr [[ARRAYIDX]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ADD]] = add nsw i32 [[TMP4]], [[RES_010]]
+// CHECK-NEXT:    [[INC]] = add i8 [[I_011]], 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CONV:%.*]] = zext i8 [[INC]] to i32
+// CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ugt i32 [[CALL]], [[CONV]]
+// CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY]], label %[[FOR_COND_CLEANUP]], {{!llvm.loop ![0-9]+}}
+//
+int read_from_global_array_trap_last_iter_opaque() {
+    int res = 0;
+  for (unsigned char i = 0; i < opaque(5); i++) {
+    res += a[i];
+  }
+  return res;
+}
+
 // CHECK-LABEL: define dso_local i32 @read_from_global_array_cannot_rename(
-// CHECK-SAME: i32 noundef [[N:%.*]]) local_unnamed_addr #[[ATTR3:[0-9]+]] {
+// CHECK-SAME: i32 noundef [[N:%.*]]) local_unnamed_addr #[[ATTR5:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*]]:
 // CHECK-NEXT:    [[CMP9_NOT:%.*]] = icmp eq i32 [[N]], 0
 // CHECK-NEXT:    br i1 [[CMP9_NOT]], label %[[FOR_COND_CLEANUP:.*]], label %[[FOR_BODY:.*]]
@@ -91,7 +186,7 @@ typedef struct {
 } hdr_t;
 
 // CHECK-LABEL: define dso_local void @concat_to_separate_clobals(
-// CHECK-SAME: ptr nofree noundef readonly captures(address) [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-SAME: ptr nofree noundef readonly captures(address) [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR6:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 4
 // CHECK-NEXT:    [[OFFSET:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 2
@@ -198,6 +293,112 @@ void concat_to_separate_clobals(hdr_t *p_buf) {
   }
 }
 
+// CHECK-LABEL: define dso_local void @concat_to_separate_clobals_opaque(
+// CHECK-SAME: ptr noundef [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR7:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[PAYLOAD:%.*]] = getelementptr i8, ptr [[P_BUF]], i64 4
+// CHECK-NEXT:    [[OFFSET:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 2
+// CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr [[OFFSET]], align 2, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV:%.*]] = zext i16 [[TMP0]] to i64
+// CHECK-NEXT:    [[TMP1:%.*]] = load i16, ptr [[P_BUF]], align 2, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV3:%.*]] = zext i16 [[TMP1]] to i64
+// CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds nuw i8, ptr [[PAYLOAD]], i64 [[CONV]]
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds nuw i8, ptr [[TMP2]], i64 [[CONV3]]
+// CHECK-NEXT:    [[CALL139:%.*]] = tail call i32 @opaque(i32 noundef 4) {{#[0-9]+}}
+// CHECK-NEXT:    [[CMP140:%.*]] = icmp sgt i32 [[CALL139]], 0
+// CHECK-NEXT:    br i1 [[CMP140]], label %[[FOR_BODY_LR_PH:.*]], label %[[FOR_COND_CLEANUP:.*]]
+// CHECK:       [[FOR_BODY_LR_PH]]:
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[P_BUF]], i64 7
+// CHECK-NEXT:    [[SUB_PTR_LHS_CAST:%.*]] = ptrtoint ptr [[ADD_PTR]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP26_NOT:%.*]] = icmp uge ptr [[BOUND_PTR_ARITH]], [[PAYLOAD]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br label %[[FOR_BODY:.*]]
+// CHECK:       [[FOR_COND_CLEANUP]]:
+// CHECK-NEXT:    ret void
+// CHECK:       [[FOR_BODY]]:
+// CHECK-NEXT:    [[PARAMS_SROA_0_0142:%.*]] = phi ptr [ [[BOUND_PTR_ARITH]], %[[FOR_BODY_LR_PH]] ], [ [[ADD_PTR50:%.*]], %[[CONT114:.*]] ]
+// CHECK-NEXT:    [[I_0141:%.*]] = phi i8 [ 0, %[[FOR_BODY_LR_PH]] ], [ [[INC:%.*]], %[[CONT114]] ]
+// CHECK-NEXT:    [[CMP14_NOT:%.*]] = icmp ule ptr [[PARAMS_SROA_0_0142]], [[ADD_PTR]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND136_NOT138:%.*]] = and i1 [[CMP14_NOT]], [[CMP26_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_RHS_CAST:%.*]] = ptrtoint ptr [[PARAMS_SROA_0_0142]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_SUB:%.*]] = sub i64 [[SUB_PTR_LHS_CAST]], [[SUB_PTR_RHS_CAST]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP38:%.*]] = icmp sgt i64 [[SUB_PTR_SUB]], 3, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND137:%.*]] = select i1 [[OR_COND136_NOT138]], i1 [[CMP38]], i1 false, {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND137]], label %[[CONT:.*]], label %[[TRAP:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT]]:
+// CHECK-NEXT:    [[ADD_PTR50]] = getelementptr inbounds nuw i8, ptr [[PARAMS_SROA_0_0142]], i64 4
+// CHECK-NEXT:    [[IDXPROM:%.*]] = zext i8 [[I_0141]] to i64
+// CHECK-NEXT:    [[ARRAYIDX60:%.*]] = getelementptr [4 x i8], ptr @a, i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i8, ptr [[ARRAYIDX60]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP4:%.*]] = icmp ule ptr [[TMP3]], getelementptr inbounds nuw (i8, ptr @a, i64 16), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP5:%.*]] = icmp ule ptr [[ARRAYIDX60]], [[TMP3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND117:%.*]] = and i1 [[TMP4]], [[TMP5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP6:%.*]] = icmp uge ptr [[ARRAYIDX60]], @a, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND118:%.*]] = and i1 [[TMP6]], [[OR_COND117]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND118]], label %[[CONT63:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT63]]:
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0142]], i64 3
+// CHECK-NEXT:    [[TMP7:%.*]] = load i8, ptr [[ARRAYIDX]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV59:%.*]] = zext i8 [[TMP7]] to i32
+// CHECK-NEXT:    store i32 [[CONV59]], ptr [[ARRAYIDX60]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX77:%.*]] = getelementptr [4 x i8], ptr @b, i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr [[ARRAYIDX77]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[TMP8]], getelementptr inbounds nuw (i8, ptr @b, i64 16), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP10:%.*]] = icmp ule ptr [[ARRAYIDX77]], [[TMP8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND120:%.*]] = and i1 [[TMP9]], [[TMP10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP11:%.*]] = icmp uge ptr [[ARRAYIDX77]], @b, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND121:%.*]] = and i1 [[TMP11]], [[OR_COND120]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND121]], label %[[CONT80:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT80]]:
+// CHECK-NEXT:    [[ARRAYIDX68:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0142]], i64 1
+// CHECK-NEXT:    [[TMP12:%.*]] = load i8, ptr [[ARRAYIDX68]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV75:%.*]] = zext i8 [[TMP12]] to i32
+// CHECK-NEXT:    store i32 [[CONV75]], ptr [[ARRAYIDX77]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX94:%.*]] = getelementptr [4 x i8], ptr @c, i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[ARRAYIDX94]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], getelementptr inbounds nuw (i8, ptr @c, i64 16), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX94]], [[TMP13]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND123:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP16:%.*]] = icmp uge ptr [[ARRAYIDX94]], @c, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND124:%.*]] = and i1 [[TMP16]], [[OR_COND123]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND124]], label %[[CONT97:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT97]]:
+// CHECK-NEXT:    [[ARRAYIDX85:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0142]], i64 2
+// CHECK-NEXT:    [[TMP17:%.*]] = load i8, ptr [[ARRAYIDX85]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV92:%.*]] = zext i8 [[TMP17]] to i32
+// CHECK-NEXT:    store i32 [[CONV92]], ptr [[ARRAYIDX94]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX111:%.*]] = getelementptr [4 x i8], ptr @d, i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP18:%.*]] = getelementptr i8, ptr [[ARRAYIDX111]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP19:%.*]] = icmp ule ptr [[TMP18]], getelementptr inbounds nuw (i8, ptr @d, i64 16), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP20:%.*]] = icmp ule ptr [[ARRAYIDX111]], [[TMP18]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND126:%.*]] = and i1 [[TMP19]], [[TMP20]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP21:%.*]] = icmp uge ptr [[ARRAYIDX111]], @d, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND127:%.*]] = and i1 [[TMP21]], [[OR_COND126]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND127]], label %[[CONT114]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT114]]:
+// CHECK-NEXT:    [[TMP22:%.*]] = load i8, ptr [[PARAMS_SROA_0_0142]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV109:%.*]] = zext i8 [[TMP22]] to i32
+// CHECK-NEXT:    store i32 [[CONV109]], ptr [[ARRAYIDX111]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[INC]] = add i8 [[I_0141]], 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CONV4:%.*]] = zext i8 [[INC]] to i32
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 4) {{#[0-9]+}}
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[CALL]], [[CONV4]]
+// CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY]], label %[[FOR_COND_CLEANUP]], {{!llvm.loop ![0-9]+}}
+//
+void concat_to_separate_clobals_opaque(hdr_t *p_buf) {
+  uint8_t *params = p_buf->payload + 3;
+  for (unsigned char i = 0; i < opaque(4); i++) {
+    uint8_t *__counted_by(4) p = params;
+    a[i] = p[3]; // checks not removed for p[]
+    b[i] = p[1]; // checks not removed for b[] and p[]
+    c[i] = p[2]; // checks not removed for c[] and p[]
+    d[i] = p[0]; // checks not removed for d[]
+    params += 4;
+  }
+}
+
 struct arrays {
   int a[4];
   int b[4];
@@ -206,7 +407,7 @@ struct arrays {
 };
 
 // CHECK-LABEL: define dso_local void @concat_to_arrays_struct_can_remove_arrays_check(
-// CHECK-SAME: ptr nofree noundef writeonly captures(none) [[ARRAYS:%.*]], ptr nofree noundef readonly captures(address) [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR5:[0-9]+]] {
+// CHECK-SAME: ptr nofree noundef writeonly captures(none) [[ARRAYS:%.*]], ptr nofree noundef readonly captures(address) [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR8:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 4
 // CHECK-NEXT:    [[OFFSET:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 2
@@ -329,8 +530,115 @@ void concat_to_arrays_struct_can_remove_arrays_check(struct arrays *arrays, hdr_
   }
 }
 
+// CHECK-LABEL: define dso_local void @concat_to_arrays_struct_can_remove_arrays_check_opaque(
+// CHECK-SAME: ptr nofree noundef writeonly captures(address) [[ARRAYS:%.*]], ptr noundef [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR9:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[PAYLOAD:%.*]] = getelementptr i8, ptr [[P_BUF]], i64 4
+// CHECK-NEXT:    [[OFFSET:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 2
+// CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr [[OFFSET]], align 2, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV:%.*]] = zext i16 [[TMP0]] to i64
+// CHECK-NEXT:    [[TMP1:%.*]] = load i16, ptr [[P_BUF]], align 2, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV3:%.*]] = zext i16 [[TMP1]] to i64
+// CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds nuw i8, ptr [[PAYLOAD]], i64 [[CONV]]
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds nuw i8, ptr [[TMP2]], i64 [[CONV3]]
+// CHECK-NEXT:    [[CALL149:%.*]] = tail call i32 @opaque(i32 noundef 4) {{#[0-9]+}}
+// CHECK-NEXT:    [[CMP150:%.*]] = icmp sgt i32 [[CALL149]], 0
+// CHECK-NEXT:    br i1 [[CMP150]], label %[[FOR_BODY_LR_PH:.*]], label %[[FOR_COND_CLEANUP:.*]]
+// CHECK:       [[FOR_BODY_LR_PH]]:
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[P_BUF]], i64 7
+// CHECK-NEXT:    [[SUB_PTR_LHS_CAST:%.*]] = ptrtoint ptr [[ADD_PTR]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYS]], i64 16
+// CHECK-NEXT:    [[UPPER78:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYS]], i64 32
+// CHECK-NEXT:    [[UPPER97:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYS]], i64 48
+// CHECK-NEXT:    [[UPPER116:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYS]], i64 64
+// CHECK-NEXT:    [[CMP26_NOT:%.*]] = icmp uge ptr [[BOUND_PTR_ARITH]], [[PAYLOAD]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br label %[[FOR_BODY:.*]]
+// CHECK:       [[FOR_COND_CLEANUP]]:
+// CHECK-NEXT:    ret void
+// CHECK:       [[FOR_BODY]]:
+// CHECK-NEXT:    [[PARAMS_SROA_0_0152:%.*]] = phi ptr [ [[BOUND_PTR_ARITH]], %[[FOR_BODY_LR_PH]] ], [ [[ADD_PTR50:%.*]], %[[CONT121:.*]] ]
+// CHECK-NEXT:    [[I_0151:%.*]] = phi i8 [ 0, %[[FOR_BODY_LR_PH]] ], [ [[INC:%.*]], %[[CONT121]] ]
+// CHECK-NEXT:    [[CMP14_NOT:%.*]] = icmp ule ptr [[PARAMS_SROA_0_0152]], [[ADD_PTR]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND146_NOT148:%.*]] = and i1 [[CMP14_NOT]], [[CMP26_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_RHS_CAST:%.*]] = ptrtoint ptr [[PARAMS_SROA_0_0152]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_SUB:%.*]] = sub i64 [[SUB_PTR_LHS_CAST]], [[SUB_PTR_RHS_CAST]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP38:%.*]] = icmp sgt i64 [[SUB_PTR_SUB]], 3, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND147:%.*]] = select i1 [[OR_COND146_NOT148]], i1 [[CMP38]], i1 false, {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND147]], label %[[CONT:.*]], label %[[TRAP:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT]]:
+// CHECK-NEXT:    [[ADD_PTR50]] = getelementptr inbounds nuw i8, ptr [[PARAMS_SROA_0_0152]], i64 4
+// CHECK-NEXT:    [[IDXPROM:%.*]] = zext i8 [[I_0151]] to i64
+// CHECK-NEXT:    [[ARRAYIDX61:%.*]] = getelementptr [4 x i8], ptr [[ARRAYS]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i8, ptr [[ARRAYIDX61]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP4:%.*]] = icmp ule ptr [[TMP3]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP5:%.*]] = icmp ule ptr [[ARRAYIDX61]], [[TMP3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND124:%.*]] = and i1 [[TMP4]], [[TMP5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP6:%.*]] = icmp uge ptr [[ARRAYIDX61]], [[ARRAYS]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND125:%.*]] = and i1 [[TMP6]], [[OR_COND124]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND125]], label %[[CONT64:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT64]]:
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 3
+// CHECK-NEXT:    [[TMP7:%.*]] = load i8, ptr [[ARRAYIDX]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV59:%.*]] = zext i8 [[TMP7]] to i32
+// CHECK-NEXT:    store i32 [[CONV59]], ptr [[ARRAYIDX61]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX80:%.*]] = getelementptr [4 x i8], ptr [[UPPER]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr [[ARRAYIDX80]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[TMP8]], [[UPPER78]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP10:%.*]] = icmp ule ptr [[ARRAYIDX80]], [[TMP8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND127:%.*]] = and i1 [[TMP9]], [[TMP10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP11:%.*]] = icmp uge ptr [[ARRAYIDX80]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND128:%.*]] = and i1 [[TMP11]], [[OR_COND127]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND128]], label %[[CONT83:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT83]]:
+// CHECK-NEXT:    [[ARRAYIDX69:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 1
+// CHECK-NEXT:    [[TMP12:%.*]] = load i8, ptr [[ARRAYIDX69]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV76:%.*]] = zext i8 [[TMP12]] to i32
+// CHECK-NEXT:    store i32 [[CONV76]], ptr [[ARRAYIDX80]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX99:%.*]] = getelementptr [4 x i8], ptr [[UPPER78]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[ARRAYIDX99]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], [[UPPER97]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX99]], [[TMP13]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND130:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND130]], label %[[CONT102:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT102]]:
+// CHECK-NEXT:    [[ARRAYIDX88:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 2
+// CHECK-NEXT:    [[TMP16:%.*]] = load i8, ptr [[ARRAYIDX88]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV95:%.*]] = zext i8 [[TMP16]] to i32
+// CHECK-NEXT:    store i32 [[CONV95]], ptr [[ARRAYIDX99]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX118:%.*]] = getelementptr [4 x i8], ptr [[UPPER97]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP17:%.*]] = getelementptr i8, ptr [[ARRAYIDX118]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[TMP17]], [[UPPER116]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP19:%.*]] = icmp ule ptr [[ARRAYIDX118]], [[TMP17]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND133:%.*]] = and i1 [[TMP18]], [[TMP19]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND133]], label %[[CONT121]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT121]]:
+// CHECK-NEXT:    [[TMP20:%.*]] = load i8, ptr [[PARAMS_SROA_0_0152]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV114:%.*]] = zext i8 [[TMP20]] to i32
+// CHECK-NEXT:    store i32 [[CONV114]], ptr [[ARRAYIDX118]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[INC]] = add i8 [[I_0151]], 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CONV4:%.*]] = zext i8 [[INC]] to i32
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 4) {{#[0-9]+}}
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[CALL]], [[CONV4]]
+// CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY]], label %[[FOR_COND_CLEANUP]], {{!llvm.loop ![0-9]+}}
+//
+void concat_to_arrays_struct_can_remove_arrays_check_opaque(struct arrays *arrays, hdr_t *p_buf) {
+  uint8_t *params = p_buf->payload + 3;
+
+  for (unsigned char i = 0; i < opaque(4); i++) {
+    uint8_t *__counted_by(4) p = params;
+    arrays->a[i] = p[3]; // checks not removed for p[]
+    arrays->b[i] = p[1]; // checks not removed for b[] and p[]
+    arrays->c[i] = p[2]; // checks not removed for c[] and p[]
+    arrays->d[i] = p[0]; // checks not removed for d[]
+    params += 4;
+  }
+}
+
 // CHECK-LABEL: define dso_local void @concat_to_arrays_struct_trap_on_last_iter(
-// CHECK-SAME: ptr nofree noundef writeonly captures(address) [[ARRAYS:%.*]], ptr nofree noundef readonly captures(address) [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR6:[0-9]+]] {
+// CHECK-SAME: ptr nofree noundef writeonly captures(address) [[ARRAYS:%.*]], ptr nofree noundef readonly captures(address) [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR10:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 4
 // CHECK-NEXT:    [[OFFSET:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 2
@@ -458,8 +766,115 @@ void concat_to_arrays_struct_trap_on_last_iter(struct arrays *arrays, hdr_t *p_b
   }
 }
 
+// CHECK-LABEL: define dso_local void @concat_to_arrays_struct_trap_on_last_iter_opaque(
+// CHECK-SAME: ptr nofree noundef writeonly captures(address) [[ARRAYS:%.*]], ptr noundef [[P_BUF:%.*]]) local_unnamed_addr #[[ATTR9]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[PAYLOAD:%.*]] = getelementptr i8, ptr [[P_BUF]], i64 4
+// CHECK-NEXT:    [[OFFSET:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 2
+// CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr [[OFFSET]], align 2, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV:%.*]] = zext i16 [[TMP0]] to i64
+// CHECK-NEXT:    [[TMP1:%.*]] = load i16, ptr [[P_BUF]], align 2, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV3:%.*]] = zext i16 [[TMP1]] to i64
+// CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds nuw i8, ptr [[PAYLOAD]], i64 [[CONV]]
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds nuw i8, ptr [[TMP2]], i64 [[CONV3]]
+// CHECK-NEXT:    [[CALL149:%.*]] = tail call i32 @opaque(i32 noundef 5) {{#[0-9]+}}
+// CHECK-NEXT:    [[CMP150:%.*]] = icmp sgt i32 [[CALL149]], 0
+// CHECK-NEXT:    br i1 [[CMP150]], label %[[FOR_BODY_LR_PH:.*]], label %[[FOR_COND_CLEANUP:.*]]
+// CHECK:       [[FOR_BODY_LR_PH]]:
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[P_BUF]], i64 7
+// CHECK-NEXT:    [[SUB_PTR_LHS_CAST:%.*]] = ptrtoint ptr [[ADD_PTR]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYS]], i64 16
+// CHECK-NEXT:    [[UPPER78:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYS]], i64 32
+// CHECK-NEXT:    [[UPPER97:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYS]], i64 48
+// CHECK-NEXT:    [[UPPER116:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYS]], i64 64
+// CHECK-NEXT:    [[CMP26_NOT:%.*]] = icmp uge ptr [[BOUND_PTR_ARITH]], [[PAYLOAD]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br label %[[FOR_BODY:.*]]
+// CHECK:       [[FOR_COND_CLEANUP]]:
+// CHECK-NEXT:    ret void
+// CHECK:       [[FOR_BODY]]:
+// CHECK-NEXT:    [[PARAMS_SROA_0_0152:%.*]] = phi ptr [ [[BOUND_PTR_ARITH]], %[[FOR_BODY_LR_PH]] ], [ [[ADD_PTR50:%.*]], %[[CONT121:.*]] ]
+// CHECK-NEXT:    [[I_0151:%.*]] = phi i8 [ 0, %[[FOR_BODY_LR_PH]] ], [ [[INC:%.*]], %[[CONT121]] ]
+// CHECK-NEXT:    [[CMP14_NOT:%.*]] = icmp ule ptr [[PARAMS_SROA_0_0152]], [[ADD_PTR]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND146_NOT148:%.*]] = and i1 [[CMP14_NOT]], [[CMP26_NOT]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_RHS_CAST:%.*]] = ptrtoint ptr [[PARAMS_SROA_0_0152]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_SUB:%.*]] = sub i64 [[SUB_PTR_LHS_CAST]], [[SUB_PTR_RHS_CAST]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP38:%.*]] = icmp sgt i64 [[SUB_PTR_SUB]], 3, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND147:%.*]] = select i1 [[OR_COND146_NOT148]], i1 [[CMP38]], i1 false, {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND147]], label %[[CONT:.*]], label %[[TRAP:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[TRAP]]:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT]]:
+// CHECK-NEXT:    [[ADD_PTR50]] = getelementptr inbounds nuw i8, ptr [[PARAMS_SROA_0_0152]], i64 4
+// CHECK-NEXT:    [[IDXPROM:%.*]] = zext i8 [[I_0151]] to i64
+// CHECK-NEXT:    [[ARRAYIDX61:%.*]] = getelementptr [4 x i8], ptr [[ARRAYS]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i8, ptr [[ARRAYIDX61]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP4:%.*]] = icmp ule ptr [[TMP3]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP5:%.*]] = icmp ule ptr [[ARRAYIDX61]], [[TMP3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND124:%.*]] = and i1 [[TMP4]], [[TMP5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP6:%.*]] = icmp uge ptr [[ARRAYIDX61]], [[ARRAYS]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND125:%.*]] = and i1 [[TMP6]], [[OR_COND124]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND125]], label %[[CONT64:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT64]]:
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 3
+// CHECK-NEXT:    [[TMP7:%.*]] = load i8, ptr [[ARRAYIDX]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV59:%.*]] = zext i8 [[TMP7]] to i32
+// CHECK-NEXT:    store i32 [[CONV59]], ptr [[ARRAYIDX61]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX80:%.*]] = getelementptr [4 x i8], ptr [[UPPER]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr [[ARRAYIDX80]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[TMP8]], [[UPPER78]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP10:%.*]] = icmp ule ptr [[ARRAYIDX80]], [[TMP8]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND127:%.*]] = and i1 [[TMP9]], [[TMP10]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP11:%.*]] = icmp uge ptr [[ARRAYIDX80]], [[UPPER]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND128:%.*]] = and i1 [[TMP11]], [[OR_COND127]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND128]], label %[[CONT83:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT83]]:
+// CHECK-NEXT:    [[ARRAYIDX69:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 1
+// CHECK-NEXT:    [[TMP12:%.*]] = load i8, ptr [[ARRAYIDX69]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV76:%.*]] = zext i8 [[TMP12]] to i32
+// CHECK-NEXT:    store i32 [[CONV76]], ptr [[ARRAYIDX80]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX99:%.*]] = getelementptr [4 x i8], ptr [[UPPER78]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[ARRAYIDX99]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], [[UPPER97]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX99]], [[TMP13]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND130:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND130]], label %[[CONT102:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT102]]:
+// CHECK-NEXT:    [[ARRAYIDX88:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 2
+// CHECK-NEXT:    [[TMP16:%.*]] = load i8, ptr [[ARRAYIDX88]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV95:%.*]] = zext i8 [[TMP16]] to i32
+// CHECK-NEXT:    store i32 [[CONV95]], ptr [[ARRAYIDX99]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX118:%.*]] = getelementptr [4 x i8], ptr [[UPPER97]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP17:%.*]] = getelementptr i8, ptr [[ARRAYIDX118]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[TMP17]], [[UPPER116]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP19:%.*]] = icmp ule ptr [[ARRAYIDX118]], [[TMP17]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND133:%.*]] = and i1 [[TMP18]], [[TMP19]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND133]], label %[[CONT121]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       [[CONT121]]:
+// CHECK-NEXT:    [[TMP20:%.*]] = load i8, ptr [[PARAMS_SROA_0_0152]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV114:%.*]] = zext i8 [[TMP20]] to i32
+// CHECK-NEXT:    store i32 [[CONV114]], ptr [[ARRAYIDX118]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[INC]] = add i8 [[I_0151]], 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CONV4:%.*]] = zext i8 [[INC]] to i32
+// CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @opaque(i32 noundef 5) {{#[0-9]+}}
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[CALL]], [[CONV4]]
+// CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY]], label %[[FOR_COND_CLEANUP]], {{!llvm.loop ![0-9]+}}
+//
+void concat_to_arrays_struct_trap_on_last_iter_opaque(struct arrays *arrays, hdr_t *p_buf) {
+  uint8_t *params = p_buf->payload + 3;
+
+  for (unsigned char i = 0; i < opaque(5); i++) {
+    uint8_t *__counted_by(4) p = params;
+    arrays->a[i] = p[3]; // checks not removed for p[]
+    arrays->b[i] = p[1]; // checks not removed for b[] and p[]
+    arrays->c[i] = p[2]; // checks not removed for c[] and p[]
+    arrays->d[i] = p[0]; // checks not removed for d[]
+    params += 4;
+  }
+}
+
 // CHECK-LABEL: define dso_local void @concat_to_arrays_struct_cannot_remove_arrays_check(
-// CHECK-SAME: ptr nofree noundef writeonly captures(address) [[ARRAYS:%.*]], ptr noundef [[P_BUF:%.*]], i32 noundef [[N:%.*]]) local_unnamed_addr #[[ATTR5]] {
+// CHECK-SAME: ptr nofree noundef writeonly captures(address) [[ARRAYS:%.*]], ptr noundef [[P_BUF:%.*]], i32 noundef [[N:%.*]]) local_unnamed_addr #[[ATTR8]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = getelementptr i8, ptr [[P_BUF]], i64 4
 // CHECK-NEXT:    [[OFFSET:%.*]] = getelementptr inbounds nuw i8, ptr [[P_BUF]], i64 2

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations-constexpr-geps.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations-constexpr-geps.c
@@ -39,7 +39,7 @@ int opaque(int x) {
 // CHECK-NEXT:    ret i32 [[ADD_3]]
 //
 int read_from_global_array_can_remove_checks() {
-    int res = 0;
+  int res = 0;
   for (unsigned char i = 0; i < 4; i++) {
     res += a[i];
   }
@@ -79,7 +79,10 @@ int read_from_global_array_can_remove_checks() {
 // CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY]], label %[[FOR_COND_CLEANUP]], {{!llvm.loop ![0-9]+}}
 //
 int read_from_global_array_can_remove_checks_opaque() {
-    int res = 0;
+  // opaque bound: unlike the non-opaque version above, the trip count is not
+  // known at compile time, so the range checks are NOT removed and remain as
+  // a runtime-checked loop.
+  int res = 0;
   for (unsigned char i = 0; i < opaque(4); i++) {
     res += a[i];
   }
@@ -93,7 +96,7 @@ int read_from_global_array_can_remove_checks_opaque() {
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 int read_from_global_array_trap_last_iter() {
-    int res = 0;
+  int res = 0;
   for (unsigned char i = 0; i < 5; i++) {
     res += a[i];
   }
@@ -133,7 +136,11 @@ int read_from_global_array_trap_last_iter() {
 // CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY]], label %[[FOR_COND_CLEANUP]], {{!llvm.loop ![0-9]+}}
 //
 int read_from_global_array_trap_last_iter_opaque() {
-    int res = 0;
+  // opaque bound: unlike the non-opaque version above (which folds to an
+  // unconditional trap), the out-of-bounds access is not known at compile
+  // time, so this emits a runtime-checked loop that traps on the OOB
+  // iteration.
+  int res = 0;
   for (unsigned char i = 0; i < opaque(5); i++) {
     res += a[i];
   }
@@ -284,11 +291,11 @@ typedef struct {
 void concat_to_separate_clobals(hdr_t *p_buf) {
   uint8_t *params = p_buf->payload + 3;
   for (unsigned char i = 0; i < 4; i++) {
-    uint8_t *__counted_by(4) p = params;
-    a[i] = p[3]; // checks not removed for p[]
-    b[i] = p[1]; // checks not removed for b[] and p[]
-    c[i] = p[2]; // checks not removed for c[] and p[]
-    d[i] = p[0]; // checks not removed for d[]
+    uint8_t *__counted_by(4) p = params; // initial p check against FAM bounds here remains
+    a[i] = p[3]; // const bound: a[] check removed, p[] check removed
+    b[i] = p[1]; // const bound: b[] check removed, p[] check removed
+    c[i] = p[2]; // const bound: c[] check removed, p[] check removed
+    d[i] = p[0]; // const bound: d[] check removed, p[] check removed
     params += 4;
   }
 }
@@ -390,11 +397,11 @@ void concat_to_separate_clobals(hdr_t *p_buf) {
 void concat_to_separate_clobals_opaque(hdr_t *p_buf) {
   uint8_t *params = p_buf->payload + 3;
   for (unsigned char i = 0; i < opaque(4); i++) {
-    uint8_t *__counted_by(4) p = params;
-    a[i] = p[3]; // checks not removed for p[]
-    b[i] = p[1]; // checks not removed for b[] and p[]
-    c[i] = p[2]; // checks not removed for c[] and p[]
-    d[i] = p[0]; // checks not removed for d[]
+    uint8_t *__counted_by(4) p = params; // initial p check against FAM bounds here remains
+    a[i] = p[3]; // opaque bound: a[] check NOT removed, p[] check removed
+    b[i] = p[1]; // opaque bound: b[] check NOT removed, p[] check removed
+    c[i] = p[2]; // opaque bound: c[] check NOT removed, p[] check removed
+    d[i] = p[0]; // opaque bound: d[] check NOT removed, p[] check removed
     params += 4;
   }
 }
@@ -521,11 +528,11 @@ void concat_to_arrays_struct_can_remove_arrays_check(struct arrays *arrays, hdr_
   uint8_t *params = p_buf->payload + 3;
 
   for (unsigned char i = 0; i < 4; i++) {
-    uint8_t *__counted_by(4) p = params;
-    arrays->a[i] = p[3]; // checks not removed for p[]
-    arrays->b[i] = p[1]; // checks not removed for b[] and p[]
-    arrays->c[i] = p[2]; // checks not removed for c[] and p[]
-    arrays->d[i] = p[0]; // checks not removed for d[]
+    uint8_t *__counted_by(4) p = params; // initial p check against FAM bounds here remains
+    arrays->a[i] = p[3]; // const bound: a[] check removed, p[] check removed
+    arrays->b[i] = p[1]; // const bound: b[] check removed, p[] check removed
+    arrays->c[i] = p[2]; // const bound: c[] check removed, p[] check removed
+    arrays->d[i] = p[0]; // const bound: d[] check removed, p[] check removed
     params += 4;
   }
 }
@@ -628,11 +635,11 @@ void concat_to_arrays_struct_can_remove_arrays_check_opaque(struct arrays *array
   uint8_t *params = p_buf->payload + 3;
 
   for (unsigned char i = 0; i < opaque(4); i++) {
-    uint8_t *__counted_by(4) p = params;
-    arrays->a[i] = p[3]; // checks not removed for p[]
-    arrays->b[i] = p[1]; // checks not removed for b[] and p[]
-    arrays->c[i] = p[2]; // checks not removed for c[] and p[]
-    arrays->d[i] = p[0]; // checks not removed for d[]
+    uint8_t *__counted_by(4) p = params; // initial p check against FAM bounds here remains
+    arrays->a[i] = p[3]; // opaque bound: a[] check NOT removed, p[] check removed
+    arrays->b[i] = p[1]; // opaque bound: b[] check NOT removed, p[] check removed
+    arrays->c[i] = p[2]; // opaque bound: c[] check NOT removed, p[] check removed
+    arrays->d[i] = p[0]; // opaque bound: d[] check NOT removed, p[] check removed
     params += 4;
   }
 }
@@ -756,12 +763,14 @@ void concat_to_arrays_struct_can_remove_arrays_check_opaque(struct arrays *array
 void concat_to_arrays_struct_trap_on_last_iter(struct arrays *arrays, hdr_t *p_buf) {
   uint8_t *params = p_buf->payload + 3;
 
+  // const bound: i==4 is out of bounds for the [4] arrays, so this folds to a
+  // trap on the last iteration.
   for (unsigned char i = 0; i < 5; i++) {
-    uint8_t *__counted_by(4) p = params;
-    arrays->a[i] = p[3]; // checks not removed for p[]
-    arrays->b[i] = p[1]; // checks not removed for b[] and p[]
-    arrays->c[i] = p[2]; // checks not removed for c[] and p[]
-    arrays->d[i] = p[0]; // checks not removed for d[]
+    uint8_t *__counted_by(4) p = params; // initial p check against FAM bounds here remains
+    arrays->a[i] = p[3]; // const bound: a[] check removed, p[] check removed
+    arrays->b[i] = p[1]; // const bound: b[] check removed, p[] check removed
+    arrays->c[i] = p[2]; // const bound: c[] check removed, p[] check removed
+    arrays->d[i] = p[0]; // const bound: d[] check removed, p[] check removed
     params += 4;
   }
 }
@@ -864,11 +873,11 @@ void concat_to_arrays_struct_trap_on_last_iter_opaque(struct arrays *arrays, hdr
   uint8_t *params = p_buf->payload + 3;
 
   for (unsigned char i = 0; i < opaque(5); i++) {
-    uint8_t *__counted_by(4) p = params;
-    arrays->a[i] = p[3]; // checks not removed for p[]
-    arrays->b[i] = p[1]; // checks not removed for b[] and p[]
-    arrays->c[i] = p[2]; // checks not removed for c[] and p[]
-    arrays->d[i] = p[0]; // checks not removed for d[]
+    uint8_t *__counted_by(4) p = params; // initial p check against FAM bounds here remains
+    arrays->a[i] = p[3]; // opaque bound: a[] check NOT removed, p[] check removed
+    arrays->b[i] = p[1]; // opaque bound: b[] check NOT removed, p[] check removed
+    arrays->c[i] = p[2]; // opaque bound: c[] check NOT removed, p[] check removed
+    arrays->d[i] = p[0]; // opaque bound: d[] check NOT removed, p[] check removed
     params += 4;
   }
 }
@@ -969,11 +978,11 @@ void concat_to_arrays_struct_cannot_remove_arrays_check(struct arrays *arrays, h
   uint8_t *params = p_buf->payload + 3;
 
   for (unsigned char i = 0; i < n; i++) {
-    uint8_t *__counted_by(4) p = params;
-    arrays->a[i] = p[3]; // checks not removed for p[]
-    arrays->b[i] = p[1]; // checks not removed for b[] and p[]
-    arrays->c[i] = p[2]; // checks not removed for c[] and p[]
-    arrays->d[i] = p[0]; // checks not removed for d[]
+    uint8_t *__counted_by(4) p = params; // initial p check against FAM bounds here remains
+    arrays->a[i] = p[3]; // runtime bound: a[] check NOT removed, p[] check removed
+    arrays->b[i] = p[1]; // runtime bound: b[] check NOT removed, p[] check removed
+    arrays->c[i] = p[2]; // runtime bound: c[] check NOT removed, p[] check removed
+    arrays->d[i] = p[0]; // runtime bound: d[] check NOT removed, p[] check removed
     params += 4;
   }
 }


### PR DESCRIPTION
…GEP-cmp fold

Upstream commit https://github.com/llvm/llvm-project/pull/208547 teaches InstCombine to fold `icmp pred (gep base, C1), (gep base, C2)` into `icmp pred C1, C2` for constant offsets even without matching nowrap flags on both GEPs, as long as they cross the base's alignment boundary the same number of times.

This lets the optimizer statically determine that some of these bounds checks will fail.

rdar://182908744