### PR TITLE
[lldb] Release CAS object stores when they are no longer needed

### DIFF
--- a/lldb/include/lldb/Core/DataBufferCAS.h
+++ b/lldb/include/lldb/Core/DataBufferCAS.h
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// A DataBuffer whose bytes are owned by a CAS ObjectStore.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_CORE_DATABUFFERCAS_H
+#define LLDB_CORE_DATABUFFERCAS_H
+
+#include "lldb/Utility/DataBufferLLVM.h"
+
+#include <memory>
+#include <utility>
+
+namespace llvm {
+class MemoryBuffer;
+namespace cas {
+class ObjectStore;
+} // namespace cas
+} // namespace llvm
+
+namespace lldb_private {
+
+/// A DataBuffer whose bytes are owned by a CAS \c ObjectStore.
+///
+/// ObjectStore::getMemoryBuffer() returns a non-owning buffer aliasing
+/// storage the ObjectStore owns, so releasing the last reference to the
+/// ObjectStore invalidates it; this buffer holds a reference to prevent
+/// that, regardless of teardown order.
+class DataBufferCAS : public DataBufferLLVM {
+public:
+  /// \param buffer A non-owning buffer aliasing storage owned by \p cas. Must
+  ///        be a valid pointer.
+  /// \param cas The ObjectStore that owns \p buffer's bytes.
+  DataBufferCAS(std::unique_ptr<llvm::MemoryBuffer> buffer,
+                std::shared_ptr<llvm::cas::ObjectStore> cas)
+      : DataBufferLLVM(std::move(buffer)), m_cas(std::move(cas)) {}
+
+private:
+  /// Destroyed before the base class releases \c Buffer: safe, since the
+  /// aliasing MemoryBuffer's destructor never dereferences its bytes.
+  std::shared_ptr<llvm::cas::ObjectStore> m_cas;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_CORE_DATABUFFERCAS_H

--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -911,6 +911,26 @@ public:
 
   void ClearModuleDependentCaches();
 
+  // BEGIN CAS
+  /// Whether this module's object file is read straight out of a CAS memory
+  /// mapping, in which case the store cannot be released without destroying
+  /// the module.
+  bool WasLoadedFromCAS() const { return m_loaded_from_cas; }
+
+  enum class CASReleaseResult {
+    /// This module was not keeping a CAS alive.
+    NothingToRelease,
+    /// This module let go of its CAS and is still usable.
+    Released,
+    /// This module has to be destroyed to release its CAS.
+    MustBeDestroyed,
+  };
+
+  /// Drop what this module holds that keeps a CAS ObjectStore alive: the CAS
+  /// instances, and any CAS-backed state in its type systems.
+  CASReleaseResult ReleaseCASReferences();
+  // END CAS
+
   void SetTypeSystemMap(const TypeSystemMap &type_system_map) {
     m_type_system_map = type_system_map;
   }
@@ -1162,6 +1182,8 @@ protected:
   /// means that this module has no CAS associated with it.
   std::optional<std::vector<ModuleList::CAS>> m_cas;
   mutable std::mutex m_cas_init_mutex;
+
+  bool m_loaded_from_cas = false;
 
   // END CAS
 

--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -577,8 +577,10 @@ public:
   /// Find an initialize every CAS associated with \c module_sp.
   static void ConfigureCASStorage(const lldb::ModuleSP &module_sp);
 
-  /// Return a list of all CAS associated with \c module_sp.
-  static llvm::ArrayRef<CAS> GetCASStorage(const lldb::ModuleSP &module_sp);
+  /// Return all CAS associated with \c module_sp. Returns a copy: the caller's
+  /// shared_ptrs keep the stores alive for as long as it uses them, whatever
+  /// ReleaseObjectStore() does to the module in the meantime.
+  static std::vector<CAS> GetCASStorage(const lldb::ModuleSP &module_sp);
 
   /// Return the first CAS associated with \c module_sp whose
   /// ObjectStore resolves \c cas_id. Returns an error if no CAS
@@ -602,6 +604,18 @@ public:
                          llvm::StringRef name_for_diagnostics,
                          const lldb::ModuleSP &nearby, ModuleSpec &module_spec,
                          lldb::ModuleSP &module_sp);
+
+  /// Release every CAS ObjectStore that is no longer referenced.
+  ///
+  /// A module that only looked something up in a CAS lets go of the store and
+  /// is kept. A module that was loaded *out of* a CAS cannot let go, so it is
+  /// removed, along with whatever holds it -- but only if nothing else
+  /// references it. A process that never instantiated a CAS is left untouched.
+  ///
+  /// \return
+  ///    The number of CAS instances still referenced after this call. Each
+  ///    one is logged by path under the "modules" log channel.
+  static size_t ReleaseObjectStore();
   // END CAS
 
   static bool RemoveSharedModule(lldb::ModuleSP &module_sp);

--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -506,6 +506,19 @@ public:
   /// the module in the statistics.
   virtual ModuleList GetDebugInfoModules() { return ModuleList(); }
 
+  // BEGIN CAS
+  /// Get the modules that this symbol file holds a strong reference to.
+  virtual ModuleList GetLoadedReferencedModules() { return ModuleList(); }
+
+  /// Let go of the modules this symbol file loaded out of a CAS, so that the
+  /// store can be released without destroying this symbol file. They are
+  /// loaded again the next time something needs them.
+  ///
+  /// \return
+  ///     Whether every CAS-loaded module could be given up.
+  virtual bool ReleaseCASLoadedModules() { return true; }
+  // END CAS
+
   /// Accessors for the bool that indicates if the debug info index was loaded
   /// from, or saved to the module index cache.
   ///

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -92,6 +92,13 @@ public:
   /// removing all the TypeSystems from the TypeSystemMap.
   virtual void Finalize() {}
 
+  // BEGIN CAS
+  /// Drop what this type system holds that keeps a CAS ObjectStore alive. It
+  /// stays alive and usable, so whatever is dropped must be reconstructible on
+  /// demand.
+  virtual void ReleaseCASReferences() {}
+  // END CAS
+
   virtual plugin::dwarf::DWARFASTParser *GetDWARFParser() { return nullptr; }
 
   virtual PDBASTParser *GetPDBParser() { return nullptr; }

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -973,6 +973,16 @@ void Debugger::Destroy(DebuggerSP &debugger_sp) {
 
   debugger_sp->Clear();
 
+  // BEGIN CAS
+  // Drop every CAS object store that nothing needs any more, sparing whatever
+  // was only holding one. Modules are cached in the global shared module list
+  // and deliberately outlive the debugger that loaded them, so nothing else
+  // would drop this debugger's reference to a CAS. Without this,
+  // lldb-rpc-server -- which serves many sessions from one process -- would
+  // keep every session's CAS mapped for the life of the process.
+  ModuleList::ReleaseObjectStore();
+  // END CAS
+
   if (g_debugger_list_ptr && g_debugger_list_mutex_ptr) {
     std::lock_guard<std::recursive_mutex> guard(*g_debugger_list_mutex_ptr);
     DebuggerList::iterator pos, end = g_debugger_list_ptr->end();

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1822,6 +1822,56 @@ std::vector<DataBufferSP> Module::GetASTData(lldb::LanguageType language) {
 }
 // END SWIFT
 
+// BEGIN CAS
+Module::CASReleaseResult Module::ReleaseCASReferences() {
+  bool loaded_from_cas = false;
+  std::vector<ModuleList::CAS> released;
+  {
+    std::lock_guard<std::mutex> lock(m_cas_init_mutex);
+    loaded_from_cas = m_loaded_from_cas;
+    if (m_cas && !m_cas->empty()) {
+      released = std::move(*m_cas);
+      // Back to uninitialized, not to "no CAS": the configuration search runs
+      // again the next time this module needs one. An engaged but empty m_cas
+      // is a negative result worth keeping, so it is left alone.
+      //
+      // Letting go here, before draining the type systems below, is what keeps
+      // the two consistent: one created in the meantime looks a CAS up afresh
+      // rather than binding this vector after it was meant to be gone.
+      m_cas.reset();
+    }
+  }
+  if (released.empty() && !loaded_from_cas)
+    return CASReleaseResult::NothingToRelease;
+
+  // The type systems hold non-owning aliases into the store's memory, so they
+  // have to let go too. The copy above keeps it mapped until they have. Only
+  // already-created type systems are visited.
+  ForEachTypeSystem([](lldb::TypeSystemSP type_system_sp) {
+    if (type_system_sp)
+      type_system_sp->ReleaseCASReferences();
+    return true;
+  });
+
+  // Let go of the modules read out of the store, so that this module does not
+  // have to be destroyed along with them. Only an already-parsed symbol file is
+  // asked; one that does not exist yet holds nothing.
+  bool released_loaded_modules = true;
+  if (m_did_load_symfile)
+    if (SymbolFile *sym_file = GetSymbolFile())
+      released_loaded_modules = sym_file->ReleaseCASLoadedModules();
+
+  // MustBeDestroyed says releasing the store needs this module gone, not that
+  // the module is now unusable: a DataBufferCAS holds its own reference to the
+  // store, so the object file's bytes stay valid either way. If it turns out
+  // not to be orphaned it is left alone and the store is reported still
+  // referenced.
+  if (loaded_from_cas || !released_loaded_modules)
+    return CASReleaseResult::MustBeDestroyed;
+  return CASReleaseResult::Released;
+}
+// END CAS
+
 uint32_t Module::Hash() {
   std::string identifier;
   llvm::raw_string_ostream id_strm(identifier);

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -32,6 +32,7 @@
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-private-enumerations.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/ThreadPool.h"
@@ -1184,6 +1185,18 @@ public:
 
   std::recursive_mutex &GetMutex() const { return m_list.GetMutex(); }
 
+  // BEGIN CAS
+  /// The modules currently in the list, as weak references so that the snapshot
+  /// itself does not keep any of them alive.
+  std::vector<lldb::ModuleWP> SnapshotModules() const {
+    std::lock_guard<std::recursive_mutex> guard(GetMutex());
+    std::vector<lldb::ModuleWP> modules;
+    for (const ModuleSP &module_sp : m_list.ModulesNoLocking())
+      modules.push_back(module_sp);
+    return modules;
+  }
+  // END CAS
+
 private:
   ModuleSP FindModuleInMap(const Module &module) const {
     if (!module.GetFileSpec().GetFilename())
@@ -1655,15 +1668,16 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
 llvm::Expected<ModuleSpec> ModuleList::LoadModuleFromCAS(
     llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
     const ModuleSP &nearby, const UUID &uuid, const ArchSpec &arch) {
-  ConfigureCASStorage(nearby);
   if (!nearby) {
     LLDB_LOG(GetLog(LLDBLog::Modules),
              "Failed to load module '{0}' at '{1}' from CAS: no module",
              name_for_diagnostics, cas_id);
     return ModuleSpec();
   }
-  assert(nearby->m_cas && "ConfigureCASStorage should have populated m_cas");
-  if (nearby->m_cas->empty()) {
+  // A copy, so that a concurrent ReleaseObjectStore() cannot pull the stores
+  // out from under the loop below.
+  std::vector<CAS> all_cas = GetCASStorage(nearby);
+  if (all_cas.empty()) {
     LLDB_LOG(GetLog(LLDBLog::Modules),
              "Failed to load module '{0}' at '{1}' from CAS: no CAS "
              "associated with module",
@@ -1673,7 +1687,7 @@ llvm::Expected<ModuleSpec> ModuleList::LoadModuleFromCAS(
 
   // Try each CAS in turn; return on the first successful resolve.
   llvm::Error errors = llvm::Error::success();
-  for (const auto &entry : *nearby->m_cas) {
+  for (const auto &entry : all_cas) {
     const auto &cas = entry.object_store;
     if (!cas)
       continue;
@@ -1890,38 +1904,50 @@ FindOrCreateInSharedCache(const llvm::cas::CASConfiguration &cas_config,
 void ModuleList::ConfigureCASStorage(const ModuleSP &module_sp) {
   if (!module_sp)
     return;
-  std::lock_guard<std::mutex> module_lock(module_sp->m_cas_init_mutex);
-  std::optional<std::vector<ModuleList::CAS>> &module_cas = module_sp->m_cas;
-  if (module_cas)
-    return; // Already initialized.
+  {
+    std::lock_guard<std::mutex> module_lock(module_sp->m_cas_init_mutex);
+    if (module_sp->m_cas)
+      return; // Already initialized.
+  }
+
+  // Searching for the configurations reaches into the module's symbol file and
+  // so takes the module mutex, and a symbol file asks for a CAS with that mutex
+  // already held. Search without m_cas_init_mutex held, so the two orders
+  // cannot deadlock against each other.
   std::vector<llvm::cas::CASConfiguration> found =
       FindCASConfigurations(module_sp);
-  auto &entries = module_cas.emplace();
-  if (found.empty())
-    return;
-  auto &shared_module_list = GetSharedModuleListInfo();
-  std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
-  entries.reserve(found.size());
-  for (auto &cfg : found)
-    entries.push_back(FindOrCreateInSharedCache(cfg, shared_module_list));
+
+  std::vector<CAS> entries;
+  if (!found.empty()) {
+    auto &shared_module_list = GetSharedModuleListInfo();
+    std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
+    entries.reserve(found.size());
+    for (auto &cfg : found)
+      entries.push_back(FindOrCreateInSharedCache(cfg, shared_module_list));
+  }
+
+  std::lock_guard<std::mutex> module_lock(module_sp->m_cas_init_mutex);
+  // Another thread may have got there first. Its result is as good as this one:
+  // the shared cache hands out the same instance for the same configuration.
+  if (!module_sp->m_cas)
+    module_sp->m_cas = std::move(entries);
 }
 
-llvm::ArrayRef<ModuleList::CAS>
+std::vector<ModuleList::CAS>
 ModuleList::GetCASStorage(const ModuleSP &module_sp) {
   ConfigureCASStorage(module_sp);
   if (!module_sp)
     return {};
+  // Copied under the lock: ReleaseObjectStore() may reset m_cas concurrently,
+  // and the caller's shared_ptrs have to outlive that.
+  std::lock_guard<std::mutex> lock(module_sp->m_cas_init_mutex);
   assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
   return *module_sp->m_cas;
 }
 
 bool ModuleList::IsCASID(const ModuleSP &module_sp,
                          llvm::StringRef id) {
-  ConfigureCASStorage(module_sp);
-  if (!module_sp)
-    return false;
-  assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
-  for (const auto &entry : *module_sp->m_cas) {
+  for (const auto &entry : GetCASStorage(module_sp)) {
     if (!entry.object_store)
       continue;
     auto ref = entry.object_store->parseID(id);
@@ -1934,14 +1960,13 @@ bool ModuleList::IsCASID(const ModuleSP &module_sp,
 
 llvm::Expected<ModuleList::CAS>
 ModuleList::GetCASForID(const ModuleSP &module_sp, llvm::StringRef cas_id) {
-  ConfigureCASStorage(module_sp);
   if (!module_sp)
     return llvm::createStringError("no lldb::Module available");
-  assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
-  if (module_sp->m_cas->empty())
+  std::vector<CAS> all_cas = GetCASStorage(module_sp);
+  if (all_cas.empty())
     return llvm::createStringError("no CAS associated with module");
   llvm::Error errors = llvm::Error::success();
-  for (const auto &entry : *module_sp->m_cas) {
+  for (const auto &entry : all_cas) {
     if (!entry.object_store)
       continue;
     auto id = entry.object_store->parseID(cas_id);
@@ -1986,11 +2011,186 @@ llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
     if (module_sp) {
       std::lock_guard<std::mutex> dest_lock(module_sp->m_cas_init_mutex);
       module_sp->m_cas = nearby->m_cas;
+      // This module's object file is a non-owning alias into the store's
+      // memory, so it cannot outlive the store.
+      module_sp->m_loaded_from_cas = true;
     }
     return true;
   }
 
   return status.takeError();
+}
+
+size_t ModuleList::ReleaseObjectStore() {
+  Log *log = GetLog(LLDBLog::Modules | LLDBLog::Symbols);
+
+  // Bail out before touching any module lifetimes if this process never
+  // instantiated a CAS.
+  {
+    auto &shared_module_list = GetSharedModuleListInfo();
+    std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
+    bool any_live = false;
+    for (const auto &entry : shared_module_list.module_list.m_cas_cache) {
+      if (entry.second && !entry.second->object_store.expired()) {
+        any_live = true;
+        break;
+      }
+    }
+    if (!any_live)
+      return 0;
+  }
+
+  // Make every module that keeps a CAS alive let go of it. A module that must
+  // be destroyed for that has to be removed together with everything holding
+  // it, and a module can be held by one of the children of another Module
+  // rather than by the shared list. So walk the whole "is held by" graph
+  // reachable from the shared module list.
+  //
+  // Only unreferenced modules are removed: other debuggers may still be
+  // alive with targets holding these modules.
+  std::vector<ModuleWP> roots = GetSharedModuleList().SnapshotModules();
+
+  llvm::DenseSet<Module *> release_set;
+  llvm::DenseSet<Module *> kept_set;
+  llvm::DenseMap<Module *, llvm::SmallPtrSet<Module *, 4>> held_by;
+
+  // Enumerate what is reachable before touching anything. Only symbol files
+  // that are already parsed are asked: forcing one to load during teardown
+  // would be gratuitous work.
+  auto for_each_held = [](const ModuleSP &module_sp, auto &&fn) {
+    if (!module_sp->m_did_load_symfile)
+      return;
+    if (SymbolFile *sym_file = module_sp->GetSymbolFile())
+      sym_file->GetLoadedReferencedModules().ForEach(
+          [&](const ModuleSP &held_sp) {
+            fn(held_sp);
+            return IterationAction::Continue;
+          });
+  };
+
+  llvm::DenseSet<Module *> visited;
+  std::vector<ModuleWP> reachable;
+  {
+    std::vector<ModuleSP> worklist;
+    for (const ModuleWP &root_wp : roots)
+      if (ModuleSP root_sp = root_wp.lock())
+        if (visited.insert(root_sp.get()).second)
+          worklist.push_back(std::move(root_sp));
+    for (size_t idx = 0; idx < worklist.size(); ++idx) {
+      ModuleSP module_sp = worklist[idx];
+      reachable.push_back(module_sp);
+      for_each_held(module_sp, [&](const ModuleSP &held_sp) {
+        if (visited.insert(held_sp.get()).second)
+          worklist.push_back(held_sp);
+      });
+    }
+  }
+
+  // Now let every one of them go. A module that can let go of the store keeps
+  // its object file, symbol table and DWARF index; one that was read out of the
+  // store cannot, and neither can one that could not give up a module it read
+  // out of the store.
+  for (const ModuleWP &module_wp : reachable) {
+    ModuleSP module_sp = module_wp.lock();
+    if (!module_sp)
+      continue;
+    switch (module_sp->ReleaseCASReferences()) {
+    case Module::CASReleaseResult::NothingToRelease:
+      break;
+    case Module::CASReleaseResult::Released:
+      kept_set.insert(module_sp.get());
+      break;
+    case Module::CASReleaseResult::MustBeDestroyed:
+      release_set.insert(module_sp.get());
+      break;
+    }
+  }
+
+  // Collect the "is held by" edges that survived, so that the propagation below
+  // does not drag in a holder that has already given the module up.
+  for (const ModuleWP &module_wp : reachable) {
+    ModuleSP module_sp = module_wp.lock();
+    if (!module_sp)
+      continue;
+    for_each_held(module_sp, [&](const ModuleSP &held_sp) {
+      held_by[held_sp.get()].insert(module_sp.get());
+    });
+  }
+
+  // Propagate along those edges so that everything still keeping a CAS-backed
+  // module alive joins the set to remove.
+  std::vector<Module *> propagate(release_set.begin(), release_set.end());
+  while (!propagate.empty()) {
+    Module *module = propagate.back();
+    propagate.pop_back();
+    auto pos = held_by.find(module);
+    if (pos == held_by.end())
+      continue;
+    for (Module *holder : pos->second)
+      if (release_set.insert(holder).second)
+        propagate.push_back(holder);
+  }
+
+  // The propagation may have dragged a module that released in place into the
+  // removal set after all.
+  size_t kept_modules = 0;
+  for (Module *module : kept_set)
+    if (!release_set.contains(module))
+      ++kept_modules;
+
+  // Removing a holder can make the module it held unreferenced, so iterate
+  // removing modules until a fixed point is reached.
+  size_t removed_modules = 0;
+  bool made_progress = true;
+  while (made_progress) {
+    made_progress = false;
+    for (const ModuleWP &root_wp : roots) {
+      if (root_wp.expired())
+        continue;
+      {
+        // Scoped so the ModuleSP is gone before the orphan check below, which
+        // an extra reference would defeat.
+        ModuleSP root_sp = root_wp.lock();
+        if (!root_sp || !release_set.contains(root_sp.get()))
+          continue;
+      }
+      if (RemoveSharedModuleIfOrphaned(root_wp)) {
+        ++removed_modules;
+        made_progress = true;
+      }
+    }
+  }
+
+  // Now report: forget the stores that are really gone, and name the ones
+  // that are not. A non-zero result means something still holds a reference.
+  auto &shared_module_list = GetSharedModuleListInfo();
+  std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
+  auto &cas_cache = shared_module_list.module_list.m_cas_cache;
+
+  llvm::SmallVector<llvm::cas::CASConfiguration, 4> released;
+  size_t still_referenced = 0;
+  for (const auto &entry : cas_cache) {
+    // A disengaged optional is a negative cache entry for a CAS that failed
+    // to instantiate. Leave it be.
+    if (!entry.second)
+      continue;
+    if (entry.second->object_store.expired() &&
+        entry.second->action_cache.expired()) {
+      released.push_back(entry.first);
+      continue;
+    }
+    ++still_referenced;
+    LLDB_LOG(log, "CAS at {0} is still referenced", entry.first.CASPath);
+  }
+  for (const auto &config : released) {
+    cas_cache.erase(config);
+    LLDB_LOG(log, "Released CAS at {0}", config.CASPath);
+  }
+  LLDB_LOG(log,
+           "Released object stores: {0} module(s) kept, {1} module(s) removed, "
+           "{2} released, {3} still referenced",
+           kept_modules, removed_modules, released.size(), still_referenced);
+  return still_referenced;
 }
 
 bool ModuleList::RemoveSharedModule(lldb::ModuleSP &module_sp) {

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Core/ModuleList.h"
+#include "lldb/Core/DataBufferCAS.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleSpec.h"
@@ -1690,7 +1691,7 @@ llvm::Expected<ModuleSpec> ModuleList::LoadModuleFromCAS(
       continue;
     }
     auto file_buffer =
-        std::make_shared<DataBufferLLVM>(module_proxy->getMemoryBuffer());
+        std::make_shared<DataBufferCAS>(module_proxy->getMemoryBuffer(), cas);
     FileSpec cas_spec;
     cas_spec.SetDirectory(ConstString(entry.configuration.CASPath));
     cas_spec.SetFilename(ConstString(cas_id));

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1054,6 +1054,15 @@ void ClangASTImporter::ForgetSource(clang::ASTContext *dst_ast,
   md->removeOriginsWithContext(src_ast);
 }
 
+// BEGIN CAS
+bool ClangASTImporter::HasImportedFrom(clang::ASTContext *src_ast) const {
+  return llvm::any_of(m_metadata_map, [src_ast](const auto &entry) {
+    return entry.second->m_delegates.contains(src_ast) ||
+           entry.second->hasOriginsWithContext(src_ast);
+  });
+}
+// END CAS
+
 ClangASTImporter::MapCompleter::~MapCompleter() = default;
 
 llvm::Expected<Decl *>

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.h
@@ -243,6 +243,14 @@ public:
   void ForgetDestination(clang::ASTContext *dst_ctx);
   void ForgetSource(clang::ASTContext *dst_ctx, clang::ASTContext *src_ctx);
 
+  // BEGIN CAS
+  /// Whether anything imported through this importer still depends on
+  /// \c src_ctx, either through an importer delegate or through a decl that may
+  /// still have to be completed out of it. If nothing does, destroying
+  /// \c src_ctx leaves nothing dangling behind.
+  bool HasImportedFrom(clang::ASTContext *src_ctx) const;
+  // END CAS
+
   struct DeclOrigin {
     DeclOrigin() = default;
 
@@ -396,6 +404,16 @@ public:
           ++iter;
       }
     }
+
+    // BEGIN CAS
+    /// Whether any DeclOrigin points to the given ASTContext, i.e. whether a
+    /// decl imported from it may still have to be completed out of it.
+    bool hasOriginsWithContext(clang::ASTContext *ctx) const {
+      return llvm::any_of(m_origins, [ctx](const auto &entry) {
+        return entry.second.ctx == ctx;
+      });
+    }
+    // END CAS
 
     /// Returns the DeclOrigin for the given Decl or an invalid DeclOrigin
     /// instance if there no known DeclOrigin for the given Decl.

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1070,7 +1070,12 @@ bool SymbolFileDWARF::ForEachExternalModule(
     return false;
 
   UpdateExternalModuleListIfNeeded();
-  for (auto &p : m_external_type_modules) {
+  ExternalTypeModuleMap external_type_modules;
+  {
+    std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
+    external_type_modules = m_external_type_modules;
+  }
+  for (auto &p : external_type_modules) {
     ModuleSP module = p.second;
     if (!module)
       continue;
@@ -1714,11 +1719,112 @@ bool SymbolFileDWARF::GetFunction(const DWARFDIE &die, SymbolContext &sc) {
 
 lldb::ModuleSP SymbolFileDWARF::GetExternalModule(ConstString name) {
   UpdateExternalModuleListIfNeeded();
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   const auto &pos = m_external_type_modules.find(name);
   if (pos == m_external_type_modules.end())
     return lldb::ModuleSP();
   return pos->second;
 }
+
+// BEGIN CAS
+ModuleList SymbolFileDWARF::GetLoadedReferencedModules() {
+  // Deliberately does not call UpdateExternalModuleListIfNeeded(): this is
+  // asked during teardown, where loading anything new would be pointless.
+  ModuleList result;
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
+  auto append = [&result](const ExternalTypeModuleMap &external_type_modules) {
+    for (const auto &entry : external_type_modules)
+      if (entry.second)
+        result.AppendIfNeeded(entry.second);
+  };
+  append(m_external_type_modules);
+
+  // A split-DWARF unit's SymbolFileDWARFDwo imports its own clang modules and
+  // is not owned by any Module, so nothing else would report them.
+  // GetDwoSymbolFile(false) does not go looking for an unopened .dwo.
+  if (m_info)
+    for (size_t idx = 0, end = m_info->GetNumUnits(); idx < end; ++idx)
+      if (DWARFUnit *unit = m_info->GetUnitAtIndex(idx))
+        if (SymbolFileDWARFDwo *dwo_symfile =
+                unit->GetDwoSymbolFile(/*load_all_debug_info=*/false))
+          append(dwo_symfile->getExternalTypeModules());
+  return result;
+}
+
+bool SymbolFileDWARF::ReleaseCASLoadedModules() {
+  // A module can only be given up if nothing was imported out of its clang AST
+  // into an AST that survives. DWARFASTParserClang imports a forward
+  // declaration and completes it lazily out of the source ASTContext, and
+  // nothing re-establishes that link when the module is loaded again -- the
+  // type is already cached in GetDIEToType(). Destroying the source would leave
+  // either a dangling ASTContext or a permanently incomplete type.
+  //
+  // The AST that did the importing is the one GetTypeSystemForLanguage() hands
+  // out, which for a debug map .o belongs to the executable, not to the .o. A
+  // SymbolFileDWARFDwo forwards to its base symbol file, i.e. to this one.
+  ModuleSP importer_module_sp = GetObjectFile()->GetModule();
+  if (SymbolFileDWARFDebugMap *debug_map = GetDebugMapSymfile())
+    if (ObjectFile *debug_map_obj = debug_map->GetObjectFile())
+      importer_module_sp = debug_map_obj->GetModule();
+
+  auto is_imported_from = [&importer_module_sp](Module &loaded_module) -> bool {
+    clang::ASTContext *src_ast = nullptr;
+    loaded_module.ForEachTypeSystem([&](lldb::TypeSystemSP type_system_sp) {
+      if (auto *clang_ts =
+              llvm::dyn_cast_or_null<TypeSystemClang>(type_system_sp.get()))
+        src_ast = &clang_ts->getASTContext();
+      return !src_ast;
+    });
+    // No clang AST was ever built for it, so nothing can have been imported.
+    if (!src_ast)
+      return false;
+
+    bool imported = false;
+    importer_module_sp->ForEachTypeSystem([&](lldb::TypeSystemSP
+                                                 type_system_sp) {
+      if (!type_system_sp)
+        return true;
+      auto *parser = llvm::dyn_cast_or_null<DWARFASTParserClang>(
+          type_system_sp->GetDWARFParser());
+      if (parser && parser->GetClangASTImporter().HasImportedFrom(src_ast))
+        imported = true;
+      return !imported;
+    });
+    return imported;
+  };
+
+  bool released_everything = true;
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
+  auto release = [&](SymbolFileDWARF &dwarf) {
+    llvm::SmallVector<ConstString, 4> cas_loaded;
+    for (const auto &entry : dwarf.m_external_type_modules) {
+      if (!entry.second || !entry.second->WasLoadedFromCAS())
+        continue;
+      if (is_imported_from(*entry.second)) {
+        released_everything = false;
+        continue;
+      }
+      cas_loaded.push_back(entry.first);
+    }
+    if (cas_loaded.empty())
+      return;
+    for (ConstString name : cas_loaded)
+      dwarf.m_external_type_modules.erase(name);
+    // Re-run the DW_AT_dwo_name walk on the next access. The entries that were
+    // not erased are left alone by UpdateExternalModuleListIfNeeded().
+    dwarf.m_fetched_external_modules = false;
+  };
+
+  release(*this);
+  if (m_info)
+    for (size_t idx = 0, end = m_info->GetNumUnits(); idx < end; ++idx)
+      if (DWARFUnit *unit = m_info->GetUnitAtIndex(idx))
+        if (SymbolFileDWARFDwo *dwo_symfile =
+                unit->GetDwoSymbolFile(/*load_all_debug_info=*/false))
+          release(*dwo_symfile);
+  return released_everything;
+}
+// END CAS
 
 SymbolFileDWARF *SymbolFileDWARF::GetDIERefSymbolFile(const DIERef &die_ref) {
   // Anytime we get a "lldb::user_id_t" from an lldb_private::SymbolFile API we
@@ -1977,6 +2083,12 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
 }
 
 void SymbolFileDWARF::UpdateExternalModuleListIfNeeded() {
+  // BEGIN CAS
+  // m_external_type_modules is written here and read by GetExternalModule() and
+  // ForEachExternalModule(); ReleaseCASLoadedModules() also erases from it, on a
+  // teardown thread. Guard all of them with the module mutex.
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
+  // END CAS
   if (m_fetched_external_modules)
     return;
   m_fetched_external_modules = true;

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -252,6 +252,13 @@ public:
 
   typedef std::map<ConstString, lldb::ModuleSP> ExternalTypeModuleMap;
 
+  // BEGIN CAS
+  /// The external type modules -- the clang modules this symbol file loaded for
+  /// -gmodules debug info -- are kept alive by this symbol file.
+  ModuleList GetLoadedReferencedModules() override;
+  bool ReleaseCASLoadedModules() override;
+  // END CAS
+
   /// Return the list of Clang modules imported by this SymbolFile.
   const ExternalTypeModuleMap &getExternalTypeModules() const {
     return m_external_type_modules;

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1657,6 +1657,18 @@ SymbolFileDWARFDebugMap::GetASTData(lldb::LanguageType language) {
   return ast_datas;
 }
 
+// BEGIN CAS
+ModuleList SymbolFileDWARFDebugMap::GetLoadedReferencedModules() {
+  // Unlike GetDebugInfoModules(), this must not parse anything: report the .o
+  // modules that have already been loaded and nothing more.
+  ModuleList oso_modules;
+  for (const CompileUnitInfo &comp_unit_info : m_compile_unit_infos)
+    if (comp_unit_info.oso_sp && comp_unit_info.oso_sp->module_sp)
+      oso_modules.AppendIfNeeded(comp_unit_info.oso_sp->module_sp);
+  return oso_modules;
+}
+// END CAS
+
 ModuleList SymbolFileDWARFDebugMap::GetDebugInfoModules() {
   ModuleList oso_modules;
   ForEachSymbolFile("Parsing modules", [&](SymbolFileDWARF &oso_dwarf) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
@@ -154,6 +154,12 @@ public:
   // Statistics overrides.
   ModuleList GetDebugInfoModules() override;
 
+  // BEGIN CAS
+  /// The .o files backing this debug map are kept alive by this symbol file.
+  /// Only the ones that have already been loaded are reported.
+  ModuleList GetLoadedReferencedModules() override;
+  // END CAS
+
   void
   GetCompileOptions(std::unordered_map<lldb::CompUnitSP, Args> &args) override;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -935,8 +935,7 @@ static std::string GetClangModulesCacheProperty() {
 }
 
 void SwiftASTContext::ConfigureDefaultCASStorage(const ModuleSP &module_sp) {
-  llvm::ArrayRef<ModuleList::CAS> all_cas =
-      ModuleList::GetCASStorage(module_sp);
+  std::vector<ModuleList::CAS> all_cas = ModuleList::GetCASStorage(module_sp);
   if (all_cas.empty()) {
     HEALTH_LOG_PRINTF("Did not create CAS: no CAS associated with module");
     return;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -995,6 +995,16 @@ protected:
   /// Data members.
   /// @{
   std::weak_ptr<TypeSystemSwiftTypeRef> m_typeref_typesystem;
+  // BEGIN CAS
+  /// ObjectStore and ActionCache. Like the CompilerInvocation, SourceMgr and
+  /// DiagEngine below, these must come before the ASTContext so they get
+  /// deallocated *after* it. The ObjectStore owns the memory backing the
+  /// serialized module buffers held by the AST's module loaders, the
+  /// include-tree VFS installed on the SourceMgr, and the PCH handed to
+  /// ClangImporter; releasing it first would leave all of those dangling.
+  std::shared_ptr<llvm::cas::ObjectStore> m_cas;
+  std::shared_ptr<llvm::cas::ActionCache> m_action_cache;
+  // END CAS
   std::unique_ptr<swift::CompilerInvocation> m_compiler_invocation_up;
   std::unique_ptr<swift::SourceManager> m_source_manager_up;
   std::unique_ptr<swift::DiagnosticEngine> m_diagnostic_engine_up;
@@ -1042,9 +1052,6 @@ protected:
       library_load_cache;
   /// A cache for GetCompileUnitImports();
   llvm::DenseSet<std::pair<Module *, lldb::user_id_t>> m_cu_imports;
-  /// ObjectStore and ActionCache;
-  std::shared_ptr<llvm::cas::ObjectStore> m_cas;
-  std::shared_ptr<llvm::cas::ActionCache> m_action_cache;
 
   typedef std::map<Module *, std::vector<lldb::DataBufferSP>> ASTFileDataMap;
   ASTFileDataMap m_ast_file_data_map;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2827,6 +2827,29 @@ void TypeSystemSwiftTypeRef::ClearModuleDependentCaches() {
   });
 }
 
+// BEGIN CAS
+void TypeSystemSwiftTypeRef::ReleaseCASReferences() {
+  std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
+  llvm::SmallVector<const char *, 4> keys;
+  for (auto &it : m_swift_ast_context_map) {
+    auto *swift_ast_ctx =
+        llvm::dyn_cast_or_null<SwiftASTContext>(it.second.typesystem.get());
+    if (swift_ast_ctx && swift_ast_ctx->HasCAS())
+      keys.push_back(it.first);
+  }
+  // Erasing the last shared_ptr is not necessarily what destroys the context:
+  // a client still holding a CompilerType keeps it, and thus the CAS, alive.
+  // ModuleList::ReleaseObjectStore() reports such a straggler.
+  for (const char *key : keys) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "{0}::ReleaseCASReferences() -- discarding CAS-backed "
+             "SwiftASTContext '{1}'",
+             m_description, key ? key : "");
+    m_swift_ast_context_map.erase(key);
+  }
+}
+// END CAS
+
 const char *
 TypeSystemSwiftTypeRef::AsMangledName(opaque_compiler_type_t type) const {
   if (IsFrameBoundType(type)) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -116,6 +116,12 @@ public:
   llvm::Triple GetTriple() const;
   void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override;
   void ClearModuleDependentCaches() override;
+  // BEGIN CAS
+  /// A SwiftASTContext's AST is built out of CAS-owned memory, so letting go of
+  /// the store means letting go of the context. Discards every SwiftASTContext
+  /// that holds one; a fresh one is created on the next GetSwiftASTContext().
+  void ReleaseCASReferences() override;
+  // END CAS
   lldb::TargetWP GetTargetWP() const override { return {}; }
 
   /// Return a SwiftASTContext type for type.

--- a/lldb/test/API/functionalities/cas/gmodules/Makefile
+++ b/lldb/test/API/functionalities/cas/gmodules/Makefile
@@ -1,0 +1,42 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS = -g -I$(SRCDIR)
+LD_EXTRAS = $(BUILDDIR)/cached/libcached.dylib $(BUILDDIR)/uncached/libuncached.dylib
+
+all: a.out
+
+include Makefile.rules
+
+# Two dylibs built from the same headers. The cached one is compiled through
+# the explicit-module driver with a CAS, so its DWARF refers to the .pcm by
+# CASID; the uncached one is built the ordinary way, so its DWARF refers to the
+# .pcm by path. Both get a .cas-config next to them pointing at a CAS of their
+# own, so both resolve to a CAS -- but only the cached one loads a module out of
+# one.
+#
+# Built with explicit rules rather than DYLIB_C_SOURCES because the cached
+# dylib needs a bespoke compile step and neither may be run through dsymutil:
+# that would resolve the -gmodules references and there would be no module
+# left to load out of the CAS.
+
+CAS_DIR = $(BUILDDIR)/cached
+NOCAS_DIR = $(BUILDDIR)/uncached
+MODULE_FLAGS = -fmodules -gmodules -I$(SRCDIR)
+LINK_FLAGS = $(SYSROOT_FLAGS) $(ARCHFLAG) $(ARCH)
+EXPLICIT_MODULE_BUILD = $(LLDB_BASE_DIR)/scripts/clang-explicit-module-build.py
+
+a.out: $(CAS_DIR)/libcached.dylib $(NOCAS_DIR)/libuncached.dylib
+
+$(CAS_DIR)/libcached.dylib: $(SRCDIR)/cached.c
+	mkdir -p $(CAS_DIR)
+	echo '{"CASPath": "$(CAS_DIR)/cas"}' > $(CAS_DIR)/.cas-config
+	python3 $(EXPLICIT_MODULE_BUILD) -cas-path $(CAS_DIR)/cas -- \
+	  $(CC) -c -g $(MODULE_FLAGS) -fmodules-cache-path=$(CAS_DIR)/module-cache \
+	  -o $(CAS_DIR)/cached.o $(SRCDIR)/cached.c
+	$(CC) -dynamiclib -g $(LINK_FLAGS) $(CAS_DIR)/cached.o -o $@
+
+$(NOCAS_DIR)/libuncached.dylib: $(SRCDIR)/uncached.c
+	mkdir -p $(NOCAS_DIR)
+	echo '{"CASPath": "$(NOCAS_DIR)/cas"}' > $(NOCAS_DIR)/.cas-config
+	$(CC) -c -g $(MODULE_FLAGS) -fmodules-cache-path=$(NOCAS_DIR)/module-cache \
+	  -o $(NOCAS_DIR)/uncached.o $(SRCDIR)/uncached.c
+	$(CC) -dynamiclib -g $(LINK_FLAGS) $(NOCAS_DIR)/uncached.o -o $@

--- a/lldb/test/API/functionalities/cas/gmodules/TestCASReleaseObjectStore.py
+++ b/lldb/test/API/functionalities/cas/gmodules/TestCASReleaseObjectStore.py
@@ -1,0 +1,112 @@
+"""
+Test that CAS object stores are released once nothing references the modules
+that were loaded out of them.
+"""
+
+import re
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCASReleaseObjectStore(TestBase):
+    def load_both_modules(self, target):
+        """Stop in each dylib and evaluate an expression there, so that both
+        SymbolFiles import their clang module -- one out of the CAS, one from a
+        .pcm on disk."""
+        for source, pattern, expected in [
+            ("cached.c", "BREAK CACHED", "x = 41"),
+            ("uncached.c", "BREAK UNCACHED", "y = 17"),
+        ]:
+            bkpt = target.BreakpointCreateBySourceRegex(
+                pattern, lldb.SBFileSpec(source)
+            )
+            self.assertEqual(bkpt.GetNumLocations(), 1, source)
+
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertState(process.GetState(), lldb.eStateStopped)
+
+        for variable, expected in [("c", "x = 41"), ("u", "y = 17")]:
+            frame = process.GetSelectedThread().GetFrameAtIndex(0)
+            value = frame.EvaluateExpression(variable)
+            self.assertSuccess(value.GetError(), "evaluating '%s'" % variable)
+            self.assertIn(expected, str(value))
+            process.Continue()
+
+        return process
+
+    def debug_in_a_fresh_debugger(self, executable, log_path):
+        """Debug `executable` in a debugger of our own -- the test's primary
+        debugger would keep the modules alive -- capturing the module log,
+        then destroy that debugger. Returns the log contents."""
+        debugger = lldb.SBDebugger.Create()
+        try:
+            debugger.SetAsync(False)
+            result = lldb.SBCommandReturnObject()
+            debugger.GetCommandInterpreter().HandleCommand(
+                'log enable lldb module -f "%s"' % log_path, result
+            )
+            self.assertTrue(result.Succeeded(), result.GetError())
+
+            target = debugger.CreateTarget(executable)
+            self.assertTrue(target.IsValid())
+            self.load_both_modules(target)
+        finally:
+            lldb.SBDebugger.Destroy(debugger)
+
+        with open(log_path, "r") as f:
+            return f.read()
+
+    def assertModuleConstructed(self, log_contents, path, msg=None):
+        pattern = r"Module::Module\(\(.*?\) '%s'\)" % re.escape(path)
+        self.assertRegex(log_contents, pattern, msg)
+
+    def assertModuleNotConstructed(self, log_contents, path, msg=None):
+        pattern = r"Module::Module\(\(.*?\) '%s'\)" % re.escape(path)
+        self.assertNotRegex(log_contents, pattern, msg)
+
+    @skipUnlessDarwin
+    def test_release_on_debugger_destroy(self):
+        """Destroying a debugger releases its CAS object stores. A module that
+        only looked something up in a CAS is kept; only a module that was
+        loaded out of one, and whatever holds it, is removed. Debugging the
+        same binary again works, and reloads and reparses only the modules that
+        were removed -- everything else is reused."""
+        self.build()
+        executable = self.getBuildArtifact("a.out")
+
+        first_log = self.debug_in_a_fresh_debugger(
+            executable, self.getBuildArtifact("first_session.log")
+        )
+        self.assertIn("Released CAS at", first_log)
+        # Both dylibs resolve to a CAS of their own and both stores are
+        # released, but only the cached dylib loaded a module out of its CAS.
+        self.assertIn(
+            "Released object stores: 1 module(s) kept, 2 module(s) removed, "
+            "2 released, 0 still referenced",
+            first_log,
+        )
+
+        # Debug the same binary again in a new debugger. This must still
+        # work, and the log tells us what got rebuilt in the process.
+        second_log = self.debug_in_a_fresh_debugger(
+            executable, self.getBuildArtifact("second_session.log")
+        )
+
+        cached_dylib = self.getBuildArtifact("cached/libcached.dylib")
+        uncached_dylib = self.getBuildArtifact("uncached/libuncached.dylib")
+
+        # The cached dylib's Module, and the clang module loaded out of the
+        # CAS, were both removed, so both are constructed afresh and their
+        # debug info is reparsed to satisfy the new breakpoint and expression.
+        self.assertModuleConstructed(second_log, cached_dylib)
+        self.assertIn("Loading module 'Cached' from CAS at", second_log)
+        self.assertIn("Initialized CAS at", second_log)
+
+        # The uncached dylib and the executable were never removed. Their
+        # Module objects, and the SymbolFile that already parsed their debug
+        # info the first time, are reused rather than rebuilt from scratch.
+        self.assertModuleNotConstructed(second_log, uncached_dylib)
+        self.assertModuleNotConstructed(second_log, executable)

--- a/lldb/test/API/functionalities/cas/gmodules/cached.c
+++ b/lldb/test/API/functionalities/cas/gmodules/cached.c
@@ -1,0 +1,7 @@
+#include "cached.h"
+
+int cached_fn(void) {
+  struct Cached c;
+  c.x = 41;
+  return c.x; // BREAK CACHED
+}

--- a/lldb/test/API/functionalities/cas/gmodules/cached.h
+++ b/lldb/test/API/functionalities/cas/gmodules/cached.h
@@ -1,0 +1,2 @@
+#pragma once
+struct Cached { int x; };

--- a/lldb/test/API/functionalities/cas/gmodules/main.c
+++ b/lldb/test/API/functionalities/cas/gmodules/main.c
@@ -1,0 +1,4 @@
+int cached_fn(void);
+int uncached_fn(void);
+
+int main(void) { return cached_fn() + uncached_fn() - 58; }

--- a/lldb/test/API/functionalities/cas/gmodules/module.modulemap
+++ b/lldb/test/API/functionalities/cas/gmodules/module.modulemap
@@ -1,0 +1,2 @@
+module Cached { header "cached.h" export * }
+module Uncached { header "uncached.h" export * }

--- a/lldb/test/API/functionalities/cas/gmodules/uncached.c
+++ b/lldb/test/API/functionalities/cas/gmodules/uncached.c
@@ -1,0 +1,7 @@
+#include "uncached.h"
+
+int uncached_fn(void) {
+  struct Uncached u;
+  u.y = 17;
+  return u.y; // BREAK UNCACHED
+}

--- a/lldb/test/API/functionalities/cas/gmodules/uncached.h
+++ b/lldb/test/API/functionalities/cas/gmodules/uncached.h
@@ -1,0 +1,2 @@
+#pragma once
+struct Uncached { int y; };

--- a/lldb/test/API/functionalities/cas/swift/Makefile
+++ b/lldb/test/API/functionalities/cas/swift/Makefile
@@ -1,0 +1,13 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_COMPILE_CACHE := YES
+# Without a .swiftmodule next to the binary, the SwiftASTContext has to load
+# the module out of the CAS, which is the reference we want released.
+HIDE_SWIFTMODULE := YES
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR)
+
+all: a.out cas-config
+
+include Makefile.rules
+
+cas-config:
+	echo "{\"CASPath\": \"$(BUILDDIR)/cas\"}" > .cas-config

--- a/lldb/test/API/functionalities/cas/swift/TestSwiftCASReleaseObjectStore.py
+++ b/lldb/test/API/functionalities/cas/swift/TestSwiftCASReleaseObjectStore.py
@@ -1,0 +1,130 @@
+"""
+Test that a Swift debug session releases its CAS object store when the debugger
+is destroyed, and gives up as little as it can to do so: a SwiftASTContext is
+rebuilt on demand, an lldb Module's symbol table and DWARF index are not.
+"""
+
+import re
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftCASReleaseObjectStore(TestBase):
+    def debug_in_a_fresh_debugger(self, executable, log_path):
+        """Debug `executable` in a debugger of our own -- the test's primary
+        debugger would keep the modules alive -- evaluate an expression that
+        needs the CAS-backed Swift module, then destroy that debugger. Returns
+        the log contents."""
+        debugger = lldb.SBDebugger.Create()
+        try:
+            debugger.SetAsync(False)
+            result = lldb.SBCommandReturnObject()
+            debugger.GetCommandInterpreter().HandleCommand(
+                'log enable lldb module -f "%s"' % log_path, result
+            )
+            self.assertTrue(result.Succeeded(), result.GetError())
+
+            target = debugger.CreateTarget(executable)
+            self.assertTrue(target.IsValid())
+
+            breakpoint = target.BreakpointCreateBySourceRegex(
+                "break here", lldb.SBFileSpec("main.swift")
+            )
+            self.assertEqual(breakpoint.GetNumLocations(), 1)
+
+            process = target.LaunchSimple(
+                None, None, self.get_process_working_directory()
+            )
+            self.assertState(process.GetState(), lldb.eStateStopped)
+
+            frame = process.GetSelectedThread().GetFrameAtIndex(0)
+            value = frame.EvaluateExpression("obj")
+            self.assertSuccess(value.GetError(), "evaluating 'obj'")
+            self.assertIn("x = 0", str(value))
+
+            # The Swift module was hidden from the filesystem, so the context
+            # that just answered this can only have loaded it out of the CAS.
+            self.assertTrue(
+                frame.GetLanguageSpecificData()
+                .GetValueForKey("SwiftHasCAS")
+                .GetBooleanValue()
+            )
+        finally:
+            lldb.SBDebugger.Destroy(debugger)
+
+        with open(log_path, "r") as f:
+            return f.read()
+
+    def assertModuleNotConstructed(self, log_contents, path, msg=None):
+        pattern = r"Module::Module\(\(.*?\) '%s'\)" % re.escape(path)
+        self.assertNotRegex(log_contents, pattern, msg)
+
+    def countModulesConstructed(self, log_contents):
+        return len(re.findall(r"Module::Module\(", log_contents))
+
+    @skipEmbeddedSwift
+    # Don't run ClangImporter tests if ClangImporter is disabled.
+    @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
+    @skipIf(setting=("symbols.swift-precise-compiler-invocation", "false"))
+    @skipUnlessDarwin
+    @swiftTest
+    def test_release_on_debugger_destroy(self):
+        """Destroying a debugger releases the CAS its SwiftASTContext loaded
+        modules out of, and debugging the same binary again evaluates the same
+        expression out of a store that has to be instantiated again."""
+        self.build()
+        executable = self.getBuildArtifact("a.out")
+
+        first_log = self.debug_in_a_fresh_debugger(
+            executable, self.getBuildArtifact("first_session.log")
+        )
+        self.assertIn("Released CAS at", first_log)
+        self.assertIn("0 still referenced", first_log)
+
+        # How much this costs depends on the debug info format. With a dSYM,
+        # dsymutil has resolved the -gmodules references, so the store is only
+        # held by the SwiftASTContext and Module::m_cas, and nothing at all has
+        # to be evicted. Without one, main.swift.o is read through a debug map
+        # and its DWARF still refers to the clang modules of the explicit module
+        # build by CASID, so those are read out of the store and have to go --
+        # but nothing imported clang types out of them, so main.swift.o gives
+        # them up and it and the executable are still kept.
+        if self.getDebugInfo() == "dsym":
+            self.assertRegex(
+                first_log,
+                r"Released object stores: [1-9][0-9]* module\(s\) kept, "
+                r"0 module\(s\) removed,",
+            )
+        else:
+            self.assertIn("Loading module 'ClangA' from CAS at", first_log)
+            self.assertRegex(
+                first_log,
+                r"Released object stores: [1-9][0-9]* module\(s\) kept, "
+                r"[1-9][0-9]* module\(s\) removed,",
+            )
+
+        # Debug the same binary again. The expression has to produce the same
+        # answer out of a CAS that has to be instantiated again -- both asserted
+        # in debug_in_a_fresh_debugger().
+        second_log = self.debug_in_a_fresh_debugger(
+            executable, self.getBuildArtifact("second_session.log")
+        )
+        self.assertIn("Initialized CAS at", second_log)
+
+        # Whatever was not removed is reused rather than rebuilt: no ObjectFile,
+        # symbol table or DWARF index is reconstructed for it. Compared by order
+        # of magnitude, since the exact count depends on what the OS loads.
+        first_modules = self.countModulesConstructed(first_log)
+        second_modules = self.countModulesConstructed(second_log)
+        self.assertGreater(first_modules, 10, "first session built the world")
+        self.assertLess(
+            second_modules,
+            first_modules // 10,
+            "second session rebuilt %d of the first session's %d module(s)"
+            % (second_modules, first_modules),
+        )
+        # The executable is kept in both formats, so it is never rebuilt.
+        self.assertModuleNotConstructed(second_log, executable)

--- a/lldb/test/API/functionalities/cas/swift/a.h
+++ b/lldb/test/API/functionalities/cas/swift/a.h
@@ -1,0 +1,3 @@
+struct A {
+  int x;
+};

--- a/lldb/test/API/functionalities/cas/swift/main.swift
+++ b/lldb/test/API/functionalities/cas/swift/main.swift
@@ -1,0 +1,4 @@
+import ClangA
+
+let obj = A()
+print("break here \(obj)")

--- a/lldb/test/API/functionalities/cas/swift/module.modulemap
+++ b/lldb/test/API/functionalities/cas/swift/module.modulemap
@@ -1,0 +1,3 @@
+module ClangA {
+  header "a.h"
+}

--- a/lldb/test/Shell/SymbolFile/cas-gmodule.test
+++ b/lldb/test/Shell/SymbolFile/cas-gmodule.test
@@ -31,6 +31,11 @@
 # CHECK: Initialized CAS at [[CAS]]
 # CHECK: Loading module 'Top' from CAS at
 
+# Destroying the debugger releases the CAS-backed modules, which drops the
+# last references to the CAS. Nothing may still be holding on to it.
+# CHECK: Released CAS at [[CAS]]
+# CHECK: {{[0-9]+}} released, 0 still referenced
+
 # NONCAS-NOT: is not valid CASID
 # NONCAS: Unable to locate module needed for external types
 


### PR DESCRIPTION
lldb-rpc-server holds a CAS `ObjectStore` alive for the lifetime of the
process, keeping the on-disk database mapped and its lock held, which
prevents CAS pruning. A CAS is created lazily per session, so a server
serving many sessions accumulates one per session and never lets go.

The store is kept alive by state that a finished session leaves behind, much of
it in modules. Those live in the global shared module list, which deliberately
outlives the debugger that loaded them, and nothing dropped them at session
teardown: `RemoveOrphanSharedModules()` was only reachable through
`SBDebugger::MemoryPressureDetected()`,
`SBModule::GarbageCollectAllocatedModules()` and `target delete --clean`.
In the `lldb` driver this is invisible because the process exits right
afterwards.

Three changes:

1. **Keep the store alive for as long as its buffers are readable.**
   `ObjectStore::getMemoryBuffer()` does not copy: it returns a non-owning
   `MemoryBuffer` aliasing storage owned by the store, which for an on-disk
   CAS is a mapping of the database. `LoadModuleFromCAS()` handed such a
   buffer to a module's `ObjectFile` while the only reference to the store
   lived in `Module::m_cas`, declared *after* `m_extractor_sp` and
   `m_objfile_sp` — so `~Module` released the store before destroying the
   object file still pointing into it. A new `DataBufferCAS` holds a
   reference to the store backing its bytes. Still an alias; nothing copied.

2. **Destroy a `SwiftASTContext`'s CAS after the AST that points into it.**
   `m_cas`/`m_action_cache` were declared after `m_source_manager_up` and
   `m_ast_context_up`, so `~SwiftASTContext` released the store before
   destroying the AST that still referenced it — the serialized module
   buffers held by the module loaders, the include-tree VFS on the
   `SourceManager`, and the PCH given to `ClangImporter`. Masked only
   because `LLDBExplicitSwiftModuleLoader`, owned by that `ASTContext`,
   holds a second reference; the mask disappears when the explicit module
   loader is off but the PCH or VFS still come from the CAS. Moved up next
   to the `CompilerInvocation`, `SourceMgr` and `DiagEngine`, which already
   carry the same invariant.

3. **Actually release the store.** `ModuleList::ReleaseObjectStore()`, called
   at the end of `Debugger::Destroy()` once `Clear()` has torn down the targets.
   It returns immediately, without touching any module, when no CAS was ever
   instantiated, so sessions that do not use a CAS see no change in module
   lifetimes.

Releasing the store means finding everything that references it, which is more
than the modules that were loaded out of one — and most of it can be given up
without evicting anything:

- `Module::m_cas` is populated on every module that ever *asked* for a CAS, not
  only on those that read something out of one; for Swift that is every module
  with a `SwiftASTContext`. It is a lookup cache, so
  `Module::ReleaseCASReferences()` resets it to uninitialized and the
  configuration search runs again on the next access.

- A `SwiftASTContext`'s AST is built out of CAS-owned memory — the serialized
  module buffers, the include-tree VFS, the PCH — so the store cannot be
  released without discarding the context. `TypeSystem::ReleaseCASReferences()`
  lets a type system drop such state; `TypeSystemSwiftTypeRef` discards every
  `SwiftASTContext` that holds a CAS and builds a fresh one on demand, keeping
  itself and its own caches. Erasing an entry from `m_swift_ast_context_map` is
  what the fatal-error retry path already does.

- A module loaded *out of* a CAS reads its object file straight out of the
  store's memory mapping and cannot let go, so it has to be destroyed. Its
  holder can often be spared, though:
  `SymbolFile::ReleaseCASLoadedModules()` drops such a module from
  `SymbolFileDWARF::m_external_type_modules` and resets
  `m_fetched_external_modules`, so the `DW_AT_dwo_name` walk runs again and
  reloads it on the next access.

That last one is only safe when nothing was imported out of the module's clang
AST into an AST that survives. `ParseTypeFromClangModule()` imports a forward
declaration through `ClangASTImporter` and completes it lazily from the source
`ASTContext`; nothing calls `ForgetSource()` when a `TypeSystemClang` is
destroyed, and the importing symbol file has already cached the type in
`GetDIEToType()`, so a reload would never re-parse it. Severing anyway segfaults
in `ClangASTImporter::CompleteType()` on the next session, so
`ClangASTImporter::HasImportedFrom()` gates it. The AST to ask is the one
`GetTypeSystemForLanguage()` hands out, which for a debug map `.o` belongs to the
executable rather than to the `.o`.

Whatever cannot be spared is removed together with the module it holds, and that
is not necessarily a module in the shared list: for a Darwin debug map it is the
`.o` module held by the debug map's symbol file, and a `SymbolFileDWARFDwo` is
owned by no `Module` at all. So `SymbolFile::GetLoadedReferencedModules()`
reports what a symbol file already holds without parsing anything to answer, and
the "is held by" graph reachable from the shared module list is walked to find
the roots to remove.

Only unreferenced modules are removed. `Debugger::Destroy()` destroys one
debugger, not the process: other debuggers may still be alive with targets
holding these modules.

Because those others can be running concurrently, the state this touches has to
be safe to touch, and two things were not. `Module::m_cas` was read without
`m_cas_init_mutex` by `LoadModuleFromCAS()`, `IsCASID()` and `GetCASForID()`, and
`GetCASStorage()` returned an `ArrayRef` *into* the vector, so resetting it was a
use-after-free — `GetCASStorage()` now returns a copy taken under the lock, which
also keeps the stores alive for as long as its caller uses them.
`m_external_type_modules` was unsynchronised altogether, which erasing from it
made considerably worse, so it and `m_fetched_external_modules` are now guarded
by the module mutex.

That last guard makes the module mutex precede `m_cas_init_mutex`, because a
symbol file asks for a CAS with it held. `ConfigureCASStorage()` took them the
other way round, via `FindCASConfigurations()` reaching `GetSymbolFile()`, so it
now searches for the configurations before taking `m_cas_init_mutex` and
double-checks on the way back in. Nor can the shared module list's own mutex be
held across any of this: `UpdateExternalModuleListIfNeeded()` reaches
`ModuleList::GetSharedModule()` with the module mutex held.
`ReleaseCASReferences()` also lets go of `m_cas` *before* draining the type
systems rather than after, keeping a copy alive across the drain, so a type
system created in the meantime looks a CAS up afresh instead of binding a vector
that was meant to be gone — and no lock is held across type system teardown.

Because the shared CAS cache holds weak references, the function can report
exactly which stores were released and which are still referenced, so "the
CAS should be gone by now" is checkable rather than assumed. A non-zero
result is a leak, and each straggler is logged by path.

### Testing

Two API tests, `functionalities/cas/gmodules` and `functionalities/cas/swift`,
drive a debugger of their own — the test's primary debugger would keep the
modules alive — check the module log for what was given up, then debug the same
binary again to check that redebugging still evaluates the same expression and
that only what was removed gets rebuilt.

Both run in the `dsym` and `dwarf` variants, which is not redundant here:
dsymutil resolves the `-gmodules` references, so whether anything is read out of
the CAS at all depends on the debug info format.

| | kept | removed | rebuilt in session 2 |
|---|---|---|---|
| `gmodules` dsym | 1 | 2 | 3 of 127 |
| `gmodules` dwarf | 1 | 2 | 3 of 128 |
| `swift` dsym | 1 | **0** | 1 of 255 |
| `swift` dwarf | 2 | **2** | 3 of 258 |

- `gmodules` builds one dylib with compilation caching and one without, but
  points both at a CAS. Either way 1 module is kept and 2 removed; marking every
  module that transitively held a CAS removes 3. Its dylibs are never
  dsymutil'd, so its CAS-loaded clang module always hangs off a `.o` module held
  by `SymbolFileDWARFDebugMap`.
- `swift` hides the `.swiftmodule` so the `SwiftASTContext` can only load it out
  of the CAS. With a dSYM nothing is removed at all. Without one,
  `main.swift.o` is read through a debug map and its DWARF still refers to the
  explicit module build's clang modules (`ClangA`, `_SwiftConcurrencyShims`) by
  CASID, so those two are read out of the store and removed — but nothing
  imported clang types out of them, so `main.swift.o` gives them up and both it
  and the executable are kept. Either way the executable is never rebuilt in the
  second session. The `dwarf` variant is what keeps the read-out-of-the-CAS case
  covered at all, since dsymutil resolves those references away.

`lldb/test/Shell/SymbolFile/cas-gmodule.test` also gains checks that the store
is released with nothing still referencing it.

Both tests fail against the revision of this branch that released a store by
removing every module which transitively held one: it removed 3 modules rather
than 2 on the gmodules test, and on Swift it removed the executable module and
rebuilt it in the second session.

Also run: full lldb Shell suite (645 passed, 10 expectedly failed, 0
unexpected), and `test/API/lang/swift/explicit_modules` +
`test/API/lang/swift/clangimporter` + `test/API/lang/c` (793 tests, all passing).
`test/API/lang/objc` has a pre-existing crash unrelated to this
(`ConstantDataSequential::getAsString`), which reproduces with no `.cas-config`
anywhere and therefore with every path here inert.

A follow-up adds `SBDebugger::ReleaseCASObjectStores()` and an API test that
asserts the store cannot be released while a target still uses it and is
reclaimed once the target is deleted. It is held back because it regenerates
the checked-in static Python bindings.

rdar://183455561

