### PR TITLE
[lldb][Windows] Fix reflection registration + symbol resolution for opaque types in secondary DLLs

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -100,52 +100,32 @@ LLDBMemoryReader::getSymbolAddress(const std::string &name) {
   }
 
   SymbolContext sym_ctx;
-  // Remove undefined symbols from the list.
-  size_t num_sc_matches = sc_list.GetSize();
-  if (num_sc_matches > 1) {
-    SymbolContextList tmp_sc_list(sc_list);
-    sc_list.Clear();
-    for (size_t idx = 0; idx < num_sc_matches; idx++) {
-      tmp_sc_list.GetContextAtIndex(idx, sym_ctx);
-      if (sym_ctx.symbol &&
-          sym_ctx.symbol->GetType() != lldb::eSymbolTypeUndefined) {
-        sc_list.Append(sym_ctx);
-      }
+  {
+    size_t num = sc_list.GetSize();
+    SymbolContextList defined, resolvable;
+    SymbolContext sc;
+    for (size_t idx = 0; idx < num; idx++) {
+      sc_list.GetContextAtIndex(idx, sc);
+      if (!sc.symbol || sc.symbol->GetType() == lldb::eSymbolTypeUndefined)
+        continue;
+      defined.Append(sc);
+      if (sc.symbol->GetLoadAddress(&m_process.GetTarget()) !=
+          LLDB_INVALID_ADDRESS)
+        resolvable.Append(sc);
     }
+    if (resolvable.GetSize())
+      sc_list = resolvable;
+    else if (defined.GetSize())
+      sc_list = defined;
   }
-  if (sc_list.GetSize() == 1 && sc_list.GetContextAtIndex(0, sym_ctx)) {
-    if (sym_ctx.symbol) {
-      auto load_addr = sym_ctx.symbol->GetLoadAddress(&m_process.GetTarget());
-      LLDB_LOGV(log, "[MemoryReader] symbol resolved to {0:x}", load_addr);
-      return swift::remote::RemoteAddress(
-          load_addr, swift::remote::RemoteAddress::DefaultAddressSpace);
-    }
+  if (sc_list.GetContextAtIndex(0, sym_ctx) && sym_ctx.symbol) {
+    auto load_addr = sym_ctx.symbol->GetLoadAddress(&m_process.GetTarget());
+    LLDB_LOGV(log, "[MemoryReader] symbol resolved to {0:x}", load_addr);
+    return swift::remote::RemoteAddress(
+        load_addr, swift::remote::RemoteAddress::DefaultAddressSpace);
   }
-
-  // Empty list, resolution failed.
-  if (sc_list.GetSize() == 0) {
-    LLDB_LOGV(log, "[MemoryReader] symbol resolution failed {0}", name);
-    return swift::remote::RemoteAddress();
-  }
-
-  // If there's a single symbol, then we're golden. If there's more than
-  // a symbol, then just make sure all of them agree on the value.
-  Status error;
-  auto load_addr = sym_ctx.symbol->GetLoadAddress(&m_process.GetTarget());
-  uint64_t sym_value = m_process.GetTarget().ReadUnsignedIntegerFromMemory(
-      load_addr, m_process.GetAddressByteSize(), 0, error, true);
-  for (unsigned i = 1; i < sc_list.GetSize(); ++i) {
-    uint64_t other_sym_value =
-        m_process.GetTarget().ReadUnsignedIntegerFromMemory(
-            load_addr, m_process.GetAddressByteSize(), 0, error, true);
-    if (sym_value != other_sym_value) {
-      LLDB_LOGV(log, "[MemoryReader] symbol resolution failed {0}", name);
-      return swift::remote::RemoteAddress();
-    }
-  }
-  LLDB_LOGV(log, "[MemoryReader] symbol resolved to {0}", load_addr);
-  return swift::remote::RemoteAddress(
-      load_addr, swift::remote::RemoteAddress::DefaultAddressSpace);
+  LLDB_LOGV(log, "[MemoryReader] symbol resolution failed {0}", name);
+  return swift::remote::RemoteAddress();
 }
 
 swift::remote::RemoteAddress

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -927,6 +927,10 @@ bool SwiftLanguageRuntime::AddModuleToReflectionContext(
     return false;
   }
   bool found = HasReflectionInfo(obj_file);
+
+  if (found && !m_registered_reflection_images.insert(load_ptr).second)
+    return true;
+
   LLDB_LOGV(GetLog(LLDBLog::Types), "{0} reflection metadata in \"{1}\"",
             found ? "Adding" : "No",
             module_sp->GetObjectName() ? module_sp->GetObjectName()

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -440,7 +440,8 @@ void SwiftLanguageRuntime::ProcessModulesToAdd() {
   modules_to_add_snapshot.ForEach(
       [&](const ModuleSP &module_sp) -> IterationAction {
         if (module_sp) {
-          AddModuleToReflectionContext(module_sp);
+          if (!AddModuleToReflectionContext(module_sp))
+            m_modules_to_add.AppendIfNeeded(module_sp);
           progress.Increment(
               ++completion, module_sp->GetFileSpec().GetFilename().GetString());
         }
@@ -891,6 +892,29 @@ bool SwiftLanguageRuntime::AddModuleToReflectionContext(
         module_sp->GetArchitecture().GetTriple().getObjectFormat();
     return AddJitObjectFileToReflectionContext(*obj_file, object_format_type,
                                                likely_module_names);
+  }
+
+  if (load_ptr == 0 || load_ptr == LLDB_INVALID_ADDRESS) {
+    // The queued ModuleSP can be a stale duplicate (Windows, secondary DLL)
+    // whose sections aren't load-registered. Re-register via the target's
+    // mapped module of the same UUID.
+    UUID uuid = module_sp->GetUUID();
+    if (uuid.IsValid()) {
+      ModuleSP mapped;
+      target.GetImages().ForEach([&](const ModuleSP &m) -> IterationAction {
+        if (m && m.get() != module_sp.get() && m->GetUUID() == uuid) {
+          if (ObjectFile *mof = m->GetObjectFile())
+            if (mof->GetBaseAddress().GetLoadAddress(&target) !=
+                LLDB_INVALID_ADDRESS) {
+              mapped = m;
+              return IterationAction::Stop;
+            }
+        }
+        return IterationAction::Continue;
+      });
+      if (mapped)
+        return AddModuleToReflectionContext(mapped);
+    }
   }
 
   if (load_ptr == 0 || load_ptr == LLDB_INVALID_ADDRESS) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -976,6 +976,9 @@ private:
   /// added to the reflection context once it's being initialized.
   ModuleList m_modules_to_add;
 
+  /// Load addresses of the images already handed to the reflection context.
+  llvm::DenseSet<lldb::addr_t> m_registered_reflection_images;
+
   /// Increased every time SymbolsDidLoad is called.
   unsigned m_generation = 0;
   /// Add the image to the reflection context.

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/Makefile
@@ -6,6 +6,13 @@ all: clean SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
 
 include Makefile.rules
 
+# -rpath does not exist on Windows.
+ifeq "$(OS)" "Windows_NT"
+SOMELIBRARY_LD_EXTRAS = -L$(BUILDDIR)
+else
+SOMELIBRARY_LD_EXTRAS = -L$(BUILDDIR) -Xlinker -rpath -Xlinker $(BUILDDIR)
+endif
+
 SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
 	"$(MAKE)" BASENAME=$(shell basename $@ .swiftmodule) \
 		SWIFTFLAGS_EXTRAS=-enable-library-evolution \
@@ -14,7 +21,7 @@ SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
 SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
 	"$(MAKE)" BASENAME=$(shell basename $@ .swiftmodule) \
 		SWIFTFLAGS_EXTRAS=-enable-library-evolution \
-		VPATH=$(SRCDIR) LD_EXTRAS="-L$(BUILDDIR) -Xlinker -rpath -Xlinker $(BUILDDIR)" -f $(SRCDIR)/../dylib.mk all
+		VPATH=$(SRCDIR) LD_EXTRAS="$(SOMELIBRARY_LD_EXTRAS)" -f $(SRCDIR)/../dylib.mk all
 
 clean::
 	$(call RM_RF,*.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface)

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -39,7 +39,9 @@ class TestLibraryResilient(TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @expectedFailureAll(oslist=["windows"]) # Requires Remote Mirrors support
+    # rdar://183113341: on Windows `expr container.wrapped` fails because swiftc does not export
+    # SomeLibrary.ContainsTwoInts.wrapped.getter from SomeLibrary.dll.
+    @expectedFailureWindows
     def test_implementation_only_import_library(self):
         """Test `@_implementationOnly import` in a resilient library used by the main executable
 


### PR DESCRIPTION
On Windows, a secondary DLL loaded via `extra_images` can end up represented as two module instances in the target: a stale placeholder and the real, mapped module. Because of this, lldb cannot size a generic structure specialized with an opaque return type in that secondary DLL.

**Example:**
Consider `MyLib.dll` which exports a function returning `some Collection`, and code elsewhere does:
```swift
struct Wrapper<T> { let value: T }
let w = Wrapper(value: myLib.getItems())
```

In this scenario, lldb can't compute the size of `Wrapper<some Collection>`. Because that DLL is represented twice, two things go wrong:

1. **Reflection context setup silently gives up:** The call fails for the placeholder, the address is invalid.
Fix: failed modules are now re-queued so `GetReflectionContext` retries them later, and if the original module still isn't loaded, lldb falls back to the target's mapped module with the same UUID.

2. **Symbol lookup picked the wrong copy:** `LLDBMemoryReader::getSymbolAddress` could return the stale module's symbol for the opaque type descriptor.
Fix: prefer a symbol whose load address actually resolves.

rdar://183113341