### PR TITLE
[BoundsSafety][rt-test] don't require exit code 0 for soft trap tests

### DIFF
--- a/compiler-rt/test/bounds_safety/scripts/expect_trap.py
+++ b/compiler-rt/test/bounds_safety/scripts/expect_trap.py
@@ -43,12 +43,6 @@ def run_direct(binary, args):
 def run_direct_soft_trap(binary, args):
     """Verify a soft trap fires in direct mode."""
     result = subprocess.run([binary] + args, capture_output=True, text=True)
-    if result.returncode != 0:
-        log.error(
-            "expected soft trap but process exited with status %d",
-            result.returncode,
-        )
-        return 1
     if SOFT_TRAP_MARKER not in result.stderr:
         log.error("soft trap marker not found in stderr")
         log.error("stderr: %s", result.stderr)


### PR DESCRIPTION
bounds_safety/bidi_indexable/lower_upper_check.c would fail with optimizations enabled, because LLVM was figuring out that the read was UB and inserted a trap instruction right after the call to the soft trap handler (since any path from there would lead to an undefined read). Given that most soft trap tests are going to lead to UB after the handler (since we are confirmed OOB), it seems like we can't expect to hide this information from LLVM. This removes the requirement for a clean exit code for soft trap tests: we are still checking that the handler logging output is present, and that the debugger stops at the soft trap. We just allow it to fail _after_ that.

rdar://182985676