### PR TITLE
[Cherry-pick into next] [LLDB] Create enum children as synthetic VOs instead of casts

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
@@ -313,6 +313,14 @@ lldb::ValueObjectSP lldb_private::formatters::swift::
     return nullptr;
 
   ValueObjectSP some = m_some;
+
+  // This frontend hides the `some` level so `x.some.a` becomes `x.a`.
+  // A clone is a ValueObjectCast, which stands in for its parent
+  // rather than nesting under it, so the children hang off the
+  // Optional directly.
+  if (ValueObjectSP transparent_sp = some->Clone(ConstString()))
+    some = transparent_sp;
+
   if (some->HasSyntheticValue())
     some = some->GetSyntheticValue();
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1863,8 +1863,8 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
     assert(false);
     return llvm::createStringError("enum with unexpected offset");
   }
-  return ValueObjectCast::Create(valobj, ConstString(field_info.Name),
-                                 projected_type);
+  return valobj.GetSyntheticChildAtOffset(0, projected_type, /*can_create=*/true,
+                                          ConstString(field_info.Name));
 }
 
 std::pair<SwiftLanguageRuntime::LookupResult, std::optional<size_t>>

--- a/lldb/test/API/lang/swift/enum_expression_path/Makefile
+++ b/lldb/test/API/lang/swift/enum_expression_path/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/enum_expression_path/TestSwiftEnumExpressionPath.py
+++ b/lldb/test/API/lang/swift/enum_expression_path/TestSwiftEnumExpressionPath.py
@@ -1,0 +1,105 @@
+"""
+Test that the expression path of a payload enum's case includes the name of
+the enum-typed member it was projected from.
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEnumExpressionPath(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def expression_path(self, valobj):
+        stream = lldb.SBStream()
+        self.assertTrue(valobj.IsValid(), "invalid value object")
+        self.assertTrue(valobj.GetExpressionPath(stream))
+        return stream.GetData()
+
+    @swiftTest
+    @skipEmbeddedSwiftOnWindows
+    def test_enum_expression_path(self):
+        """The projected case of a payload enum must not drop the enum member
+        from its expression path."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        # `frame variable --flat` prints the expression path of each leaf.
+        self.expect(
+            "frame variable --flat --depth 6",
+            substrs=[
+                "self.outer.box = boxed",
+                "self.outer.box.boxed.leaf.a = 1",
+                "self.outer.box.boxed.leaf.b = 2",
+            ],
+        )
+
+        # The same paths must come out of the SB API, since that is what IDEs
+        # feed back into `watchpoint set variable`.
+        self_var = self.frame().FindVariable("self")
+        outer = self_var.GetChildMemberWithName("outer")
+        box = outer.GetChildMemberWithName("box")
+        boxed = box.GetChildAtIndex(0)
+        leaf = boxed.GetChildMemberWithName("leaf")
+        a = leaf.GetChildMemberWithName("a")
+
+        self.assertEqual(self.expression_path(outer), "self.outer")
+        self.assertEqual(self.expression_path(box), "self.outer.box")
+        self.assertEqual(self.expression_path(boxed), "self.outer.box.boxed")
+        self.assertEqual(self.expression_path(leaf), "self.outer.box.boxed.leaf")
+        self.assertEqual(self.expression_path(a), "self.outer.box.boxed.leaf.a")
+
+        # A path produced by GetExpressionPath has to round-trip through the
+        # expression path parser.
+        self.assertEqual(
+            self.frame()
+            .GetValueForVariablePath("self.outer.box.boxed.leaf.a")
+            .GetValueAsSigned(),
+            1,
+        )
+
+        # ...and work as a `frame variable` argument, which is what a user
+        # copying it out of the UI would type.
+        self.expect(
+            "frame variable self.outer.box.boxed.leaf.a",
+            substrs=["self.outer.box.boxed.leaf.a = 1"],
+        )
+
+    @swiftTest
+    @skipEmbeddedSwiftOnWindows
+    @add_test_categories(["watchpoint"])
+    def test_watchpoint_on_expression_path(self):
+        """A path produced by GetExpressionPath has to be usable as a
+        watchpoint location."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        a = (
+            self.frame()
+            .FindVariable("self")
+            .GetChildMemberWithName("outer")
+            .GetChildMemberWithName("box")
+            .GetChildAtIndex(0)
+            .GetChildMemberWithName("leaf")
+            .GetChildMemberWithName("a")
+        )
+        path = self.expression_path(a)
+        self.assertEqual(path, "self.outer.box.boxed.leaf.a")
+
+        self.expect(
+            "watchpoint set variable " + path,
+            substrs=["Watchpoint created", "size = 8"],
+        )
+
+        process = self.process()
+        process.Continue()
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertStopReason(
+            process.GetSelectedThread().GetStopReason(), lldb.eStopReasonWatchpoint
+        )
+        self.assertEqual(self.target().GetWatchpointAtIndex(0).GetHitCount(), 1)

--- a/lldb/test/API/lang/swift/enum_expression_path/main.swift
+++ b/lldb/test/API/lang/swift/enum_expression_path/main.swift
@@ -1,0 +1,17 @@
+struct Leaf { var a: Int; var b: Int }
+struct Mid { var leaf: Leaf }
+enum Box { case empty; case boxed(Mid) }
+struct Outer { var box: Box }
+
+final class Holder {
+    var outer = Outer(box: .boxed(Mid(leaf: Leaf(a: 1, b: 2))))
+    func run() {
+        print("break here")
+        outer.box = .boxed(Mid(leaf: Leaf(a: 99, b: 3)))
+        if case .boxed(let mid) = outer.box {
+            print(mid.leaf.a)
+        }
+    }
+}
+
+Holder().run()

--- a/lldb/test/API/lang/swift/optional_expression_path/Makefile
+++ b/lldb/test/API/lang/swift/optional_expression_path/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/optional_expression_path/TestSwiftOptionalExpressionPath.py
+++ b/lldb/test/API/lang/swift/optional_expression_path/TestSwiftOptionalExpressionPath.py
@@ -1,0 +1,114 @@
+"""
+Test that the expression path of an Optional's payload does not contain the
+`some` level that the synthetic children provider hides.
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftOptionalExpressionPath(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def expression_path(self, valobj):
+        stream = lldb.SBStream()
+        self.assertTrue(valobj.IsValid(), "invalid value object")
+        self.assertTrue(valobj.GetExpressionPath(stream))
+        return stream.GetData()
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+    @swiftTest
+    @skipEmbeddedSwiftOnWindows
+    def test_optional_expression_path(self):
+        # `frame variable --flat` prints the expression path of each leaf it
+        # descends into. There should be no `.some`
+        self.expect(
+            "frame variable --flat",
+            substrs=["holder.opt = ", "holder.n = 5", "scalar = 42"],
+        )
+        self.expect("frame variable --flat", matching=False, substrs=["some"])
+
+        plain = self.frame().FindVariable("plain")
+        self.assertEqual(self.expression_path(plain), "plain")
+        self.assertEqual(self.expression_path(plain.GetChildAtIndex(0)), "plain.a")
+        self.assertEqual(self.expression_path(plain.GetChildAtIndex(1)), "plain.b")
+
+        opt = self.frame().FindVariable("holder").GetChildMemberWithName("opt")
+        self.assertEqual(self.expression_path(opt), "holder.opt")
+        self.assertEqual(self.expression_path(opt.GetChildAtIndex(0)), "holder.opt.a")
+
+        # A doubly-wrapped Optional is flattened all the way down, so neither
+        # `some` level appears in the path.
+        nested = self.frame().FindVariable("nested")
+        self.assertEqual(self.expression_path(nested), "nested")
+        self.assertEqual(self.expression_path(nested.GetChildAtIndex(0)), "nested.a")
+        self.assertEqual(nested.GetChildAtIndex(0).GetValueAsSigned(), 3)
+
+        # A path produced by GetExpressionPath has to resolve back to the same
+        # value, both through the SBAPI and as a `frame variable` argument.
+        for name in ["plain", "holder"]:
+            var = self.frame().FindVariable(name)
+            for i in range(var.GetNumChildren()):
+                child = var.GetChildAtIndex(i)
+                if child.GetNumChildren():
+                    continue  # only compare leaves by value
+                path = self.expression_path(child)
+
+                resolved = self.frame().GetValueForVariablePath(path)
+                self.assertTrue(resolved.IsValid(), "path %s does not resolve" % path)
+                self.assertEqual(
+                    resolved.GetValueAsSigned(),
+                    child.GetValueAsSigned(),
+                    "path %s resolves to a different value" % path,
+                )
+
+                # The path also has to work in the `frame variable` command,
+                # which is what a user copying it out of the UI would type.
+                self.expect(
+                    "frame variable " + path,
+                    substrs=["%s = %s" % (path, child.GetValue())],
+                )
+
+        # Hiding `some` from the path must not disturb the value presentation.
+        self.expect(
+            "frame variable plain scalar empty",
+            substrs=["(a = 1, b = 2)", "42", "nil"],
+        )
+        self.assertEqual(plain.GetNumChildren(), 2)
+        self.assertEqual(self.frame().FindVariable("empty").GetNumChildren(), 0)
+
+    @swiftTest
+    @skipEmbeddedSwiftOnWindows
+    @expectedFailureAll(
+        bugnumber="The expression path parser cannot unwrap two Optional levels"
+    )
+    def test_doubly_nested_optional_round_trips(self):
+        """The flattened path of a doubly-wrapped Optional does not yet parse
+        back: `nested.a` is rejected on Optional<Optional<Leaf>>."""
+        path = self.expression_path(
+            self.frame().FindVariable("nested").GetChildAtIndex(0)
+        )
+        self.assertEqual(path, "nested.a")
+        self.assertTrue(self.frame().GetValueForVariablePath(path).IsValid())
+
+    @swiftTest
+    @skipEmbeddedSwiftOnWindows
+    @add_test_categories(["watchpoint"])
+    def test_watchpoint_on_expression_path(self):
+        """A path produced by GetExpressionPath has to be usable as a
+        watchpoint location."""
+        path = self.expression_path(
+            self.frame().FindVariable("plain").GetChildAtIndex(0)
+        )
+        self.assertEqual(path, "plain.a")
+        self.expect(
+            "watchpoint set variable " + path,
+            substrs=["Watchpoint created", "size = 8"],
+        )

--- a/lldb/test/API/lang/swift/optional_expression_path/main.swift
+++ b/lldb/test/API/lang/swift/optional_expression_path/main.swift
@@ -1,0 +1,20 @@
+struct Leaf { var a: Int; var b: Int }
+struct Holder { var opt: Leaf?; var n: Int }
+
+func use(_ leaf: Leaf?) -> Int {
+    if let leaf { return leaf.a + leaf.b }
+    return 0
+}
+
+func f() {
+    let holder = Holder(opt: Leaf(a: 7, b: 8), n: 5)
+    let plain: Leaf? = Leaf(a: 1, b: 2)
+    let scalar: Int? = 42
+    let nested: Leaf?? = Leaf(a: 3, b: 4)
+    let empty: Leaf? = nil
+    print("break here")
+    _ = use(holder.opt) + use(plain) + (scalar ?? 0) + use(nested ?? nil)
+        + use(empty)
+}
+
+f()


### PR DESCRIPTION
```
commit 49d6ddb55c8ad3d7f6f919f35758be51159220af
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Jul 28 16:06:15 2026 -0700

    [LLDB] Create enum children as synthetic VOs instead of casts
    
    The previous code prevented the expression path API from functioning,
    because casts are transparent. Indirectly this made it impossible to
    set a watchpoint on an enum.
    
    rdar://182954842
    
    Assisted-by: claude

commit 84f808f1a26e80647516119ddf1dcc9a97f04244
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Jul 28 17:21:02 2026 -0700

    [LLDB] Hide `.some` children in Optional synthetic child provider
    
    The underlying enum that implements Optional has a .some child but
    this is typically hidded from users behind the ? syntactic sugar, so
    LLDB printing it is just confusing. Also, the resulting expression
    path is not actually accepted by the expression path parser.
    
    Assisted-by: claude
```
