### PR TITLE
[WebKit Checkers] Share the safety model of WebKit smart pointers (#210195)

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -139,6 +139,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   WebKit/RawPtrRefLambdaCapturesChecker.cpp
   WebKit/RawPtrRefLocalVarsChecker.cpp
   WebKit/RawPtrRefMemberChecker.cpp
+  WebKit/RawPtrRefSafetyModel.cpp
 
   # This is a temporary checker to make the old spelling of the checker valid.
   MigrateOldUsesOfCoreFixedAddressDereferenceChecker.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_ANALYZER_WEBKIT_PTRTYPESEMANTICS_H
 #define LLVM_CLANG_ANALYZER_WEBKIT_PTRTYPESEMANTICS_H
 
+#include "clang/AST/Stmt.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -9,6 +9,7 @@
 #include "ASTUtils.h"
 #include "DiagOutputUtils.h"
 #include "PtrTypesSemantics.h"
+#include "RawPtrRefSafetyModel.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
@@ -36,19 +37,13 @@ class RawPtrRefCallArgsChecker
 
 protected:
   mutable BugReporter *BR;
-  mutable std::optional<RetainTypeChecker> RTC;
+  const std::unique_ptr<PtrRefSafetyModel> Model;
 
 public:
-  RawPtrRefCallArgsChecker(const char *description)
-      : Bug(this, description, "WebKit coding guidelines") {}
-
-  virtual std::optional<bool> isUnsafeType(QualType) const = 0;
-  virtual std::optional<bool> isUnsafePtr(QualType) const = 0;
-  virtual bool isSafePtr(const CXXRecordDecl *Record) const = 0;
-  virtual bool isSafePtrType(const QualType type) const = 0;
-  virtual bool isSafeExpr(const Expr *) const { return false; }
-  virtual bool isSafeDecl(const Decl *) const { return false; }
-  virtual const char *typeName() const = 0;
+  RawPtrRefCallArgsChecker(const char *description,
+                           std::unique_ptr<PtrRefSafetyModel> Model)
+      : Bug(this, description, "WebKit coding guidelines"),
+        Model(std::move(Model)) {}
 
   void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
                     BugReporter &BRArg) const {
@@ -92,8 +87,8 @@ public:
       }
 
       bool VisitTypedefDecl(TypedefDecl *TD) override {
-        if (Checker->RTC)
-          Checker->RTC->visitTypedef(TD);
+        if (auto *RTC = Checker->Model->retainTypeChecker())
+          RTC->visitTypedef(TD);
         return true;
       }
 
@@ -104,7 +99,7 @@ public:
     };
 
     LocalVisitor visitor(this);
-    if (RTC)
+    if (auto *RTC = Model->retainTypeChecker())
       RTC->visitTranslationUnitDecl(TUD);
     visitor.TraverseDecl(const_cast<TranslationUnitDecl *>(TUD));
   }
@@ -124,7 +119,7 @@ public:
       if (ArgIdx) {
         auto *Arg = CE->getArg(0);
         QualType ArgType = Arg->getType().getCanonicalType();
-        std::optional<bool> IsUnsafe = isUnsafeType(ArgType);
+        std::optional<bool> IsUnsafe = Model->isUnsafeType(ArgType);
         if (IsUnsafe && *IsUnsafe && !isPtrOriginSafe(Arg))
           reportBugOnThis(F, Arg, D);
       }
