### PR TITLE
[lldb][test] Enable ten Swift tests off Darwin

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -10,7 +10,7 @@ class TestSwiftWerror(TestBase):
     @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipUnlessDarwin
+    @skipIfLinux
     @swiftTest
     def test(self):
         """This tests that -Werror is removed from ClangImporter options by

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -23,7 +23,6 @@ class TestSwiftHeadermapConflict(TestBase):
         setting=("symbols.use-swift-clangimporter", "false"),
     )
     @skipEmbeddedSwift
-    @skipUnlessDarwin
     @swiftTest
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -21,7 +21,6 @@ class TestSwiftIncludeConflict(TestBase):
     @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipUnlessDarwin
     @swiftTest
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.

--- a/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
+++ b/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftClashingABIName(TestBase):
     @skipEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
     def test(self):
         """Test that expressions with types in modules with clashing abi names works"""
         self.build()
@@ -25,7 +24,6 @@ class TestSwiftClashingABIName(TestBase):
                     substrs=['a.Generic2<a.Generic<a.One>>', 't2 =', 't =', 'j = 98'])
     @skipEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
     def test_in_self(self):
         """Test a library with a private import for which there is no debug info"""
         self.build()

--- a/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
+++ b/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftEnableTesting(TestBase):
 
     @skipEmbeddedSwift
-    @skipUnlessDarwin
+    @skipIfLinux
     @swiftTest
     def test(self):
         """Test that expression evaluation generates a direct member access to a private property in a module compiled with -enable-library-evolution and -enable-testing"""

--- a/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
+++ b/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
@@ -19,7 +19,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestResilientObjectInOptional(TestBase):
     @skipEmbeddedSwift
-    @skipUnlessDarwin
     @swiftTest
     def test_optional_of_resilient(self):
         """Test that can extract resilient objects from an Optional"""

--- a/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
+++ b/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
@@ -14,7 +14,7 @@ class TestSwiftPrivateDiscriminator(lldbtest.TestBase):
     # FIXME: The only reason this doesn't work on Linux is because the
     # dylib hasn't been loaded when run_to_source_breakpoint wants to
     # set the breakpoints.
-    @skipUnlessDarwin
+    @skipIfLinux
     def test(self):
         """Test what happens when a private type cannot be reconstructed in the AST."""
         self.build()

--- a/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
+++ b/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPrivateImport(TestBase):
     @skipEmbeddedSwift
-    @skipUnlessDarwin
     @swiftTest
     def test_private_import(self):
         """Test a library with a private import for which there is no debug info"""

--- a/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
+++ b/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftPrivateMember(TestBase):
 
     @skipEmbeddedSwift
-    @skipUnlessDarwin
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
+++ b/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
@@ -7,13 +7,11 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftResilienceOtherModule(TestBase):
 
     @skipEmbeddedSwift
-    @skipUnlessDarwin
     @swiftTest
     def test_with_debug_info(self):
         self.impl('break here with debug info')
 
     @skipEmbeddedSwift
-    @skipUnlessDarwin
     @swiftTest
     def test_without_debug_info(self):
         self.impl('break here without debug info')


### PR DESCRIPTION
These have no Darwin dependency: no ObjC, no Foundation, no Darwin-only framework in their sources.

Verified on Windows: all ten pass, three consecutive runs each.