### PR TITLE
[lldb][embedded] Don't initialize ast context with objc interop

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3842,8 +3842,10 @@ bool SwiftASTContext::SetTriple(const llvm::Triple triple, Module *module) {
 
   // Every time the triple is changed the LangOpts must be updated
   // too, because Swift default-initializes the EnableObjCInterop
-  // flag based on the triple.
-  GetLanguageOptions().EnableObjCInterop = triple.isOSDarwin();
+  // flag based on the triple. Embedded Swift is the one exception.
+  GetLanguageOptions().EnableObjCInterop =
+      triple.isOSDarwin() &&
+      !GetLanguageOptions().hasFeature(swift::Feature::Embedded);
   return true;
 }
 

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -19,7 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftProtocolTypes(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_swift_protocol_types(self):
         """Test support for protocol types"""


### PR DESCRIPTION
In embedded swift, the ast context should not be initialized with objc interop on, even on Darwin.