### PR TITLE
[lldb] Ask the reporter what happened in a bug report (#213173)

### DIFF
--- a/lldb/include/lldb/Core/BugReporter.h
+++ b/lldb/include/lldb/Core/BugReporter.h
@@ -12,6 +12,8 @@
 #include "lldb/Core/Diagnostics.h"
 #include "lldb/Core/PluginInterface.h"
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
 namespace lldb_private {
@@ -23,6 +25,10 @@ class BugReporter : public PluginInterface {
 public:
   virtual llvm::Error File(const Diagnostics::Report &report) = 0;
 };
+
+/// The questions only the person filing the report can answer. Shared so every
+/// reporter asks for the same thing.
+llvm::ArrayRef<llvm::StringRef> GetBugReportQuestions();
 
 } // namespace lldb_private
 

--- a/lldb/source/Commands/CommandObjectDiagnostics.cpp
+++ b/lldb/source/Commands/CommandObjectDiagnostics.cpp
@@ -199,6 +199,9 @@ protected:
       for (const std::string &file : report->attachments.files)
         out << "  [ ] " << file << "\n";
     }
+    out << "Complete the report before sharing it:\n";
+    out << "  [ ] Give the report a descriptive title\n";
+    out << "  [ ] Answer the questions\n";
     result.AppendWarning("the report may contain file paths, command history "
                          "and program data. Review it before attaching it to a "
                          "public issue");

--- a/lldb/source/Core/BugReporter.cpp
+++ b/lldb/source/Core/BugReporter.cpp
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Core/BugReporter.h"
+
+llvm::ArrayRef<llvm::StringRef> lldb_private::GetBugReportQuestions() {
+  static constexpr llvm::StringRef g_questions[] = {
+      "What were you doing?",
+      "What did you expect to happen?",
+      "What happened instead?",
+  };
+  return g_questions;
+}

--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -22,6 +22,7 @@ add_lldb_library(lldbCore NO_PLUGIN_DEPENDENCIES
   AddressRangeListImpl.cpp
   AddressResolver.cpp
   AddressResolverFileLine.cpp
+  BugReporter.cpp
   Communication.cpp
   DataFileCache.cpp
   Debugger.cpp

--- a/lldb/source/Plugins/BugReporter/GitHub/GitHubReporter.cpp
+++ b/lldb/source/Plugins/BugReporter/GitHub/GitHubReporter.cpp
@@ -39,6 +39,11 @@ std::unique_ptr<BugReporter> GitHubReporter::CreateInstance() {
 llvm::Error GitHubReporter::File(const Diagnostics::Report &report) {
   std::string body;
   llvm::raw_string_ostream os(body);
+  // Lead with the questions: an oversized body is truncated from the end.
+  os << "### Please answer these questions\n\n";
+  for (llvm::StringRef question : GetBugReportQuestions())
+    os << "- " << question << "\n";
+  os << "\n\n";
   os << "### LLDB version\n" << report.version << "\n\n";
   os << "### Host\n" << report.os << "\n\n";
   if (!report.invocation.empty())
@@ -57,9 +62,11 @@ llvm::Error GitHubReporter::File(const Diagnostics::Report &report) {
     body += "\n\n...(truncated, see the attached diagnostics directory)";
   }
 
+  // No title parameter: GitHub blocks submission until the field is filled in,
+  // so an empty one yields a title describing this bug instead of a generic
+  // default nobody edits.
   std::string url = llvm::formatv("https://github.com/llvm/llvm-project/issues/"
-                                  "new?title={0}&body={1}&labels=lldb",
-                                  Host::URLEncode("[lldb] Bug report"),
+                                  "new?body={0}&labels=lldb",
                                   Host::URLEncode(body));
 
   return Host::OpenURL(url);

--- a/lldb/test/Shell/Diagnostics/TestReport.test
+++ b/lldb/test/Shell/Diagnostics/TestReport.test
@@ -7,6 +7,9 @@
 # CHECK: Attach the following files to the issue:
 # CHECK-DAG: [ ] statistics.json
 # CHECK-DAG: [ ] commands.txt
+# CHECK: Complete the report before sharing it:
+# CHECK: [ ] Give the report a descriptive title
+# CHECK: [ ] Answer the questions
 # CHECK: warning: the report may contain
 
 # Scalars (version, OS, invocation) ride in the report, not as redundant files.


### PR DESCRIPTION
A diagnostics bundle records the state of the debugger, never what the user was doing or what they expected instead, so reports arrive with a generic title and no description of the problem. Pre-fill the report with the questions only the person filing it can answer, and print a checklist when the bundle is written so an incomplete report doesn't get shared as-is.

rdar://183356348
(cherry picked from commit d9278ad4e640cf04e5fa0bd22898f5aa0351b564)