@@ -182,7 +177,7 @@ public:
       return;
 
     if (auto *Receiver = E->getInstanceReceiver()) {
-      std::optional<bool> IsUnsafe = isUnsafePtr(E->getReceiverType());
+      std::optional<bool> IsUnsafe = Model->isUnsafePtr(E->getReceiverType());
       if (IsUnsafe && *IsUnsafe && !isPtrOriginSafe(Receiver)) {
         if (isAllocInit(E))
           return;
@@ -203,7 +198,7 @@ public:
       bool hasParam = i < MethodDecl->param_size();
       auto *Param = hasParam ? MethodDecl->getParamDecl(i) : nullptr;
       auto ArgType = Arg->getType();
-      std::optional<bool> IsUnsafe = isUnsafePtr(ArgType);
+      std::optional<bool> IsUnsafe = Model->isUnsafePtr(ArgType);
       if (!IsUnsafe || !(*IsUnsafe))
         continue;
       if (isPtrOriginSafe(Arg))
@@ -225,7 +220,7 @@ public:
     }
     auto *ThisExpr = MemberCallExpr->getImplicitObjectArgument();
     QualType ArgType = MemberCallExpr->getObjectType().getCanonicalType();
-    std::optional<bool> IsUnsafe = isUnsafeType(ArgType);
+    std::optional<bool> IsUnsafe = Model->isUnsafeType(ArgType);
     if (!IsUnsafe || !*IsUnsafe)
       return;
 
@@ -237,7 +232,7 @@ public:
 
   void checkArg(const NamedDecl *Callee, const Expr *Arg, QualType ParamType,
                 const ParmVarDecl *Param, const Decl *DeclWithIssue) const {
-    std::optional<bool> IsUncounted = isUnsafePtr(ParamType);
+    std::optional<bool> IsUncounted = Model->isUnsafePtr(ParamType);
     if (!IsUncounted || !(*IsUncounted))
       return;
 
@@ -253,9 +248,13 @@ public:
   bool isPtrOriginSafe(const Expr *Arg) const {
     return tryToFindPtrOrigin(
         Arg, /*StopAtFirstRefCountedObj=*/true,
-        [&](const clang::CXXRecordDecl *Record) { return isSafePtr(Record); },
-        [&](const clang::QualType T) { return isSafePtrType(T); },
-        [&](const clang::Decl *D) { return isSafeDecl(D); },
+        [&](const clang::CXXRecordDecl *Record) {
+          return Model->isSafePtr(Record);
+        },
+        [&](const clang::QualType T) { return Model->isSafePtrType(T); },
+        [&](const clang::Decl *D) {
+          return Model->isSafeDecl(D, BR->getSourceManager());
+        },
         [&](const clang::Expr *ArgOrigin, bool IsSafe) {
           if (IsSafe)
             return true;
@@ -278,7 +277,7 @@ public:
             if (isPtrOriginSafe(MCE->getImplicitObjectArgument()))
               return true;
           }
-          if (isSafeExpr(ArgOrigin))
+          if (Model->isSafeExpr(ArgOrigin))
             return true;
           return false;
         });
@@ -308,7 +307,7 @@ public:
         auto *callee = MemberOp->getDirectCallee();
         if (auto *calleeDecl = dyn_cast<CXXMethodDecl>(callee)) {
           if (const CXXRecordDecl *classDecl = calleeDecl->getParent()) {
-            if (isSafePtr(classDecl))
+            if (Model->isSafePtr(classDecl))
               return true;
           }
         }
@@ -413,6 +412,7 @@ public:
       ArgType = QT.getTypePtr();
     }
     if (printPointer(Os, ArgType) == PrintDeclKind::Pointer) {
+      auto *RTC = Model->retainTypeChecker();
       assert(RTC);
       if (auto *Decl = RTC->getCanonicalDecl(QT)) {
         printQuotedQualifiedName(Os, Decl);
@@ -453,7 +453,7 @@ public:
       Os << " to ";
       printQuotedQualifiedName(Os, Callee);
     }
-    Os << ") is a raw pointer to " << typeName() << " ";
+    Os << ") is a raw pointer to " << Model->typeName() << " ";
     printTypeName(Os, CallArg->getType());
 
     PathDiagnosticLocation BSLoc(SrcLocToReport, BR->getSourceManager());
@@ -478,7 +478,7 @@ public:
       printQuotedQualifiedName(Os, Callee);
       Os << ")";
     }
-    Os << " is a raw pointer to " << typeName() << " ";
+    Os << " is a raw pointer to " << Model->typeName() << " ";
     printTypeName(Os, CallArg->getType());
 
     PathDiagnosticLocation BSLoc(SrcLocToReport, BR->getSourceManager());
@@ -504,11 +504,18 @@ public:
   }
 
   enum class PrintDeclKind { Pointee, Pointer };
-  virtual PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
-                                     const Type *T) const {
+  PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
+                             const Type *T) const {
+    // Retain/OS types are frequently spelled through a typedef (e.g. CFXXXRef);
+    // print the typedef name rather than desugaring to the pointee.
+    if (Model->retainTypeChecker() && isa<TypedefType>(T)) {
+      Os << Model->typeName() << " ";
+      return PrintDeclKind::Pointer;
+    }
     T = T->getUnqualifiedDesugaredType();
     bool IsPtr = isa<PointerType, ObjCObjectPointerType>(T);
-    Os << "raw " << (IsPtr ? "pointer" : "reference") << " to " << typeName();
+    Os << "raw " << (IsPtr ? "pointer" : "reference") << " to "
+       << Model->typeName();
     return PrintDeclKind::Pointee;
   }
 };
