### PR TITLE
[ConstraintElim] Update check for NFC precommit retry-without-decomposition.ll

### DIFF
--- a/llvm/test/Transforms/ConstraintElimination/retry-without-decomposition.ll
+++ b/llvm/test/Transforms/ConstraintElimination/retry-without-decomposition.ll
@@ -12,8 +12,7 @@ define i1 @retry_recovers_uge(i16 %x, i16 %y, i16 %z) {
 ; CHECK-NEXT:    [[ADD:%.*]] = add nsw i16 [[X]], [[Y]]
 ; CHECK-NEXT:    [[C:%.*]] = icmp ugt i16 [[ADD]], [[Z]]
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[C]])
-; CHECK-NEXT:    [[T:%.*]] = icmp uge i16 [[ADD]], [[Z]]
-; CHECK-NEXT:    ret i1 [[T]]
+; CHECK-NEXT:    ret i1 true
 ;
 entry:
   %add = add nsw i16 %x, %y


### PR DESCRIPTION
Regenerate `llvm/test/Transforms/ConstraintElimination/retry-without-decomposition.ll` added by `[ConstraintElim] Precommit additional tests (NFC).` https://github.com/llvm/llvm-project/pull/211802, but downstream already contains the to be upstreamed behavior.

rdar://183148476