### PR TITLE
[clang][ExtractAPI] Fix assertion on invalid UTF-8 in doc comments (#212394)

### DIFF
--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -262,7 +262,11 @@ std::optional<Object> serializeDocComment(const DocComment &Comment) {
   Array LinesArray;
   for (const auto &CommentLine : Comment) {
     Object Line;
-    Line["text"] = CommentLine.Text;
+    // Comments in source files may contain invalid UTF-8. JSON values must be
+    // valid UTF-8, so replace any invalid sequences before serializing.
+    Line["text"] = json::isUTF8(CommentLine.Text)
+                       ? CommentLine.Text
+                       : json::fixUTF8(CommentLine.Text);
     serializeObject(Line, "range",
                     serializeSourceRange(CommentLine.Begin, CommentLine.End));
     LinesArray.emplace_back(std::move(Line));

--- a/clang/test/ExtractAPI/invalid_utf8_doc_comment.c
+++ b/clang/test/ExtractAPI/invalid_utf8_doc_comment.c
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -extract-api --pretty-sgf -verify \
+// RUN:   -triple arm64-apple-macosx -x c-header %s -o %t/output.symbols.json
+// RUN: FileCheck %s --input-file %t/output.symbols.json
+
+// This file is purposefully NOT valid UTF-8. The doc comment below contains a
+// raw 0xD5 byte. Be careful when modifying.
+
+// expected-no-diagnostics
+
+/*! @brief The senderÕs storage. */
+int foo(void);
+
+// CHECK:      "docComment": {
+// CHECK-NEXT:   "lines": [
+// CHECK:          "text": "@brief The senderï¿½s storage. "
+// CHECK:        ]
+// CHECK-NEXT: },


### PR DESCRIPTION
A doc comment can contain invalid UTF-8. The raw bytes reach serializeDocComment, which assigned them to a llvm::json::Value, tripping its valid-UTF-8 assertion. This is hit by legacy headers that are not UTF-8 encoded, which compile fine but crash -extract-api.

Sanitize with json::isUTF8/fixUTF8 before serializing.

Fixes #212393

(cherry picked from commit 462b109cbcfe5d8adb46af4e6f82dc96c0a5c9f7)

Conflicts:
	clang/docs/ReleaseNotes.md