@@ -517,95 +524,24 @@ class UncountedCallArgsChecker final : public RawPtrRefCallArgsChecker {
 public:
   UncountedCallArgsChecker()
       : RawPtrRefCallArgsChecker("Uncounted call argument for a raw "
-                                 "pointer/reference parameter") {}
-
-  std::optional<bool> isUnsafeType(QualType QT) const final {
-    return isUncounted(QT);
-  }
-
-  std::optional<bool> isUnsafePtr(QualType QT) const final {
-    return isUncountedPtr(QT.getCanonicalType());
-  }
-
-  bool isSafePtr(const CXXRecordDecl *Record) const final {
-    return isRefCounted(Record) || isCheckedPtr(Record);
-  }
-
-  bool isSafePtrType(const QualType type) const final {
-    return isRefOrCheckedPtrType(type);
-  }
-
-  const char *typeName() const final { return "RefPtr-capable type"; }
+                                 "pointer/reference parameter",
+                                 makeRefPtrSafetyModel()) {}
 };
 
 class UncheckedCallArgsChecker final : public RawPtrRefCallArgsChecker {
 public:
   UncheckedCallArgsChecker()
       : RawPtrRefCallArgsChecker("Unchecked call argument for a raw "
-                                 "pointer/reference parameter") {}
-
-  std::optional<bool> isUnsafeType(QualType QT) const final {
-    return isUnchecked(QT);
-  }
-
-  std::optional<bool> isUnsafePtr(QualType QT) const final {
-    return isUncheckedPtr(QT.getCanonicalType());
-  }
-
-  bool isSafePtr(const CXXRecordDecl *Record) const final {
-    return isRefCounted(Record) || isCheckedPtr(Record);
-  }
-
-  bool isSafePtrType(const QualType type) const final {
-    return isRefOrCheckedPtrType(type);
-  }
-
-  bool isSafeExpr(const Expr *E) const final {
-    return isExprToGetCheckedPtrCapableMember(E);
-  }
-
-  const char *typeName() const final { return "CheckedPtr-capable type"; }
+                                 "pointer/reference parameter",
+                                 makeCheckedPtrSafetyModel()) {}
 };
 
 class UnretainedCallArgsChecker final : public RawPtrRefCallArgsChecker {
 public:
   UnretainedCallArgsChecker()
       : RawPtrRefCallArgsChecker("Unretained call argument for a raw "
-                                 "pointer/reference parameter") {
-    RTC = RetainTypeChecker();
-  }
-
-  std::optional<bool> isUnsafeType(QualType QT) const final {
-    return RTC->isUnretained(QT);
-  }
-
-  std::optional<bool> isUnsafePtr(QualType QT) const final {
-    return RTC->isUnretained(QT);
-  }
-
-  bool isSafePtr(const CXXRecordDecl *Record) const final {
-    return isRetainPtrOrOSPtr(Record);
-  }
-
-  bool isSafePtrType(const QualType type) const final {
-    return isRetainPtrOrOSPtrType(type);
-  }
-
-  bool isSafeDecl(const Decl *D) const final {
-    // Treat NS/CF globals in system header as immortal.
-    return BR->getSourceManager().isInSystemHeader(D->getLocation());
-  }
-
-  PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
-                             const Type *T) const final {
-    if (isa<TypedefType>(T)) {
-      Os << typeName() << " ";
-      return PrintDeclKind::Pointer;
-    }
-    return RawPtrRefCallArgsChecker::printPointer(Os, T);
-  }
-
-  const char *typeName() const final { return "RetainPtr-capable type"; }
+                                 "pointer/reference parameter",
+                                 makeRetainPtrSafetyModel()) {}
 };
 
 } // namespace

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -9,6 +9,7 @@
 #include "ASTUtils.h"
 #include "DiagOutputUtils.h"
 #include "PtrTypesSemantics.h"
+#include "RawPtrRefSafetyModel.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/BugReporter/BugReporter.h"
@@ -28,15 +29,20 @@ private:
   TrivialFunctionAnalysis TFA;
 
 protected:
-  mutable std::optional<RetainTypeChecker> RTC;
+  const std::unique_ptr<PtrRefSafetyModel> Model;
 
 public:
-  RawPtrRefLambdaCapturesChecker(const char *description)
-      : Bug(this, description, "WebKit coding guidelines") {}
+  RawPtrRefLambdaCapturesChecker(const char *description,
+                                 std::unique_ptr<PtrRefSafetyModel> Model)
+      : Bug(this, description, "WebKit coding guidelines"),
+        Model(std::move(Model)) {}
 
-  virtual std::optional<bool> isUnsafePtr(QualType) const = 0;
-  virtual bool isPtrType(const std::string &) const = 0;
-  virtual const char *typeName() const = 0;
+  std::optional<bool> isUnsafePtr(QualType QT) const {
+    return isUnsafePtrForStorage(*Model, QT);
+  }
+  bool isPtrType(const std::string &Name) const {
+    return Model->isPtrType(Name);
+  }
 
   void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
                     BugReporter &BRArg) const {
@@ -93,8 +99,8 @@ public:
       }
 
       bool VisitTypedefDecl(TypedefDecl *TD) override {
-        if (Checker->RTC)
-          Checker->RTC->visitTypedef(TD);
+        if (auto *RTC = Checker->Model->retainTypeChecker())
+          RTC->visitTypedef(TD);
         return true;
       }
 
@@ -494,7 +500,7 @@ public:
     };
 
     LocalVisitor visitor(this);
-    if (RTC)
+    if (auto *RTC = Model->retainTypeChecker())
       RTC->visitTranslationUnitDecl(TUD);
     visitor.TraverseDecl(const_cast<TranslationUnitDecl *>(TUD));
   }
@@ -573,7 +579,7 @@ public:
       Os << "Implicitly captured ";
     }
 
-    Os << "variable 'this' is a raw pointer to " << typeName();
+    Os << "variable 'this' is a raw pointer to " << Model->typeName();
     if (auto *RD = T->getPointeeCXXRecordDecl()) {
       Os << " ";
       printQuotedQualifiedName(Os, RD);
@@ -584,12 +590,36 @@ public:
     BR->emitReport(std::move(Report));
   }
 
