### PR TITLE
[lldb][Windows] Build REPL module-import test libraries with the platform library name

### DIFF
--- a/lldb/test/Shell/SwiftREPL/LookupAfterImport.test
+++ b/lldb/test/Shell/SwiftREPL/LookupAfterImport.test
@@ -4,7 +4,7 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir %t
-// RUN: %target-swiftc -emit-library %S/Inputs/A.swift -module-name A -emit-module-path %t/A.swiftmodule -o %t/libA%target-shared-library-suffix
+// RUN: %target-swiftc -emit-library %S/Inputs/A.swift -module-name A -emit-module-path %t/A.swiftmodule -o %t/%target-shared-library-prefixA%target-shared-library-suffix
 // RUN: %lldb --repl="-I%t -L%t -lA" < %s 2>&1 | FileCheck %s
 
 "".foo()

--- a/lldb/test/Shell/SwiftREPL/LookupWithAttributedImport.test
+++ b/lldb/test/Shell/SwiftREPL/LookupWithAttributedImport.test
@@ -4,7 +4,7 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir %t
-// RUN: %target-swiftc -emit-library %S/Inputs/Test.swift -module-name Test -emit-module-path %t/Test.swiftmodule -o %t/libTest%target-shared-library-suffix -Onone -g  -enable-testing
+// RUN: %target-swiftc -emit-library %S/Inputs/Test.swift -module-name Test -emit-module-path %t/Test.swiftmodule -o %t/%target-shared-library-prefixTest%target-shared-library-suffix -Onone -g  -enable-testing
 
 // RUN: %lldb --repl="-I%t -L%t -lTest" < %s 2>&1 | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/SwiftInterface.test
+++ b/lldb/test/Shell/SwiftREPL/SwiftInterface.test
@@ -4,7 +4,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: cp %S/Inputs/A.swift %t/AA.swift
-// RUN: %target-swiftc -swift-version 5 -module-name AA -emit-module-interface-path %t/AA.swiftinterface -emit-library -o %t/libAA%target-shared-library-suffix %t/AA.swift
+// RUN: %target-swiftc -swift-version 5 -module-name AA -emit-module-interface-path %t/AA.swiftinterface -emit-library -o %t/%target-shared-library-prefixAA%target-shared-library-suffix %t/AA.swift
 // RUN: rm %t/AA.swift
 // RUN: %lldb --repl="-I%t -L%t -lAA" < %s | FileCheck %s
 

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -241,8 +241,17 @@ def use_support_substitutions(config):
     else:
         host_flags += ["-pthread"]
 
-    config.target_shared_library_suffix = (
-        ".dylib" if platform.system() in ["Darwin"] else ".so"
+    if platform.system() == "Darwin":
+        config.target_shared_library_prefix = "lib"
+        config.target_shared_library_suffix = ".dylib"
+    elif platform.system() == "Windows":
+        config.target_shared_library_prefix = ""
+        config.target_shared_library_suffix = ".dll"
+    else:
+        config.target_shared_library_prefix = "lib"
+        config.target_shared_library_suffix = ".so"
+    config.substitutions.append(
+        ("%target-shared-library-prefix", config.target_shared_library_prefix)
     )
     config.substitutions.append(
         ("%target-shared-library-suffix", config.target_shared_library_suffix)

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -17,11 +17,8 @@ xfail lldb-shell :: Swift/global.test
 xfail lldb-shell :: Swift/runtime-initialization.test
 xfail lldb-shell :: SwiftREPL/ClosureScope.test
 xfail lldb-shell :: SwiftREPL/ExistentialTypes.test
-xfail lldb-shell :: SwiftREPL/LookupAfterImport.test
-xfail lldb-shell :: SwiftREPL/LookupWithAttributedImport.test
 xfail lldb-shell :: SwiftREPL/OptionalUnowned.test
 xfail lldb-shell :: SwiftREPL/RedirectInputUnreadable.test
-xfail lldb-shell :: SwiftREPL/SwiftInterface.test
 
 ### Tests that pass locally, but fail in CI reliably ###
 


### PR DESCRIPTION
The prefix was wrong on Windows.