### PR TITLE
[LLDB] Fix expression variable lookup in inlined functions 

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -251,7 +251,7 @@ bool SwiftUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
   innermost_block->AppendVariables(/*can_create*/
                                    true,
                                    /*get_parent_variables*/ true,
-                                   /*stop_if_block_is_inlined_function*/ false,
+                                   /*stop_if_block_is_inlined_function*/ true,
                                    /*filter*/
                                    [&](Variable *var) {
                                      if (!variable_list.Empty())

--- a/lldb/test/API/lang/swift/inlined_self_scope/Makefile
+++ b/lldb/test/API/lang/swift/inlined_self_scope/Makefile
@@ -1,0 +1,8 @@
+SWIFT_SOURCES := main.swift
+
+# -O is required: the bug only manifests when the PC is inside an inlined
+# function. The test asserts that the frame really is inlined, so it fails
+# loudly rather than silently passing if the optimizer stops inlining here.
+SWIFTFLAGS_EXTRAS := -O
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/inlined_self_scope/TestSwiftInlinedSelfScope.py
+++ b/lldb/test/API/lang/swift/inlined_self_scope/TestSwiftInlinedSelfScope.py
@@ -1,0 +1,52 @@
+"""
+Test expression evaluation when stopped inside an inlined function.
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftInlinedSelfScope(TestBase):
+    def assert_stopped_in_inlined_frame(self, thread, name):
+        frame = thread.GetSelectedFrame()
+        self.assertTrue(
+            frame.IsInlined(),
+            "expected to be stopped in an inlined frame, but stopped in '%s'; "
+            "the optimizer may no longer be inlining %s"
+            % (frame.GetFunctionName(), name),
+        )
+        return frame
+
+    @skipEmbeddedSwift
+    @swiftTest
+    def test_self_scope_in_inlined_frames(self):
+        self.build()
+
+        # An inlined *free function* has no `self` of its own, and the
+        # caller's `self` must not leak into scope. 
+        _, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self,
+            "break here in free function",
+            lldb.SBFileSpec("main.swift"),
+        )
+        self.assert_stopped_in_inlined_frame(thread, "freeFunction()")
+
+        value = thread.GetSelectedFrame().EvaluateExpression("self.count")
+        error = value.GetError().GetCString() or ""
+        self.assertIn("cannot find 'self' in scope", error)
+        # The regression: the wrapper referenced an undeclared variable.
+        self.assertNotIn("$__lldb_injected_self", error)
+
+        # Sanity check: An inlined *method* keeps its own `self`, which stays usable.
+        threads = lldbutil.continue_to_source_breakpoint(
+            self,
+            process,
+            "break here in method",
+            lldb.SBFileSpec("main.swift"),
+        )
+        self.assertEqual(len(threads), 1, "expected one thread at the breakpoint")
+        self.assert_stopped_in_inlined_frame(threads[0], "Tester.inlinedMethod()")
+
+        self.expect("expression self.count", substrs=["41"])
+        self.expect("expression count", substrs=["41"])

--- a/lldb/test/API/lang/swift/inlined_self_scope/main.swift
+++ b/lldb/test/API/lang/swift/inlined_self_scope/main.swift
@@ -1,0 +1,33 @@
+@inline(never)
+func blackhole(_ x: Int) {
+  if x == -12345 {
+    print(x)
+  }
+}
+
+// A free function with no parameters and no local variables (and no `self`).
+@inline(__always)
+func freeFunction() {
+  blackhole(42) // break here in free function
+}
+
+class Tester {
+  var count = 41
+
+  // An inlined *method* with its own `self`.
+  // This is `private` matters, otherwise the compiler also emits an out-of-line copy
+  // of the method.
+  @inline(__always)
+  private func inlinedMethod() {
+    blackhole(count) // break here in method
+  }
+
+  @inline(never)
+  func testTop() {
+    freeFunction()
+    inlinedMethod()
+    blackhole(count)
+  }
+}
+
+Tester().testTop()


### PR DESCRIPTION
When creating the list of visible variables, inlined function scopes need to be taken into account otherwise variables from the parent function are visible to the expression.

rdar://172154660