### PR TITLE
[BoundsSafety] Fix bug validating soft traps under debugger and then make `lower_upper_check.c`  pass again

### DIFF
--- a/compiler-rt/test/bounds_safety/bidi_indexable/lower_upper_check_inline_bad_read.c
+++ b/compiler-rt/test/bounds_safety/bidi_indexable/lower_upper_check_inline_bad_read.c
@@ -1,17 +1,19 @@
+// This is a variant of `lower_upper_check` that requests inlining of `bad_read`
+// that can lead to LLVM discovering UB in soft trap mode.
 // RUN: %clang_bsafe %s -o %t
 // RUN: %expect-no-trap %t
 // RUN: %expect-trap --verify-prefix=lower-trap %s %t arg1
 // RUN: %expect-trap --verify-prefix=upper-trap %s %t arg1 arg2
+// FIXME: With soft-traps in optimized builds LLVM can detect that the lower bound
+// access leads to UB and emits a trap (rdar://183581715).
+// XFAIL: soft-traps && optimized
 #include <ptrcheck.h>
 #include <stdio.h>
 #include "soft_trap_runtime_impl.h"
 
-// `noinline` here is used to prevent inlining which can indirectly lead to
-// LLVM figuring out UB is happening during soft traps and emit a hard trap
-// after the soft trap call. This is a workaround for rdar://183581715
 // lower-trap-merged{bad_read}
 // upper-trap-merged{bad_read}
