### PR TITLE
[lldb] Don't invent an alignment if not encoded

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -30,6 +30,7 @@
 #include "lldb/Utility/Flags.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -497,11 +498,14 @@ DWARFASTParserSwift::getBuiltinTypeDescriptor(
     return nullptr;
   auto &[type, die] = *pair;
 
+  // Whether this descriptor describes an aggregate rather than a primitive.
+  // It decides how a missing DW_AT_alignment is read below.
   bool is_enum = false;
   if (!llvm::isa<swift::reflection::BuiltinTypeRef>(TR) &&
       !TypeSystemSwiftTypeRef::IsBuiltinType(type)) {
     if (die.Tag() == llvm::dwarf::DW_TAG_structure_type) {
       auto child = die.GetFirstChild();
+      // From the non-builtin types, only enums have a builtin type descriptor.
       if (child.Tag() != llvm::dwarf::DW_TAG_variant_part)
         return nullptr;
       is_enum = true;
@@ -514,21 +518,35 @@ DWARFASTParserSwift::getBuiltinTypeDescriptor(
   if (byte_size == LLDB_INVALID_ADDRESS)
     return nullptr;
 
-  // Enums with DWARF byte_size 0 are an LLVM artifact: the compiler
-  // can't emit unsized types, so an unsubstituted generic enum's size
-  // is emitted as 0.  If we're here this must be a payload-carrying
-  // enum, and such an enum is never 0 bytes, even if its payload is
-  // size 0. Decline to synthesize a fixed descriptor so reflection
-  // instead derives the layout dynamically from the payloads.
-  if (is_enum && byte_size == 0)
+  // The compiler emits DW_AT_alignment whenever it knows a type's alignment, so
+  // a missing attribute means the alignment is unknown. It does not mean the
+  // natural alignment for the type, which is the usual DWARF reading: that
+  // convention only works for a consumer that can recompute the natural
+  // alignment itself, and an aggregate's alignment is the maximum over its
+  // members, which cannot be recovered here without reimplementing Swift's
+  // type layout.
+  auto maybe_alignment =
+      die.GetAttributeValueAsOptionalUnsigned(llvm::dwarf::DW_AT_alignment);
+
+  bool is_unsubustituted_enum = !maybe_alignment && is_enum;
+  // If we don't know the alignment there are two cases:
+  // - This is a builtin type, encoded as a DW_TAG_base_type, whose alignment
+  // matches its size.
+  // - This is an unsubstituted enum, in which case we can't procude a builtin
+  // descriptor since we can't know the alignment.
+  if (is_unsubustituted_enum)
     return nullptr;
 
-  auto alignment = die.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_alignment,
-                                                   byte_size ? byte_size : 8);
+  uint64_t alignment = maybe_alignment.value_or(byte_size);
+  if (alignment == 0) {
+    assert(false && "Unexpected 0 alignment!");
+    return nullptr;
+  }
 
-  // TODO: this seems simple to calculate but maybe we should encode the stride
-  // in DWARF? That's what reflection metadata does.
-  unsigned stride = ((byte_size + alignment - 1) & ~(alignment - 1));
+  // Clamping to 1 matches how reflection lowers a zero-sized type; see the
+  // stride computation in TypeLowering.cpp. Leaving it at 0 would make
+  // distinct elements of a zero-sized type share an address.
+  unsigned stride = std::max<unsigned>(llvm::alignTo(byte_size, alignment), 1);
 
   auto num_extra_inhabitants = die.GetAttributeValueAsUnsigned(
       llvm::dwarf::DW_AT_LLVM_num_extra_inhabitants, 0);

--- a/lldb/test/API/lang/swift/embedded/multipayload_enum_alignment/Makefile
+++ b/lldb/test/API/lang/swift/embedded/multipayload_enum_alignment/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/multipayload_enum_alignment/TestSwiftEmbeddedMultiPayloadEnumAlignment.py
+++ b/lldb/test/API/lang/swift/embedded/multipayload_enum_alignment/TestSwiftEmbeddedMultiPayloadEnumAlignment.py
@@ -1,0 +1,104 @@
+"""
+Test that a multi-payload enum's alignment is not fabricated from its
+DW_AT_byte_size in embedded Swift.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedMultiPayloadEnumAlignment(TestBase):
+    def setup_test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        return thread.GetSelectedFrame()
+
+    @skipUnlessDarwin
+    @skipUnlessEmbeddedSwift
+    # The expected sizes and offsets assume Int64 is 8-byte aligned.
+    @skipIf(archs=no_match(["arm64", "x86_64"]))
+    @swiftTest
+    def test_enum_stride(self):
+        frame = self.setup_test()
+
+        wide_enum = frame.FindVariable("w").GetType()
+        self.assertIn("WideEnum", wide_enum.GetName())
+        self.assertEqual(wide_enum.GetByteSize(), 34)
+
+        pairs = frame.FindVariable("pairs")
+        self.assertTrue(pairs.IsValid(), "pairs is valid")
+        self.assertEqual(pairs.GetType().GetByteSize(), 74)
+        self.assertEqual(pairs.GetNumChildren(), 2)
+
+        base = pairs.GetLoadAddress()
+        self.assertNotEqual(base, lldb.LLDB_INVALID_ADDRESS)
+        self.assertEqual(pairs.GetChildAtIndex(0).GetLoadAddress() - base, 0)
+        self.assertEqual(
+            pairs.GetChildAtIndex(1).GetLoadAddress() - base,
+            40,
+            "WideEnum's stride is alignUp(34, 8) = 40, not alignUp(34, 34) = 66",
+        )
+
+        self.expect(
+            "frame variable pairs",
+            substrs=["first", "pair", "0 = 7", "1 = 8", "second", "0 = 9", "1 = 10"],
+        )
+
+    @skipUnlessDarwin
+    @skipUnlessEmbeddedSwift
+    @skipIf(archs=no_match(["arm64", "x86_64"]))
+    @swiftTest
+    def test_enum_alignment(self):
+        frame = self.setup_test()
+
+        prefixed = frame.FindVariable("prefixed")
+        self.assertTrue(prefixed.IsValid(), "prefixed is valid")
+        self.assertEqual(prefixed.GetType().GetByteSize(), 42)
+
+        base = prefixed.GetLoadAddress()
+        self.assertNotEqual(base, lldb.LLDB_INVALID_ADDRESS)
+        payload = prefixed.GetChildMemberWithName("payload")
+        self.assertTrue(payload.IsValid(), "payload is valid")
+        self.assertEqual(
+            payload.GetLoadAddress() - base,
+            8,
+            "WideEnum's alignment is 8 (the max of the payload alignments), not 34",
+        )
+
+        self.expect(
+            "frame variable prefixed",
+            substrs=["tag = 3", "payload", "pair", "0 = 11", "1 = 12"],
+        )
+
+    @skipUnlessDarwin
+    @skipUnlessEmbeddedSwift
+    @skipIf(archs=no_match(["arm64", "x86_64"]))
+    @swiftTest
+    def test_zero_sized_enum(self):
+        frame = self.setup_test()
+
+        zero = frame.FindVariable("zero")
+        self.assertTrue(zero.IsValid(), "zero is valid")
+        self.assertEqual(zero.GetType().GetByteSize(), 0)
+        self.expect("frame variable zero", substrs=["only"])
+
+        prefixed_zero = frame.FindVariable("prefixedZero")
+        self.assertTrue(prefixed_zero.IsValid(), "prefixedZero is valid")
+        self.assertEqual(prefixed_zero.GetType().GetByteSize(), 1)
+
+        base = prefixed_zero.GetLoadAddress()
+        self.assertNotEqual(base, lldb.LLDB_INVALID_ADDRESS)
+        payload = prefixed_zero.GetChildMemberWithName("payload")
+        self.assertTrue(payload.IsValid(), "payload is valid")
+        self.assertEqual(
+            payload.GetLoadAddress() - base,
+            1,
+            "a zero-sized enum is 1-byte aligned, so it follows the tag byte",
+        )
+
+        self.expect("frame variable prefixedZero", substrs=["tag = 4", "payload"])

--- a/lldb/test/API/lang/swift/embedded/multipayload_enum_alignment/main.swift
+++ b/lldb/test/API/lang/swift/embedded/multipayload_enum_alignment/main.swift
@@ -1,0 +1,75 @@
+// Every size and offset this test checks is expressed in explicitly sized types
+// (Int64/UInt8/Int8), so none of them depend on the pointer width. They do
+// depend on Int64 being 8-byte aligned, which the test gates on.
+
+// A 33-byte payload: four Int64s (alignment 8) plus a trailing UInt8. Its
+// DW_AT_byte_size (33) is deliberately not a power of two and much larger than
+// its real alignment (8).
+struct Wide {
+  var a: Int64 = 1
+  var b: Int64 = 2
+  var c: Int64 = 3
+  var d: Int64 = 4
+  var e: UInt8 = 5
+}
+
+// A multi-payload enum: emitted as a DW_TAG_structure_type whose first child is
+// a DW_TAG_variant_part, with DW_AT_byte_size 34 and DW_AT_alignment 8. Its
+// alignment (the max of its payload alignments) is not recoverable from the
+// byte_size, which is why the compiler has to record it: stride is
+// alignUp(34, 8) = 40, not alignUp(34, 34) = 66.
+enum WideEnum {
+  case wide(Wide)
+  case pair(Int64, Int64)
+  case none
+}
+
+// Two enums back to back: the offset of `second`, and the whole struct's size,
+// are a direct readout of the enum's stride. Correct: 40 + 34 = 74.
+struct EnumPair {
+  var first: WideEnum
+  var second: WideEnum
+}
+
+// A one-byte prefix followed by an enum: the offset of `payload` is a readout
+// of the enum's alignment. Correct: the payload lands at alignUp(1, 8) = 8, so
+// the struct's size is 8 + 34 = 42. A fabricated alignment of 34 rounded 1 up
+// to 2 instead (the mask-based round-up is only valid for powers of two).
+struct PrefixedEnum {
+  var tag: Int8
+  var payload: WideEnum
+}
+
+@inline(never)
+func blackHole(_ x: Int64) {}
+
+// An empty type is zero-sized but still 1-byte aligned.
+struct Empty {}
+
+enum ZeroSized {
+  case only(Empty)
+}
+
+// One byte followed by a zero-sized enum: size 1, with the enum at offset 1.
+struct PrefixedZeroSized {
+  var tag: Int8
+  var payload: ZeroSized
+}
+
+func f() {
+  let w = WideEnum.wide(Wide())
+  let pairs = EnumPair(first: .pair(7, 8), second: .pair(9, 10))
+  let prefixed = PrefixedEnum(tag: 3, payload: .pair(11, 12))
+  let zero = ZeroSized.only(Empty())
+  let prefixedZero = PrefixedZeroSized(tag: 4, payload: .only(Empty()))
+
+  if case .pair(let x, _) = pairs.second { blackHole(x) }
+  if case .pair(let y, _) = prefixed.payload { blackHole(y) }
+  if case .wide(let z) = w { blackHole(z.a) }
+  if case .only = zero { blackHole(Int64(prefixedZero.tag)) }
+
+  let s = StaticString("break here")
+  print(s) // break here
+}
+
+f()


### PR DESCRIPTION
The compiler only emits non-standard alignments into DWARF. RemoteMirror's TypeLowering knows how to calculate an enum's alignment from its payloads. If we don't know the type's alignment, let it do it.

Assisted-by: Claude