### PR TITLE
[Modules] Handle decl attributes on deserialization the same as during parsing. (#208348)

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -870,6 +870,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   the `sized_by`/`sized_by_or_null` attributes. Because `sized_by` and
   `sized_by_or_null` describe the size in bytes rather than a count of elements,
   they are now correctly accepted on such pointers.
+- Propagate attributes on redeclarations across modules.
 
 #### Bug Fixes to C++ Support
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -279,6 +279,12 @@ class Parser : public CodeCompletionHandler {
   /// Implementations are in Parser.cpp
   ///@{
 
+private:
+  /// Prepare the parser and its components.
+  ///
+  /// The lack of initialization can lead to missing functionality.
+  void Initialize();
+
 public:
   friend class ColonProtectionRAIIObject;
   friend class PoisonSEHIdentifiersRAIIObject;
@@ -305,10 +311,6 @@ public:
   // different actual classes based on the actions in place.
   typedef OpaquePtr<DeclGroupRef> DeclGroupPtrTy;
   typedef OpaquePtr<TemplateName> TemplateTy;
-
-  /// Initialize - Warm up the parser.
-  ///
-  void Initialize();
 
   /// Parse the first top-level declaration in a translation unit.
   ///

--- a/clang/lib/Interpreter/IncrementalParser.cpp
+++ b/clang/lib/Interpreter/IncrementalParser.cpp
@@ -43,7 +43,7 @@ IncrementalParser::IncrementalParser(CompilerInstance &Instance,
   if (ExternalASTSource *External = S.getASTContext().getExternalSource())
     External->StartTranslationUnit(Consumer);
 
-  P->Initialize();
+  P->ConsumeToken();
 }
 
 IncrementalParser::~IncrementalParser() { P.reset(); }

--- a/clang/lib/Parse/ParseAST.cpp
+++ b/clang/lib/Parse/ParseAST.cpp
@@ -160,7 +160,7 @@ void clang::ParseAST(Sema &S, bool PrintStats, bool SkipFunctionBodies) {
       }
       return M;
     });
