### PR TITLE
[lldb] Reenable subclassing test

### DIFF
--- a/lldb/test/API/repl/subclassing/TestREPLSubclassing.py
+++ b/lldb/test/API/repl/subclassing/TestREPLSubclassing.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinrepl as lldbinrepl
 import lldbsuite.test.lldbtest as lldbtest
-import lldbsuite.test.decorators as decorators
 
-lldbinrepl.MakeREPLTest(__file__, globals(),
-        decorators=[decorators.skipIfDarwin, decorators.skipUnlessDarwin])
+lldbinrepl.MakeREPLTest(__file__, globals())


### PR DESCRIPTION
I'm not sure why this test was skipped. This is to re-enable it if it passes in CI.