### PR TITLE
[BoundsSafety] update expected AST for comma operator (NFC)

### DIFF
--- a/clang/test/BoundsSafety/AST/dynamic-count-assignment-in-comma-op.c
+++ b/clang/test/BoundsSafety/AST/dynamic-count-assignment-in-comma-op.c
@@ -561,7 +561,7 @@ void assign_assign(char *__sized_by(len) p, unsigned long long len,
 // CHECK: |   |       `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |   |         `-IntegerLiteral {{.+}} 0
 // CHECK: |   |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | |-BoundsCheckExpr {{.+}} '(len = ilen , p = ip) <= __builtin_get_pointer_upper_bound((len = ilen , p = ip)) && __builtin_get_pointer_lower_bound((len = ilen , p = ip)) <= (len = ilen , p = ip) && 0 <= (char *)__builtin_get_pointer_upper_bound((len = ilen , p = ip)) - (char *__single)(len = ilen , p = ip)'
+// CHECK: |   | |-BoundsCheckExpr {{.+}} '(len = ilen, p = ip) <= __builtin_get_pointer_upper_bound((len = ilen, p = ip)) && __builtin_get_pointer_lower_bound((len = ilen, p = ip)) <= (len = ilen, p = ip) && 0 <= (char *)__builtin_get_pointer_upper_bound((len = ilen, p = ip)) - (char *__single)(len = ilen, p = ip)'
 // CHECK: |   | | |-BinaryOperator {{.+}} 'char *__single __sized_by(llen)':'char *__single' '='
 // CHECK: |   | | | |-DeclRefExpr {{.+}} [[var_lp_1]]
 // CHECK: |   | | | `-OpaqueValueExpr [[ove_32:0x[^ ]+]] {{.*}} 'char *__single __sized_by(len)':'char *__single'

--- a/clang/test/CodeGen/attr-typed-memory-operation-sizeof-compound.c
+++ b/clang/test/CodeGen/attr-typed-memory-operation-sizeof-compound.c
@@ -84,20 +84,20 @@ void *test_homogeneous_header_array(__SIZE_TYPE__ n) {
 void *test_prefixed_array_comma(__SIZE_TYPE__ n) {
   return malloc(((void)0, sizeof(struct Header) + sizeof(struct Element) * n));
   // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
-  // expected-note@-2 {{inferred header prefixed array of {'struct Header':'struct Element'} from expression '(void)0 , sizeof(struct Header) + sizeof(struct Element) * n'}}
+  // expected-note@-2 {{inferred header prefixed array of {'struct Header':'struct Element'} from expression '(void)0, sizeof(struct Header) + sizeof(struct Element) * n'}}
   // expected-note@-3 {{encoding 'struct Header' as 74310495310558338. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "HeaderPrefixedArray" ] }, "TypeHash": 1947317378 }}}
 }
 
 void *test_array_comma(__SIZE_TYPE__ n) {
   return malloc(((void)0, sizeof(struct Element) * n));
   // expected-remark@-1 {{passing TMO information for array of type 'struct Element' to 'typed_real_malloc' (retargeted from 'malloc')}}
-  // expected-note@-2 {{inferred array of 'struct Element' from expression '(void)0 , sizeof(struct Element) * n'}}
+  // expected-note@-2 {{inferred array of 'struct Element' from expression '(void)0, sizeof(struct Element) * n'}}
   // expected-note@-3 {{encoding array of 'struct Element' as 72058145178419728. { "Summary": { "LayoutSemantics": [ "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "Array" ] }, "TypeHash": 1384677904 }}}
 }
 
 void *test_tuple_comma(void) {
   return malloc(((void)0, sizeof(struct Header) + sizeof(struct Element)));
   // expected-remark@-1 {{passing TMO information for type 'struct Header' to 'typed_real_malloc' (retargeted from 'malloc')}}
-  // expected-note@-2 {{inferred tuple of ('struct Header', 'struct Element') from expression '(void)0 , sizeof(struct Header) + sizeof(struct Element)'}}
+  // expected-note@-2 {{inferred tuple of ('struct Header', 'struct Element') from expression '(void)0, sizeof(struct Header) + sizeof(struct Element)'}}
   // expected-note@-3 {{encoding 'struct Header' as 74309670676837506. { "Summary": { "LayoutSemantics": [ "AnonymousPointer", "GenericData" ], "TypeFlags": [ ], "TypeKind": "KindC", "CallsiteFlags": [ "FixedSize" ] }, "TypeHash": 1947317378 }}}
 }


### PR DESCRIPTION
Upstream commit c6bb072d9e40 ("[Clang] Don't print extra whitespace for comma expression in StmtPrinter (#210920)") changed StmtPrinter to print comma expressions as `a, b` instead of `a , b`.

rdar://182813287