### PR TITLE
[stable/21.x][ClangScanDeps] Avoid use-of-uninitialized-memory for end-of-directive edge case

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -460,6 +460,9 @@ void Preprocessor::ReadMacroName(Token &MacroNameTok, MacroUse isDefineUndef,
 SourceLocation Preprocessor::CheckEndOfDirective(const char *DirType,
                                                  bool EnableMacros) {
   Token Tmp;
+  // Avoid use-of-uninitialized-memory for edge case(s) where there is no extra
+  // token to be parsed.
+  Tmp.startToken();
   // Lex unexpanded tokens for most directives: macros might expand to zero
   // tokens, causing us to miss diagnosing invalid lines.  Some directives (like
   // #line) allow empty macros.

--- a/clang/test/ClangScanDeps/p1689-suppress-warnings-no-eol.cppm
+++ b/clang/test/ClangScanDeps/p1689-suppress-warnings-no-eol.cppm
@@ -1,0 +1,25 @@
+// Test that there is no use-of-uninitialized memory when parsing '#include' in
+// the last line, without a newline.
+//
+// Forked from p1689-suppress-warnings.cppm.
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// Test P1689 format - should NOT emit warnings
+// RUN: clang-scan-deps -format=p1689 -- %clang++ -std=c++20 -I%t -c %t/mylib.cppm -o %t/mylib.o 2>&1 | FileCheck %s
+
+// CHECK-NOT: warning:
+// CHECK: {
+// CHECK: "revision"
+
+//--- header.h
+// Empty header for testing
+
+//--- mylib.cppm
+module;
+
+export module mylib;
+
+#include <header.h>


### PR DESCRIPTION
Cherry pick https://github.com/llvm/llvm-project/pull/188590