-    P.Initialize();
+    P.ConsumeToken();
     Parser::DeclGroupPtrTy ADecl;
     Sema::ModuleImportState ImportState;
     EnterExpressionEvaluationContext PotentiallyEvaluated(

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -1556,7 +1556,7 @@ void HandleRootSignatureTarget(Sema &S, StringRef EntryRootSig) {
 
   bool HaveLexer = S.getPreprocessor().getCurrentLexer();
   if (HaveLexer) {
-    P->Initialize();
+    P->ConsumeToken();
     S.ActOnStartOfTranslationUnit();
 
     // Skim through the file to parse to find the define

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -96,6 +96,8 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
         this->ParseLexedFunctionReturnTypeBoundsAttrs(D, FD);
       };
   /* TO_UPSTREAM(BoundsSafety) OFF */
+
+  Initialize();
 }
 
 DiagnosticBuilder Parser::Diag(SourceLocation Loc, unsigned DiagID) {
@@ -597,9 +599,6 @@ void Parser::Initialize() {
   }
 
   Actions.Initialize();
-
-  // Prime the lexer look-ahead.
-  ConsumeToken();
 }
 
 void Parser::DestroyTemplateIds() {

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -734,6 +734,10 @@ Sema::~Sema() {
   if (ExternalSemaSource *ExternalSema
         = dyn_cast_or_null<ExternalSemaSource>(Context.getExternalSource()))
     ExternalSema->ForgetSema();
+  // FIXME: keep just a single ExternalSemaSource instead of 2 with a slightly
+  // different behavior.
+  if (ExternalSource)
+    ExternalSource->ForgetSema();
 
   // Delete cached satisfactions.
   std::vector<ConstraintSatisfaction *> Satisfactions;

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -286,7 +286,7 @@ public:
                                      Decl *Previous, Decl *Canon);
   static void attachPreviousDeclImpl(ASTReader &Reader, ...);
   static void attachPreviousDecl(ASTReader &Reader, Decl *D, Decl *Previous,
-                                 Decl *Canon);
+                                 Decl *PreviousNonLocal, Decl *Canon);
 
   static void checkMultipleDefinitionInNamedModules(ASTReader &Reader, Decl *D,
                                                     Decl *Previous);
@@ -3669,28 +3669,6 @@ Decl *ASTReader::getMostRecentExistingDecl(Decl *D) {
   return ASTDeclReader::getMostRecentDecl(D->getCanonicalDecl());
 }
 
-namespace {
-void mergeInheritableAttributes(ASTReader &Reader, Decl *D, Decl *Previous) {
-  InheritableAttr *NewAttr = nullptr;
-  ASTContext &Context = Reader.getContext();
-  const auto *IA = Previous->getAttr<MSInheritanceAttr>();
-
-  if (IA && !D->hasAttr<MSInheritanceAttr>()) {
-    NewAttr = cast<InheritableAttr>(IA->clone(Context));
-    NewAttr->setInherited(true);
-    D->addAttr(NewAttr);
-  }
-
-  if (!D->hasAttr<AvailabilityAttr>()) {
-    for (const auto *AA : Previous->specific_attrs<AvailabilityAttr>()) {
-      NewAttr = AA->clone(Context);
-      NewAttr->setInherited(true);
-      D->addAttr(NewAttr);
-    }
-  }
-}
-} // namespace
-
 template<typename DeclT>
 void ASTDeclReader::attachPreviousDeclImpl(ASTReader &Reader,
                                            Redeclarable<DeclT> *D,
@@ -3902,7 +3880,8 @@ void ASTDeclReader::checkMultipleDefinitionInNamedModules(ASTReader &Reader,
 }
 
 void ASTDeclReader::attachPreviousDecl(ASTReader &Reader, Decl *D,
-                                       Decl *Previous, Decl *Canon) {
+                                       Decl *Previous, Decl *PreviousNonLocal,
+                                       Decl *Canon) {
   assert(D && Previous);
 
   switch (D->getKind()) {
@@ -3931,11 +3910,12 @@ void ASTDeclReader::attachPreviousDecl(ASTReader &Reader, Decl *D,
     inheritDefaultTemplateArguments(Reader.getContext(),
                                     cast<TemplateDecl>(Previous), TD);
 
-  // If any of the declaration in the chain contains an Inheritable attribute,
-  // it needs to be added to all the declarations in the redeclarable chain.
-  // FIXME: Only the logic of merging MSInheritableAttr is present, it should
-  // be extended for all inheritable attributes.
-  mergeInheritableAttributes(Reader, D, Previous);
+  if (PreviousNonLocal) {
+    if (Sema *S = Reader.getSema()) {
+      if (auto *ND = dyn_cast<NamedDecl>(D))
+        S->mergeDeclAttributes(ND, PreviousNonLocal);
+    }
+  }
 }
 
 template<typename DeclT>
@@ -4586,17 +4566,17 @@ void ASTReader::loadDeclUpdateRecords(PendingUpdateRecord &Record) {
 void ASTReader::loadPendingDeclChain(Decl *FirstLocal, uint64_t LocalOffset) {
   // Attach FirstLocal to the end of the decl chain.
   Decl *CanonDecl = FirstLocal->getCanonicalDecl();
+  Decl *NonLocalMostRecent = nullptr;
   if (FirstLocal != CanonDecl) {
     Decl *PrevMostRecent = ASTDeclReader::getMostRecentDecl(CanonDecl);
-    ASTDeclReader::attachPreviousDecl(
-        *this, FirstLocal, PrevMostRecent ? PrevMostRecent : CanonDecl,
-        CanonDecl);
+    NonLocalMostRecent = PrevMostRecent ? PrevMostRecent : CanonDecl;
+    ASTDeclReader::attachPreviousDecl(*this, FirstLocal, NonLocalMostRecent,
+                                      NonLocalMostRecent, CanonDecl);
+    ASTDeclReader::attachLatestDecl(CanonDecl, FirstLocal);
   }
 
-  if (!LocalOffset) {
-    ASTDeclReader::attachLatestDecl(CanonDecl, FirstLocal);
+  if (!LocalOffset)
     return;
-  }
 
   // Load the list of other redeclarations from this module file.
   ModuleFile *M = getOwningModuleFile(FirstLocal);
@@ -4630,10 +4610,11 @@ void ASTReader::loadPendingDeclChain(Decl *FirstLocal, uint64_t LocalOffset) {
   for (unsigned I = 0, N = Record.size(); I != N; ++I) {
     unsigned Idx = N - I - 1;
     auto *D = ReadDecl(*M, Record, Idx);
-    ASTDeclReader::attachPreviousDecl(*this, D, MostRecent, CanonDecl);
+    ASTDeclReader::attachPreviousDecl(*this, D, MostRecent, NonLocalMostRecent,
+                                      CanonDecl);
     MostRecent = D;
+    ASTDeclReader::attachLatestDecl(CanonDecl, MostRecent);
   }
-  ASTDeclReader::attachLatestDecl(CanonDecl, MostRecent);
 }
 
 namespace {

--- a/clang/test/Modules/decl-attr-merge-explicit-modules.c
+++ b/clang/test/Modules/decl-attr-merge-explicit-modules.c
@@ -1,0 +1,79 @@
+// Check merging attributes when modules are built explicitly.
+//
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-name=first -xc %t/headers/first.modulemap -emit-module -o %t/first.pcm
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-name=second -xc %t/headers/second.modulemap -emit-module -o %t/second.pcm
+
+// Without module names.
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-file=%t/first.pcm -fmodule-file=%t/second.pcm -fsyntax-only %t/test.c -verify
+// With module names.
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-file=first=%t/first.pcm -fmodule-file=second=%t/second.pcm -fsyntax-only %t/test.c -verify
+
+// Reverse order.
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-file=%t/second.pcm -fmodule-file=%t/first.pcm -fsyntax-only %t/test-reverse.c -verify
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-file=second=%t/second.pcm -fmodule-file=first=%t/first.pcm -fsyntax-only %t/test-reverse.c -verify
+
+// With a transitive module dependency.
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-file=first=%t/first.pcm \
+// RUN:   -fmodule-name=second_transitive -xc %t/headers/second-transitive.modulemap -emit-module -o %t/second-transitive.pcm
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-file=%t/second-transitive.pcm -fsyntax-only %t/test-transitive.c -verify
+// RUN: %clang_cc1 -fmodules -fno-implicit-modules -triple arm64-apple-macosx10.7.0 -I%t/headers \
+// RUN:   -fmodule-file=second_transitive=%t/second-transitive.pcm -fsyntax-only %t/test-transitive.c -verify
+
+//--- headers/first.h
+// Added "used" attribute to add corresponding `FunctionDecl` to `EagerlyDeserializedDecls`.
+void availabilityAttr(void) __attribute__((used)) __attribute__((availability(macos,unavailable)));
+//--- headers/first.modulemap
+module first {
+  header "first.h" export *
+}
+
+//--- headers/second.h
+void availabilityAttr(void) __attribute__((used)) __attribute__((availability(ios,introduced=4.0)));
+//--- headers/second.modulemap
+module second {
+  header "second.h" export *
+}
+
+//--- headers/second-transitive.h
+#include <first.h>
+void availabilityAttr(void) __attribute__((availability(ios,introduced=4.0)));
+//--- headers/second-transitive.modulemap
+module second_transitive {
+  header "second-transitive.h" export *
+}
+
+//--- test.c
+#include <first.h>
+#include <second.h>
+void test(void) {
+  availabilityAttr();
+  // expected-error@-1 {{'availabilityAttr' is unavailable: not available on macOS}}
+  // expected-note@first.h:* {{'availabilityAttr' has been explicitly marked unavailable here}}
+}
+
+//--- test-reverse.c
+#include <second.h>
+#include <first.h>
+void test(void) {
+  availabilityAttr();
+  // expected-error@-1 {{'availabilityAttr' is unavailable: not available on macOS}}
+  // expected-note@first.h:* {{'availabilityAttr' has been explicitly marked unavailable here}}
+}
+
+//--- test-transitive.c
+#include <second-transitive.h>
+void test(void) {
+  availabilityAttr();
+  // expected-error@-1 {{'availabilityAttr' is unavailable: not available on macOS}}
+  // expected-note@first.h:* {{'availabilityAttr' has been explicitly marked unavailable here}}
+}

--- a/clang/test/Modules/decl-attr-merge2.c
+++ b/clang/test/Modules/decl-attr-merge2.c
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps \
+// RUN:   -fmodules-cache-path=%t/mcache -triple arm64-apple-macosx10.7.0 \
+// RUN:   -I%t/headers -fsyntax-only %t/test.c -verify
+
+// Check more cases of attribute merging across multiple modules.
+
+//--- headers/module.modulemap
+module First {
+  header "first.h" export *
+}
+module Second {
+  header "second.h" export *
+}
+//--- headers/first.h
+void additiveAttr(void) __attribute__((availability(macos,unavailable)));
+void exclusiveAttr(void) __attribute__((hot));
+
+//--- headers/second.h
+void additiveAttr(void) __attribute__((availability(ios,introduced=4.0)));
+void exclusiveAttr(void) __attribute__((cold));
+
+//--- test.c
+#include <first.h>
+#include <second.h>
+
+void test(void) {
+  // Check the attribute from "second.h" doesn't hide the attribute from "first.h".
+  additiveAttr();
+  // expected-error@-1 {{'additiveAttr' is unavailable: not available on macOS}}
+  // expected-note@first.h:* {{'additiveAttr' has been explicitly marked unavailable here}}
+
+  // Check calling a function with `MutualExclusions` attributes.
+  exclusiveAttr();
+  // expected-error@second.h:* {{'cold' and 'hot' attributes are not compatible}}
+  // expected-note@first.h:* {{conflicting attribute is here}}
+}

--- a/clang/test/OpenMP/declare_variant_construct_codegen_1.c
+++ b/clang/test/OpenMP/declare_variant_construct_codegen_1.c
@@ -28,8 +28,8 @@
 void p_vxv(int *v1, int *v2, int *v3, int n);
 void t_vxv(int *v1, int *v2, int *v3, int n);
 
-#pragma omp declare variant(t_vxv) match(construct={target})
 #pragma omp declare variant(p_vxv) match(construct={parallel})
+#pragma omp declare variant(t_vxv) match(construct={target})
 void vxv(int *v1, int *v2, int *v3, int n) {
     for (int i = 0; i < n; i++) v3[i] = v1[i] * v2[i];
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -791,7 +791,7 @@ ClangModulesDeclVendor::Create(Target &target) {
       instance->getPreprocessor(), instance->getSema(), skipFunctionBodies));
 
   instance->getPreprocessor().EnterMainSourceFile();
-  parser->Initialize();
+  parser->ConsumeToken();
 
   clang::Parser::DeclGroupPtrTy parsed;
   auto ImportState = clang::Sema::ModuleImportState::NotACXX20Module;


### PR DESCRIPTION
Replace manual handling of 2 attributes with
`Sema::mergeDeclAttributes`, which is called during parsing too. Also propagate attributes not from a previous redeclaration but from a previous redeclaration outside of the current module. This is done to avoid double propagation because attributes from a previous decl in the same module are already handled when a module is built.

Call `ASTDeclReader::attachLatestDecl` after each decl is added to a redeclaration chain, not once per `ASTReader::loadPendingDeclChain` call. This is done to maintain correct redeclaration chain for each `ASTDeclReader::attachPreviousDecl` call because [newly added] `mergeDeclAttributes` requires a correct redeclaration chain.

Separated `Parser::Initialize` and `Parser::ConsumeToken` so can move the initialization earlier, into `Parser` constructor. This way `Parser::Initialize`, `Sema::Initialize`, `ASTReader::InitializeSema` are executed before deserialization. This specific case is verified by "Modules/decl-attr-merge-explicit-modules.c".

The change can cause compilation errors for downstream `Parser` clients. Instead of calling `Parser::Initialize` now you need to call `Parser::ConsumeToken`.

rdar://175997317
(cherry picked from commit 3ce0df7ca8027229618de9802eeffe1f0023bf74)