-__attribute__((noinline)) int bad_read(int *__bidi_indexable ptr, int idx) {
+__attribute__((always_inline)) int bad_read(int *__bidi_indexable ptr, int idx) {
   // lower-trap@+2{indexing below lower bound in 'ptr[idx]'}
   // upper-trap@+1{indexing above upper bound in 'ptr[idx]'}
   return ptr[idx];

--- a/compiler-rt/test/bounds_safety/scripts/expect_trap.py
+++ b/compiler-rt/test/bounds_safety/scripts/expect_trap.py
@@ -453,6 +453,44 @@ def check_trap(lldb, process, expectation, verify_source, merged_traps=False,
     return 0
 
 
+def resume_and_expect_clean_exit(lldb, process):
+    """Resume a process stopped at a soft trap and require a clean exit.
+
+    Soft traps are non-fatal: after the trap is validated the process must run
+    to completion and exit with status 0. This is what distinguishes a soft
+    trap from a hard trap and is what catches miscompiles that turn a soft trap
+    into a fatal one. Assumes exactly one soft trap fires before exit (we do not
+    yet support multiple verify expectations); a second stop is reported as a
+    failure rather than silently passing.
+    """
+    # LLDBProcessContextManager runs in synchronous mode (SetAsync(False)), so
+    # Continue() blocks until the process next stops or exits.
+    error = process.Continue()
+    if error.Fail():
+        log.error("failed to resume process after soft trap: %s", error)
+        return 1
+
+    state = process.GetState()
+    if state != lldb.eStateExited:
+        log.error(
+            "process did not exit after soft trap (state=%s); the soft trap "
+            "may have become fatal", state,
+        )
+        log_stop_info(process.GetSelectedThread())
+        return 1
+
+    exit_status = process.GetExitStatus()
+    if exit_status != 0:
+        log.error(
+            "process exited with status %d after soft trap (expected 0)",
+            exit_status,
+        )
+        return 1
+
+    log.info("Process exited cleanly after soft trap")
+    return 0
+
+
 def run_debugger(binary, args, lldb_python_path, verify_source, verify_prefix,
                   merged_traps=False, soft_traps=False):
     # Parse and validate verify comments before launching the debugger so we
@@ -513,10 +551,21 @@ def run_debugger(binary, args, lldb_python_path, verify_source, verify_prefix,
             return 1
 
         if soft_traps and not has_plugin:
-            return check_soft_trap_no_plugin(lldb, ctx.process, expectation,
-                                             verify_source)
-        return check_trap(lldb, ctx.process, expectation, verify_source,
-                          merged_traps, soft_traps)
+            rc = check_soft_trap_no_plugin(lldb, ctx.process, expectation,
+                                           verify_source)
+        else:
+            rc = check_trap(lldb, ctx.process, expectation, verify_source,
+                            merged_traps, soft_traps)
+        if rc != 0:
+            return rc
+
+        # Hard/merged traps: stopping at the trap is the entire check.
+        if not soft_traps:
+            return 0
+
+        # Soft traps are non-fatal: after validating the trap the process must
+        # resume and run to a clean exit.
+        return resume_and_expect_clean_exit(lldb, ctx.process)
 
 
 def main():


### PR DESCRIPTION
This PR consists of two commits:

[BoundsSafety] Verify soft-trapping tests exit cleanly under the debugger

Soft traps (`-fbounds-safety-soft-traps=...`) are non-fatal: when a bounds
check fails the compiler calls `__bounds_safety_soft_trap()`, which reports the
violation and returns, and execution continues to a normal exit. The
`expect_trap.py` "direct" runner (`run_direct_soft_trap`) already checks this
end-to-end: it runs the binary to completion and requires both the soft-trap
marker and a zero exit code.

The debugger runner (`run_debugger`, used for `--use-debugger` configurations)
did not. For a soft trap it stopped at the first `__bounds_safety_soft_trap`,
validated the trap's location and message, and returned immediately. The
process was left stopped and subsequently killed by
`LLDBProcessContextManager` on teardown. As a result the debugger path only
verified that a soft trap *fires* at the expected location; it never checked
the property that actually distinguishes a soft trap from a hard trap, namely
that the process resumes and exits cleanly.

This patch teaches `run_debugger` to resume the process after a soft trap has
been validated and to require a clean exit. A new
`resume_and_expect_clean_exit()` helper calls `process.Continue()` (which runs
synchronously because the debugger is created with `SetAsync(False)`) and then
requires the process to reach `eStateExited` with an exit status of 0. If the
process stops again or exits with a non-zero status the check fails and a
backtrace is logged. This mirrors the clean-exit check already performed by the
direct runner and by `expect_no_trap.py`'s `check_no_trap()`.

Hard traps (`unique-traps` and `merged-traps`) are unaffected: for those,
stopping at the trap is the entire check, so `run_debugger` returns as before
without resuming. The soft-trap handling works for both older LLDB (which lacks
the bounds-safety instrumentation-runtime plugin and relies on a manual
breakpoint on `__bounds_safety_soft_trap`) and newer LLDB (which stops with
`eStopReasonInstrumentation`).

This assumes a single soft trap fires before the process exits, which is
sufficient for the current tests. Supporting multiple soft traps per run would
require supporting multiple verify expectations, which the harness does not yet
do; until then a second stop is reported as a failure rather than silently
ignored.

Assisted-by: Claude Code

rdar://183573672

---


[BoundsSafety] Work around a soft trap triggering a hard trap in the `lower_upper_check.c` test

In optimized builds with soft traps, LLVM can inline `bad_read()` into
`main()`, prove that the out-of-bounds access `local[-1]` is undefined
behavior, and emit a hard trap (`brk`) on the path following the
`__bounds_safety_soft_trap()` call. Building the test case and running
it without `-fbounds-safety` (requires removing the `__bidi_indexable` to
build) doesn't reproduce a trap, which implies `-fbounds-safety` is
unintentionally causing the optimizer to add a trap. This is arguably a
miscompile.

A soft trap is meant to be non-fatal, so reporting the soft trap and then
hard trapping anyway is undesirable. We are technically executing UB, so
the optimizer is within its rights to do this, but we should investigate
whether it's possible to avoid this miscompile. Doing that is tracked in
rdar://183581715.

`bidi_indexable/lower_upper_check.c` hits this in the `soft-traps` +
`optimized` configuration. To keep the test meaningful while the compiler bug
is open, this patch makes two changes:

* Mark `bad_read()` in `lower_upper_check.c` with `__attribute__((noinline))`.
  Preventing inlining stops LLVM from proving the access is UB in this
  translation, so the test reliably passes and continues to provide coverage
  that soft-trap mode is non-fatal in optimized builds.

* Add `bidi_indexable/lower_upper_check_inline_bad_read.c`, a variant that
  forces inlining with `__attribute__((always_inline))` and thereby reproduces
  the miscompile. It is marked `XFAIL: soft-traps && optimized`, so the testsuite
  passes again while still explicitly exercising and tracking the miscompile.

Assisted-by: Claude Code

rdar://183581715

