### PR TITLE
[lldb] Discern embedded swift tests that can't run vs buggy ones

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -27,6 +27,7 @@ from lldbsuite.support import funcutils
 from lldbsuite.test import lldbplatform
 from lldbsuite.test import lldbplatformutil
 import swift
+from lldbsuite.test.skip_reason import UnsupportedReason
 
 
 class DecorateMode:
@@ -1085,9 +1086,34 @@ def requiresSwiftPlugin(min_apple_os_version=None):
     return decorate
 
 def skipEmbeddedSwift(func):
+    """Skip a test that ought to work in embedded Swift but currently doesn't.
+
+    Use this when the test is expected to run in embedded Swift eventually and
+    removing the annotation is the goal.    
+    
+    For a test that can never run in embedded Swift, use
+    `requireNotEmbeddedSwift` instead.
+    """
     def skip_fn(swift_embedded=None, **kwargs):
         if swift_embedded == "swiftembed":
             return "not supported in embedded Swift"
+        return None
+    return _skipForVariant("swift_embedded", skip_fn, func)
+
+def requireNotEmbeddedSwift(func):
+    """Mark a test as inherently inapplicable to embedded Swift.
+
+    Use this when the test can never run as embedded Swift: it imports
+    Foundation or another Objective-C module, needs library evolution, drives a
+    facility with no embedded counterpart (playgrounds, the sanitizer runtimes),
+    or uses a language feature not available in Embedded Swift.
+
+    Unlike `skipEmbeddedSwift`, these tests are reported as UNSUPPORTED rather
+    than SKIPPED.
+    """
+    def skip_fn(swift_embedded=None, **kwargs):
+        if swift_embedded == "swiftembed":
+            return UnsupportedReason("requires non-embedded Swift")
         return None
     return _skipForVariant("swift_embedded", skip_fn, func)
 

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -1212,6 +1212,12 @@ def run_suite():
 
     configuration.failed = not result.wasSuccessful()
 
+    if getattr(result, "skipped", None):
+        sys.stderr.write(
+            "Skip breakdown (unsupported=%d, skipped=%d)\n"
+            % (result.countUnsupported(), result.countSkipped())
+        )
+
     if configuration.sdir_has_content and configuration.verbose:
         sys.stderr.write(
             "Session logs for test failures/errors/unexpected successes"

--- a/lldb/packages/Python/lldbsuite/test/skip_reason.py
+++ b/lldb/packages/Python/lldbsuite/test/skip_reason.py
@@ -1,0 +1,17 @@
+"""
+Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+See https://llvm.org/LICENSE.txt for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+Distinguishes the two reasons a test can end up not running.
+"""
+
+
+class UnsupportedReason(str):
+    """A skip reason meaning "this test can never run here", not "this test is
+    broken here". Reported as UNSUPPORTED rather than SKIPPED."""
+
+
+def is_unsupported(reason):
+    """Return True if *reason* marks a test as unsupported rather than skipped."""
+    return isinstance(reason, UnsupportedReason)

--- a/lldb/packages/Python/lldbsuite/test/test_result.py
+++ b/lldb/packages/Python/lldbsuite/test/test_result.py
@@ -16,6 +16,7 @@ import unittest
 
 # LLDB Modules
 from . import configuration
+from .skip_reason import UnsupportedReason, is_unsupported
 from lldbsuite.test_event import build_exception
 
 
@@ -162,9 +163,17 @@ class LLDBTestResult(unittest.TextTestResult):
         getattr(test, test._testMethodName).__func__.__unittest_skip__ = True
         getattr(
             test, test._testMethodName
-        ).__func__.__unittest_skip_why__ = (
+        ).__func__.__unittest_skip_why__ = UnsupportedReason(
             "test case does not fall in any category of interest for this run"
         )
+
+    def countUnsupported(self):
+        """Number of skipped tests that can never run in this configuration."""
+        return sum(1 for _, reason in self.skipped if is_unsupported(reason))
+
+    def countSkipped(self):
+        """Number of skipped tests that ought to run here but don't work yet."""
+        return len(self.skipped) - self.countUnsupported()
 
     def checkExclusion(self, exclusion_list, name):
         if exclusion_list:
@@ -282,9 +291,13 @@ class LLDBTestResult(unittest.TextTestResult):
         method = getattr(test, "markSkippedTest", None)
         if method:
             method()
+        # A test turned off by a `require*` decorator can never run in this
+        # configuration, so report it as UNSUPPORTED. Anything else is a test
+        # that ought to run here but doesn't work yet: report it as SKIPPED.
+        status = "UNSUPPORTED" if is_unsupported(reason) else "SKIPPED"
         self.stream.write(
-            "UNSUPPORTED: LLDB (%s) :: %s (%s) \n"
-            % (self._config_string(test), str(test), reason)
+            "%s: LLDB (%s) :: %s (%s) \n"
+            % (status, self._config_string(test), str(test), reason)
         )
 
     def addUnexpectedSuccess(self, test):

--- a/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_po_address(self):
         self.build()
@@ -21,7 +21,7 @@ class TestCase(TestBase):
         self.expect(f"dwim-print -O -- 0x{hex_addr}", patterns=[f"Object@0x0*{hex_addr}"])
         self.expect(f"dwim-print -O -- {addr}", patterns=[f"Object@0x0*{hex_addr}"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_po_non_address_hex(self):
         """No special handling of non-memory integer values."""
@@ -31,7 +31,7 @@ class TestCase(TestBase):
         )
         self.expect(f"dwim-print -O -- 0x1000", substrs=["4096"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_print_swift_object_does_not_show_name(self):
         """Ensure that objects are printed without a name, and without the '='

--- a/lldb/test/API/commands/frame/var/direct-ivar/swift/TestSwiftFrameVarDirectIvar.py
+++ b/lldb/test/API/commands/frame/var/direct-ivar/swift/TestSwiftFrameVarDirectIvar.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_objc_self(self):
@@ -13,7 +13,7 @@ class TestCase(TestBase):
         lldbutil.run_to_source_breakpoint(self, "check self", lldb.SBFileSpec("main.swift"))
         self.expect("frame variable _prop", startstr="(Int) _prop = 30")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_objc_self_capture_idiom(self):

--- a/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
+++ b/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
@@ -25,7 +25,7 @@ class AsanSwiftTestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
@@ -21,7 +21,7 @@ import os
 
 @skipIfWindows
 class TestSwiftErrorBreakpoint(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @decorators.skipIfLinux  # <rdar://problem/30909618>
     @swiftTest
     def test_swift_error_no_typename(self):
@@ -29,21 +29,21 @@ class TestSwiftErrorBreakpoint(TestBase):
         self.build()
         self.do_tests(None)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_error_matching_base_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests("EnumError")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_error_matching_full_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests("a.EnumError")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_error_bogus_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""

--- a/lldb/test/API/functionalities/data-formatter/swift/bridged-string/TestSwiftBridgedStringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/bridged-string/TestSwiftBridgedStringFormatters.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/functionalities/data-formatter/swift/date/TestSwiftDateFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/date/TestSwiftDateFormatters.py
@@ -11,7 +11,7 @@ import sys
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessFoundationEssentials
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
@@ -11,7 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessFoundationEssentials
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest
@@ -77,7 +77,7 @@ class TestCase(TestBase):
             ],
         )
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessFoundation
     @swiftTest
     def test_swift_string_index_formatters_bridged(self):

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -9,7 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_substring_formatters(self):
         """Test Subtring summary strings."""

--- a/lldb/test/API/functionalities/mtc/swift-property/TestSwiftMTCProperty.py
+++ b/lldb/test/API/functionalities/mtc/swift-property/TestSwiftMTCProperty.py
@@ -13,7 +13,7 @@ import json
 
 
 class MTCSwiftPropertyTestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/functionalities/mtc/swift/TestSwiftMTC.py
+++ b/lldb/test/API/functionalities/mtc/swift/TestSwiftMTC.py
@@ -13,7 +13,7 @@ import json
 
 
 class MTCSwiftTestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -15,7 +15,7 @@ class TestSwiftProgressReporting(TestBase):
         self.listener = lldbutil.start_listening_from(self.broadcaster,
                                         lldb.SBDebugger.eBroadcastBitProgress)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/functionalities/swift-runtime-reporting/exclusivity-violation/TestExclusivityViolation.py
+++ b/lldb/test/API/functionalities/swift-runtime-reporting/exclusivity-violation/TestExclusivityViolation.py
@@ -25,7 +25,7 @@ class SwiftRuntimeReportingExclusivityViolationTestCase(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.skipEmbeddedSwift
+    @decorators.requireNotEmbeddedSwift
     @decorators.skipIfLinux
     @decorators.expectedFailureWindows
     def test_swift_runtime_reporting(self):

--- a/lldb/test/API/functionalities/tsan/swift-access-race/TestSwiftTsanAccessRace.py
+++ b/lldb/test/API/functionalities/tsan/swift-access-race/TestSwiftTsanAccessRace.py
@@ -25,7 +25,7 @@ class TsanSwiftAccessRaceTestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/functionalities/tsan/swift/TestSwiftTsan.py
+++ b/lldb/test/API/functionalities/tsan/swift/TestSwiftTsan.py
@@ -24,7 +24,7 @@ class TsanSwiftTestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/lang/swift/accelerate_simd/TestAccelerateSIMD.py
+++ b/lldb/test/API/lang/swift/accelerate_simd/TestAccelerateSIMD.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
+++ b/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
@@ -44,7 +44,7 @@ class TestSwiftAddressOf(lldbtest.TestBase):
         self.assertSuccess(error)
 
         
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
+++ b/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
@@ -23,7 +23,7 @@ class TestSwiftAnyType(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_any_type(self):
         """Test the Any type"""

--- a/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
+++ b/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
@@ -20,7 +20,8 @@ import os
 
 
 class TestSwiftArchetypeResolution(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux # the embedded stdlib's hashing seed needs arc4random_buf, which does not link on Linux.
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_swift_archetype_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""

--- a/lldb/test/API/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
+++ b/lldb/test/API/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/array_bridged_enum/TestArrayBridgedEnum.py
+++ b/lldb/test/API/lang/swift/array_bridged_enum/TestArrayBridgedEnum.py
@@ -1,5 +1,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift,
         swiftTest, skipUnlessFoundation])

--- a/lldb/test/API/lang/swift/array_element/TestSwiftArrayElement.py
+++ b/lldb/test/API/lang/swift/array_element/TestSwiftArrayElement.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/array_enum/TestArrayEnum.py
+++ b/lldb/test/API/lang/swift/array_enum/TestArrayEnum.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
+++ b/lldb/test/API/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
@@ -1,6 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift,
         swiftTest, skipIfLinux,
     expectedFailureAll(archs=['arm64_32'], bugnumber="<rdar://problem/58065423>")])

--- a/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
+++ b/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftArrayUninitialized(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test unitialized global arrays"""

--- a/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
+++ b/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftArtificialSubclass(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessObjCInterop
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/associated_self_type/TestSwiftAssociatedSelfType.py
+++ b/lldb/test/API/lang/swift/associated_self_type/TestSwiftAssociatedSelfType.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftArchetypeResolution(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_associated_type_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""

--- a/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
+++ b/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
@@ -8,7 +8,7 @@ class TestSwiftAsyncFnArgs(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows',])
     def test(self):

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test_unsafe_continuation_printing(self):
         """Print an UnsafeContinuation and verify its children."""
@@ -34,7 +34,7 @@ class TestCase(TestBase):
             ],
         )
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test_checked_continuation_printing(self):
         """Print an CheckedContinuation and verify its children."""

--- a/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
+++ b/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
@@ -8,7 +8,7 @@ class TestSwiftAsyncExpressions(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(archs=no_match(["aarch", "arm64", "arm64e", "arm64_32", "x86_64"]))
     def test_actor(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_top_level_task(self):
         """Test Task synthetic child provider for top-level Task."""
@@ -34,7 +34,7 @@ class TestCase(TestBase):
             ],
         )
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_current_task(self):
         """Test Task synthetic child for UnsafeCurrentTask (from an async let)."""

--- a/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_summary_contains_name(self):
         self.build()
@@ -16,7 +16,7 @@ class TestCase(TestBase):
         )
         self.expect("v task", patterns=[r'"Chore" id:[1-9]'])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows # rdar://176009590
     def test_thread_contains_name(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/parent/TestSwiftSyntheticTaskParent.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/parent/TestSwiftSyntheticTaskParent.py
@@ -9,7 +9,7 @@ ADDR_PATTERN = "(0x[0-9a-f]{6,})"
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test(self):
         """Test summary formatter for TaskPriority."""

--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -7,7 +7,7 @@ class TestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=['windows'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
@@ -67,7 +67,7 @@ class TestCase(lldbtest.TestBase):
             myvar = frame.FindVariable("myvar")
             lldbutil.check_variable(self, myvar, False, value=expected_value)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
+++ b/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
@@ -6,7 +6,7 @@ import re
 
 
 class TestCase(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
@@ -8,7 +8,7 @@ class TestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     @skipIf(macos_version=["<", "26.0"], asan=True) # rdar://138777205

--- a/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
@@ -28,7 +28,7 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.assertEqual(thread.frames[0].GetFunctionName(), expected_func_name)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -17,7 +17,7 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):
@@ -40,7 +40,7 @@ class TestCase(lldbtest.TestBase):
             self.check_is_in_line(thread, expected_line_num)
             self.check_x_is_available(thread.frames[0])
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @skipIfOutOfTreeDebugserver
     @swiftTest
     @skipIf(oslist=["windows", "linux"])

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
@@ -12,7 +12,7 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows"])
     def test_nothrow(self):
@@ -32,7 +32,7 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.check_is_in_line(thread, expected_line_num)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows"])
     def test_throw(self):

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_print_task_group(self):
         """Print a TaskGroup and verify its children."""
@@ -17,7 +17,7 @@ class TestCase(TestBase):
         )
         self.do_test_print()
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_print_throwing_task_group(self):
         """Print a ThrowingTaskGroup and verify its children."""
@@ -61,7 +61,7 @@ class TestCase(TestBase):
             ],
         )
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_api_task_group(self):
         """Verify a TaskGroup contains its expected children."""
@@ -71,7 +71,7 @@ class TestCase(TestBase):
         )
         self.do_test_api(process)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_api_throwing_task_group(self):
         """Verify a ThrowingTaskGroup contains its expected children."""

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_backtrace_task_variable(self):
         self.build()
@@ -14,7 +14,7 @@ class TestCase(TestBase):
         )
         self.do_backtrace("task")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_backtrace_task_address(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_backtrace_selected_task_variable(self):
         self.build()
@@ -14,7 +14,7 @@ class TestCase(TestBase):
         )
         self.do_backtrace_selected_task("task")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_backtrace_selected_task_address(self):
         self.build()
@@ -38,7 +38,7 @@ class TestCase(TestBase):
             ],
         )
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_navigate_stack_of_selected_task_variable(self):
         self.build()
