### PR TITLE
Fix build on Linux

### DIFF
--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_ADT_DENSEMAPINFO_H
 #define LLVM_ADT_DENSEMAPINFO_H
 
+#include <cstdlib>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
```
In file included from /home/build-user/llvm-project/llvm/include/llvm/ADT/StringRef.h:12,
                 from /home/build-user/llvm-project/llvm/include/llvm/FileCheck/FileCheck.h:16,
                 from /home/build-user/llvm-project/llvm/unittests/FileCheck/FileCheckTest.cpp:9:
/home/build-user/llvm-project/llvm/include/llvm/ADT/DenseMapInfo.h: In static member function 'static T* llvm::DenseMapInfo<T*>::getEmptyKey()':
/home/build-user/llvm-project/llvm/include/llvm/ADT/DenseMapInfo.h:68:5: error: there are no arguments to 'abort' that depend on a template parameter, so a declaration of 'abort' must be available [-fpermissive]
   68 |     abort();
      |     ^~~~~

```