### PR TITLE
[Cherry-pick into next] [LLDB] Add a test for nested typealises in embedded Swift

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -569,11 +569,13 @@ getDWARFBuiltinTypeDescriptor(TypeSystemSwiftTypeRef &swift_typesystem,
     return nullptr;
   auto &[type, die] = *pair;
 
+  bool is_enum = false;
   if (!TypeSystemSwiftTypeRef::IsBuiltinType(type)) {
     if (die.Tag() == llvm::dwarf::DW_TAG_structure_type) {
       auto child = die.GetFirstChild();
       if (child.Tag() != llvm::dwarf::DW_TAG_variant_part)
         return nullptr;
+      is_enum = true;
     } else if (die.Tag() != llvm::dwarf::DW_TAG_base_type)
       return nullptr;
   }
@@ -581,6 +583,15 @@ getDWARFBuiltinTypeDescriptor(TypeSystemSwiftTypeRef &swift_typesystem,
   auto byte_size = die.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_byte_size,
                                                    LLDB_INVALID_ADDRESS);
   if (byte_size == LLDB_INVALID_ADDRESS)
+    return nullptr;
+
+  // Enums with DWARF byte_size 0 are an LLVM artifact: the compiler
+  // can't emit unsized types, so an unsubstituted generic enum's size
+  // is emitted as 0.  If we're here this must be a payload-carrying
+  // enum, and such an enum is never 0 bytes, even if its payload is
+  // size 0. Decline to synthesize a fixed descriptor so reflection
+  // instead derives the layout dynamically from the payloads.
+  if (is_enum && byte_size == 0)
     return nullptr;
 
   auto alignment = die.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_alignment,

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -95,6 +95,12 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         nonPayload2 = frame.FindVariable("nonPayload2")
         lldbutil.check_variable(self, nonPayload2, True, value="two")
 
+        trivial = frame.FindVariable("trivial")
+        lldbutil.check_variable(self, trivial, True, value="theCase")
+
+        voidPayload = frame.FindVariable("voidPayload")
+        lldbutil.check_variable(self, voidPayload, True, value="theCase")
+
         singlePayload = frame.FindVariable("singlePayload")
         payload = singlePayload.GetChildMemberWithName("payload")
         field = payload.GetChildMemberWithName("a").GetChildMemberWithName("field")

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -12,6 +12,12 @@ enum TrivialEnum {
   case theCase
 }
 
+// Single case whose payload is (): zero-sized, yet it syntactically carries a
+// payload. It collapses to a trivial layout (no DWARF variant part).
+enum VoidPayloadEnum {
+  case theCase(())
+}
+
 // Enum with 2 or more non-payload cases and no payload cases
 enum NonPayloadEnum {
   case one
@@ -156,6 +162,7 @@ func g() {
     )
     let array : [Int] = [1, 2, 3, 4]
     let trivial = TrivialEnum.theCase
+    let voidPayload = VoidPayloadEnum.theCase(())
     let nonPayload1 = NonPayloadEnum.one
     let nonPayload2 = NonPayloadEnum.two
     let singlePayload = SinglePayloadEnum.payload(B())

--- a/lldb/test/API/lang/swift/embedded/nested_type_alias/Makefile
+++ b/lldb/test/API/lang/swift/embedded/nested_type_alias/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/nested_type_alias/TestSwiftEmbeddedNestedTypeAlias.py
+++ b/lldb/test/API/lang/swift/embedded/nested_type_alias/TestSwiftEmbeddedNestedTypeAlias.py
@@ -1,0 +1,40 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedNestedTypeAlias(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    @skipUnlessEmbeddedSwift
+    def test(self):
+        """Test rhat stored propertues typed through a nested type alias and
+        used only as a generic argument is represented iun debug info."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        _, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        storage = thread.frames[0].FindVariable("storage")
+
+        # `state` is the nested State struct. Computing its layout requires
+        # resolving the type alias `Handler` used by its `handler` field;
+        # without a DW_TAG_typedef for the alias this fails and State has no
+        # children.
+        state = storage.GetChildMemberWithName("state")
+        lldbutil.check_variable(
+            self, state, typename="a.Storage<Swift.Int>.State", num_children=2
+        )
+
+        handler = state.GetChildMemberWithName("handler")
+        lldbutil.check_variable(
+            self,
+            handler,
+            typename="Swift.Optional<@Sendable (Swift.Int) -> ()>",
+            summary="nil",
+        )
+
+        flag = state.GetChildMemberWithName("flag")
+        lldbutil.check_variable(self, flag, typename="Swift.Bool", summary="false")

--- a/lldb/test/API/lang/swift/embedded/nested_type_alias/main.swift
+++ b/lldb/test/API/lang/swift/embedded/nested_type_alias/main.swift
@@ -1,0 +1,18 @@
+// A generic class with a nested closure type alias.
+final class Storage<Element> {
+  typealias Handler = @Sendable (Element) -> Void
+  struct State {
+    var handler: Handler? = nil
+    var flag: Bool = false
+  }
+  var state = State()
+  init() {}
+}
+
+func main() {
+  let storage = Storage<Int>()
+  print("break here")
+  _ = storage
+}
+
+main()


### PR DESCRIPTION
```
commit a80927200af5b7d980231bb246dd5deb85e71106
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jul 23 16:09:06 2026 -0700

    [LLDB] Add a test for nested typealises in embedded Swift
    
    rdar://178774840

commit 9b36bdc3d19cdd9d55345c2c50b37e0827e7d105
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Jul 24 16:35:26 2026 -0700

    [LLDB] Fix layout for unsized embedded Swift enums
    
    Due to an LLVM limitation, the Swift compiler emits these with size 0,
    but really the size is unknown.
```
