### PR TITLE
[lldb] Read builtin extra inhabitant counts from DWARF instead of hardcoding them

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -177,6 +177,8 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
   }
 
   TypeSP lldb_type = ts.FindTypeInModule(type.GetOpaqueQualType());
+  if (!lldb_type && llvm::isa<swift::reflection::BuiltinTypeRef>(TR))
+    lldb_type = ts.FindBuiltinTypeInModule(type.GetMangledTypeName());
   if (!lldb_type) {
     if (ts.ContainsBoundGenericType(type.GetOpaqueQualType())) {
       CompilerType generic_type = ts.MapOutOfContext(type.GetOpaqueQualType());
@@ -267,96 +269,6 @@ public:
 
   llvm::StringRef getMangledTypeName() override { return m_type_name; }
 };
-
-/// Builtin type descriptor that owns its type name string, used for hardcoded
-/// fallback descriptors.
-class HardcodedBuiltinTypeDescriptorImpl
-    : public swift::reflection::BuiltinTypeDescriptorBase {
-  std::string m_type_name;
-
-public:
-  HardcodedBuiltinTypeDescriptorImpl(uint32_t size, uint32_t alignment,
-                                     uint32_t stride,
-                                     uint32_t num_extra_inhabitants,
-                                     swift::reflection::BitwiseBorrowability borrowability,
-                                     bool addr_for_dependencies,
-                                     std::string type_name)
-      : swift::reflection::BuiltinTypeDescriptorBase(
-            size, alignment, stride, num_extra_inhabitants, borrowability,
-            addr_for_dependencies),
-        m_type_name(std::move(type_name)) {}
-  ~HardcodedBuiltinTypeDescriptorImpl() override = default;
-
-  llvm::StringRef getMangledTypeName() override { return m_type_name; }
-};
-
-/// Returns a hardcoded builtin type descriptor for special stdlib builtin
-/// types. This mirrors the types created by
-/// IRGenModule::getOrCreateSpecialStlibBuiltinTypes() in the Swift compiler.
-static std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
-getHardcodedBuiltinTypeDescriptor(const swift::reflection::TypeRef *TR,
-                                  uint32_t pointer_size) {
-  auto *builtin_TR = llvm::dyn_cast<swift::reflection::BuiltinTypeRef>(TR);
-  if (!builtin_TR)
-    return nullptr;
-
-  llvm::StringRef mangled_name = builtin_TR->getMangledName();
-
-  auto makePointerSizedDescriptor =
-      [pointer_size](std::string name, uint32_t num_extra_inhabitants) {
-        return std::make_unique<HardcodedBuiltinTypeDescriptorImpl>(
-            /*size=*/pointer_size,
-            /*alignment=*/pointer_size,
-            /*stride=*/pointer_size,
-            /*num_extra_inhabitants=*/num_extra_inhabitants,
-            /*borrowability=*/swift::reflection::BitwiseBorrowability::TakableAndBorrowable,
-            /*addr_for_dependencies=*/false,
-            std::move(name));
-      };
-
-  // Builtin.NativeObject (Bo).
-  if (mangled_name == "Bo")
-    return makePointerSizedDescriptor("Bo", /*num_extra_inhabitants=*/1);
-
-  // Builtin.UnknownObject (BO).
-  if (mangled_name == "BO")
-    return makePointerSizedDescriptor("BO", /*num_extra_inhabitants=*/1);
-
-  // Builtin.BridgeObject (Bb).
-  if (mangled_name == "Bb") {
-    uint32_t extra_inhabitants = pointer_size == 8 ? 0x7FFFFFFF : 0x3FFFFFFF;
-    return makePointerSizedDescriptor("Bb", extra_inhabitants);
-  }
-
-  // Builtin.RawPointer.
-  if (mangled_name == "Bp")
-    return makePointerSizedDescriptor("Bp", /*num_extra_inhabitants=*/1);
-
-  // Builtin.UnsafeValueBuffer.
-  if (mangled_name == "BB") {
-    uint32_t size = pointer_size * 3;
-    return std::make_unique<HardcodedBuiltinTypeDescriptorImpl>(
-        /*size=*/size,
-        /*alignment=*/pointer_size,
-        /*stride=*/size,
-        /*num_extra_inhabitants=*/0,
-        /*borrowability=*/swift::reflection::BitwiseBorrowability::TakableAndBorrowable,
-        /*addr_for_dependencies=*/true,
-        "BB");
-  }
-
-  // Thin function type () -> ().
-  if (mangled_name == "yyXf")
-    return makePointerSizedDescriptor("yyXf", /*num_extra_inhabitants=*/1);
-
-  // Existential metatype Any.Type.
-  if (mangled_name == "ypXp") {
-    uint32_t extra_inhabitants = pointer_size == 8 ? 0x7FFFFFFF : 0x0FFFFFFF;
-    return makePointerSizedDescriptor("ypXp", extra_inhabitants);
-  }
-
-  return nullptr;
-}
 
 class DWARFFieldRecordImpl : public swift::reflection::FieldRecordBase {
   ConstString m_field_name;
@@ -560,16 +472,22 @@ public:
 } // namespace
 
 /// Constructs a builtin type descriptor from DWARF information.
-static std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
-getDWARFBuiltinTypeDescriptor(TypeSystemSwiftTypeRef &swift_typesystem,
-                              const swift::reflection::TypeRef *TR) {
-  auto pair = getTypeAndDie(swift_typesystem, TR);
+std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
+DWARFASTParserSwift::getBuiltinTypeDescriptor(
+    const swift::reflection::TypeRef *TR) {
+  assert(ModuleList::GetGlobalModuleListProperties()
+                 .GetSwiftEnableFullDwarfDebugging() !=
+             lldb_private::AutoBool::False &&
+         "Full DWARF debugging for Swift is disabled!");
+
+  auto pair = getTypeAndDie(m_swift_typesystem, TR);
   if (!pair)
     return nullptr;
   auto &[type, die] = *pair;
 
   bool is_enum = false;
-  if (!TypeSystemSwiftTypeRef::IsBuiltinType(type)) {
+  if (!llvm::isa<swift::reflection::BuiltinTypeRef>(TR) &&
+      !TypeSystemSwiftTypeRef::IsBuiltinType(type)) {
     if (die.Tag() == llvm::dwarf::DW_TAG_structure_type) {
       auto child = die.GetFirstChild();
       if (child.Tag() != llvm::dwarf::DW_TAG_variant_part)
@@ -611,24 +529,6 @@ getDWARFBuiltinTypeDescriptor(TypeSystemSwiftTypeRef &swift_typesystem,
       byte_size, alignment, stride, num_extra_inhabitants,
       borrowability, addressable_for_dependencies,
       type.GetMangledTypeName());
-}
-
-/// Constructs a builtin type descriptor from DWARF information.
-/// Falls back to hardcoded descriptors for special stdlib builtin types
-/// that may not be present in DWARF.
-std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
-DWARFASTParserSwift::getBuiltinTypeDescriptor(
-    const swift::reflection::TypeRef *TR) {
-  assert(ModuleList::GetGlobalModuleListProperties()
-                 .GetSwiftEnableFullDwarfDebugging() !=
-             lldb_private::AutoBool::False &&
-         "Full DWARF debugging for Swift is disabled!");
-
-  if (auto descriptor = getDWARFBuiltinTypeDescriptor(m_swift_typesystem, TR))
-    return descriptor;
-
-  uint32_t pointer_size = m_swift_typesystem.GetPointerByteSize();
-  return getHardcodedBuiltinTypeDescriptor(TR, pointer_size);
 }
 
 std::unique_ptr<swift::reflection::MultiPayloadEnumDescriptorBase>

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2811,27 +2811,6 @@ llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
   return {};
 }
 
-bool TypeSystemSwiftTypeRef::IsEmbeddedSwift() {
-  llvm::call_once(m_is_embedded_swift_once_flag, [&]() {
-    Module *module = GetModule();
-    if (!module)
-      return;
-    // A Swift module is compiled either entirely as Embedded Swift or not at
-    // all, so the first Swift compile unit has the answer for all of them.
-    const size_t num_compile_units = module->GetNumCompileUnits();
-    for (size_t i = 0; i < num_compile_units; ++i) {
-      lldb::CompUnitSP cu_sp = module->GetCompileUnitAtIndex(i);
-      if (!cu_sp || cu_sp->GetLanguage() != lldb::eLanguageTypeSwift)
-        continue;
-      m_is_embedded_swift = ShouldEnableEmbeddedSwift(cu_sp.get());
-      LLDB_LOGF(GetLog(LLDBLog::Types), "%s::IsEmbeddedSwift() = %d",
-                m_description.c_str(), m_is_embedded_swift);
-      return;
-    }
-  });
-  return m_is_embedded_swift;
-}
-
 void TypeSystemSwiftTypeRef::SetTriple(const SymbolContext &sc,
                                        const llvm::Triple triple) {
   // This function appears to be only called via

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3071,14 +3071,18 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
 
 TypeSP
 TypeSystemSwiftTypeRef::FindBuiltinTypeInModule(ConstString mangled_name) {
-  // The same lookup BuildDeclContext() uses for a mangling that demangles to a
-  // builtin type name.
   std::vector<CompilerContext> context = {
-      {CompilerContextKind::Module, ConstString("Builtin")},
       {CompilerContextKind::AnyType, mangled_name}};
-  return FindTypeInModule(
-      context, GetModule(),
-      SwiftLanguageRuntime::GetManglingFlavor(mangled_name.GetStringRef()));
+  TypeQuery query(context, TypeQueryOptions::e_find_one);
+  query.SetLanguages(TypeSystemSwift::GetSupportedLanguagesForTypes());
+
+  TypeResults results;
+  if (auto *M = GetModule())
+    M->FindTypes(query, results);
+
+  if (results.Done(query))
+    return results.GetFirstType();
+  return {};
 }
 
 // Tests

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2811,6 +2811,27 @@ llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
   return {};
 }
 
+bool TypeSystemSwiftTypeRef::IsEmbeddedSwift() {
+  llvm::call_once(m_is_embedded_swift_once_flag, [&]() {
+    Module *module = GetModule();
+    if (!module)
+      return;
+    // A Swift module is compiled either entirely as Embedded Swift or not at
+    // all, so the first Swift compile unit has the answer for all of them.
+    const size_t num_compile_units = module->GetNumCompileUnits();
+    for (size_t i = 0; i < num_compile_units; ++i) {
+      lldb::CompUnitSP cu_sp = module->GetCompileUnitAtIndex(i);
+      if (!cu_sp || cu_sp->GetLanguage() != lldb::eLanguageTypeSwift)
+        continue;
+      m_is_embedded_swift = ShouldEnableEmbeddedSwift(cu_sp.get());
+      LLDB_LOGF(GetLog(LLDBLog::Types), "%s::IsEmbeddedSwift() = %d",
+                m_description.c_str(), m_is_embedded_swift);
+      return;
+    }
+  });
+  return m_is_embedded_swift;
+}
+
 void TypeSystemSwiftTypeRef::SetTriple(const SymbolContext &sc,
                                        const llvm::Triple triple) {
   // This function appears to be only called via
@@ -3067,6 +3088,18 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
     return {};
   context[0].name = ConstString("_Concurrency");
   return FindTypeInModule(context, M, flavor);
+}
+
+TypeSP
+TypeSystemSwiftTypeRef::FindBuiltinTypeInModule(ConstString mangled_name) {
+  // The same lookup BuildDeclContext() uses for a mangling that demangles to a
+  // builtin type name.
+  std::vector<CompilerContext> context = {
+      {CompilerContextKind::Module, ConstString("Builtin")},
+      {CompilerContextKind::AnyType, mangled_name}};
+  return FindTypeInModule(
+      context, GetModule(),
+      SwiftLanguageRuntime::GetManglingFlavor(mangled_name.GetStringRef()));
 }
 
 // Tests

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -27,7 +27,6 @@
 #include "clang/Basic/Module.h"
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Threading.h"
 
 namespace swift {
 class DWARFImporterDelegate;
@@ -115,12 +114,6 @@ public:
   SwiftDWARFImporterForClangTypes &GetSwiftDWARFImporterForClangTypes();
   ClangNameImporter *GetNameImporter() const;
   llvm::Triple GetTriple() const;
-  /// Returns true if the module this type system was created for was compiled
-  /// as Embedded Swift. This is deliberately a *per-module* property: one
-  /// target can mix embedded and non-embedded modules, so the answer cannot
-  /// come from the target or from a global setting. The result is cached,
-  /// because computing it walks the module's compile units.
-  bool IsEmbeddedSwift();
   void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override;
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
@@ -708,10 +701,6 @@ protected:
   /// mangled type name.
   mutable llvm::DenseSet<std::pair<const char *, const char *>>
       m_dangerous_types;
-
-  /// Lazily computed cache behind IsEmbeddedSwift().
-  llvm::once_flag m_is_embedded_swift_once_flag;
-  bool m_is_embedded_swift = false;
 
   mutable std::unique_ptr<SwiftDWARFImporterForClangTypes>
       m_dwarf_importer_for_clang_types_up;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -27,6 +27,7 @@
 #include "clang/Basic/Module.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Threading.h"
 
 namespace swift {
 class DWARFImporterDelegate;
@@ -114,6 +115,12 @@ public:
   SwiftDWARFImporterForClangTypes &GetSwiftDWARFImporterForClangTypes();
   ClangNameImporter *GetNameImporter() const;
   llvm::Triple GetTriple() const;
+  /// Returns true if the module this type system was created for was compiled
+  /// as Embedded Swift. This is deliberately a *per-module* property: one
+  /// target can mix embedded and non-embedded modules, so the answer cannot
+  /// come from the target or from a global setting. The result is cached,
+  /// because computing it walks the module's compile units.
+  bool IsEmbeddedSwift();
   void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override;
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
@@ -529,6 +536,11 @@ public:
   /// Lookup a type in the debug info.
   lldb::TypeSP FindTypeInModule(lldb::opaque_compiler_type_t type);
 
+  /// Lookup a builtin type in the debug info by its mangled name. Unlike
+  /// FindTypeInModule(), this does not need the mangling to have a decl
+  /// context, which some of the special stdlib builtins do not have.
+  lldb::TypeSP FindBuiltinTypeInModule(ConstString mangled_name);
+
   /// Desugar a CompilerType and resolve type aliases by looking up
   /// their types in the debug info.
   CompilerType Canonicalize(CompilerType type);
@@ -696,6 +708,10 @@ protected:
   /// mangled type name.
   mutable llvm::DenseSet<std::pair<const char *, const char *>>
       m_dangerous_types;
+
+  /// Lazily computed cache behind IsEmbeddedSwift().
+  llvm::once_flag m_is_embedded_swift_once_flag;
+  bool m_is_embedded_swift = false;
 
   mutable std::unique_ptr<SwiftDWARFImporterForClangTypes>
       m_dwarf_importer_for_clang_types_up;

--- a/lldb/test/API/lang/swift/embedded/pointer_extra_inhabitants/Makefile
+++ b/lldb/test/API/lang/swift/embedded/pointer_extra_inhabitants/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/pointer_extra_inhabitants/TestSwiftEmbeddedPointerExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/embedded/pointer_extra_inhabitants/TestSwiftEmbeddedPointerExtraInhabitants.py
@@ -1,0 +1,72 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedPointerExtraInhabitants(TestBase):
+    """
+    Tests the extra inhabitant count LLDB reports for a not-nullable
+    pointer-sized builtin in embedded Swift.
+
+    A thin function pointer ("yyXf") exercises both halves of that: its
+    mangling demangles to a function type, which has no decl context to look a
+    type up in, and it is emitted as a DW_TAG_structure_type wrapping a "ptr"
+    member rather than a base type.
+
+    The count is observable through nested Optionals, because the Nth level of
+    nesting needs an Nth extra inhabitant of the payload. With enough of them
+    the whole nest stays pointer sized; with only one -- the Builtin.RawPointer
+    answer -- every level past the first grows a discriminator byte.
+    """
+
+    @skipUnlessDarwin
+    @swiftTest
+    @skipUnlessEmbeddedSwift
+    def test_not_nullable_pointer_extra_inhabitants(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        frame = thread.GetSelectedFrame()
+
+        # Every level is spare-bit encoded into the pointer itself, so all three
+        # fields are 8 bytes and the struct is 3 * 8 = 24.
+        fn_holder = frame.FindVariable("fnHolder")
+        self.assertSuccess(fn_holder.GetError(), "fnHolder is available")
+        self.assertEqual(fn_holder.GetType().GetByteSize(), 24)
+        for name in ["a", "b", "c"]:
+            field = fn_holder.GetChildMemberWithName(name)
+            self.assertSuccess(field.GetError(), "fnHolder.%s is available" % name)
+            self.assertEqual(
+                field.GetType().GetByteSize(),
+                8,
+                "nested Optional of a thin function pointer stays pointer sized",
+            )
+
+        # The control: one extra inhabitant, so 8, then a byte per extra level.
+        # 8 + 9 + (10 padded up to alignment 8, i.e. 16) = 34.
+        raw_holder = frame.FindVariable("rawHolder")
+        self.assertSuccess(raw_holder.GetError(), "rawHolder is available")
+        self.assertEqual(raw_holder.GetType().GetByteSize(), 34)
+        for name, size in [("a", 8), ("b", 9), ("c", 10)]:
+            field = raw_holder.GetChildMemberWithName(name)
+            self.assertSuccess(field.GetError(), "rawHolder.%s is available" % name)
+            self.assertEqual(field.GetType().GetByteSize(), size)
+
+        # If the function pointer is ever given RawPointer's count again,
+        # FnHolder collapses onto RawHolder's layout.
+        self.assertNotEqual(
+            fn_holder.GetType().GetByteSize(),
+            raw_holder.GetType().GetByteSize(),
+            "a not-nullable function pointer must not be laid out like a "
+            "nullable raw pointer",
+        )
+
+        self.expect(
+            "frame variable fnHolder",
+            substrs=["FnHolder", "a = ", "b = ", "c = "],
+        )

--- a/lldb/test/API/lang/swift/embedded/pointer_extra_inhabitants/main.swift
+++ b/lldb/test/API/lang/swift/embedded/pointer_extra_inhabitants/main.swift
@@ -1,0 +1,41 @@
+// The extra inhabitant count of a pointer-sized builtin drives how deeply an
+// Optional can be nested before the layout has to grow an out-of-line
+// discriminator byte. A thin function pointer ("yyXf") is not nullable, so it
+// has many extra inhabitants and three nested Optionals still fit in 8 bytes.
+// Builtin.RawPointer ("Bp") is nullable and null is its only extra inhabitant,
+// so each additional Optional level costs a byte. Both counts come from the
+// same hardcoded-builtin-descriptor path in LLDB, which makes RawHolder the
+// control for FnHolder: if the thin function pointer were also reported as
+// having a single extra inhabitant, FnHolder would take on RawHolder's layout.
+typealias CFn = @convention(c) () -> Void
+
+func target() {}
+
+struct FnHolder {
+    var a: CFn?
+    var b: CFn??
+    var c: CFn???
+}
+
+struct RawHolder {
+    var a: UnsafeRawPointer?
+    var b: UnsafeRawPointer??
+    var c: UnsafeRawPointer???
+}
+
+@inline(never)
+func blackHole<T>(_ x: T) {}
+
+func test() {
+    var pointer = UnsafeRawPointer(bitPattern: 0x1000)
+    var fnHolder = FnHolder(a: target, b: target, c: target)
+    var rawHolder = RawHolder(a: pointer, b: pointer, c: pointer)
+    print("break here")
+    blackHole(fnHolder)
+    blackHole(rawHolder)
+    fnHolder.a = nil
+    rawHolder.a = nil
+    pointer = nil
+}
+
+test()


### PR DESCRIPTION
getHardcodedBuiltinTypeDescriptor() answered with a table of constants for the special stdlib builtin types, because the compiler did not emit usable DIEs for all of them. It now does, so read the numbers from DWARF and delete the table.

Assisted-by: claude