### PR TITLE
[llvm] Update llvm-cas-dump enums_split test for new DWARF type emiss…

### DIFF
--- a/llvm/test/tools/llvm-cas-dump/enums_split.ll
+++ b/llvm/test/tools/llvm-cas-dump/enums_split.ll
@@ -10,18 +10,20 @@
 ; DWARF-DIE-NEXT:   CAS Block: llvmcas://{{.*}}
 ; DWARF-DIE-NEXT:   DW_TAG_compile_unit  AbbrevIdx = 2
 ; DWARF-DIE:        CAS Block: llvmcas://{{.*}}
-; DWARF-DIE-NEXT:   DW_TAG_enumeration_type     AbbrevIdx = 3
-; DWARF-DIE-NEXT:     DW_AT_type                     DW_FORM_ref4_cas           [distinct] [47]
+; DWARF-DIE-NEXT:   DW_TAG_subprogram    AbbrevIdx = 3
+; DWARF-DIE:        CAS Block: llvmcas://{{.*}}
+; DWARF-DIE-NEXT:   DW_TAG_enumeration_type     AbbrevIdx = 4
+; DWARF-DIE-NEXT:     DW_AT_type                     DW_FORM_ref4_cas           [distinct] [64]
 ; DWARF-DIE-NEXT:     DW_AT_enum_class               DW_FORM_flag_present       [dedups]   []
-; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp_cas           [distinct] [88 1]
+; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp_cas           [distinct] [8C 1]
 ; DWARF-DIE-NEXT:     DW_AT_byte_size                DW_FORM_data1              [dedups]   [4]
 ; DWARF-DIE-NEXT:     DW_AT_decl_file                DW_FORM_data1              [distinct] [1]
 ; DWARF-DIE-NEXT:     DW_AT_decl_line                DW_FORM_data1              [dedups]   [3]
-; DWARF-DIE-NEXT:     DW_TAG_enumerator         AbbrevIdx = 4
-; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas           [distinct] [96 1]
+; DWARF-DIE-NEXT:     DW_TAG_enumerator         AbbrevIdx = 5
+; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas           [distinct] [9A 1]
 ; DWARF-DIE-NEXT:       DW_AT_const_value              DW_FORM_sdata              [dedups]   [0]
-; DWARF-DIE-NEXT:     DW_TAG_enumerator         AbbrevIdx = 4
-; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas           [distinct] [9B 1]
+; DWARF-DIE-NEXT:     DW_TAG_enumerator         AbbrevIdx = 5
+; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas           [distinct] [9F 1]
 ; DWARF-DIE-NEXT:       DW_AT_const_value              DW_FORM_sdata              [dedups]   [1]
 
 target triple = "arm64-apple-macosx13.0.0"


### PR DESCRIPTION
…ion order

Upstream aa50eb69d6eb ("[DebugInfo][DwarfDebug] Move emission of types from beginModule() to endModule() (7/7) (#211536)") moved emission of enum and retained types out of beginModule() into endModule(), so types are now emitted after subprograms rather than before them. That reordering shifts the abbrev indices and distinct-data offsets seen by the MCCAS DWARF-DIE splitter, which the Apple-only llvm-cas-dump test enums_split.ll checks literally; the upstream commit updated its own DebugInfo tests but not this MCCAS test.

Update the DWARF-DIE expectations to the new emission order: match the subprogram CAS block first, then the enumeration_type block with AbbrevIdx 4 (enumerators at 5) and the corresponding string/type offsets. This is a test-only change matching the structure already used by the sibling types_split.ll test; no functional change.

rdar://183384832