### PR TITLE
[Cherry-pick into next] [LLDB] Diagnose an error for AccessorFunctionReference nodes

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -835,6 +835,18 @@ private:
                                      VisitCallback visit_callback);
 };
 
+/// Augment generic reflection failures with LLDB-specific explanations.
+static llvm::Error AugmentReflectionError(llvm::Error error) {
+  std::string message;
+  llvm::handleAllErrors(std::move(error), [&](const llvm::ErrorInfoBase &info) {
+    message = info.message();
+  });
+  if (llvm::StringRef(message).contains("accessor function symbolic reference"))
+    message += ": non-copyable fields in resilient types with "
+               "a deployment target < 27.0 are not supported in LLDB";
+  return llvm::createStringError(message);
+}
+
 llvm::Expected<unsigned>
 SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
                                    VisitCallback visit_callback) {
@@ -1311,7 +1323,7 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
           *tr, &tip,
           ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope()));
       if (!cti_or_err)
-        return cti_or_err.takeError();
+        return AugmentReflectionError(cti_or_err.takeError());
       if (auto *rti = llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(
               &*cti_or_err)) {
         LLDB_LOG(GetLog(LLDBLog::Types),
@@ -1455,11 +1467,9 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
 
       auto cti_or_err =
           reflection_ctx->GetClassInstanceTypeInfo(*tr, &tip, desc_finder);
-      const swift::reflection::TypeInfo *cti = nullptr;
-      if (cti_or_err)
-        cti = &*cti_or_err;
-      else
-        LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), cti_or_err.takeError(), "{0}");
+      if (!cti_or_err)
+        return AugmentReflectionError(cti_or_err.takeError());
+      const swift::reflection::TypeInfo *cti = &*cti_or_err;
       if (auto *rti =
               llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(cti)) {
         auto fields = rti->getFields();

--- a/lldb/test/API/lang/swift/noncopyable_field_reflection/Makefile
+++ b/lldb/test/API/lang/swift/noncopyable_field_reflection/Makefile
@@ -1,0 +1,20 @@
+SWIFT_SOURCES := main.swift
+
+# Pin the deployment target below macOS 27 (NoncopyableReflectionSafety).
+# This forces IRGen to emit the noncopyable field's reflection type ref as
+# an accessor-function symbolic reference.
+DEPLOYMENT_TARGET = -target $(ARCH)-apple-macosx15.0
+
+SWIFTFLAGS_EXTRAS = -I. -enable-library-evolution $(DEPLOYMENT_TARGET)
+
+LD_EXTRAS = -L. -Xlinker -rpath -Xlinker $(BUILDDIR) -lLib
+
+all: dylib $(EXE)
+.PHONY: dylib
+
+include Makefile.rules
+dylib: lib.swift
+	"$(MAKE)" -f $(MAKEFILE_RULES) \
+		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=Lib \
+		DYLIB_SWIFT_SOURCES="lib.swift" \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution $(DEPLOYMENT_TARGET)"

--- a/lldb/test/API/lang/swift/noncopyable_field_reflection/TestSwiftNoncopyableFieldReflection.py
+++ b/lldb/test/API/lang/swift/noncopyable_field_reflection/TestSwiftNoncopyableFieldReflection.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftNoncopyableFieldReflection(lldbtest.TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        """Test that LLDB surfaces an error when a resilient class
+        has a noncopyable stored property whose reflection type ref is
+        an accessor-function symbolic reference. Such a field type ref
+        cannot be resolved by passive reflection (LLDB cannot run the
+        accessor in the target), so laying out the class fails.
+        """
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "Set breakpoint here", lldb.SBFileSpec("main.swift"),
+            extra_images=["Lib"])
+
+        self.runCmd(
+            "settings set symbols.swift-typesystem-compiler-fallback false")
+
+        # Inspect a plain, fully reflectable struct first. This succeeds and
+        # resets the reflection reader's transient "last demangle failure"
+        # state to make we're not picking up a stale error.
+        self.expect("frame variable p", substrs=["value = 7"])
+
+        var_h = thread.frames[0].FindVariable("h")
+        self.assertTrue(var_h.IsValid(), "'h' is a valid variable")
+        self.expect("frame variable h",
+                    substrs=["non-copyable fields in resilient types with a "
+                             "deployment target < 27.0 are not supported"])

--- a/lldb/test/API/lang/swift/noncopyable_field_reflection/lib.swift
+++ b/lldb/test/API/lang/swift/noncopyable_field_reflection/lib.swift
@@ -1,0 +1,17 @@
+// A plain, fully reflectable resilient struct.
+public struct Plain {
+    public var value: Int = 7
+    public init() {}
+}
+
+// A noncopyable type stored in a resilient class.
+public struct NC: ~Copyable {}
+
+public class Holder {
+    // Unresolvable reflection type ref.
+    let field = NC()
+    // A plain copyable sibling. Ideally it remains inspectable even though the
+    // noncopyable field above cannot be resolved.
+    public var tag: Int = 42
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/noncopyable_field_reflection/main.swift
+++ b/lldb/test/API/lang/swift/noncopyable_field_reflection/main.swift
@@ -1,0 +1,7 @@
+import Lib
+
+func inspect(_ h: Holder, _ p: Plain) {
+    print(h.tag) // Set breakpoint here
+}
+
+inspect(Holder(), Plain())


### PR DESCRIPTION
```
commit 788fa5d4f87e6917fb5173933a4e94dcf14a5a39
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jul 23 15:13:41 2026 -0700

    [LLDB] Diagnose an error for AccessorFunctionReference nodes
    
    LLDB currently does not support non-copyable fields in resilient types
    with a deployment target < 27.0. Instead of failing with a generic
    "cannot get fields" error, diagnose a specific failure reason. THis
    helps with bug triage and explains to users how to work around the
    problem.
    
    rdar://182849569
    
    Assisted-by: claude
```
