### PR TITLE
[lldb][Windows] Re-enable 5 tests from the Swift lit override list

### DIFF
--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -8,7 +8,6 @@
 
 ### Tests that fail reliably ###
 
-xfail lldb-api :: lang/cpp/unique-types4/TestUniqueTypes4.py
 xfail lldb-shell :: Recognizer/verbose_trap.test
 xfail lldb-shell :: Settings/TestEchoCommands.test
 xfail lldb-shell :: Swift/MissingVFSOverlay.test
@@ -54,9 +53,6 @@ skip lldb-unit :: Symbol/./SymbolTests.exe
 
 ### Tests that fail occasionally ###
 
-# https://github.com/swiftlang/llvm-project/issues/9705
-skip lldb-api :: python_api/section/TestSectionAPI.py
-
 # Passes upstream in bot lldb-aarch64-windows; it fails in swiftlang
 # since https://github.com/swiftlang/llvm-project/pull/9493 relanded
 skip lldb-api :: functionalities/breakpoint/same_cu_name/TestFileBreakpoinsSameCUName.py
@@ -71,10 +67,6 @@ skip lldb-api :: tools/lldb-server
 
 # https://github.com/swiftlang/llvm-project/issues/9887
 skip lldb-api :: lang/swift/async/tasks/TestSwiftTaskSelect.py
-
-skip lldb-api :: functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py
-skip lldb-api :: tools/lldb-dap/instruction-breakpoint/TestDAP_instruction_breakpoint.py
-skip lldb-api :: tools/lldb-dap/output/TestDAP_output.py
 
 ### Untriaged ###
 


### PR DESCRIPTION
(cherry picked from commit fef3a7fa9d2e272aabccb9399c657961587e97f6)