### PR TITLE
[lldb][Windows] Run TestSwiftNoProcess.test_swift_no_process on Windows

### DIFF
--- a/lldb/test/API/lang/swift/expression/no_calculator/TestSwiftNoProcess.py
+++ b/lldb/test/API/lang/swift/expression/no_calculator/TestSwiftNoProcess.py
@@ -37,7 +37,7 @@ class TestSwiftNoProcess(TestBase):
             "Swift expression with no target should fail.")
 
     @swiftTest
-    @skipIf(oslist=['windows'])
+    @skipEmbeddedSwiftOnWindows
     def test_swift_no_process(self):
         """Tests that we give a reasonable error if we try to run expressions with no process"""
         self.build()


### PR DESCRIPTION
Only the embedded-Swift variant of `test_swift_no_process` fails on Windows (cannot resolve the 'Swift' module). The dwarf `clang/noclang` variants pass. Replace the `@skipIf(oslist=['windows'])` with `@skipEmbeddedSwiftOnWindows` so the non-embedded variants run.