### PR TITLE
[AArch64] Add aarch64-unknown-uefi target support

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -190,6 +190,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       default: // Assume MSVC for unknown environments
         return std::make_unique<MicrosoftARM64TargetInfo>(Triple, Opts);
       }
+    case llvm::Triple::UEFI:
+      return std::make_unique<UEFIAArch64TargetInfo>(Triple, Opts);
     default:
       return std::make_unique<AArch64leTargetInfo>(Triple, Opts);
     }

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1862,6 +1862,43 @@ MinGWARM64TargetInfo::MinGWARM64TargetInfo(const llvm::Triple &Triple,
   TheCXXABI.set(TargetCXXABI::GenericAArch64);
 }
 
+UEFIAArch64TargetInfo::UEFIAArch64TargetInfo(const llvm::Triple &Triple,
+                                             const TargetOptions &Opts)
+    : UEFITargetInfo<AArch64leTargetInfo>(Triple, Opts) {
+  // UEFI images are PE/COFF and follow the Microsoft ARM64 ABI. The UEFI spec
+  // does not mandate a specific C++ ABI or integer model, so we match the
+  // Windows ARM64 target -- the only supported way to produce AArch64 EFI
+  // binaries with Clang/LLVM today.
+  TheCXXABI.set(TargetCXXABI::Microsoft);
+
+  // LLP64 data model: int:4, long:4, long long:8, long double:8.
+  IntWidth = IntAlign = 32;
+  LongWidth = LongAlign = 32;
+  DoubleAlign = LongLongAlign = 64;
+  LongDoubleWidth = LongDoubleAlign = 64;
+  LongDoubleFormat = &llvm::APFloat::IEEEdouble();
+  IntMaxType = SignedLongLong;
+  Int64Type = SignedLongLong;
+  SizeType = UnsignedLongLong;
+  PtrDiffType = SignedLongLong;
+  IntPtrType = SignedLongLong;
+}
+
+void UEFIAArch64TargetInfo::setDataLayout() {
+  // PE/COFF image: use the same data layout the LLVM AArch64 TargetMachine
+  // computes for COFF. This must be an override (not just a ctor call) because
+  // handleTargetFeatures() re-invokes setDataLayout() after construction, and
+  // the AArch64le base only knows MachO/ELF -- it would otherwise revert to an
+  // ELF layout that mismatches the backend.
+  resetDataLayout("e-m:w-p270:32:32-p271:32:32-p272:64:64-p:64:64-i32:32-"
+                  "i64:64-i128:128-n32:64-S128-Fn32");
+}
+
+AArch64TargetInfo::BuiltinVaListKind
+UEFIAArch64TargetInfo::getBuiltinVaListKind() const {
+  return TargetInfo::CharPtrBuiltinVaList;
+}
+
 AppleMachOAArch64TargetInfo::AppleMachOAArch64TargetInfo(
     const llvm::Triple &Triple, const TargetOptions &Opts)
     : AppleMachOTargetInfo<AArch64leTargetInfo>(Triple, Opts) {}

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1865,23 +1865,13 @@ MinGWARM64TargetInfo::MinGWARM64TargetInfo(const llvm::Triple &Triple,
 UEFIAArch64TargetInfo::UEFIAArch64TargetInfo(const llvm::Triple &Triple,
                                              const TargetOptions &Opts)
     : UEFITargetInfo<AArch64leTargetInfo>(Triple, Opts) {
-  // UEFI images are PE/COFF and follow the Microsoft ARM64 ABI. The UEFI spec
-  // does not mandate a specific C++ ABI or integer model, so we match the
-  // Windows ARM64 target -- the only supported way to produce AArch64 EFI
-  // binaries with Clang/LLVM today.
-  TheCXXABI.set(TargetCXXABI::Microsoft);
-
-  // LLP64 data model: int:4, long:4, long long:8, long double:8.
-  IntWidth = IntAlign = 32;
-  LongWidth = LongAlign = 32;
-  DoubleAlign = LongLongAlign = 64;
-  LongDoubleWidth = LongDoubleAlign = 64;
-  LongDoubleFormat = &llvm::APFloat::IEEEdouble();
-  IntMaxType = SignedLongLong;
-  Int64Type = SignedLongLong;
-  SizeType = UnsignedLongLong;
-  PtrDiffType = SignedLongLong;
-  IntPtrType = SignedLongLong;
+  // UEFI images are PE/COFF, but we keep the AArch64 LP64 data model (inherited
+  // from the freestanding ELF base) rather than the Windows LLP64 model. The
+  // UEFI spec does not mandate a C integer model, a freestanding Swift firmware
+  // does not interop with UEFI/Windows C `long`, and LP64 keeps `long` == word
+  // size, which is what higher-level toolchains (e.g. Swift's Int <-> C integer
+  // mapping) assume. Only the object format and CFI are Windows-like -- see
+  // setDataLayout() below and the AArch64 frame lowering.
 }
 
 void UEFIAArch64TargetInfo::setDataLayout() {

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -316,6 +316,17 @@ public:
   MinGWARM64TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts);
 };
 
