### PR TITLE
[lldb] Add skipUnlessFoundationEssentials and enable Foundation value-type tests off-Darwin

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1114,9 +1114,29 @@ def skipUnlessDarwin(func):
 
 
 def skipUnlessFoundation(func):
-    """Decorate the item to skip tests that should be skipped on any non-Foundation platform."""
+    """Decorate the item to skip tests that need full (Darwin) Foundation.
+
+    This is for tests that rely on Objective-C bridging / the Apple Foundation
+    framework (NSString/NSDictionary/NSNumber bridging, CoreFoundation types,
+    ObjC-backed value-type formatters). That capability only exists on Darwin.
+    For tests that only need the cross-platform Swift Foundation core (Data,
+    Date, URL, UUID, JSON coding, NSObject/NSRange from swift-corelibs
+    Foundation), use skipUnlessFoundationEssentials instead.
+    """
     # FIXME: This is just an alias for Darwin and is consistent with Swift's test suite.
     return skipUnlessDarwin(func)
+
+
+def skipUnlessFoundationEssentials(func):
+    """Decorate the item to skip tests unless a cross-platform Foundation exists.
+
+    FoundationEssentials (and the swift-corelibs Foundation overlay built on top
+    of it) ships in the Swift SDK on Darwin, Linux and Windows, so these tests
+    run on all three.
+    """
+    return skipUnlessPlatform(
+        lldbplatformutil.getDarwinOSTriples() + ["linux", "windows"]
+    )(func)
 
 
 def skipUnlessObjCInterop(func):

--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -66,12 +66,9 @@ bool lldb_private::formatters::swift::Date_SummaryProvider(
   tm *tm_date = gmtime(&epoch);
   if (!tm_date)
     return false;
-  std::string buffer(1024, 0);
-  if (strftime(&buffer[0], 1023, "%Z", tm_date) == 0)
-    return false;
-  stream.Printf("%04d-%02d-%02d %02d:%02d:%02d %s", tm_date->tm_year + 1900,
+  stream.Printf("%04d-%02d-%02d %02d:%02d:%02d UTC", tm_date->tm_year + 1900,
                 tm_date->tm_mon + 1, tm_date->tm_mday, tm_date->tm_hour,
-                tm_date->tm_min, tm_date->tm_sec, buffer.c_str());
+                tm_date->tm_min, tm_date->tm_sec);
   return true;
 }
 
@@ -123,9 +120,18 @@ bool lldb_private::formatters::swift::SwiftURL_SummaryProvider(
   static ConstString g__baseURL("_baseURL");
   static ConstString g__parseInfo("_parseInfo");
   static ConstString g_urlString("urlString");
+  static ConstString g__info("_info");
+  static ConstString g_string("string");
 
+  // The relative URL string lives at a different path depending on which
+  // swift-foundation URL backing is in use:
+  //   _SwiftURL (RFC3986 parser):   _parseInfo.urlString
+  //   _URL      (Span-based, v2):   _info.string
+  // On non-Darwin platforms the backing is always _URL. Darwin can use either.
   ValueObjectSP rel_str_sp(
       valobj.GetChildAtNamePath({g__parseInfo, g_urlString}));
+  if (!rel_str_sp)
+    rel_str_sp = valobj.GetChildAtNamePath({g__info, g_string});
   if (!rel_str_sp)
     return false;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -707,7 +707,7 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::SwiftURL_SummaryProvider,
       "URL summary provider",
-      ConstString("^Foundation(Essentials)?\\._SwiftURL$"),
+      ConstString("^Foundation(Essentials)?\\._(SwiftURL|URL)$"),
       TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true), true);
 
   lldb_private::formatters::AddStringSummary(

--- a/lldb/test/API/functionalities/data-formatter/swift/date/TestSwiftDateFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/date/TestSwiftDateFormatters.py
@@ -12,7 +12,8 @@ import sys
 
 class TestCase(TestBase):
     @skipEmbeddedSwift
-    @skipUnlessFoundation
+    @skipUnlessFoundationEssentials
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
     def test_swift_date_formatters(self):
         """Test Date summary strings."""
@@ -24,7 +25,9 @@ class TestCase(TestBase):
 
         self.expect(
             "frame var date",
-            startstr="(Foundation.Date) date = 2001-01-15 13:12:00 UTC",
+            patterns=[
+                r"\(Foundation(Essentials)?\.Date\) date = 2001-01-15 13:12:00 UTC"
+            ],
         )
 
         if sys.platform != "win32":
@@ -32,5 +35,5 @@ class TestCase(TestBase):
 
         self.expect(
             "frame var nsdate",
-            startstr="(Foundation.NSDate) date = 2001-01-15 13:12:00 UTC",
+            substrs=["(Foundation.NSDate) nsdate = ", "2001-01-15 13:12:00 UTC"],
         )

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
@@ -12,12 +12,13 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @skipEmbeddedSwift
-    @skipUnlessFoundation
+    @skipUnlessFoundationEssentials
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
-    def test_swift_string_index_formatters(self):
-        """Test String.Index summary strings."""
+    def test_swift_string_index_formatters_native(self):
+        """Test String.Index summary strings for a native (non-bridged) String."""
         self.build()
-        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+        lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
 
@@ -74,6 +75,16 @@ class TestCase(TestBase):
                 "9[utf8]",
                 "10[utf8]",
             ],
