### PR TITLE
[lldb][test][Windows] Enable dwarfimporter/from_dylib, no_calculator, and implementation_only main_executable

### DIFF
--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/TestSwiftDWARFImporterFromDylib.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/TestSwiftDWARFImporterFromDylib.py
@@ -11,7 +11,7 @@ class TestSwiftDWARFImporterFromDylib(lldbtest.TestBase):
     @skipEmbeddedSwift
     @swiftTest
     # This test needs a working Remote Mirrors implementation.
-    @skipIf(oslist=['linux', 'windows'])
+    @skipIfLinux
     def test_dwarf_importer(self):
         self.build()
         #os.remove(self.getBuildArtifact('Foo.swiftmodule'))

--- a/lldb/test/API/lang/swift/expression/no_calculator/TestSwiftNoProcess.py
+++ b/lldb/test/API/lang/swift/expression/no_calculator/TestSwiftNoProcess.py
@@ -26,7 +26,7 @@ class TestSwiftNoProcess(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
-    @skipIf(oslist=['linux', 'windows'])
+    @skipIfLinux
     def test_swift_no_target(self):
         """Tests that we give a reasonable error if we try to run expressions with no target"""
         result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/Makefile
@@ -1,7 +1,7 @@
 SWIFT_SOURCES=main.swift
-SWIFTFLAGS_EXTRAS= -I$(shell pwd)
+SWIFTFLAGS_EXTRAS= -I$(BUILDDIR)
 MODULENAME=main
-LD_EXTRAS=-L$(shell pwd)
+LD_EXTRAS=-L$(BUILDDIR)
 
 all: clean SomeLibrary.swiftmodule a.out
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -43,7 +43,6 @@ class TestMainExecutable(TestBase):
     )
     @swiftTest
     @skipEmbeddedSwift
-    @skipIfWindows
     def test_implementation_only_import_main_executable(self):
         """Test `@_implementationOnly import` in the main executable
 
@@ -51,7 +50,13 @@ class TestMainExecutable(TestBase):
         """
 
         self.build()
-        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+        lldbutil.run_to_source_breakpoint(
+            self,
+            "break here",
+            lldb.SBFileSpec("main.swift"),
+            self.launch_info(),
+            extra_images=["SomeLibrary"],
+        )
 
         # This test is deliberately checking what the user will see, rather than
         # the structure provided by the Python API, in order to test the recovery.
@@ -69,8 +74,11 @@ class TestMainExecutable(TestBase):
     )
     @swiftTest
     @skipEmbeddedSwift
-    @skipIfWindows
     @skipIfLinux # rdar://problem/67348391
+    # On Windows lldb resolves the type via DWARFImporter even with the
+    # swiftmodule removed, so the expected "<could not resolve type>" recovery
+    # output differs.
+    @skipIfWindows
     def test_implementation_only_import_main_executable_no_library_module(self):
         """Test `@_implementationOnly import` in the main executable, after removing the library's swiftmodule
 
@@ -81,7 +89,13 @@ class TestMainExecutable(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter false")
         os.remove(self.getBuildArtifact("SomeLibrary.swiftmodule"))
         os.remove(self.getBuildArtifact("SomeLibrary.swiftinterface"))
-        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+        lldbutil.run_to_source_breakpoint(
+            self,
+            "break here",
+            lldb.SBFileSpec("main.swift"),
+            self.launch_info(),
+            extra_images=["SomeLibrary"],
+        )
 
         # FIXME: This particular test config is producing different results on
         # different machines, but it's also the least important configuration
@@ -102,8 +116,6 @@ class TestMainExecutable(TestBase):
 
     @swiftTest
     @skipEmbeddedSwift
-    @skipIfWindows
-    @expectedFailureAll(oslist=["windows"])
     def test_implementation_only_import_main_executable_resilient(self):
         """Test `@_implementationOnly import` in the main executable with a resilient library
 
@@ -111,7 +123,13 @@ class TestMainExecutable(TestBase):
         """
 
         self.build(dictionary={"LIBRARY_SWIFTFLAGS_EXTRAS": "-enable-library-evolution"})
-        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+        lldbutil.run_to_source_breakpoint(
+            self,
+            "break here",
+            lldb.SBFileSpec("main.swift"),
+            self.launch_info(),
+            extra_images=["SomeLibrary"],
+        )
 
         # This test is deliberately checking what the user will see, rather than
         # the structure provided by the Python API, in order to test the recovery.
@@ -125,7 +143,6 @@ class TestMainExecutable(TestBase):
 
     @swiftTest
     @skipEmbeddedSwift
-    @skipIfWindows
     @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
     def test_implementation_only_import_main_executable_resilient_no_library_module(self):
         """Test `@_implementationOnly import` in the main executable with a resilient library, after removing the library's swiftmodule
@@ -136,7 +153,13 @@ class TestMainExecutable(TestBase):
         self.build(dictionary={"LIBRARY_SWIFTFLAGS_EXTRAS": "-enable-library-evolution"})
         os.remove(self.getBuildArtifact("SomeLibrary.swiftmodule"))
         os.remove(self.getBuildArtifact("SomeLibrary.swiftinterface"))
-        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+        lldbutil.run_to_source_breakpoint(
+            self,
+            "break here",
+            lldb.SBFileSpec("main.swift"),
+            self.launch_info(),
+            extra_images=["SomeLibrary"],
+        )
 
         # This test is deliberately checking what the user will see, rather than
         # the structure provided by the Python API, in order to test the recovery.


### PR DESCRIPTION
2 bugs:

1. The Makefile used `-I$(shell pwd)/-L$(shell pwd)`. On Windows GnuWin32 make `$(shell pwd)` returns an MSYS path (`/s/m/...`) that the frontend/linker can't resolve, so `SomeLibrary` failed to resolve at build time. Switch to `$(BUILDDIR)` (native path on Windows).
2. The tests never registered `SomeLibrary` via extra_images, so the inferior couldn't find `SomeLibrary.dll` on Windows and exited `0xc0000135` at launch. Add `extra_images=["SomeLibrary"]`.