### PR TITLE
[lldb][test][Windows] Fix dwarfimporter/C: use $(BUILDDIR) not $(shell pwd)

### DIFF
--- a/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
@@ -36,9 +36,7 @@ class TestSwiftDWARFImporterBridgingHeader(lldbtest.TestBase):
         shutil.rmtree(include)
 
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
-    # This test needs a working Remote Mirrors implementation.
-    @skipIf(oslist=['windows'])
-    # We delete the pch that would contains the debug info as part of the setup.
+    @skipEmbeddedSwiftOnWindows
     #@skipIf(debug_info=no_match(["dsym"]))
     @swiftTest
     def test_dwarf_importer(self):

--- a/lldb/test/API/lang/swift/dwarfimporter/C/Makefile
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/Makefile
@@ -1,5 +1,5 @@
 SWIFT_ENABLE_EXPLICIT_MODULES := NO
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -I$(BUILDDIR)/include -Xcc -I$(BUILDDIR)/include
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)/include -Xcc -I$(BUILDDIR)/include
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/dwarfimporter/C/Makefile
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/Makefile
@@ -1,5 +1,5 @@
 SWIFT_ENABLE_EXPLICIT_MODULES := NO
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -I$(shell pwd)/include -Xcc -I$(shell pwd)/include
+SWIFTFLAGS_EXTRAS := -I$(BUILDDIR)/include -Xcc -I$(BUILDDIR)/include
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -36,9 +36,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
     @swiftTest
-    @skipIfWindows
-    # This test needs a working Remote Mirrors implementation.
-    @skipIf(oslist=['windows'])
+    @skipEmbeddedSwiftOnWindows
     def test_dwarf_importer(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -75,9 +73,6 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
     @skipEmbeddedSwift
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
     @swiftTest
-    @skipIfWindows
-    # This test needs a working Remote Mirrors implementation.
-    @skipIf(oslist=['windows'])
     def test_dwarf_importer_exprs(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -103,7 +98,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
     @swiftTest
-    @skipIfWindows
+    @skipEmbeddedSwiftOnWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     def test_negative(self):
         lldb.SBDebugger.MemoryPressureDetected()

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
@@ -8,7 +8,6 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     def test_with_deleted_header(self):
         """Test explicit Swift modules with bridging headers"""
@@ -36,7 +35,6 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     def test(self):
         """Test explicit Swift modules with bridging headers"""


### PR DESCRIPTION
On Windows, `$(shell pwd)` is converted to a POSIX path (because it runs in the Git bash shell). Instead of `C:\foo`, the path is `/c/foo`. This causes the tests to fail to build.

Use `$(BUILDDIR)` instead.