### PR TITLE
[lldb][Windows] Normalize function name in SwiftASTContext LOG_PRINTF

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -142,6 +142,7 @@
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 
+#include <cstring>
 #include <iterator>
 #include <memory>
 #include <mutex>
@@ -156,6 +157,21 @@ std::recursive_mutex g_log_mutex;
 
 } // namespace
 
+#ifdef _MSC_VER
+/// MSVC's __FUNCTION__ is fully qualified (e.g. "lldb_private::Class::Method")
+/// whereas Clang/GCC expand it to just "Method". Return the unqualified name so
+/// LOG_PRINTF output is identical across host compilers.
+static constexpr const char *
+UnqualifiedFunctionName(const char *function_name) {
+  if (const char *last_colon = std::strrchr(function_name, ':'))
+    return last_colon + 1;
+  return function_name;
+}
+#define LLDB_LOG_FUNCTION_NAME UnqualifiedFunctionName(__FUNCTION__)
+#else
+#define LLDB_LOG_FUNCTION_NAME __FUNCTION__
+#endif
+
 /// Similar to LLDB_LOG, but with richer contextual information.
 #define LOG_PRINTF(CHANNEL, FMT, ...)                                          \
   LOG_PRINTF_IMPL(CHANNEL, false, FMT, ##__VA_ARGS__)
@@ -169,7 +185,8 @@ std::recursive_mutex g_log_mutex;
       if (!(VERBOSE) || log->GetVerbose()) {                                   \
         std::lock_guard<std::recursive_mutex> locker(g_log_mutex);             \
         /* The format string is optimized for code size, not speed. */         \
-        log->Printf("%s::%s%s" FMT, m_description.c_str(), __FUNCTION__,       \
+        log->Printf("%s::%s%s" FMT, m_description.c_str(),                     \
+                    LLDB_LOG_FUNCTION_NAME,                                    \
                     (FMT && FMT[0] == '(') ? "" : "() -- ", ##__VA_ARGS__);    \
       }                                                                        \
   } while (0)

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
@@ -10,7 +10,6 @@ class TestSwiftForwardInteropCxxLangOpt(TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIfWindows
     def test_class(self):
         """
         Test that C++ interoperability is enabled on a per-CU basis.


### PR DESCRIPTION
`LOG_PRINTF` builds its prefix as `"<description>::<__FUNCTION__>"`.
- MSVC expands `__FUNCTION__` to the fully-qualified name (e.g.
`"lldb_private::SwiftASTContext::LogConfiguration"`).
- Clang/GCC expand it to just "LogConfiguration".

Strip the qualification to the unqualified name.

Enable `cxx_interop/forward/langopt` on Windows.

rdar://183113459