-  virtual void printPointer(llvm::raw_svector_ostream &Os,
-                            const Type *T) const {
+  void printPointer(llvm::raw_svector_ostream &Os, const Type *T) const {
+    if (Model->retainTypeChecker()) {
+      // An OS object may be spelled as an id qualified by an OS_-prefixed
+      // protocol; print that protocol name.
+      if (auto *ObjCPtr = dyn_cast<ObjCObjectPointerType>(T)) {
+        for (ObjCProtocolDecl *P : ObjCPtr->quals()) {
+          if (const auto *II = P->getIdentifier()) {
+            auto Name = II->getName();
+            if (Name.starts_with("OS_")) {
+              Os << Model->typeName() << " ";
+              printQuotedQualifiedName(Os, P);
+              return;
+            }
+          }
+        }
+      }
+      // Retain/OS types are frequently spelled through a typedef (e.g.
+      // CFXXXRef); print the typedef name rather than desugaring.
+      if (!isa<ObjCObjectPointerType>(T) && T->getAs<TypedefType>()) {
+        auto Typedef = T->getAs<TypedefType>();
+        assert(Typedef);
+        Os << Model->typeName() << " ";
+        printQuotedQualifiedName(Os, Typedef->getDecl());
+        return;
+      }
+    }
     T = T->getUnqualifiedDesugaredType();
     bool IsPtr = isa<PointerType>(T) || isa<ObjCObjectPointerType>(T);
     Os << (IsPtr ? "raw pointer" : "raw reference") << " to ";
-    Os << typeName();
+    Os << Model->typeName();
 
     if (auto *RD = T->getPointeeType()->getAsRecordDecl()) {
       Os << " ";
@@ -604,79 +634,23 @@ public:
 class UncountedLambdaCapturesChecker : public RawPtrRefLambdaCapturesChecker {
 public:
   UncountedLambdaCapturesChecker()
-      : RawPtrRefLambdaCapturesChecker("Lambda capture of uncounted variable") {
-  }
-
-  std::optional<bool> isUnsafePtr(QualType QT) const final {
-    return isUncountedPtr(QT.getCanonicalType());
-  }
-
-  virtual bool isPtrType(const std::string &Name) const final {
-    return isRefType(Name);
-  }
-
-  const char *typeName() const final { return "RefPtr-capable type"; }
+      : RawPtrRefLambdaCapturesChecker("Lambda capture of uncounted variable",
+                                       makeRefPtrSafetyModel()) {}
 };
 
 class UncheckedLambdaCapturesChecker : public RawPtrRefLambdaCapturesChecker {
 public:
   UncheckedLambdaCapturesChecker()
-      : RawPtrRefLambdaCapturesChecker("Lambda capture of unchecked variable") {
-  }
-
-  std::optional<bool> isUnsafePtr(QualType QT) const final {
-    return isUncheckedPtr(QT.getCanonicalType());
-  }
-
-  virtual bool isPtrType(const std::string &Name) const final {
-    return isCheckedPtr(Name);
-  }
-
-  const char *typeName() const final { return "CheckedPtr-capable type"; }
+      : RawPtrRefLambdaCapturesChecker("Lambda capture of unchecked variable",
+                                       makeCheckedPtrSafetyModel()) {}
 };
 
 class UnretainedLambdaCapturesChecker : public RawPtrRefLambdaCapturesChecker {
 public:
   UnretainedLambdaCapturesChecker()
       : RawPtrRefLambdaCapturesChecker("Lambda capture of unretained "
-                                       "variables") {
-    RTC = RetainTypeChecker();
-  }
-
-  std::optional<bool> isUnsafePtr(QualType QT) const final {
-    if (QT.hasStrongOrWeakObjCLifetime())
-      return false;
-    return RTC->isUnretained(QT);
-  }
-
-  virtual bool isPtrType(const std::string &Name) const final {
-    return isRetainPtrOrOSPtr(Name);
-  }
-
-  const char *typeName() const final { return "RetainPtr-capable type"; }
-
-  void printPointer(llvm::raw_svector_ostream &Os, const Type *T) const final {
-    if (auto *ObjCPtr = dyn_cast<ObjCObjectPointerType>(T)) {
-      for (ObjCProtocolDecl *P : ObjCPtr->quals()) {
-        if (const auto *II = P->getIdentifier()) {
-          auto Name = II->getName();
-          if (Name.starts_with("OS_")) {
-            Os << typeName() << " ";
-            printQuotedQualifiedName(Os, P);
-            return;
-          }
-        }
-      }
-    }
-    if (!isa<ObjCObjectPointerType>(T) && T->getAs<TypedefType>()) {
-      auto Typedef = T->getAs<TypedefType>();
-      assert(Typedef);
-      Os << typeName() << " ";
-      printQuotedQualifiedName(Os, Typedef->getDecl());
-      return;
-    }
-    return RawPtrRefLambdaCapturesChecker::printPointer(Os, T);
-  }
+                                       "variables",
+                                       makeRetainPtrSafetyModel()) {}
 };
 
 } // namespace

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -9,6 +9,7 @@
 #include "ASTUtils.h"
 #include "DiagOutputUtils.h"
 #include "PtrTypesSemantics.h"
+#include "RawPtrRefSafetyModel.h"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -196,18 +197,17 @@ class RawPtrRefLocalVarsChecker
 
 protected:
   mutable BugReporter *BR;
-  mutable std::optional<RetainTypeChecker> RTC;
+  const std::unique_ptr<PtrRefSafetyModel> Model;
 
 public:
-  RawPtrRefLocalVarsChecker(const char *description)
-      : Bug(this, description, "WebKit coding guidelines") {}
+  RawPtrRefLocalVarsChecker(const char *description,
+                            std::unique_ptr<PtrRefSafetyModel> Model)
+      : Bug(this, description, "WebKit coding guidelines"),
+        Model(std::move(Model)) {}
 
-  virtual std::optional<bool> isUnsafePtr(const QualType T) const = 0;
-  virtual bool isSafePtr(const CXXRecordDecl *) const = 0;
-  virtual bool isSafePtrType(const QualType) const = 0;
-  virtual bool isSafeExpr(const Expr *) const { return false; }
-  virtual bool isSafeDecl(const Decl *) const { return false; }
-  virtual const char *typeName() const = 0;
+  std::optional<bool> isUnsafePtr(QualType T) const {
+    return isUnsafePtrForStorage(*Model, T);
+  }
 
   void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
                     BugReporter &BRArg) const {
@@ -237,8 +237,8 @@ public:
       }
 
       bool VisitTypedefDecl(TypedefDecl *TD) override {
-        if (Checker->RTC)
-          Checker->RTC->visitTypedef(TD);
+        if (auto *RTC = Checker->Model->retainTypeChecker())
+          RTC->visitTypedef(TD);
         return true;
       }
 
