### PR TITLE
[cherry-pick][DWARFLinker] Keep DW_TAG_enumerator children of a live enumeration_type and [lldb][test] Test that dsymutil keeps the cases of an embedded raw-value enum

### DIFF
--- a/lldb/test/API/lang/swift/embedded/dwarflinker_raw_value_enum/Makefile
+++ b/lldb/test/API/lang/swift/embedded/dwarflinker_raw_value_enum/Makefile
@@ -1,0 +1,8 @@
+SWIFT_SOURCES := main.swift
+
+# The DWARFLinker truncation this test covers only reproduces at -O. At -Onone
+# the enumeration type is reached first through a local variable's DW_AT_type,
+# which marks its enumerators Keep before the parent walk can short-circuit.
+SWIFTFLAGS_EXTRAS := -O
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/dwarflinker_raw_value_enum/TestSwiftEmbeddedDWARFLinkerRawValueEnum.py
+++ b/lldb/test/API/lang/swift/embedded/dwarflinker_raw_value_enum/TestSwiftEmbeddedDWARFLinkerRawValueEnum.py
@@ -1,0 +1,30 @@
+"""
+Test that dsymutil preserves the DW_TAG_enumerator children of an embedded
+Swift raw-value enum.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedDWARFLinkerRawValueEnum(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    @skipUnlessEmbeddedSwift
+    def test(self):
+        """A raw-value enum keeps its case names after dsymutil links the dSYM."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame variable ev",
+            substrs=["Event", "fault"],
+            error=False,
+            matching=True,
+        )

