### PR TITLE
[lldb][test][Windows] Enable Swift async unwind/stepping/frame tests that pass

### DIFF
--- a/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
+++ b/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
@@ -10,7 +10,6 @@ class TestSwiftAsyncFnArgs(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=['windows',])
     def test(self):
         """Test function arguments in async functions"""
         self.build()

--- a/lldb/test/API/lang/swift/async/frame/language_specific_data/TestSwiftAsyncLanguageSpecificData.py
+++ b/lldb/test/API/lang/swift/async/frame/language_specific_data/TestSwiftAsyncLanguageSpecificData.py
@@ -9,7 +9,6 @@ class TestCase(lldbtest.TestBase):
 
     @no_debug_info_test
     @swiftTest
-    @skipIf(oslist=['windows'])
     def test(self):
         """Test SBFrame.GetLanguageSpecificData() in async functions"""
         self.build()

--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -9,7 +9,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=['windows'])
     def test(self):
         """Test `frame variable` in async functions"""
         self.build()

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
@@ -69,7 +69,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=["windows"])
     def test(self):
         """Test `frame variable` in async functions"""
         self.build()

--- a/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
@@ -10,7 +10,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=['windows'])
     def test(self):
         """Test step-in to async functions"""
         self.build()

--- a/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
@@ -30,7 +30,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=["windows"])
     def test(self):
         """Test `frame variable` in async functions"""
         self.build()

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
@@ -7,7 +7,6 @@ class TestDisableLanguageUnwinder(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=['windows',])
     def test(self):
         """Test async unwind"""
         self.build()

--- a/lldb/test/API/lang/swift/async/unwind/hidden_frames/TestSwiftAsyncHiddenFrames.py
+++ b/lldb/test/API/lang/swift/async/unwind/hidden_frames/TestSwiftAsyncHiddenFrames.py
@@ -10,7 +10,6 @@ class TestSwiftAsyncHiddenFrames(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=['windows',])
     def test(self):
         """Test async unwind"""
         self.build()

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
@@ -14,7 +14,6 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=['windows',])
     def test(self):
         """Test async unwind"""
         self.build()

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
@@ -10,7 +10,6 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=["windows",])
     def test(self):
         """Test async unwinding with short backtraces work properly"""
         self.build()

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
@@ -12,7 +12,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=["windows",])
     @skipIf(archs=["arm64e"])
     def test(self):
         """Test that the debugger can unwind at all instructions of all funclets"""


### PR DESCRIPTION
The async unwinder is arch gated (x86_64 -> r14, arm64 -> x22 in GetAsyncUnwindRegisterNumbers), not OS-gated, so much of it already works on Windows.

rdar://183113449