@@ -305,7 +305,7 @@ public:
     };
 
     LocalVisitor visitor(this);
-    if (RTC)
+    if (auto *RTC = Model->retainTypeChecker())
       RTC->visitTranslationUnitDecl(TUD);
     visitor.TraverseDecl(const_cast<TranslationUnitDecl *>(TUD));
   }
@@ -339,9 +339,13 @@ public:
                        const Decl *DeclWithIssue) const {
     return tryToFindPtrOrigin(
         Value, /*StopAtFirstRefCountedObj=*/false,
-        [&](const clang::CXXRecordDecl *Record) { return isSafePtr(Record); },
-        [&](const clang::QualType Type) { return isSafePtrType(Type); },
-        [&](const clang::Decl *D) { return isSafeDecl(D); },
+        [&](const clang::CXXRecordDecl *Record) {
+          return Model->isSafePtr(Record);
+        },
+        [&](const clang::QualType Type) { return Model->isSafePtrType(Type); },
+        [&](const clang::Decl *D) {
+          return Model->isSafeDecl(D, BR->getSourceManager());
+        },
         [&](const clang::Expr *InitArgOrigin, bool IsSafe) {
           if (!InitArgOrigin || IsSafe)
             return true;
@@ -361,7 +365,7 @@ public:
           if (EFA.isACallToEnsureFn(InitArgOrigin))
             return true;
 
-          if (isSafeExpr(InitArgOrigin))
+          if (Model->isSafeExpr(InitArgOrigin))
             return true;
 
           if (auto *Ref = llvm::dyn_cast<DeclRefExpr>(InitArgOrigin)) {
@@ -374,7 +378,7 @@ public:
                     MaybeGuardianArgType->getAsCXXRecordDecl();
                 if (MaybeGuardianArgCXXRecord) {
                   if (MaybeGuardian->isLocalVarDecl() &&
-                      (isSafePtr(MaybeGuardianArgCXXRecord) ||
+                      (Model->isSafePtr(MaybeGuardianArgCXXRecord) ||
                        isRefcountedStringsHack(MaybeGuardian)) &&
                       isGuardedScopeEmbeddedInGuardianScope(V, MaybeGuardian))
                     return true;
@@ -452,9 +456,9 @@ public:
     if (auto *ET = dyn_cast_or_null<ElaboratedType>(QT.getTypePtrOrNull()))
       QT = ET->desugar();
     auto *VarType = QT.getTypePtr();
+    auto *RTC = Model->retainTypeChecker();
     if (RTC && isa<TypedefType>(VarType)) {
-      Os << typeName() << " ";
-      assert(RTC);
+      Os << Model->typeName() << " ";
       if (auto *Decl = RTC->getCanonicalDecl(QT)) {
         printQuotedQualifiedName(Os, Decl);
       } else {
@@ -466,7 +470,7 @@ public:
       auto *DesugaredType = VarType->getUnqualifiedDesugaredType();
       bool IsPtr = isa<PointerType, ObjCObjectPointerType>(DesugaredType);
       Os << "raw " << (IsPtr ? "pointer" : "reference") << " to ";
-      Os << typeName() << " ";
+      Os << Model->typeName() << " ";
       printTypeName(Os, QT);
     }
   }
@@ -476,62 +480,24 @@ class UncountedLocalVarsChecker final : public RawPtrRefLocalVarsChecker {
 public:
   UncountedLocalVarsChecker()
       : RawPtrRefLocalVarsChecker("Uncounted raw pointer or reference not "
-                                  "provably backed by ref-counted variable") {}
-  std::optional<bool> isUnsafePtr(const QualType T) const final {
-    return isUncountedPtr(T);
-  }
-  bool isSafePtr(const CXXRecordDecl *Record) const final {
-    return isRefCounted(Record) || isCheckedPtr(Record);
-  }
-  bool isSafePtrType(const QualType type) const final {
-    return isRefOrCheckedPtrType(type);
-  }
-  const char *typeName() const final { return "RefPtr-capable type"; }
+                                  "provably backed by ref-counted variable",
+                                  makeRefPtrSafetyModel()) {}
 };
 
 class UncheckedLocalVarsChecker final : public RawPtrRefLocalVarsChecker {
 public:
   UncheckedLocalVarsChecker()
       : RawPtrRefLocalVarsChecker("Unchecked raw pointer or reference not "
-                                  "provably backed by checked variable") {}
-  std::optional<bool> isUnsafePtr(const QualType T) const final {
-    return isUncheckedPtr(T);
-  }
-  bool isSafePtr(const CXXRecordDecl *Record) const final {
-    return isRefCounted(Record) || isCheckedPtr(Record);
-  }
-  bool isSafePtrType(const QualType type) const final {
-    return isRefOrCheckedPtrType(type);
-  }
-  bool isSafeExpr(const Expr *E) const final {
-    return isExprToGetCheckedPtrCapableMember(E);
-  }
-  const char *typeName() const final { return "CheckedPtr-capable type"; }
+                                  "provably backed by checked variable",
+                                  makeCheckedPtrSafetyModel()) {}
 };
 
 class UnretainedLocalVarsChecker final : public RawPtrRefLocalVarsChecker {
 public:
   UnretainedLocalVarsChecker()
       : RawPtrRefLocalVarsChecker("Unretained raw pointer or reference not "
-                                  "provably backed by a RetainPtr") {
-    RTC = RetainTypeChecker();
-  }
-  std::optional<bool> isUnsafePtr(const QualType T) const final {
-    if (T.hasStrongOrWeakObjCLifetime())
-      return false;
-    return RTC->isUnretained(T);
-  }
-  bool isSafePtr(const CXXRecordDecl *Record) const final {
-    return isRetainPtrOrOSPtr(Record);
-  }
-  bool isSafePtrType(const QualType type) const final {
-    return isRetainPtrOrOSPtrType(type);
-  }
-  bool isSafeDecl(const Decl *D) const final {
-    // Treat NS/CF globals in system header as immortal.
-    return BR->getSourceManager().isInSystemHeader(D->getLocation());
-  }
-  const char *typeName() const final { return "RetainPtr-capable type"; }
+                                  "provably backed by a RetainPtr",
+                                  makeRetainPtrSafetyModel()) {}
 };
 
 } // namespace

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -9,6 +9,7 @@
 #include "ASTUtils.h"
 #include "DiagOutputUtils.h"
 #include "PtrTypesSemantics.h"
+#include "RawPtrRefSafetyModel.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
@@ -32,15 +33,17 @@ private:
   mutable llvm::DenseSet<const ObjCIvarDecl *> IvarDeclsToIgnore;
 
 protected:
-  mutable std::optional<RetainTypeChecker> RTC;
+  const std::unique_ptr<PtrRefSafetyModel> Model;
 
 public:
-  RawPtrRefMemberChecker(const char *description)
-      : Bug(this, description, "WebKit coding guidelines") {}
+  RawPtrRefMemberChecker(const char *description,
+                         std::unique_ptr<PtrRefSafetyModel> Model)
+      : Bug(this, description, "WebKit coding guidelines"),
+        Model(std::move(Model)) {}
 
-  virtual std::optional<bool> isUnsafePtr(QualType,
-                                          bool ignoreARC = false) const = 0;
-  virtual const char *typeName() const = 0;
+  std::optional<bool> isUnsafePtr(QualType QT, bool IgnoreARC = false) const {
+    return isUnsafePtrForStorage(*Model, QT, IgnoreARC);
+  }
 
   void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
                     BugReporter &BRArg) const {
@@ -59,8 +62,8 @@ public:
       }
 
       bool VisitTypedefDecl(const TypedefDecl *TD) override {
-        if (Checker->RTC)
-          Checker->RTC->visitTypedef(TD);
+        if (auto *RTC = Checker->Model->retainTypeChecker())
+          RTC->visitTypedef(TD);
         return true;
       }
 
@@ -76,7 +79,7 @@ public:
     };
 
     LocalVisitor visitor(this);