+// ARM64 UEFI target (PE/COFF image, Microsoft ARM64 ABI)
+class LLVM_LIBRARY_VISIBILITY UEFIAArch64TargetInfo
+    : public UEFITargetInfo<AArch64leTargetInfo> {
+public:
+  UEFIAArch64TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts);
+
+  void setDataLayout() override;
+
+  BuiltinVaListKind getBuiltinVaListKind() const override;
+};
+
 class LLVM_LIBRARY_VISIBILITY AArch64beTargetInfo : public AArch64TargetInfo {
 public:
   AArch64beTargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -714,8 +714,10 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
   }
 #endif
 
-  // Currently the only architecture supported by *-uefi triples are x86_64.
-  if (Target.isUEFI() && Target.getArch() != llvm::Triple::x86_64)
+  // The architectures currently supported by *-uefi triples are x86_64 and
+  // aarch64 (both emit PE/COFF images under the Microsoft ABI).
+  if (Target.isUEFI() && Target.getArch() != llvm::Triple::x86_64 &&
+      Target.getArch() != llvm::Triple::aarch64)
     D.Diag(diag::err_target_unknown_triple) << Target.str();
 
   // The `-maix[32|64]` flags are only valid for AIX targets.

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -384,12 +384,13 @@ static bool isLikelyToHaveSVEStack(const AArch64FrameLowering &AFL,
 }
 
 static bool isTargetWindows(const MachineFunction &MF) {
-  // TODO: Should this include targets like UEFI (which use Windows CFI)?
-  // Note: Currently, there is not AArch64 support for UEFI. The value returned
-  // here must align with the predicate used for returning the list of callee
-  // saved regs in AArch64RegisterInfo::getCalleeSavedRegs(), so that we use
+  // UEFI images are PE/COFF and use Windows CFI, so for frame-record layout and
+  // unwind they behave like Windows. This value must align with the predicate
+  // used for returning the list of callee saved regs in
+  // AArch64RegisterInfo::getCalleeSavedRegs(), so that we use
   // invalidateWindowsRegisterPairing() where appropriate.
-  return MF.getSubtarget<AArch64Subtarget>().isTargetWindows();
+  const AArch64Subtarget &STI = MF.getSubtarget<AArch64Subtarget>();
+  return STI.isTargetWindows() || STI.isTargetUEFI();
 }
 
 bool AArch64FrameLowering::hasSVECalleeSavesAboveFrameRecord(

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -10841,8 +10841,8 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
       Callee = DAG.getTargetGlobalAddress(CalledGlobal, DL, PtrVT, 0, OpFlags);
       Callee = DAG.getNode(AArch64ISD::LOADgot, DL, PtrVT, Callee);
     } else if (Subtarget->isTargetCOFF() && CalledGlobal->hasDLLImportStorageClass()) {
-      assert(Subtarget->isTargetWindows() &&
-             "Windows is the only supported COFF target");
+      assert((Subtarget->isTargetWindows() || Subtarget->isTargetUEFI()) &&
+             "COFF is only supported on Windows and UEFI targets");
       Callee = getGOT(G, DAG, AArch64II::MO_DLLIMPORT);
     } else if (!CLI.PAI || !IsTailCall) {
       const GlobalValue *GV = G->getGlobal();

--- a/llvm/lib/Target/AArch64/AArch64MCInstLower.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MCInstLower.cpp
@@ -112,8 +112,8 @@ MCSymbol *AArch64MCInstLower::GetGlobalValueSymbol(const GlobalValue *GV,
   if (!TheTriple.isOSBinFormatCOFF())
     return Printer.getSymbolPreferLocal(*GV);
 
-  assert(TheTriple.isOSWindows() &&
-         "Windows is the only supported COFF target");
+  assert((TheTriple.isOSWindows() || TheTriple.isUEFI()) &&
+         "COFF is only supported on Windows and UEFI targets");
 
   bool IsIndirect =
       (TargetFlags & (AArch64II::MO_DLLIMPORT | AArch64II::MO_COFFSTUB));

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -76,7 +76,11 @@ AArch64RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
   const auto &F = MF->getFunction();
   const auto *TLI = MF->getSubtarget<AArch64Subtarget>().getTargetLowering();
   const bool Darwin = MF->getSubtarget<AArch64Subtarget>().isTargetDarwin();
-  const bool Windows = MF->getSubtarget<AArch64Subtarget>().isTargetWindows();
+  // UEFI uses the Windows PE/COFF ABI, so it takes the same callee-saved
+  // register lists (this must align with isTargetWindows() in
+  // AArch64FrameLowering, which drives invalidateWindowsRegisterPairing()).
+  const bool Windows = MF->getSubtarget<AArch64Subtarget>().isTargetWindows() ||
+                       MF->getSubtarget<AArch64Subtarget>().isTargetUEFI();
 
   if (TLI->supportSwiftError() &&
       F.getAttributes().hasAttrSomewhere(Attribute::SwiftError)) {

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -312,6 +312,7 @@ public:
   bool isTargetIOS() const { return TargetTriple.isiOS(); }
   bool isTargetLinux() const { return TargetTriple.isOSLinux(); }
   bool isTargetWindows() const { return TargetTriple.isOSWindows(); }
+  bool isTargetUEFI() const { return TargetTriple.isUEFI(); }
   bool isTargetAndroid() const { return TargetTriple.isAndroid(); }
   bool isTargetFuchsia() const { return TargetTriple.isOSFuchsia(); }
   bool isWindowsArm64EC() const { return TargetTriple.isWindowsArm64EC(); }


### PR DESCRIPTION
Downstream cherry-pick of llvm/llvm-project#213275, bringing `aarch64-unknown-uefi` target support to `next` so Embedded Swift can build for AArch64 UEFI firmware ahead of the upstream→downstream merge.

UEFI on AArch64 uses PE/COFF images and the Microsoft ARM64 ABI, so it reuses the Windows COFF paths rather than the ELF ones. Clang gains a `UEFIAArch64TargetInfo` (PE/COFF, MS ARM64 ABI, LLP64); the AArch64 backend allows COFF on UEFI in addition to Windows (`isTargetUEFI()`, relaxed COFF assertions, Windows-CFI frame layout with aligned callee-saved lists).

Difference vs. the upstream PR: `next` still needs the `AArch64ISelLowering` Windows-only COFF assertion relaxed; upstream `main` already generalized that DLL-import call path, so that hunk is absent there.

### Why here as well as upstream

I'm happy either way — merge this cherry-pick now for early availability in dev snapshots, or close it and let the change arrive through the normal upstream merge from llvm/llvm-project#213275. Whatever you prefer; I only need the support to land somewhere the Swift toolchain builds against.

The motivation is the Embedded Swift AArch64 UEFI work: the companion `swiftlang/swift` and `swiftlang/swift-driver` PRs depend on this support being present here — their CI cannot pass until it is.

### Status / testing

Initial patch, lit tests to follow. Built locally against a patched toolchain: the Embedded stdlib builds for `aarch64-unknown-uefi` and a sample `@_cdecl("efi_main")` compiles to a valid `coff-arm64` object.
