### PR TITLE
[lldb][Windows] Enable TestSwiftTaskSelect and TestSwiftTaskSwitch

### DIFF
--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(lldbtest.TestBase):
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=["windows", "linux"])
+    @skipIfLinux
     @skipIf(macos_version=["<", "26.0"], asan=True) # rdar://138777205
     def test(self):
         """Test conditions for async step-in."""
@@ -24,7 +24,11 @@ class TestCase(lldbtest.TestBase):
         instructions = list(function.GetInstructions(target))
         self.assertGreater(len(instructions), 0)
         # Expected to be a trampoline that tail calls `swift_task_switch`.
-        self.assertIn("swift_task_switch", instructions[-1].GetComment(target))
+        # The tail call is the final instruction. On Windows the callee lives
+        # in another DLL. Scan the tail so both the direct and the indirect form
+        # are accepted.
+        tail_call = " ".join(inst.GetComment(target) for inst in instructions[-4:])
+        self.assertIn("swift_task_switch", tail_call)
 
         # Using the line table, build a set of the non-zero line numbers for
         # this this function - and verify that there is exactly one line.
@@ -33,7 +37,8 @@ class TestCase(lldbtest.TestBase):
         self.assertEqual(lines, {3})
 
         # Required for builds that have debug info.
-        self.runCmd("settings set target.process.thread.step-avoid-libraries libswift_Concurrency.dylib")
+        lib_name = self.platformContext.getFullLibName("swift_Concurrency")
+        self.runCmd(f"settings set target.process.thread.step-avoid-libraries {lib_name}")
         thread.StepInto()
         frame = thread.frame[0]
         # Step in from `main` should progress through to `f`.

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -64,7 +64,8 @@ class TestCase(TestBase):
         thread = process.GetSelectedThread()
 
         self.assertIn(
-            "libswift_Concurrency.", thread.GetSelectedFrame().module.file.basename
+            f"{self.platformContext.shlib_prefix}swift_Concurrency.",
+            thread.GetSelectedFrame().module.file.basename,
         )
 
         frame_idx = -1

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -62,9 +62,6 @@ skip lldb-api :: tools/lldb-server
 
 ### Tests that fail during setup and thus show up as UNRESOLVED ***
 
-# https://github.com/swiftlang/llvm-project/issues/9887
-skip lldb-api :: lang/swift/async/tasks/TestSwiftTaskSelect.py
-
 ### Untriaged ###
 
 skip lldb-shell :: Commands/command-expr-diagnostics.test


### PR DESCRIPTION
The test expects the suspend funclet to end in a tail call to `swift_task_switch` and looks for that name on the very last instruction. On Windows the callee lives in another DLL, so the tail call goes indirect through the import address table:

```
movq __imp_swift_task_switch(%rip), %rax
addq $0x48, %rsp
jmpq *%rax
```

lldb attaches the symbol name to the address load, not to the jump, and the stack epilogue sits in between. Scan the tail instead of indexing a fixed position, which accepts both the direct and the indirect form.

The tests also hardcode `libswift_Concurrency.dylib`, which can never match `swift_Concurrency.dll`.