-    if (RTC)
+    if (auto *RTC = Model->retainTypeChecker())
       RTC->visitTranslationUnitDecl(TUD);
     visitor.TraverseDecl(TUD);
   }
@@ -165,6 +168,7 @@ public:
       return;
 
     if (const ObjCInterfaceDecl *ID = dyn_cast<ObjCInterfaceDecl>(CD)) {
+      auto *RTC = Model->retainTypeChecker();
       if (!RTC || !RTC->defaultSynthProperties() ||
           ID->isObjCRequiresPropertyDefs())
         return;
@@ -299,11 +303,19 @@ public:
   }
 
   enum class PrintDeclKind { Pointee, Pointer };
-  virtual PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
-                                     const Type *T) const {
+  PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
+                             const Type *T) const {
+    // Retain/OS types are frequently spelled through a typedef (e.g. CFXXXRef);
+    // print the typedef name rather than desugaring to the pointee.
+    if (Model->retainTypeChecker() && !isa<ObjCObjectPointerType>(T) &&
+        T->getAs<TypedefType>()) {
+      Os << Model->typeName() << " ";
+      return PrintDeclKind::Pointer;
+    }
     T = T->getUnqualifiedDesugaredType();
     bool IsPtr = isa<PointerType>(T) || isa<ObjCObjectPointerType>(T);
-    Os << (IsPtr ? "raw pointer" : "reference") << " to " << typeName() << " ";
+    Os << (IsPtr ? "raw pointer" : "reference") << " to " << Model->typeName()
+       << " ";
     return PrintDeclKind::Pointee;
   }
 };