--- a/lldb/test/API/lang/swift/embedded/dwarflinker_raw_value_enum/main.swift
+++ b/lldb/test/API/lang/swift/embedded/dwarflinker_raw_value_enum/main.swift
@@ -1,0 +1,25 @@
+enum Event: Int {
+    case idle = 0
+    case start = 1
+    case fault = 100
+}
+
+@inline(never)
+func rawOf(_ n: Int) -> Int {
+    if let e = Event(rawValue: n) { return e.rawValue }
+    return -1
+}
+
+@inline(never)
+func show(_ ev: Event) {
+    let s = StaticString("break here")
+    print(s) // break here
+    print(ev.rawValue)
+}
+
+func f() {
+    print(rawOf(1))
+    show(.fault)
+}
+
+f()

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -447,6 +447,7 @@ static bool dieNeedsChildrenToBeMeaningful(uint32_t Tag) {
     return false;
   case dwarf::DW_TAG_class_type:
   case dwarf::DW_TAG_common_block:
+  case dwarf::DW_TAG_enumeration_type:
   case dwarf::DW_TAG_lexical_block:
   case dwarf::DW_TAG_structure_type:
   case dwarf::DW_TAG_subprogram:

--- a/llvm/test/tools/dsymutil/X86/keep-enumerators.test
+++ b/llvm/test/tools/dsymutil/X86/keep-enumerators.test
@@ -1,0 +1,160 @@
+# RUN: yaml2obj %s -o %t.o
+# RUN: echo '---' > %t.map
+# RUN: echo "triple:          'x86_64-apple-darwin'" >> %t.map
+# RUN: echo 'objects:'  >> %t.map
+# RUN: echo " -  filename: '%t.o'" >> %t.map
+# RUN: echo '    symbols:' >> %t.map
+# RUN: echo '      - { sym: _foo, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t.map
+# RUN: echo '...' >> %t.map
+# RUN: dsymutil --linker classic -f -y %t.map -o - | llvm-dwarfdump --debug-info - | FileCheck %s
+# RUN: dsymutil --linker parallel -f -y %t.map -o - | llvm-dwarfdump --debug-info - | FileCheck %s
+
+## An enumeration type that only becomes live through the parent chain of a kept
+## DIE -- here a subprogram definition pointing back at a declaration nested in
+## the enumeration type -- must still keep its enumerators.
+
+# CHECK: DW_TAG_enumeration_type
+# CHECK:   DW_AT_name{{.*}}"E"
+# CHECK:   DW_TAG_enumerator
+# CHECK:     DW_AT_name{{.*}}"One"
+# CHECK:   DW_TAG_enumerator
+# CHECK:     DW_AT_name{{.*}}"Two"
+
+--- !mach-o
+FileHeader:
+  magic:      0xFEEDFACF
+  cputype:    0x01000007
+  cpusubtype: 0x00000003
+  filetype:   0x00000001
+  ncmds:      2
+  sizeofcmds: 296
+  flags:      0x00002000
+  reserved:   0x00000000
+LoadCommands:
+  - cmd:      LC_SEGMENT_64
+    cmdsize:  232
+    segname:  ''
+    vmaddr:   0x00
+    vmsize:   0x200
+    fileoff:  0x200
+    filesize: 0x200
+    maxprot:  7
+    initprot: 7
+    nsects:   2
+    flags:    0
+    Sections:
+      - sectname:  __debug_abbrev
+        segname:   __DWARF
+        addr:      0x0000000000000000
+        size:      0x36
+        offset:    0x00000280
+        align:     0
+        reloff:    0x00000000
+        nreloc:    0
+        flags:     0x02000000
+        reserved1: 0x00000000
+        reserved2: 0x00000000
+        reserved3: 0x00000000
+      - sectname:  __debug_info
+        segname:   __DWARF
+        addr:      0x0000000000000100
+        size:      0x3b
+        offset:    0x000002C0
+        align:     0
+        reloff:    0x00000400
+        nreloc:    1
+        flags:     0x02000000
+        reserved1: 0x00000000
+        reserved2: 0x00000000
+        reserved3: 0x00000000
+        relocations:
+          - address:         0x2a
+            symbolnum:       0
+            pcrel:           false
+            length:          3
+            extern:          true
+            type:            0
+            scattered:       false
+            value:           0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          0x500
+    nsyms:           1
+    stroff:          0x510
+    strsize:         6
+LinkEditData:
+  NameList:
+    - n_strx:          1
+      n_type:          0x0F
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+  StringTable:
+    - ''
+    - '_foo'
+    - ''
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_enumeration_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_enumerator
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_const_value
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_declaration
+            Form:      DW_FORM_flag
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data4
+          - Attribute: DW_AT_specification
+            Form:      DW_FORM_ref4
+  debug_info:
+    - Version: 4
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: CU1
+        - AbbrCode: 2
+          Values:
+            - CStr: E
+        - AbbrCode: 3
+          Values:
+            - CStr: One
+            - Value:  0x01
+        - AbbrCode: 3
+          Values:
+            - CStr: Two
+            - Value:  0x02
+        - AbbrCode: 4
+          Values:
+            - CStr: member
+            - Value:  0x01
+        - AbbrCode: 0
+        - AbbrCode: 5
+          Values:
+            - Value:  0x0000000000000000
+            - Value:  0x00000010
+            - Value:  0x0000001f
+        - AbbrCode: 0
+...


### PR DESCRIPTION
Author: Augusto Noronha <anoronha@apple.com>
Date:   Wed Jul 29 19:32:05 2026 -0700

    [lldb][test] Test that dsymutil keeps the cases of an embedded raw-value enum

    Assisted-by: claude

Author: Augusto Noronha <anoronha@apple.com>
Date:   Wed Jul 29 15:37:10 2026 -0700

    [DWARFLinker] Keep DW_TAG_enumerator children of a live enumeration_type (#212849)

    Swift allows functions inside enums:

      enum Foo: Int {
        case bar = 0

        func baz() { ... }
        }

      DW_TAG_enumeration_type  "Foo"
        DW_TAG_enumerator        "bar"
        DW_TAG_subprogram        "baz"  DW_AT_declaration
      ...
      DW_TAG_subprogram  DW_AT_low_pc(...)  DW_AT_specification -> "baz"

    dieNeedsChildrenToBeMeaningful() did not list DW_TAG_enumeration_type,
    so the parent walk skipped the enum's children.

    Assisted-by: claude

    rdar://183549452
    (cherry picked from commit ade128740327db281859708ddcb3b072903b3414)