@@ -47,7 +47,7 @@ class TestCase(TestBase):
         )
         self.do_test_navigate_selected_task_stack(process, "task")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_navigate_stack_of_selected_task_address(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
+++ b/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
@@ -13,7 +13,7 @@ def _tail(output):
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @skipUnlessPlatform(["macosx", "linux"])
     @swiftTest
     def test_compare_printed_task_variable_to_task_info(self):
@@ -28,7 +28,7 @@ class TestCase(TestBase):
         task_info_output = self.res.GetOutput()
         self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @skipUnlessPlatform(["macosx", "linux"])
     @swiftTest
     def test_compare_printed_task_variable_to_task_info_with_address(self):

--- a/lldb/test/API/lang/swift/async/tasks/list/TestSwiftTaskList.py
+++ b/lldb/test/API/lang/swift/async/tasks/list/TestSwiftTaskList.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessPlatform(["macosx", "linux"])
     @swiftTest
     def test_task_list(self):

--- a/lldb/test/API/lang/swift/async/tasks/tree/TestSwiftTaskTree.py
+++ b/lldb/test/API/lang/swift/async/tasks/tree/TestSwiftTaskTree.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessPlatform(["macosx", "linux"])
     @swiftTest
     def test_task_tree(self):

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestDisableLanguageUnwinder(lldbtest.TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=['windows',])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/hidden_frames/TestSwiftAsyncHiddenFrames.py
+++ b/lldb/test/API/lang/swift/async/unwind/hidden_frames/TestSwiftAsyncHiddenFrames.py
@@ -8,7 +8,7 @@ class TestSwiftAsyncHiddenFrames(lldbtest.TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=['windows',])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
@@ -12,7 +12,7 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows',])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
@@ -8,7 +8,7 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows",])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -163,7 +163,7 @@ class TestCase(lldbtest.TestBase):
                 return thread, bpid
         return None, None
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
@@ -10,7 +10,7 @@ class TestCase(lldbtest.TestBase):
 
     unwind_fail_range_cache = dict()
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows",])
     @skipIf(archs=["arm64e"])

--- a/lldb/test/API/lang/swift/async/unwind/unwind_register_pressure/TestSwiftAsyncUnwindRegisterPressure.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_register_pressure/TestSwiftAsyncUnwindRegisterPressure.py
@@ -60,7 +60,7 @@ class TestCase(lldbtest.TestBase):
                 return thread, bpid
         return None, None
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/variables/TestSwiftAsyncVariables.py
+++ b/lldb/test/API/lang/swift/async/variables/TestSwiftAsyncVariables.py
@@ -8,7 +8,7 @@ class TestSwiftAsyncVariables(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=['windows'])
     def test(self):

--- a/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
+++ b/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     @skipIfLinux

--- a/lldb/test/API/lang/swift/async_breakpoints_over_many_funclets/TestSwiftAsyncBreakpointsOverManyFunclets.py
+++ b/lldb/test/API/lang/swift/async_breakpoints_over_many_funclets/TestSwiftAsyncBreakpointsOverManyFunclets.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @expectedFailureWindows
     @skipIfLinux

--- a/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
@@ -34,7 +34,7 @@ class TestAvailability(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift strips functions the program never calls, so f() is not in the binary to call
     @swiftTest
     @skipIf(oslist=['linux', 'windows'])
     def testAvailability(self):

--- a/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
+++ b/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
@@ -9,7 +9,7 @@ import os
 
 
 class TestSwiftBridgedMetatype(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test_swift_bridged_metatype(self):

--- a/lldb/test/API/lang/swift/bridged_url/TestSwiftBridgedURL.py
+++ b/lldb/test/API/lang/swift/bridged_url/TestSwiftBridgedURL.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessFoundationEssentials
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest

--- a/lldb/test/API/lang/swift/c_compat_enum/TestSwiftCCompatEnum.py
+++ b/lldb/test/API/lang/swift/c_compat_enum/TestSwiftCCompatEnum.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftCCompatEnum(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/cf/uuid/TestCFUUID.py
+++ b/lldb/test/API/lang/swift/cf/uuid/TestCFUUID.py
@@ -9,7 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
+++ b/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
@@ -21,7 +21,7 @@ class TestSwiftBridgingHeaderHeadermap(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClangImporterCaching(TestBase):
 
-    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(swift_module_importer="noclang")
     @skipIf(setting=("symbols.swift-precise-compiler-invocation", "false"))

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftNSClassBaseClass(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -17,7 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftDedupMacros(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     # NOTE: rdar://44201206 - This test may sporadically segfault. It's likely

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
@@ -20,7 +20,7 @@ class TestSwiftClangImporterCustomAlignment(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -18,7 +18,7 @@ import os
 import shutil
 
 class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIfLinux

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -7,7 +7,7 @@ class TestSwiftClangImporterExplicitNoImplicit(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
     
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/TestSwiftClangImporterExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/TestSwiftClangImporterExtraInhabitants.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClangImporterExtraInhabitants(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     # Don't run ClangImporter tests if Clangimporter is disabled.

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
@@ -9,7 +9,7 @@ class TestSwiftHardMacroConflict(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -22,7 +22,7 @@ class TestSwiftHeadermapConflict(TestBase):
         bugnumber="rdar://60396797",
         setting=("symbols.use-swift-clangimporter", "false"),
     )
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -18,7 +18,7 @@ import os
 import shutil
 
 class TestSwiftIncludeConflict(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/missing_pch/TestSwiftMissingPCH.py
+++ b/lldb/test/API/lang/swift/clangimporter/missing_pch/TestSwiftMissingPCH.py
@@ -11,7 +11,7 @@ class TestSwiftMissingVFSOverlay(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/nserror/TestNSError.py
+++ b/lldb/test/API/lang/swift/clangimporter/nserror/TestNSError.py
@@ -19,7 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class SwiftNSErrorTest(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_nserror(self):

--- a/lldb/test/API/lang/swift/clangimporter/nsinteger_nsenum/TestSwiftNSIntegerNSEnum.py
+++ b/lldb/test/API/lang/swift/clangimporter/nsinteger_nsenum/TestSwiftNSIntegerNSEnum.py
@@ -21,14 +21,14 @@ class TestSwiftNSIntegerNSEnum(lldbtest.TestBase):
         check(frame.FindVariable('e1'), 'eCase1')
         check(frame.FindVariable('e2'), 'eCase2')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_reflection(self):
         self.expect("setting set symbols.swift-enable-ast-context false")
         self.do_test(use_summary=True)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run a clangimporter test without ClangImporter.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objc/dynamic-swift-type/TestSwiftObjCDynamicType.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc/dynamic-swift-type/TestSwiftObjCDynamicType.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessFoundation
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_baseclass/TestSwiftObjCBaseClassMemberLookup.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_baseclass/TestSwiftObjCBaseClassMemberLookup.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCBaseClassMemberLookup(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_inherited_ivars/TestSwiftAtObjCIvars.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_inherited_ivars/TestSwiftAtObjCIvars.py
@@ -26,7 +26,7 @@ class TestSwiftAtObjCIvars(TestBase):
         lldbutil.check_variable(self, x, False, value='12')
         lldbutil.check_variable(self, y, False, '"12"')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_at_objc_ivars(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestObjCInternalPropertyRedecl.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestObjCInternalPropertyRedecl.py
@@ -8,7 +8,7 @@ class TestObjCInternalPropertyRedecl(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/TestSwiftObjCOptionalDict.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/TestSwiftObjCOptionalDict.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCOptionalDict(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCProtocol(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol_fields/TestSwiftObjCProtocolFields.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol_fields/TestSwiftObjCProtocolFields.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCBaseClassMemberLookup(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -22,7 +22,7 @@ import re
 import shutil
 
 class TestObjCIVarDiscovery(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
     @swiftTest
@@ -31,7 +31,7 @@ class TestObjCIVarDiscovery(TestBase):
         shutil.rmtree(self.getBuildArtifact("aTestFramework.framework/Versions/A/aTestFramework.dSYM"))
         self.do_test(False)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -18,7 +18,7 @@ import os
 import shutil
 
 class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -21,7 +21,7 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
+++ b/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessFoundationEssentials
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClangImporterProtocolComposition(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -17,7 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftRemoteASTImport(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIfLinux

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -18,7 +18,7 @@ import os
 import shutil
 
 class TestSwiftRewriteClangPaths(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
@@ -27,7 +27,7 @@ class TestSwiftRewriteClangPaths(TestBase):
     def testWithRemap(self):
         self.dotest(True)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -17,7 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
@@ -4,7 +4,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftSubmoduleImport(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test imports of Clang submodules"""

--- a/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
+++ b/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClashingABIName(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that expressions with types in modules with clashing abi names works"""
@@ -22,7 +22,7 @@ class TestSwiftClashingABIName(TestBase):
 
         self.expect('expr --bind-generic-types true -- generic3',
                     substrs=['a.Generic2<a.Generic<a.One>>', 't2 =', 't =', 'j = 98'])
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_in_self(self):
         """Test a library with a private import for which there is no debug info"""

--- a/lldb/test/API/lang/swift/class_error/TestClassError.py
+++ b/lldb/test/API/lang/swift/class_error/TestClassError.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])

--- a/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
+++ b/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
@@ -15,7 +15,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestClosureShortcuts(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -51,7 +51,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         target.BreakpointDelete(bkpt.GetID())
         return (target, process, thread)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_simple_closure(self):
         self.build()
@@ -60,7 +60,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_not_captured_error(self, thread.frames[0], "arg", "func_1(arg:)")
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_nested_closure(self):
         self.build()
@@ -85,7 +85,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     # Async variable inspection on Linux/Windows are still problematic.
     @skipIf(oslist=["windows", "linux"])
@@ -109,7 +109,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     # Async variable inspection on Linux/Windows are still problematic.
     @skipIf(oslist=["windows", "linux"])
@@ -122,7 +122,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
             self, thread.frames[0], "x", "task_inside_non_async_function()"
         )
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_ctor_class_closure(self):
         self.build()
@@ -180,7 +180,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_ctor_struct_closure(self):
         self.build()
@@ -238,7 +238,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_ctor_enum_closure(self):
         self.build()

--- a/lldb/test/API/lang/swift/command_memory_find/TestSwiftCommandMemoryFind.py
+++ b/lldb/test/API/lang/swift/command_memory_find/TestSwiftCommandMemoryFind.py
@@ -18,7 +18,8 @@ class TestSwiftCommandMemoryFind(TestBase):
         self.expect(f'memory find -e "{expr}" {hex(addr)} {hex(addr + 8)}',
                     substrs=["data found at location"])
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux # `memory find -e` does not locate the value in embedded Swift on Linux.
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
+++ b/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_scalar_types(self):
         self.build()

--- a/lldb/test/API/lang/swift/constrained_existential_metatype/TestSwiftConstrainedExistentialMetatypeFix.py
+++ b/lldb/test/API/lang/swift/constrained_existential_metatype/TestSwiftConstrainedExistentialMetatypeFix.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftConstrainedExistentialMetatypeFix(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/convention_c_function_pointer/TestSwiftConventionCFunctionPointer.py
+++ b/lldb/test/API/lang/swift/convention_c_function_pointer/TestSwiftConventionCFunctionPointer.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftConventionCFunctionPointer(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
@@ -7,7 +7,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftBackwardInteropExpressions(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_func_step_in(self):
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part01.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part01.py
@@ -32,25 +32,25 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_method_step_in_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_in(thread, 'testMethod', 'SwiftClass.swiftMethod')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_method_step_over_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_over(thread, 'testMethod')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_init_step_in_class(self):
         thread = self.setup('Break here for constructor - class')
         self.check_step_in(thread, 'testConstructor', 'SwiftClass.init')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_init_step_over_class(self):
         thread = self.setup('Break here for constructor - class')

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part02.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part02.py
@@ -32,25 +32,25 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_static_method_step_in_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_in(thread, 'testStaticMethod', 'SwiftClass.swiftStaticMethod')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_static_method_step_over_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_over(thread, 'testStaticMethod')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_getter_step_in_class(self):
         thread = self.setup('Break here for getter - class')
         self.check_step_in(thread, 'testGetter', 'SwiftClass.swiftProperty.getter')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_getter_step_over_class(self):
         thread = self.setup('Break here for getter - class')

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part03.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass_part03.py
@@ -32,26 +32,26 @@ class TestSwiftBackwardInteropSteppingClass(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_setter_step_in_class(self):
         thread = self.setup('Break here for setter - class')
         self.check_step_in(thread, 'testSetter', 'SwiftClass.swiftProperty.setter')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_setter_step_over_class(self):
         thread = self.setup('Break here for setter - class')
         self.check_step_over(thread, 'testSetter')
 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_overriden_step_in_class(self):
         thread = self.setup('Break here for overridden - class')
         self.check_step_in(thread, 'testOverridenMethod', 'SwiftSubclass.overrideableMethod')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_overriden_step_over_class(self):
         thread = self.setup('Break here for overridden')

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingFunc.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingFunc.py
@@ -33,13 +33,13 @@ class TestSwiftBackwardInteropSteppingFunc(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_func_step_in(self):
         thread = self.setup("Break here for func")
         self.check_step_in(thread, "testFunc", "swiftFunc")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_func_step_over(self):
         thread = self.setup("Break here for func")

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part01.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part01.py
@@ -33,25 +33,25 @@ class TestSwiftBackwardInteropSteppingStruct(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_method_step_in_struct(self):
         thread = self.setup("Break here for method - struct")
         self.check_step_in(thread, "testMethod", "SwiftStruct.swiftMethod")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_method_step_over_struct(self):
         thread = self.setup("Break here for method - struct")
         self.check_step_over(thread, "testMethod")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_init_step_in_struct(self):
         thread = self.setup("Break here for constructor - struct")
         self.check_step_in(thread, "testConstructor", "SwiftStruct.init")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_init_step_over_struct(self):
         thread = self.setup("Break here for constructor - struct")

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part02.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part02.py
@@ -33,25 +33,25 @@ class TestSwiftBackwardInteropSteppingStruct(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_static_method_step_in_struct(self):
         thread = self.setup("Break here for static method - struct")
         self.check_step_in(thread, "testStaticMethod", "SwiftStruct.swiftStaticMethod")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_static_method_step_over_struct(self):
         thread = self.setup("Break here for static method - struct")
         self.check_step_over(thread, "testStaticMethod")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_getter_step_in_struct(self):
         thread = self.setup("Break here for getter - struct")
         self.check_step_in(thread, "testGetter", "SwiftStruct.swiftProperty.getter")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_getter_step_over_struct(self):
         thread = self.setup("Break here for getter - struct")

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part03.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct_part03.py
@@ -33,13 +33,13 @@ class TestSwiftBackwardInteropSteppingStruct(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn(func, name)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_setter_step_in_struct(self):
         thread = self.setup("Break here for setter - struct")
         self.check_step_in(thread, "testSetter", "SwiftStruct.swiftProperty.setter")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_setter_step_over_struct(self):
         thread = self.setup("Break here for setter - struct")

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftForwardInteropCxxClass(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_class(self):
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
@@ -12,7 +12,7 @@ class TestSwiftForwardInteropSTLTypes(TestBase):
     @skipIf(
         setting=("symbols.use-swift-clangimporter", "false")
     )  # rdar://106438227 (TestSTLTypes fails when clang importer is disabled)
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -22,7 +22,7 @@ import os
 class TestSwiftDeploymentTarget(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
@@ -34,7 +34,7 @@ class TestSwiftDeploymentTarget(TestBase):
                                           lldb.SBFileSpec('main.swift'))
         self.expect("expression f", substrs=['i = 23'])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
@@ -48,7 +48,7 @@ class TestSwiftDeploymentTarget(TestBase):
         lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect("expression self", substrs=['i = 23'])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
@@ -69,7 +69,7 @@ class TestSwiftDeploymentTarget(TestBase):
 #       CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::SetTriple({{.*}}apple-macosx11.0.0
 #       CHECK-NOT: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RegisterSectionModules("a.out"){{.*}} AST Data blobs
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin  # This test uses macOS triples explicitly.
     @skipIfDarwinEmbedded
     @skipIf(macos_version=["<", "11.1"])

--- a/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
+++ b/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
@@ -30,7 +30,7 @@ class TestSwiftDeserializationFailure(TestBase):
         # FIXME: this is formatted incorrectly.
         self.expect("fr var -d no-dynamic t", substrs=["(T)"]) #, "world"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift monomorphizes every generic, so the parameter is never typed (T)
     @swiftTest
     @skipIf(debug_info=no_match(["dwarf"]))
     def test_missing_module(self):
@@ -39,7 +39,7 @@ class TestSwiftDeserializationFailure(TestBase):
         target, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'main')
         self.run_tests(target, process)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift monomorphizes every generic, so the parameter is never typed (T)
     @swiftTest
     @skipIf(debug_info=no_match(["dwarf"]))
     def test_damaged_module(self):

--- a/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
+++ b/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftDifferentABIName(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -34,7 +34,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
         self.assertTrue(os.path.isdir(include))
         shutil.rmtree(include)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):
@@ -61,7 +61,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
         #self.expect("target var -d run proto", substrs=["(ProtoImpl)", "proto"])
         #self.expect("target var -O proto", substrs=["<ProtoImpl"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_expr(self):
@@ -83,7 +83,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
                                                 "private_ivar", "42"])
 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_eager_member_completion(self):

--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -23,7 +23,7 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
         self.assertTrue(os.path.isdir(include))
         shutil.rmtree(include)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift disables ObjC interop, so this test's Foundation import does not compile
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
+++ b/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftEnableTesting(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIfLinux
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
+++ b/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
@@ -8,7 +8,7 @@ class TestSwiftAnyType(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_any_type(self):
         self.build()

--- a/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
+++ b/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @expectedFailureAll(oslist=["linux"], bugnumber="rdar://83444822")
     def test(self):

--- a/lldb/test/API/lang/swift/enums/decoding_error/TestSwiftDecodingErrorEnum.py
+++ b/lldb/test/API/lang/swift/enums/decoding_error/TestSwiftDecodingErrorEnum.py
@@ -6,7 +6,7 @@ import os
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @skipUnlessFoundationEssentials
     @swiftTest

--- a/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftErrorHandlingMissingTypes(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # the embedded variant is never crossed with noclang, so this test never runs as embedded
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'true'))
     def test(self):

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     def test_with_deleted_header(self):
@@ -33,7 +33,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         # CHECK-NOT: secret
         # CHECK: Import 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     def test(self):

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching_part01.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching_part01.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching_part02.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching_part02.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/explicit_modules/caching/TestSwiftExplicitModuleCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/caching/TestSwiftExplicitModuleCaching.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExplicitModuleCaching(TestBase):
 
-    @skipEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))

--- a/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/TestSwiftExplicitModulesChainedBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/TestSwiftExplicitModulesChainedBridgingHeader.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftExplicitModulesChainedBridgingHeader(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin # uses a framework, doesn't link with gold
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -8,7 +8,7 @@ import lldbsuite.test.lldbutil as lldbutil
 @skipIfWindows
 class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_missing(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""
@@ -32,7 +32,7 @@ class TestCase(lldbtest.TestBase):
         # CHECK: Nonexistent explicit module file
         # CHECK: Explicit modules : false (downgraded
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_sanity(self):
         """Check the normal behavior."""
@@ -60,7 +60,7 @@ class TestCase(lldbtest.TestBase):
         # CHECK-SANITY: Turning off implicit modules
         # CHECK-SANITY: Turning on implicit modules
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_setting(self):
         """Check the normal behavior."""

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
@@ -8,7 +8,7 @@ class TestSwiftExplicitModulePrivateTypeGeneric(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @expectedFailureWindows  # https://github.com/swiftlang/llvm-project/issues/13444
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test frame variable of a generic struct specialized to a

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part01.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part01.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test explicit Swift modules"""
@@ -21,7 +21,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Discovered main module {{.*}}a.swiftmodule
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Module import remark: loaded module 'a'; source: '{{.*}}a.swiftmodule', loaded: '{{.*}}a.swiftmodule'
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_disable_esml(self):
         """Test disabling the explicit Swift module loader"""

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfLinux
     def test_import(self):

--- a/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
+++ b/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
@@ -6,7 +6,7 @@ import os
 
 
 class TestSwiftExpressionActor(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_static_func(self):
         self.build()
@@ -16,7 +16,7 @@ class TestSwiftExpressionActor(TestBase):
 
         self.expect("expr self", substrs=["A.Type"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_func(self):
         self.build()

--- a/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
+++ b/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
@@ -9,7 +9,7 @@ class TestSwiftExprAllocator(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_allocator_self(self):
         """Test expressions involving self in a allocating constructor. In an

--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -14,28 +14,28 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 class TestClassConstrainedProtocol(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_extension_weak_self(self):
         """Test that we can reconstruct weak self captured in a class constrained protocol."""
         self.build()
         self.do_self_test("Break here for weak self", needs_dynamic=False)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_extension_self (self):
         """Test that we can reconstruct self in method of a class constrained protocol."""
         self.build()
         self.do_self_test("Break here in class protocol", needs_dynamic=False)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_method_weak_self(self):
         """Test that we can reconstruct weak self capture in method of a class conforming to a class constrained protocol."""
         self.build()
         self.do_self_test("Break here for method weak self", needs_dynamic=False)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_method_self(self):
         """Test that we can reconstruct self in method of a class conforming to a class constrained protocol."""

--- a/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
+++ b/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestExpressionsInSwiftMethodsFromObjC(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_expressions_from_objc(self):

--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestExpressionOpenResilientClass(TestBase):
     NO_DEBUG_INFO_TEST = True
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests calling an open resilient function"""

--- a/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -36,7 +36,7 @@ class TestUnitTests(TestBase):
     @expectedFailureAll(
         oslist=["linux"],
         bugnumber="rdar://28180489")
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test_equality_operators_fileprivate(self):
         """Test that we resolve expression operators correctly"""
         self.build()
@@ -47,7 +47,7 @@ class TestUnitTests(TestBase):
     @expectedFailureAll(
         oslist=["linux"],
         bugnumber="rdar://28180489")
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test_equality_operators_private(self):
         """Test that we resolve expression operators correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -7,7 +7,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test_missing_location(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -32,7 +32,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         self.assertIn("no location for 'self' in debug info", all_messages)
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test_missing_var(self):
         """Test error reporting in expressions reports
         only diagnostics in user code"""
@@ -118,7 +118,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
                     substrs=['self', 'not', 'found'])
 
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift monomorphizes every generic, so there is no archetype T left to diagnose
     def test_syntax(self):
         """Test syntax errors are being diagnosed"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -17,7 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftExpressionObjCContext(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -15,7 +15,7 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestOptionalAmbiguity(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_sample_rename_this(self):
         self.build()

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 
 
 class TestSwiftProtocolExtensionSelf(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that the generic self in a protocol extension works in the expression evaluator.

--- a/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftExpressionScopes(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_expression_scopes(self):
         """Tests that swift expressions resolve scoped variables correctly"""

--- a/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
@@ -21,7 +21,7 @@ import sys
 
 
 class TestSwiftSimpleExpressions(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_simple_swift_expressions(self):
         """Tests that we can run simple Swift expressions correctly"""

--- a/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftWeakGenericSelf(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Confirms that expression evaluation works with a generic class

--- a/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
@@ -18,7 +18,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftGenericExtension(TestBase):
-     @skipEmbeddedSwift
+     @requireNotEmbeddedSwift
      @swiftTest
      def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
+++ b/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
@@ -29,7 +29,7 @@ class TestFilePrivate(TestBase):
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that we find the right file-local private decls using the discriminator"""

--- a/lldb/test/API/lang/swift/first_expr_module_load/TestSwiftFirstExprModuleLoad.py
+++ b/lldb/test/API/lang/swift/first_expr_module_load/TestSwiftFirstExprModuleLoad.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFirstExprModuleLoad(lldbtest.TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_unknown_self_objc_ref(self):

--- a/lldb/test/API/lang/swift/foundation/TestSwiftFoundation.py
+++ b/lldb/test/API/lang/swift/foundation/TestSwiftFoundation.py
@@ -16,7 +16,7 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     decorators=[
-        skipEmbeddedSwift,
+        requireNotEmbeddedSwift,
         skipUnlessFoundationEssentials,
         skipIfLinux,  # https://github.com/swiftlang/llvm-project/issues/13465
         swiftTest,

--- a/lldb/test/API/lang/swift/foundation_value_types/cfstringref/TestSwiftFoundationTypeCFStringRef.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/cfstringref/TestSwiftFoundationTypeCFStringRef.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFoundationTypeCFStringRef(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
@@ -15,7 +15,7 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[skipEmbeddedSwift,
+    decorators=[requireNotEmbeddedSwift,
         swiftTest,
         skipIf(oslist=["linux"]),
         skipIf(

--- a/lldb/test/API/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[skipEmbeddedSwift,
+                          decorators=[requireNotEmbeddedSwift,
         swiftTest,skipIf(oslist=["linux"])])

--- a/lldb/test/API/lang/swift/foundation_value_types/decimal/TestSwiftFoundationTypeDecimal.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/decimal/TestSwiftFoundationTypeDecimal.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["linux", "windows"])
     def test_decimal(self):

--- a/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftFoundationValueTypeGlobal(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessFoundationEssentials
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest

--- a/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[skipEmbeddedSwift,
+                          decorators=[requireNotEmbeddedSwift,
         swiftTest,skipIf(oslist=['windows', 'linux'])])

--- a/lldb/test/API/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
@@ -23,7 +23,7 @@ class TestCase(TestBase):
         bugnumber="rdar://60396797",
         setting=("symbols.use-swift-clangimporter", "false"),
     )
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test_measurement(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -31,7 +31,7 @@ class TestCase(TestBase):
         )
         self.expect("expr -- measurement", substrs=["1.25 m"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_measurement_without_swift_ast_context(self):

--- a/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/TestSwiftSharedStringStorage.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/TestSwiftSharedStringStorage.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftSharedStringStorage(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -22,7 +22,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @expectedFailureAll(archs=["arm64_32"], bugnumber="<rdar://problem/58065423>")
     @skipUnlessFoundationEssentials
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465

--- a/lldb/test/API/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[skipEmbeddedSwift,
+                          decorators=[requireNotEmbeddedSwift,
         swiftTest,skipIf(oslist=["linux"])])

--- a/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
+++ b/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFrameworkPaths(lldbtest.TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/generic_arg_in_extension/TestSwiftGenericArgInExtension.py
+++ b/lldb/test/API/lang/swift/generic_arg_in_extension/TestSwiftGenericArgInExtension.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
+++ b/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
+++ b/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class SwiftGenericClassTest(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Tests that a generic class type can be resolved from the instance metadata alone"""

--- a/lldb/test/API/lang/swift/generic_objcclasswrapper/TestGenericObjcClassWrapper.py
+++ b/lldb/test/API/lang/swift/generic_objcclasswrapper/TestGenericObjcClassWrapper.py
@@ -1,5 +1,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift,
         swiftTest, skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/generic_struct_with_optional/TestGenericStructWithOptional.py
+++ b/lldb/test/API/lang/swift/generic_struct_with_optional/TestGenericStructWithOptional.py
@@ -1,5 +1,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift,
         swiftTest, skipIfLinux])

--- a/lldb/test/API/lang/swift/generic_type_of_nested_archetype/TestSwiftGenericTypeOfNestedArchetype.py
+++ b/lldb/test/API/lang/swift/generic_type_of_nested_archetype/TestSwiftGenericTypeOfNestedArchetype.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
+++ b/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
@@ -19,7 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class SwiftDynamicTypeGenericsTest(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_genericresolution_commands(self):
         """Check that we can correctly figure out the dynamic type of generic things"""

--- a/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
+++ b/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftGenericClassInHashedContainerTest(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests that the type of hashed container whose value type is a non-generic class declared inside a generic class can be read from instance metadata"""

--- a/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
+++ b/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
@@ -11,7 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftHashedContainerEnum(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_any_object_type(self):
         """Test combinations of hashed swift containers with enums"""

--- a/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
+++ b/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftHideRuntimeSupport(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift passes no type metadata, so there are no runtime support values to unhide
     @swiftTest
     def test_swift_hide_runtime_support(self):
         """Test that we hide runtime support values"""

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -36,7 +36,7 @@ class TestLibraryIndirect(TestBase):
 
         return info
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_implementation_only_import_library(self):
         """Test `@_implementationOnly import` behind some indirection in a library used by the main executable
@@ -70,7 +70,7 @@ class TestLibraryIndirect(TestBase):
         self.expect("expr container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "value = (first = 2, second = 3)"])
         self.expect("expr container.wrapped.value", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_impl_only_import_lib_no_lib_module(self):
         """Test `@_implementationOnly import` behind some indirection in a library used by the main executable, after removing the implementation-only library's swiftmodule

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -37,7 +37,7 @@ class TestLibraryResilient(TestBase):
 
         return info
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @expectedFailureAll(oslist=["windows"]) # Requires Remote Mirrors support
     def test_implementation_only_import_library(self):
@@ -58,7 +58,7 @@ class TestLibraryResilient(TestBase):
         self.expect("expr container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
         self.expect("expr container.wrapped", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @expectedFailureAll(oslist=["windows"]) # Requires Remote Mirrors support
     def test_implementation_only_import_library_no_library_module(self):

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -115,7 +115,7 @@ class TestMainExecutable(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
 
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # library evolution cannot be enabled with embedded Swift
     def test_implementation_only_import_main_executable_resilient(self):
         """Test `@_implementationOnly import` in the main executable with a resilient library
 
@@ -142,7 +142,7 @@ class TestMainExecutable(TestBase):
         self.expect("expr TwoInts(4, 5)", substrs=["(SomeLibrary.TwoInts)", "= (first = 4, second = 5)"])
 
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # library evolution cannot be enabled with embedded Swift
     @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
     def test_implementation_only_import_main_executable_resilient_no_library_module(self):
         """Test `@_implementationOnly import` in the main executable with a resilient library, after removing the library's swiftmodule

--- a/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftCGImportedTypes(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_cg_imported_types(self):

--- a/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
+++ b/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
@@ -23,7 +23,7 @@ class TestSwiftInstancePointerSetSP(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_instancepointerset_sp(self):
         """Test that we correctly track instance pointers in ValueObjectPrinter"""

--- a/lldb/test/API/lang/swift/late_dylib/TestSwiftLateDylib.py
+++ b/lldb/test/API/lang/swift/late_dylib/TestSwiftLateDylib.py
@@ -3,7 +3,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateDylib(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded 

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/TestSwiftLateDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/TestSwiftLateDylibClangDeps.py
@@ -3,7 +3,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateDylibClangDeps(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded 

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -4,7 +4,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftLateDylib(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # the embedded test harness appends its own -target, overriding the deployment targets under test
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
@@ -3,7 +3,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateSwiftDylibClangDeps(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIf(macos_version=["<", "14.0"])
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/late_symbols/TestSwiftLateSymbols.py
+++ b/lldb/test/API/lang/swift/late_symbols/TestSwiftLateSymbols.py
@@ -6,7 +6,6 @@ import shutil
 import os
 
 class TestSwiftLateSymbols(TestBase):
-    @skipEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -26,7 +26,7 @@ class TestSwiftMacro(lldbtest.TestBase):
             'settings set target.experimental.swift-plugin-server-for-path %s=%s'
             % (self.getBuildDir(), swift_plugin_server))
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     # At the time of writing swift/test/Macros/macro_expand.swift is also disabled.
@@ -91,7 +91,7 @@ class TestSwiftMacro(lldbtest.TestBase):
         b = target.BreakpointCreateByName("stringify")
         self.assertGreaterEqual(b.GetNumLocations(), 1)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     # At the time of writing swift/test/Macros/macro_expand.swift is also disabled.

--- a/lldb/test/API/lang/swift/marker_protocol_existential/TestMarkerProtocolExistential.py
+++ b/lldb/test/API/lang/swift/marker_protocol_existential/TestMarkerProtocolExistential.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestMarkerProtocolExistential(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_marker_only(self):
         self.build()
@@ -18,7 +18,7 @@ class TestMarkerProtocolExistential(lldbtest.TestBase):
         x = s.GetChildMemberWithName("x")
         lldbutil.check_variable(self, x, value="42")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_marker_composition(self):
         self.build()
@@ -30,7 +30,7 @@ class TestMarkerProtocolExistential(lldbtest.TestBase):
         a = t.GetChildMemberWithName("a")
         lldbutil.check_variable(self, a, value="10")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_two_markers(self):
         self.build()
@@ -43,7 +43,7 @@ class TestMarkerProtocolExistential(lldbtest.TestBase):
         b = u.GetChildMemberWithName("b")
         lldbutil.check_variable(self, b, value="20")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_any_and_marker(self):
         self.build()
@@ -56,7 +56,7 @@ class TestMarkerProtocolExistential(lldbtest.TestBase):
         x = s.GetChildMemberWithName("x")
         lldbutil.check_variable(self, x, value="42")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_any_marker_and_non_marker(self):
         self.build()

--- a/lldb/test/API/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
+++ b/lldb/test/API/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/meta/TestSwiftMeta.py
+++ b/lldb/test/API/lang/swift/meta/TestSwiftMeta.py
@@ -24,7 +24,7 @@ class TestSwiftMeta(lldbtest.TestBase):
     def test_swiftDecorator(self):
         self.assertTrue(self.getDebugInfo() != "gmodules")
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_swiftBuild(self):
         self.build()

--- a/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
+++ b/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
@@ -40,7 +40,7 @@ class TestSwiftMetadataCache(TestBase):
         return False
             
         
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_metadata_cache(self):
         """Test the swift metadata cache."""

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftMetatype(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift monomorphizes every generic, so T.self is already concrete and never resolves dynamically
     @swiftTest
     def test_metatype(self):
         """Test the formatting of Swift metatypes"""

--- a/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
+++ b/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftMixAnyObjectType(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIfLinux
     @swiftTest
     def test_any_object_type(self):

--- a/lldb/test/API/lang/swift/multi_optionals/TestMultiOptionals.py
+++ b/lldb/test/API/lang/swift/multi_optionals/TestMultiOptionals.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
+++ b/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
@@ -9,7 +9,7 @@ import os
 
 
 class TestMultilangFormatterCategories(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_multilang_formatter_categories(self):

--- a/lldb/test/API/lang/swift/nested_c_enums/TestSwiftNestedCEnums.py
+++ b/lldb/test/API/lang/swift/nested_c_enums/TestSwiftNestedCEnums.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/nested_generic/TestSwiftNestedGeneric.py
+++ b/lldb/test/API/lang/swift/nested_generic/TestSwiftNestedGeneric.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftNestedGeneric(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test the inline array synthetic child provider and summary"""

--- a/lldb/test/API/lang/swift/nested_marker_protocol_existential/TestNestedMarkerProtocolExistential.py
+++ b/lldb/test/API/lang/swift/nested_marker_protocol_existential/TestNestedMarkerProtocolExistential.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestNestedMarkerProtocolExistential(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/no_runtime/TestSwiftNoRuntime.py
+++ b/lldb/test/API/lang/swift/no_runtime/TestSwiftNoRuntime.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftNoRuntime(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift strips functions the program never calls, so test() is not in the binary to call
     @swiftTest
     def test(self):
         """Test running a Swift expression in a C program"""

--- a/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
+++ b/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
@@ -15,6 +15,6 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[skipEmbeddedSwift,
+    decorators=[requireNotEmbeddedSwift,
         swiftTest, skipUnlessDarwin, skipIf(macos_version=["=", "15.0"])],
 )

--- a/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
+++ b/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/objc_obj_field/TestSwiftObjCObjField.py
+++ b/lldb/test/API/lang/swift/objc_obj_field/TestSwiftObjCObjField.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test(self):

--- a/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
+++ b/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftObjcProtocol(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/TestSwiftObjCSuperClassNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/TestSwiftObjCSuperClassNoDebugInfo.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftObjCSuperClassNoDebugInfo(TestBase):
     @swiftTest
     @skipUnlessDarwin
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
+++ b/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftObservation(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that types with private discriminators read from the file cache work"""

--- a/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftOneCaseEnum(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_one_case_enum(self):
         """Test that an enum with only one case does not crash LLDB"""

--- a/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
+++ b/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/opaque_return/TestBoundOpaqueArchetype.py
+++ b/lldb/test/API/lang/swift/opaque_return/TestBoundOpaqueArchetype.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestBoundOpaqueArchetype(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests that a type bound to an opaque archetype can be resolved correctly"""         

--- a/lldb/test/API/lang/swift/opaque_return_frame_var/TestSwiftGlobalOpaque.py
+++ b/lldb/test/API/lang/swift/opaque_return_frame_var/TestSwiftGlobalOpaque.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftGlobalOpaque(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Tests that a type bound to an opaque archetype can be resolved correctly"""         

--- a/lldb/test/API/lang/swift/opaque_return_resilient/TestSwiftOpaqueReturnResilient.py
+++ b/lldb/test/API/lang/swift/opaque_return_resilient/TestSwiftOpaqueReturnResilient.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOpaqueReturnResilient(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/opaque_return_resilient_collection/TestSwiftOpaqueReturnResilientCollection.py
+++ b/lldb/test/API/lang/swift/opaque_return_resilient_collection/TestSwiftOpaqueReturnResilientCollection.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOpaqueReturnResilientCollection(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/opaque_return_types/TestOpaqueReturnTypes.py
+++ b/lldb/test/API/lang/swift/opaque_return_types/TestOpaqueReturnTypes.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[skipEmbeddedSwift,
+    decorators=[requireNotEmbeddedSwift,
         swiftTest,
         skipIf(macos_version=["<", "10.15"]),
     ],

--- a/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
+++ b/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOpaque(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test opaque types in parameter positions"""         

--- a/lldb/test/API/lang/swift/optional_error_handling/TestSwiftOptionalErrorHandling.py
+++ b/lldb/test/API/lang/swift/optional_error_handling/TestSwiftOptionalErrorHandling.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftOptionalErrorHandling(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that errors are surfaced"""

--- a/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
+++ b/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
@@ -18,7 +18,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestResilientObjectInOptional(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_optional_of_resilient(self):
         """Test that can extract resilient objects from an Optional"""

--- a/lldb/test/API/lang/swift/optional_url/TestOptionalURL.py
+++ b/lldb/test/API/lang/swift/optional_url/TestOptionalURL.py
@@ -5,7 +5,7 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     decorators=[
-        skipEmbeddedSwift,
+        requireNotEmbeddedSwift,
         skipIfLinux,  # https://github.com/swiftlang/llvm-project/issues/13465
         skipUnlessFoundationEssentials,
         swiftTest,

--- a/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
+++ b/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[skipEmbeddedSwift,
+                          decorators=[requireNotEmbeddedSwift,
         swiftTest,skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/orig_defined_payload/TestSwiftOriginallyDefinedInPayload.py
+++ b/lldb/test/API/lang/swift/orig_defined_payload/TestSwiftOriginallyDefinedInPayload.py
@@ -6,7 +6,7 @@ import os
 
 
 class TestSwiftOriginallyDefinedInPayload(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
+++ b/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
@@ -9,7 +9,7 @@ class TestSwiftOtherArchDylib(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # the embedded test harness appends its own -target, so the other-arch dylib is never built
     @swiftTest
     @skipUnlessDarwin
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -19,7 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftInterfaceDSYM(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # library evolution cannot be enabled with embedded Swift
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))
     def test_dsym_swiftinterface(self):
@@ -80,7 +80,7 @@ class TestSwiftInterfaceDSYM(TestBase):
         self.assertEqual(len(a_modules), 1)
 
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # library evolution cannot be enabled with embedded Swift
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))
     def test_sanity_negative(self):
@@ -116,7 +116,7 @@ class TestSwiftInterfaceDSYM(TestBase):
         self.expect("expression x", error=1)
 
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift cannot load a module from a .swiftinterface
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))
     def test_sanity_positive(self):

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part01.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part01.py
@@ -133,7 +133,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
                             "Swiftmodule file was regenerated rather than reused")
 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part02.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part02.py
@@ -133,7 +133,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
                             "Swiftmodule file was regenerated rather than reused")
 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_interface_fallback(self):
         """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part03.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part03.py
@@ -133,7 +133,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
                             "Swiftmodule file was regenerated rather than reused")
 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessPlatform(["macosx"])
     def test_prebuilt_cache_location(self):

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo_part01.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo_part01.py
@@ -101,7 +101,7 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
             self.assertTrue(is_old(file), "Swiftmodule file was regenerated rather than reused")
 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_swift_interface(self):

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo_part02.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo_part02.py
@@ -101,7 +101,7 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
             self.assertTrue(is_old(file), "Swiftmodule file was regenerated rather than reused")
 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfWindows
     def test_swift_interface_fallback(self):

--- a/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/enum/TestSwiftPartiallyGenericFuncEnum.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/enum/TestSwiftPartiallyGenericFuncEnum.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/struct/TestSwiftPartiallyGenericFuncStruct.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/struct/TestSwiftPartiallyGenericFuncStruct.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
+++ b/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
@@ -36,7 +36,7 @@ class TestNonREPLPlayground(TestBase):
     @skipIf(
         debug_info=decorators.no_match("dsym"),
         bugnumber="This test only builds one way")
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test_playgrounds(self):
         """Test that playgrounds work"""
         self.build()

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -63,7 +63,7 @@ class TestSwiftPlaygrounds(TestBase):
             triple = '{}-apple-macosx{}'.format(machine, version)
         return triple
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
@@ -73,7 +73,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.launch(True)
         self.do_basic_test(True)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
@@ -83,7 +83,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.launch(False)
         self.do_basic_test(False)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
@@ -94,7 +94,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.launch(True)
         self.do_concurrency_test()
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
+++ b/lldb/test/API/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[skipEmbeddedSwift,
+                          decorators=[requireNotEmbeddedSwift,
         swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])

--- a/lldb/test/API/lang/swift/po/objc/TestSwiftPOObjC.py
+++ b/lldb/test/API/lang/swift/po/objc/TestSwiftPOObjC.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPOObjC(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     #NO_DEBUG_INFO_TESTCASE = True
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName_part01.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName_part01.py
@@ -16,7 +16,7 @@ class TestCase(TestBase):
         self.filecheck_log(self.log, __file__, f"-check-prefix=CHECK-{key}")
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test_int(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -27,7 +27,7 @@ class TestCase(TestBase):
         # CHECK-INT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SiD")
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test_string(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName_part03.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName_part03.py
@@ -16,7 +16,7 @@ class TestCase(TestBase):
         self.filecheck_log(self.log, __file__, f"-check-prefix=CHECK-{key}")
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test_described_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -27,7 +27,7 @@ class TestCase(TestBase):
         # CHECK-DESC-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a15DescribedStructVD")
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test_described_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -38,7 +38,7 @@ class TestCase(TestBase):
         # CHECK-DESC-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a14DescribedClassCD")
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test_described_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -49,7 +49,7 @@ class TestCase(TestBase):
         # CHECK-DESC-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a13DescribedEnumOD")
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     def test_class_only_protocol(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
+++ b/lldb/test/API/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/po/ref_types/TestSwiftPORefTypes.py
+++ b/lldb/test/API/lang/swift/po/ref_types/TestSwiftPORefTypes.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/po/static_method/TestSwiftPoInClassMethod.py
+++ b/lldb/test/API/lang/swift/po/static_method/TestSwiftPoInClassMethod.py
@@ -10,7 +10,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test(self):
         """Context-free po should not emit extension $__lldb_context when
         stopped in a static method, since the frame's method context is

--- a/lldb/test/API/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
+++ b/lldb/test/API/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
@@ -14,7 +14,7 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__,
                           globals(),
-                          decorators=[skipEmbeddedSwift,
+                          decorators=[requireNotEmbeddedSwift,
         swiftTest,
                               skipIf(oslist=['windows']),
                               expectedFailureAll(oslist=["linux"],

--- a/lldb/test/API/lang/swift/po/val_types/TestSwiftPOValTypes.py
+++ b/lldb/test/API/lang/swift/po/val_types/TestSwiftPOValTypes.py
@@ -17,7 +17,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftPOValueTypes(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_value_types(self):
         """Test 'po' on a variety of value types with and without custom descriptions."""
@@ -39,7 +39,7 @@ class TestSwiftPOValueTypes(TestBase):
         self.expect("po (dm as Any, cm as Any,48 as Any)", substrs=['12', '24', '36', '48'])
         self.expect("po patatino", substrs=['foo'])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_ignore_bkpts_in_po(self):
         """Run a po expression with a breakpoint in the debugDescription, make sure we don't hit it."""

--- a/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
+++ b/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
@@ -27,7 +27,7 @@ class TestSwiftPrivateDeclName(TestBase):
         self.b_source = "b.swift"
         self.b_source_spec = lldb.SBFileSpec(self.b_source)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_private_decl_name(self):
         """Test that we correctly find private decls"""

--- a/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
+++ b/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
@@ -9,7 +9,7 @@ class TestSwiftPrivateDiscriminator(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     # FIXME: The only reason this doesn't work on Linux is because the
     # dylib hasn't been loaded when run_to_source_breakpoint wants to

--- a/lldb/test/API/lang/swift/private_generic_self/TestSwiftPrivateGenericSelf.py
+++ b/lldb/test/API/lang/swift/private_generic_self/TestSwiftPrivateGenericSelf.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -8,7 +8,7 @@ class TestSwiftPrivateGenericType(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_private_generic_type(self):

--- a/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
+++ b/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPrivateImport(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIfLinux  # Fails on Amazon Linux (rdar://183725331)
     @swiftTest
     def test_private_import(self):

--- a/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
+++ b/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPrivateMember(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/private_self/TestSwiftPrivateSelf.py
+++ b/lldb/test/API/lang/swift/private_self/TestSwiftPrivateSelf.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[skipEmbeddedSwift, swiftTest]
+    __file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest]
 )

--- a/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
+++ b/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftPrivateTypeAlias(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_private_typealias(self):
         """Test that we can correctly print variables whose types are private type aliases"""

--- a/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
+++ b/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[skipEmbeddedSwift,
+    decorators=[requireNotEmbeddedSwift,
         swiftTest,
         skipUnlessDarwin,
         expectedFailureAll(

--- a/lldb/test/API/lang/swift/protocol_optional/TestSwiftProtocolOptional.py
+++ b/lldb/test/API/lang/swift/protocol_optional/TestSwiftProtocolOptional.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/protocols/class_protocol/TestSwiftClassConstrainedProtocolArgument.py
+++ b/lldb/test/API/lang/swift/protocols/class_protocol/TestSwiftClassConstrainedProtocolArgument.py
@@ -7,5 +7,5 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
     __file__, globals(),
-            decorators=[skipEmbeddedSwift,
+            decorators=[requireNotEmbeddedSwift,
         swiftTest,skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/protocols/stepping_through_witness/TestSwiftSteppingThroughWitness.py
+++ b/lldb/test/API/lang/swift/protocols/stepping_through_witness/TestSwiftSteppingThroughWitness.py
@@ -14,7 +14,7 @@ class TestSwiftSteppingThroughWitness(TestBase):
             "settings set target.process.thread.step-avoid-libraries libswift_Concurrency.dylib"
         )
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_step_in_and_out(self):
         """Test that stepping in and out of protocol methods work"""
@@ -44,7 +44,7 @@ class TestSwiftSteppingThroughWitness(TestBase):
         frame0 = thread.frames[0]
         self.assertIn("doMath", frame0.GetFunctionName())
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_step_over(self):
         """Test that stepping over protocol methods work"""

--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftReferenceStorageTypes(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
     def test_swift_reference_storage_types(self):

--- a/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
+++ b/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
@@ -9,7 +9,7 @@ class TestSwiftReflectionLoading(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test that reflection metadata is imported"""

--- a/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
+++ b/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
@@ -9,7 +9,7 @@ class TestSwiftReflectionOnly(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test debugging a program without swiftmodules is functional"""

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegexExpr.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegexExpr.py
@@ -12,7 +12,7 @@ class TestSwiftRegexExpr(TestBase):
         TestBase.setUp(self)
         self.main_source_spec = lldb.SBFileSpec("main.swift")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(debug_info=no_match("dsym"))
     def test_swift_regex_expr(self):

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegexExprDesc.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegexExprDesc.py
@@ -12,7 +12,7 @@ class TestSwiftRegexExprDesc(TestBase):
         TestBase.setUp(self)
         self.main_source_spec = lldb.SBFileSpec("main.swift")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(debug_info=no_match("dsym"))
     def test_swift_regex_expr_desc(self):

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegexFrameVar.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegexFrameVar.py
@@ -12,7 +12,7 @@ class TestSwiftRegexFrameVar(TestBase):
         TestBase.setUp(self)
         self.main_source_spec = lldb.SBFileSpec("main.swift")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(debug_info=no_match("dsym"))
     def test_swift_regex_frame_var(self):

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegexFrameVarDesc.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegexFrameVarDesc.py
@@ -12,7 +12,7 @@ class TestSwiftRegexFrameVarDesc(TestBase):
         TestBase.setUp(self)
         self.main_source_spec = lldb.SBFileSpec("main.swift")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(debug_info=no_match("dsym"))
     def test_swift_regex_frame_var_desc(self):

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegexInExp.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegexInExp.py
@@ -12,7 +12,7 @@ class TestSwiftRegexInExp(TestBase):
         TestBase.setUp(self)
         self.main_source_spec = lldb.SBFileSpec("main.swift")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(debug_info=no_match("dsym"))
     def test_swift_regex_in_exp(self):

--- a/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
@@ -22,7 +22,7 @@ def execute_command(command):
 
 
 class TestSwiftResilience(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     # Because we rename the .swiftmodule files after building the
@@ -34,7 +34,7 @@ class TestSwiftResilience(TestBase):
         self.build()
         self.doTestWithFlavor("a", "a")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
@@ -43,7 +43,7 @@ class TestSwiftResilience(TestBase):
         self.build()
         self.doTestWithFlavor("a", "b")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
@@ -52,7 +52,7 @@ class TestSwiftResilience(TestBase):
         self.build()
         self.doTestWithFlavor("b", "a")
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
+++ b/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
@@ -6,12 +6,12 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftResilienceOtherModule(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_with_debug_info(self):
         self.impl('break here with debug info')
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_without_debug_info(self):
         self.impl('break here without debug info')

--- a/lldb/test/API/lang/swift/resilience_private_field/TestSwiftResiliencePrivateField.py
+++ b/lldb/test/API/lang/swift/resilience_private_field/TestSwiftResiliencePrivateField.py
@@ -8,7 +8,7 @@ class TestSwiftResiliencePrivateField(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/resilience_private_method/TestSwiftResiliencePrivateMethod.py
+++ b/lldb/test/API/lang/swift/resilience_private_method/TestSwiftResiliencePrivateMethod.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftResiliencePrivateMethod(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/resilience_superclass/TestSwiftResilienceSuperclass.py
+++ b/lldb/test/API/lang/swift/resilience_superclass/TestSwiftResilienceSuperclass.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftResilienceSuperclass(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIfLinux
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/TestSwiftResilienceSuperclassMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/TestSwiftResilienceSuperclassMod.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftResilienceSuperclassMod(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIfLinux
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftResilienceSuperclassOtherMod(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIfLinux
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftResilienceSwiftInterface(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
+++ b/lldb/test/API/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
@@ -32,7 +32,7 @@ class SwiftStaticLinkingMacOSTestCase(TestBase):
         self.expect("expr self", patterns=patterns,
                     substrs=substrs)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_variables_print_from_both_swift_modules(self):

--- a/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
+++ b/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjcProtocol(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/step_into_swift_override/TestStepFromObjCToSwiftOverride.py
+++ b/lldb/test/API/lang/swift/step_into_swift_override/TestStepFromObjCToSwiftOverride.py
@@ -9,7 +9,7 @@ class TestStepFromObjCToSwiftOverride(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     def test(self):
         self.build()
         (target, process, thread, breakpoint) = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -24,7 +24,7 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # embedded Swift steps to the wrong line on x86_64, and the inferior does not link on Linux.
     @skipIf(oslist=["linux"], archs=no_match("x86_64"))
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""

--- a/lldb/test/API/lang/swift/substituted_typealias/TestSwiftSubstitutedTypeAlias.py
+++ b/lldb/test/API/lang/swift/substituted_typealias/TestSwiftSubstitutedTypeAlias.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])

--- a/lldb/test/API/lang/swift/swift_array_of_objc_items/TestSwiftArrayOfObjCItems.py
+++ b/lldb/test/API/lang/swift/swift_array_of_objc_items/TestSwiftArrayOfObjCItems.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     def test(self):
         """Test that a Swift array of ObjC items prints correctly."""

--- a/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
+++ b/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftieFormatting(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swiftie_formatting(self):

--- a/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
+++ b/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 @skipIfDarwinEmbedded
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_body(self):
@@ -18,7 +18,7 @@ class TestCase(TestBase):
         )
         self._do_test("self._count", 41, is_graph_update=True)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_appear(self):
@@ -30,7 +30,7 @@ class TestCase(TestBase):
         )
         self._do_test("self._count", 41, is_graph_update=False)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_change(self):

--- a/lldb/test/API/lang/swift/symbolic_extended_existential/TestSwiftSymbolicExtendedExistential.py
+++ b/lldb/test/API/lang/swift/symbolic_extended_existential/TestSwiftSymbolicExtendedExistential.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftSymbolicExtendedExistential(lldbtest.TestBase):
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test(self):
         """Test symbolic extended existentials"""

--- a/lldb/test/API/lang/swift/system/TestSwiftSystemFilePath.py
+++ b/lldb/test/API/lang/swift/system/TestSwiftSystemFilePath.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test import lldbutil
 
 class TestSwiftSystemFilePath(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test(self):

--- a/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -8,7 +8,7 @@ class TestSwiftSystemFramework(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
     def test_system_framework(self):

--- a/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
+++ b/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
@@ -7,7 +7,7 @@ class TestSwiftTaggedPointer(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     # This test depends on NSObject, so it is not available on non-Darwin
     # platforms.

--- a/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
+++ b/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
@@ -19,7 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class SwiftTypeMetadataTest(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift never emits an uncalled generic function, so the breakpoint slides to the next line
     @swiftTest
     def test_swift_type_metadata(self):
         """Test that LLDB can effectively use the type metadata to reconstruct dynamic types for Swift"""

--- a/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
+++ b/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftTypeAliasOtherModule(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_frame_variable(self):
         """Test that type aliases can be imported from reflection metadata"""
@@ -19,7 +19,7 @@ class TestSwiftTypeAliasOtherModule(TestBase):
         self.expect("continue")
         self.expect("frame variable -- payload", substrs=["Bool", "true"])
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_expression(self):
         """Test that type aliases can be imported into expressions from reflection metadata"""

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessFoundationEssentials
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @swiftTest

--- a/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
+++ b/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
@@ -9,7 +9,7 @@ class TestSwiftCUnion(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_c_unions(self):
         self.build()

--- a/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
+++ b/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
@@ -28,7 +28,7 @@ class TestSwiftUnknownReference(lldbtest.TestBase):
         lldbutil.check_variable(self, m_string, summary='"world"')
 
     
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465
     @skipUnlessFoundationEssentials
     @swiftTest

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -33,7 +33,7 @@ class TestSwiftUnknownSelf(lldbtest.TestBase):
                     substrs=["hello"])
 
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipIf(bugnumber="SR-10216", archs=['ppc64le'])
     @skipUnlessFoundationEssentials
     @skipIfLinux  # https://github.com/swiftlang/llvm-project/issues/13465

--- a/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
+++ b/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
@@ -9,7 +9,7 @@ import os
 
 
 class TestSwiftActorTypes(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test_swift_class_types(self):
         """Test swift Actor types"""

--- a/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -23,7 +23,7 @@ import os
 
 
 class TestSwiftBridgedStringVariables(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_bridged_string_variables(self):

--- a/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestBulkyEnumVariables(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_bulky_enum_variables(self):
         """Tests that large-size Enum variables display correctly"""

--- a/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
+++ b/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftCoreGraphicsTypes(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_swift_coregraphics_types(self):

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -24,7 +24,7 @@ def stderr_print(line):
     sys.stderr.write(line + "\n")
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while

--- a/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestDictionaryNSObjectAnyObject(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_dictionary_nsobject_any_object(self):

--- a/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -83,7 +83,7 @@ class TestSwiftStdlibDictionary(TestBase):
                 found, ("found a not expected child for '%s':'%s'" %
                         (key_str, value_str)))
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     # @skipIfLinux  # bugs.swift.org/SR-844
     def test_swift_stdlib_dictionary(self):

--- a/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
+++ b/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
@@ -26,7 +26,7 @@ class TestSwiftGenericEnumTypes(TestBase):
         var.SetPreferSyntheticValue(True)
         return var
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift monomorphizes every generic, so the static type is never an unbound Optional<U>
     @swiftTest
     def test_swift_generic_enum_types(self):
         """Test that we handle reasonably generically-typed enums"""

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
+++ b/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
@@ -26,7 +26,7 @@ class TestSwiftGenericTupleLabels(lldbtest.TestBase):
     def setUp(self):
         lldbtest.TestBase.setUp(self)
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_generic_tuple_labels(self):
         """Test that LLDB can reconstruct tuple labels from metadata"""

--- a/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
+++ b/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftGenericTypes(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift monomorphizes every generic, so there is no unresolved static type to show
     @swiftTest
     def test_swift_generic_types(self):
         """Test support for generic types"""

--- a/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
+++ b/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
@@ -18,7 +18,7 @@ import os
 
 
 class TestInOutVariables(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # embedded Swift strips initializers the program never calls, so Other(in1:in2:) is not in the binary
     @swiftTest
     def test_in_out_variables(self):
         """Test that @inout variables display reasonably"""

--- a/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
+++ b/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftObjCImportedTypes(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_swift_objc_imported_types(self):

--- a/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftObjCOptionalType(TestBase):
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipUnlessDarwin
     def test_swift_objc_optional_type(self):

--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -21,7 +21,7 @@ import platform
 
 class TestSwiftTypes(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # printing the x86_64-only Float80 crashes LLDB in embedded Swift.
     def test_swift_types(self):
         """Test that we can inspect basic Swift types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
+++ b/lldb/test/API/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
@@ -4,5 +4,5 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[skipEmbeddedSwift, swiftTest],
+    decorators=[requireNotEmbeddedSwift, swiftTest],
 )

--- a/lldb/test/API/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
+++ b/lldb/test/API/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
@@ -22,7 +22,7 @@ import os
 class TestSwiftValueOfOptionalType(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     def test_swift_value_optional_type(self):
         """Check that trying to read an optional's numeric value doesn't crash LLDB"""

--- a/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
+++ b/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftVariadicGenerics(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @swiftTest
     @skipIfAsan # rdar://152465885 Address Sanitizer assert doing `expr --bind-generic-types=false -- 0`
     def test(self):

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -31,7 +31,7 @@ class TestSwiftREPLExceptions(TestBase):
         self.main_source_file = lldb.SBFileSpec("main.swift")
         self.do_repl_mode_test()
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_repl_exceptions(self):


### PR DESCRIPTION
    `@skipEmbeddedSwift` doesn't really tell us if the test is skipped
    because there's a bug vs tests that simply can't run in embedded swift
    mode (for example, dylibs, objc interop, resiliency, etc).

    Introduce requiresNonEmbeddedSwift to mean "this can't run in embedded
    swift mode" and leave skipEmbeddedSwift to identify tests that should be
    fixed.

    The split was measured by removing every annotation and running
    check-lldb-swift in the swiftembed variant:

    The split was measured by removing every annotation and running
    check-lldb-swift in the swiftembed variant:

                                                      annotations   test files
      moved to requireNotEmbeddedSwift                        347          265
      kept as skipEmbeddedSwift (concurrency opt-in)           22           19
      narrowed to skipEmbeddedSwiftOnLinux                      2            2
      removed, the test already passes                         21           16
      kept as skipEmbeddedSwift (a bug to fix)                 86           77
                                                      -----------   ----------
      before                                                  478          375
    Assisted-by: claude
