### PR TITLE
[lldb][Windows] Re-enable TestSwiftReflectionLoading on Windows

### DIFF
--- a/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
+++ b/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
@@ -11,7 +11,6 @@ class TestSwiftReflectionLoading(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test(self):
         """Test that reflection metadata is imported"""
         self.build()


### PR DESCRIPTION
Reflection metadata loading from the main executable and dynamic libraries now works on Windows, so the test passes. Remove the stale @skipIfWindows.