+        )
+
+    @skipEmbeddedSwift
+    @skipUnlessFoundation
+    @swiftTest
+    def test_swift_string_index_formatters_bridged(self):
+        """Test String.Index summary strings for a bridged String."""
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
         )
 
         #

--- a/lldb/test/API/lang/swift/bridged_url/TestSwiftBridgedURL.py
+++ b/lldb/test/API/lang/swift/bridged_url/TestSwiftBridgedURL.py
@@ -6,8 +6,9 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @skipEmbeddedSwift
+    @skipUnlessFoundationEssentials
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
-    @skipUnlessFoundation
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
+++ b/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
@@ -6,8 +6,9 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(lldbtest.TestBase):
     @skipEmbeddedSwift
+    @skipUnlessFoundationEssentials
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
-    @skipUnlessFoundation
     def test(self):
         """Check that ClangImporter options can be overridden."""
         self.build()

--- a/lldb/test/API/lang/swift/enums/decoding_error/TestSwiftDecodingErrorEnum.py
+++ b/lldb/test/API/lang/swift/enums/decoding_error/TestSwiftDecodingErrorEnum.py
@@ -7,8 +7,9 @@ import os
 
 class TestCase(TestBase):
     @skipEmbeddedSwift
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
+    @skipUnlessFoundationEssentials
     @swiftTest
-    @skipUnlessFoundation
     def test_swift_decoding_error(self):
         """Regression test for Swift.DecodingError, a specific instance of a multipayload enum."""
         self.build()

--- a/lldb/test/API/lang/swift/foundation/TestSwiftFoundation.py
+++ b/lldb/test/API/lang/swift/foundation/TestSwiftFoundation.py
@@ -12,5 +12,13 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
-        swiftTest,skipUnlessFoundation])
+lldbinline.MakeInlineTest(
+    __file__,
+    globals(),
+    decorators=[
+        skipEmbeddedSwift,
+        skipUnlessFoundationEssentials,
+        skipIfLinux,  # https://github.com/swiftlang/llvm-project/issues/13465
+        swiftTest,
+    ],
+)

--- a/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
@@ -6,8 +6,9 @@ import os
 
 class TestSwiftFoundationValueTypeGlobal(TestBase):
     @skipEmbeddedSwift
+    @skipUnlessFoundationEssentials
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
-    @skipUnlessFoundation
     def test(self):
         self.build()
         target = self.dbg.CreateTarget(self.getBuildArtifact())

--- a/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -24,7 +24,8 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     @skipEmbeddedSwift
     @expectedFailureAll(archs=["arm64_32"], bugnumber="<rdar://problem/58065423>")
-    @skipUnlessFoundation
+    @skipUnlessFoundationEssentials
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
     def test_swift_url_formatters(self):
         """Test URL summary strings."""

--- a/lldb/test/API/lang/swift/optional_url/TestOptionalURL.py
+++ b/lldb/test/API/lang/swift/optional_url/TestOptionalURL.py
@@ -1,5 +1,13 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
-        swiftTest, skipUnlessFoundation, skipIf(oslist=['windows'])])
+lldbinline.MakeInlineTest(
+    __file__,
+    globals(),
+    decorators=[
+        skipEmbeddedSwift,
+        skipIfLinux,  # https://github.com/swiftlang/llvm-project/issues/13465
+        skipUnlessFoundationEssentials,
+        swiftTest,
+    ],
+)

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
@@ -6,8 +6,9 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @skipEmbeddedSwift
+    @skipUnlessFoundationEssentials
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
-    @skipUnlessFoundation
     def test(self):
         """Print an ObjC derived object without using the AST context."""
         self.build()

--- a/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
+++ b/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
@@ -29,8 +29,9 @@ class TestSwiftUnknownReference(lldbtest.TestBase):
 
     
     @skipEmbeddedSwift
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
+    @skipUnlessFoundationEssentials
     @swiftTest
-    @skipUnlessFoundation
     def test_unknown_objc_ref(self):
         """Test unknown references to Objective-C objects."""
         self.build()

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -35,8 +35,9 @@ class TestSwiftUnknownSelf(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @skipIf(bugnumber="SR-10216", archs=['ppc64le'])
+    @skipUnlessFoundationEssentials
+    @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
-    @skipUnlessFoundation
     def test_unknown_self_objc_ref(self):
         """Test unknown references to Objective-C objects."""
         self.build()


### PR DESCRIPTION
(cherry picked from commit 9a6f535d837df65bef64981e7e8e492eadb2f90a)