### PR TITLE
[lldb][Windows] Preserve breakpoint locations across process exit

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -664,7 +664,7 @@ void ProcessWindows::OnExitProcess(uint32_t exit_code) {
     ModuleSP executable_module = target->GetExecutableModule();
     ModuleList unloaded_modules;
     unloaded_modules.Append(executable_module);
-    target->ModulesDidUnload(unloaded_modules, true);
+    target->ModulesDidUnload(unloaded_modules, false);
   }
 
   SetExitStatus(exit_code, /*exit_string=*/"");

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
@@ -10,7 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class BreakpointLocationsTestCase(TestBase):
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
+    @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr24528")
     def test_enable(self):
         """Test breakpoint enable/disable for a breakpoint ID with multiple locations."""
         self.build()

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
@@ -10,7 +10,6 @@ from lldbsuite.test import lldbutil
 
 
 class BreakpointLocationsTestCase(TestBase):
-    @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr24528")
     def test_enable(self):
         """Test breakpoint enable/disable for a breakpoint ID with multiple locations."""
         self.build()

--- a/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
+++ b/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftGenericFunction(lldbtest.TestBase):
-    @expectedFailureWindows  # https://github.com/swiftlang/llvm-project/issues/13444
     @skipEmbeddedSwift
     @swiftTest
     def test(self):


### PR DESCRIPTION
ProcessWindows::OnExitProcess unloaded the executable module with delete_locations=true, which deleted the target's breakpoint locations when the inferior exited. Other platforms keep them (locations persist unresolved and re-resolve on rerun), so inspecting a breakpoint after the process died returned no location on Windows -- SBBreakpointLocation::GetDescription printed 'No value'. Pass delete_locations=false to match the cross-platform behavior.

Requires:
- https://github.com/llvm/llvm-project/pull/212219