### PR TITLE
[clang][cas] Fix index unit assertion with PCHs

### DIFF
--- a/clang/lib/Index/IndexUnitWriter.cpp
+++ b/clang/lib/Index/IndexUnitWriter.cpp
@@ -192,10 +192,9 @@ void IndexUnitWriter::addASTFileDependency(
   SmallString<64> UnitName;
   if (!withoutUnitName)
     getUnitNameForOutputFile(ASTFile.FileName, UnitName);
-  // FIXME: This assumes ModuleFile is backed by a FileEntry.
-  auto File = FileMgr.getOptionalFileRef(ASTFile.FileName);
-  assert(File && "No FileEntry for a ModuleFile");
-  addUnitDependency(UnitName.str(), File, IsSystem, Mod);
+  // FIXME: This only works when the ModuleFile is backed by a FileEntry.
+  if (auto File = FileMgr.getOptionalFileRef(ASTFile.FileName))
+    addUnitDependency(UnitName.str(), File, IsSystem, Mod);
 }
 
 void IndexUnitWriter::addUnitDependency(StringRef UnitFile,

--- a/clang/test/CAS/index-while-building-pch.c
+++ b/clang/test/CAS/index-while-building-pch.c
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: clang-scan-deps -format experimental-include-tree-full -cas-path %t/cas -o %t/deps_pch.json -- \
+// RUN:   %clang -x c-header %t/pch.h -o %t/pch.pch
+
+// RUN: %deps-to-rsp %t/deps_pch.json --tu-index=0 > %t/pch.rsp
+// RUN: %clang @%t/pch.rsp
+
+// RUN: clang-scan-deps -format experimental-include-tree-full -cas-path %t/cas -o %t/deps_tu.json -- \
+// RUN:   %clang -c %t/tu.c -o %t/tu.o -include-pch %t/pch.pch -index-store-path %t/tu.index
+
+// RUN: %deps-to-rsp %t/deps_tu.json --tu-index=0 > %t/tu.rsp
+// FIXME: This is currently only testing that Clang doesn't crash when producing
+//        an index of a TU using a PCH with compilation caching. We should
+//        assert that it produces something reasonable that clients understand.
+// RUN: %clang @%t/tu.rsp
+
+//--- pch.h
+//--- tu.c


### PR DESCRIPTION
Since PR #11026, the on-disk path of a PCH is stripped from the include-tree structure. Together with upstream PR #185995 that stopped creating virtual file entries for such AST files, this means the index unit code doesn't have a file entry to report for PCHs with compilation caching.

Before this PR, this resulted in an assertion failure. With this PR, the PCH dependency is missing from the index unit.

rdar://182674754
(cherry picked from commit 6452ff329b1220150d1d0f918de566c51e0626bf)