### PR TITLE
[lldb][Windows] Fix async-call step-over descending into the callee

### DIFF
--- a/lldb/source/Target/ThreadPlanStepOverRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverRange.cpp
@@ -157,7 +157,29 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
   LLDB_LOGF(log, "ThreadPlanStepOverRange compare frame result: %d.",
             frame_order);
 
+  bool older_but_equivalent = false;
+  bool descended_into_callee = false;
   if (frame_order == eFrameCompareOlder) {
+    StackFrameSP cur_frame_sp = thread.GetStackFrameAtIndex(0);
+    if (cur_frame_sp && IsEquivalentContext(cur_frame_sp->GetSymbolContext(
+                            eSymbolContextEverything))) {
+      older_but_equivalent = true;
+    } else {
+      for (uint32_t i = 1;; ++i) {
+        StackFrameSP older_frame_sp = thread.GetStackFrameAtIndex(i);
+        if (!older_frame_sp)
+          break;
+        if (IsEquivalentContext(
+                older_frame_sp->GetSymbolContext(eSymbolContextEverything))) {
+          descended_into_callee = true;
+          break;
+        }
+      }
+    }
+  }
+
+  if (frame_order == eFrameCompareOlder && !older_but_equivalent &&
+      !descended_into_callee) {
     // If we're in an older frame then we should stop.
     //
     // A caveat to this is if we think the frame is older but we're actually in
@@ -173,7 +195,8 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
     if (new_plan_sp && log)
       LLDB_LOGF(log,
                 "Thought I stepped out, but in fact arrived at a trampoline.");
-  } else if (frame_order == eFrameCompareYounger) {
+  } else if (frame_order == eFrameCompareYounger ||
+             (frame_order == eFrameCompareOlder && descended_into_callee)) {
     // Make sure we really are in a new frame.  Do that by unwinding and seeing
     // if the start function really is our start function...
     for (uint32_t i = 1;; ++i) {

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -19,7 +19,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=["windows"])
     def test(self):
         """Test conditions for async step-over."""
         self.build()

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
@@ -14,7 +14,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=["windows"])
     def test_nothrow(self):
         """Test conditions for async step-over."""
         self.build()
@@ -34,7 +33,6 @@ class TestCase(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=["windows"])
     def test_throw(self):
         """Test conditions for async step-over."""
         self.build()


### PR DESCRIPTION
Stepping over an `await` call on Windows/Linux stopped incorrectly: first on the await resume point, then descending into the callee instead of reaching the next source line.

ThreadPlanStepOverRange::ShouldStop classifies the current frame relative to the start frame via CompareCurrentFrameToStartFrame, which orders frames by CFA address. A Swift async frame's CFA is its heap-allocated async context, not a stack address, so the ordering is unreliable:

1. The resumed continuation funclet of the same async function gets a different async context, so it compares eFrameCompareOlder even though we have not returned to the caller.
2. Stepping over an async call lands in the callee, which can also compare eFrameCompareOlder because the callee's async context can be numerically "older" than the caller's.

Both made the Older branch treat the situation as a return and stop.

Handle both by, when the comparison says Older, checking equivalence: if the current frame is equivalent to the start funclet, treat it as in-range; otherwise, if the start funclet is still present as an older frame in the current backtrace, we descended into a callee and route to the existing eFrameCompareYounger step-out path instead of stopping.

Enables lang/swift/async/stepping/step_over on Windows. Verified on the Windows host with no regressions in the C stepping suite (lang/c/stepping/TestThreadStepping), step_until, and the Swift async step_out/step-in tests. step_over_asynclet stays gated: async-let step-over additionally needs task-switch following, a separate gap.