@@ -312,52 +324,24 @@ class NoUncountedMemberChecker final : public RawPtrRefMemberChecker {
 public:
   NoUncountedMemberChecker()
       : RawPtrRefMemberChecker("Member variable is a raw-pointer/reference to "
-                               "reference-countable type") {}
-
-  std::optional<bool> isUnsafePtr(QualType QT, bool) const final {
-    return isUncountedPtr(QT.getCanonicalType());
-  }
-
-  const char *typeName() const final { return "RefPtr-capable type"; }
+                               "reference-countable type",
+                               makeRefPtrSafetyModel()) {}
 };
 
 class NoUncheckedPtrMemberChecker final : public RawPtrRefMemberChecker {
 public:
   NoUncheckedPtrMemberChecker()
       : RawPtrRefMemberChecker("Member variable is a raw-pointer/reference to "
-                               "checked-pointer capable type") {}
-
-  std::optional<bool> isUnsafePtr(QualType QT, bool) const final {
-    return isUncheckedPtr(QT.getCanonicalType());
-  }
-
-  const char *typeName() const final { return "CheckedPtr-capable type"; }
+                               "checked-pointer capable type",
+                               makeCheckedPtrSafetyModel()) {}
 };
 
 class NoUnretainedMemberChecker final : public RawPtrRefMemberChecker {
 public:
   NoUnretainedMemberChecker()
       : RawPtrRefMemberChecker("Member variable is a raw-pointer/reference to "
-                               "retainable type") {
-    RTC = RetainTypeChecker();
-  }
-
-  std::optional<bool> isUnsafePtr(QualType QT, bool ignoreARC) const final {
-    if (QT.hasStrongOrWeakObjCLifetime())
-      return false;
-    return RTC->isUnretained(QT, ignoreARC);
-  }
-
-  const char *typeName() const final { return "RetainPtr-capable type"; }
-
-  PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
-                             const Type *T) const final {
-    if (!isa<ObjCObjectPointerType>(T) && T->getAs<TypedefType>()) {
-      Os << typeName() << " ";
-      return PrintDeclKind::Pointer;
-    }
-    return RawPtrRefMemberChecker::printPointer(Os, T);
-  }
+                               "retainable type",
+                               makeRetainPtrSafetyModel()) {}
 };
 
 } // namespace

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefSafetyModel.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefSafetyModel.cpp
@@ -1,0 +1,111 @@
+//=======- RawPtrRefSafetyModel.cpp -----------------------------*- C++ -*-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "RawPtrRefSafetyModel.h"
+#include "ASTUtils.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/SourceManager.h"
+
+using namespace clang;
+
+namespace {
+
+class RefCountedSafetyModel : public PtrRefSafetyModel {
+public:
+  std::optional<bool> isUnsafeType(QualType QT) const override {
+    return isUncounted(QT);
+  }
+  std::optional<bool> isUnsafePtr(QualType QT, bool) const override {
+    return isUncountedPtr(QT.getCanonicalType());
+  }
+  bool isSafePtr(const CXXRecordDecl *Record) const override {
+    return isRefCounted(Record) || isCheckedPtr(Record);
+  }
+  bool isSafePtrType(QualType T) const override {
+    return isRefOrCheckedPtrType(T);
+  }
+  bool isPtrType(const std::string &Name) const override {
+    return isRefType(Name);
+  }
+  const char *typeName() const override { return "RefPtr-capable type"; }
+};
+
+class CheckedPtrSafetyModel : public PtrRefSafetyModel {
+public:
+  std::optional<bool> isUnsafeType(QualType QT) const override {
+    return isUnchecked(QT);
+  }
+  std::optional<bool> isUnsafePtr(QualType QT, bool) const override {
+    return isUncheckedPtr(QT.getCanonicalType());
+  }
+  bool isSafePtr(const CXXRecordDecl *Record) const override {
+    return isRefCounted(Record) || isCheckedPtr(Record);
+  }
+  bool isSafePtrType(QualType T) const override {
+    return isRefOrCheckedPtrType(T);
+  }
+  bool isPtrType(const std::string &Name) const override {
+    return isCheckedPtr(Name);
+  }
+  bool isSafeExpr(const Expr *E) const override {
+    return isExprToGetCheckedPtrCapableMember(E);
+  }
+  const char *typeName() const override { return "CheckedPtr-capable type"; }
+};
+
+class RetainPtrSafetyModel : public PtrRefSafetyModel {
+  mutable RetainTypeChecker RTC;
+
+public:
+  std::optional<bool> isUnsafeType(QualType QT) const override {
+    return RTC.isUnretained(QT);
+  }
+  std::optional<bool> isUnsafePtr(QualType QT, bool IgnoreARC) const override {
+    return RTC.isUnretained(QT, IgnoreARC);
+  }
+  bool isSafePtr(const CXXRecordDecl *Record) const override {
+    return isRetainPtrOrOSPtr(Record);
+  }
+  bool isSafePtrType(QualType T) const override {
+    return isRetainPtrOrOSPtrType(T);
+  }
+  bool isPtrType(const std::string &Name) const override {
+    return isRetainPtrOrOSPtr(Name);
+  }
+  bool isSafeDecl(const Decl *D, const SourceManager &SM) const override {
+    // Treat NS/CF globals in system header as immortal.
+    return SM.isInSystemHeader(D->getLocation());
+  }
+  const char *typeName() const override { return "RetainPtr-capable type"; }
+  RetainTypeChecker *retainTypeChecker() const override { return &RTC; }
+};
+
+} // namespace
+
+std::optional<bool> clang::isUnsafePtrForStorage(const PtrRefSafetyModel &Model,
+                                                 QualType T, bool IgnoreARC) {
+  // A __strong / __weak Objective-C storage location is memory managed and
+  // thus safe. This exemption applies to variables/members/captures but not to
+  // call arguments, so it lives here rather than in the policy itself.
+  if (Model.retainTypeChecker() && T.hasStrongOrWeakObjCLifetime())
+    return false;
+  return Model.isUnsafePtr(T, IgnoreARC);
+}
+
+std::unique_ptr<PtrRefSafetyModel> clang::makeRefPtrSafetyModel() {
+  return std::make_unique<RefCountedSafetyModel>();
+}
+
+std::unique_ptr<PtrRefSafetyModel> clang::makeCheckedPtrSafetyModel() {
+  return std::make_unique<CheckedPtrSafetyModel>();
+}
+
+std::unique_ptr<PtrRefSafetyModel> clang::makeRetainPtrSafetyModel() {
+  return std::make_unique<RetainPtrSafetyModel>();
+}

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefSafetyModel.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefSafetyModel.h
@@ -1,0 +1,92 @@
+//=======- RawPtrRefSafetyModel.h -------------------------------*- C++ -*-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_ANALYZER_WEBKIT_RAWPTRREFSAFETYMODEL_H
+#define LLVM_CLANG_ANALYZER_WEBKIT_RAWPTRREFSAFETYMODEL_H
+
+#include "PtrTypesSemantics.h"
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace clang {
+class CXXRecordDecl;
+class Decl;
+class Expr;
+class QualType;
+class SourceManager;
+
+/// Models one WebKit pointer-safety policy: ref-counted (RefPtr), checked
+/// (CheckedPtr), or retainable (RetainPtr/OSPtr).
+///
+/// It captures the family-specific "what is a safe/unsafe pointer" questions
+/// that are shared by the various RawPtrRef* checkers, independently of how
+/// each checker traverses the AST (call arguments, local variables, members,
+/// lambda captures, ...). This lets a single policy be defined once and reused
+/// across every traversal.
+class PtrRefSafetyModel {
+public:
+  virtual ~PtrRefSafetyModel() = default;
+
+  /// \returns whether \p QT itself is an unsafe (smart-pointer-capable but not
+  /// managed) type, false if not, std::nullopt if inconclusive.
+  virtual std::optional<bool> isUnsafeType(QualType QT) const = 0;
+
+  /// \returns whether \p QT is a raw pointer or reference to an unsafe type,
+  /// false if not, std::nullopt if inconclusive. \p IgnoreARC requests that
+  /// Objective-C ARC be ignored when deciding retainability.
+  virtual std::optional<bool> isUnsafePtr(QualType QT,
+                                          bool IgnoreARC = false) const = 0;
+
+  /// \returns whether \p Record is a safe smart pointer for this policy.
+  virtual bool isSafePtr(const CXXRecordDecl *Record) const = 0;
+
+  /// \returns whether \p T is a safe smart pointer type for this policy.
+  virtual bool isSafePtrType(QualType T) const = 0;
+
+  /// \returns whether \p Name is the name of a safe smart pointer class for
+  /// this policy.
+  virtual bool isPtrType(const std::string &Name) const = 0;
+
+  /// \returns whether \p E is known to produce a safe value for this policy.
+  virtual bool isSafeExpr(const Expr *) const { return false; }
+
+  /// \returns whether \p D refers to a declaration that is safe by construction
+  /// for this policy (e.g. immortal system-header globals).
+  virtual bool isSafeDecl(const Decl *, const SourceManager &) const {
+    return false;
+  }
+
+  /// \returns a human readable name for the safe type category, used in
+  /// diagnostics (e.g. "RefPtr-capable type").
+  virtual const char *typeName() const = 0;
+
+  /// \returns the RetainTypeChecker backing this policy, or nullptr if the
+  /// policy does not track retain/OS types.
+  virtual RetainTypeChecker *retainTypeChecker() const { return nullptr; }
+};
+
+/// Applies the memory-management exemptions that hold for a variable, member,
+/// or lambda capture (but not for a call argument) before consulting \p Model:
+/// a __strong / __weak Objective-C storage location is memory managed and thus
+/// safe. \returns whether \p T is an unsafe pointer in such a storage context.
+std::optional<bool> isUnsafePtrForStorage(const PtrRefSafetyModel &Model,
+                                          QualType T, bool IgnoreARC = false);
+
+/// \returns a policy that treats ref-counted / checked pointers as safe.
+std::unique_ptr<PtrRefSafetyModel> makeRefPtrSafetyModel();
+
+/// \returns a policy that treats checked pointers as safe.
+std::unique_ptr<PtrRefSafetyModel> makeCheckedPtrSafetyModel();
+
+/// \returns a policy that treats RetainPtr / OSPtr as safe.
+std::unique_ptr<PtrRefSafetyModel> makeRetainPtrSafetyModel();
+
+} // namespace clang
+
+#endif


### PR DESCRIPTION
This PR introduces PtrRefSafetyModel to abstract away type checks for various smart pointer types in WebKit to share more code between different checkers.

(cherry picked from commit 10e0a2ee03b02a456b8d6adca4c44f01464f3d39)