### PR TITLE
[lldb] Adapt __SharedStringStorage formatter to the removed `_owner` field

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -156,7 +156,12 @@ getSharedStringStartOffset(Process &process, lldb::addr_t storageAddress) {
   // In the new layout first_word is `start`, always a non-null pointer to the
   // code units. In the old layout it is `_owner`, always null. So a null value
   // uniquely means the old layout, where `start` is one pointer further.
-  return first_word ? header_size : header_size + ptr_size;
+  uint64_t offset = first_word ? header_size : header_size + ptr_size;
+  LLDB_LOGV(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
+            "SwiftFormatters: __SharedStringStorage `start` field at offset {0} "
+            "(detected {1} layout)",
+            offset, first_word ? "current" : "legacy (with _owner)");
+  return offset;
 }
 
 static bool makeStringGutsSummary(

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -140,6 +140,25 @@ static bool readStringFromAddress(
       StringPrinter::StringElementType::UTF8>(read_options);
 };
 
+/// Return the byte offset of the `start` code-unit pointer within a
+/// `__SharedStringStorage` instance located at `storageAddress`.
+static std::optional<uint64_t>
+getSharedStringStartOffset(Process &process, lldb::addr_t storageAddress) {
+  // `start` immediately follows the two-pointer object header. Older Swift
+  // runtimes had an additional `_owner` field preceding `start`.
+  const uint64_t ptr_size = process.GetAddressByteSize();
+  const uint64_t header_size = 2 * ptr_size;
+  Status error;
+  lldb::addr_t first_word =
+      process.ReadPointerFromMemory(storageAddress + header_size, error);
+  if (error.Fail())
+    return std::nullopt;
+  // In the new layout first_word is `start`, always a non-null pointer to the
+  // code units. In the old layout it is `_owner`, always null. So a null value
+  // uniquely means the old layout, where `start` is one pointer further.
+  return first_word ? header_size : header_size + ptr_size;
+}
+
 static bool makeStringGutsSummary(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
@@ -383,8 +402,10 @@ static bool makeStringGutsSummary(
     // Shared strings must not be tail-allocated or natively stored.
     if ((flags & 0x3000) != 0)
       return false;
-    uint64_t startOffset = (ptrSize == 8 ? 24 : 12);
-    auto address = objectAddress + startOffset;
+    auto startOffset = getSharedStringStartOffset(*process, objectAddress);
+    if (!startOffset)
+      return error("could not read shared string storage");
+    auto address = objectAddress + *startOffset;
     lldb::addr_t start = process->ReadPointerFromMemory(address, status);
     if (status.Fail())
       return error(status.AsCString());
@@ -597,14 +618,16 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider_2(
 
   lldb::addr_t raw1 = valobj.GetPointerValue().address;
   lldb::addr_t address = (raw1 & 0x00FFFFFFFFFFFFFF);
-  uint64_t startOffset = (ptr_size == 8 ? 24 : 12);
+  auto startOffset = getSharedStringStartOffset(*process, address);
+  if (!startOffset)
+    return false;
 
   lldb::addr_t start =
-      process->ReadPointerFromMemory(address + startOffset, error);
+      process->ReadPointerFromMemory(address + *startOffset, error);
   if (error.Fail())
     return false;
   lldb::addr_t raw0 =
-      process->ReadPointerFromMemory(address + startOffset + ptr_size, error);
+      process->ReadPointerFromMemory(address + *startOffset + ptr_size, error);
   if (error.Fail())
     return false;
 

--- a/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/Makefile
+++ b/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP := 1
+include Makefile.rules

--- a/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/TestSwiftSharedStringStorage.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/TestSwiftSharedStringStorage.py
@@ -1,0 +1,31 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftSharedStringStorage(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipEmbeddedSwift
+    @swiftTest
+    @skipUnlessFoundation
+    def test(self):
+        """Non-ASCII strings bridged to NSString/CFString are backed by
+        __SharedStringStorage. Check that the data formatter decodes them,
+        which depends on locating the `start` field inside the storage
+        object (the field whose offset changed when `_owner` was removed)."""
+        self.build()
+
+        logfile = self.getBuildArtifact("formatters.log")
+        self.runCmd("log enable lldb formatters -v -f " + logfile)
+
+        lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
+        self.expect("frame variable ns",
+                    substrs=["café", "non-ASCII shared-storage NSString"])
+        self.expect("frame variable cf",
+                    substrs=["alçada", "non-ASCII shared-storage CFString"])
+
+        with open(logfile) as f:
+            log = f.read()
+        self.assertIn("__SharedStringStorage `start` field at offset", log)

--- a/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/main.swift
+++ b/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/main.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+func f() {
+    // A large, non-ASCII string literal bridges to a __SharedStringStorage
+    // instance.
+    let ns = "café — a long enough non-ASCII shared-storage NSString value" as NSString
+    let cf = "alçada — a long enough non-ASCII shared-storage CFString value" as CFString
+    print("break here")
+}
+f()
+


### PR DESCRIPTION
The Swift standard library removed the now-unused `_owner` stored property from `__SharedStringStorage` (swiftlang/swift#90869). Because `_owner` preceded `start` in the layout, dropping it shifts the `start` code-unit pointer.

Assisted-by: claude