### PR TITLE
[🍒][ThreadSafety] Add two-state semantics for handleCall in beta mode (#210219)

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -488,10 +488,11 @@ public:
   /// Return the next context after processing S.  This function is used by
   /// clients of the class to get the appropriate context when traversing the
   /// CFG.  It must be called for every assignment or DeclStmt.
-  Context getNextContext(unsigned &CtxIndex, const Stmt *S, Context C) {
-    if (SavedContexts[CtxIndex+1].first == S) {
+  const Context &getNextContext(unsigned &CtxIndex, const Stmt *S,
+                                const Context &C) {
+    if (SavedContexts[CtxIndex + 1].first == S) {
       CtxIndex++;
-      Context Result = SavedContexts[CtxIndex].second;
+      const Context &Result = SavedContexts[CtxIndex].second;
       return Result;
     }
     return C;
@@ -1778,22 +1779,97 @@ class BuildLockset : public ConstStmtVisitor<BuildLockset> {
   FactSet FSet;
   // The fact set for the function on exit.
   const FactSet &FunctionExitFSet;
-  LocalVariableMap::Context LVarCtx;
-  unsigned CtxIndex;
+
+  /// A `LocalVariableMap::Context` wrapper that groups a context 'Q' with its
+  /// immediate predecessor 'P' for a program point.  If the program point is
+  /// right after a Stmt 'S', 'P' is the pre-context of 'S' and 'Q' is the
+  /// post-context of 'S'.  Otherwise, 'P' == 'Q'.
+  ///
+  /// A DualLocalVarContext sets the global context for VarDefinition lookup to
+  /// the post-context 'Q',  once CREATED or UPDATED to the next program
+  /// point.  One can temporarily switch the global context to either 'P' or 'Q'
+  /// using `switchToContextForScope`. The lifetime of the global context
+  /// switching is bound to the enclosing scope. The global context will be set
+  /// back to the prior state by the end of the scope.  This is done by the
+  /// returned ContextSwitchScope object.
+  ///
+  /// Note: The pre- and post-context of a Stmt are distinct only in Beta mode
+  /// (i.e., `Analyzer.Handler.issueBetaWarnings()`) because of the
+  /// out-parameter validation.  If not in Beta mode, the global context for
+  /// VarDefinition lookup is invisible, thus this wrapper has no impact on the
+  /// analysis.
+  class DualLocalVarContext {
+  public:
+    enum Point : char { Pre = 0, Post = 1 };
+
+    struct ContextSwitchScope {
+      DualLocalVarContext &DC;
+      Point LastPoint;
+      ContextSwitchScope(const ContextSwitchScope &) = delete;
+      ContextSwitchScope &operator=(const ContextSwitchScope &) = delete;
+      ~ContextSwitchScope() { DC.switchContextTo(LastPoint); }
+    };
+
+    /// Temporarily switch context to \p P as long as the returned object lives.
+    [[nodiscard]] ContextSwitchScope switchToContextForScope(Point P) {
+      Point PriorPoint = CurrPoint;
+      switchContextTo(P);
+      return ContextSwitchScope{*this, PriorPoint};
+    }
+
+    /// Update the pre- and post-contexts to be associated with the next Stmt \p
+    /// S. Set the global context to the post-context of \p S upon returning.
+    ///
+    /// If \p S is null, the behavior is as if the Stmt is a no-op--the
+    /// post-context will shift to be the pre-context and the new post-context
+    /// is the same as the old one, resulting in identical pre- and
+    /// post-contexts.
+    void moveToNextContext(const Stmt *S) {
+      PrePost[Pre] = PrePost[Post];
+
+      const LocalVariableMap::Context &NewPostCtx =
+          S ? Analyzer.LocalVarMap.getNextContext(CtxIndex, S, *PrePost[Post])
+            : *PrePost[Pre];
+
+      PrePost[Post] = &NewPostCtx;
+      switchContextTo(Post);
+    }
+
+    /// Constructs a DualLocalVarContext for the entry program point, where pre-
+    /// and post-contexts are both equal to the \p EntryContext.
+    DualLocalVarContext(ThreadSafetyAnalyzer &Analyzer, unsigned EntryIdx,
+                        const LocalVariableMap::Context *EntryContext)
+        : Analyzer(Analyzer), PrePost{EntryContext, EntryContext},
+          CurrPoint(Post), CtxIndex(EntryIdx) {
+      assert(EntryContext);
+      switchContextTo(Post);
+    }
+
+  private:
+    ThreadSafetyAnalyzer &Analyzer;
+    // PrePost[0] points to the pre-context and
+    // PrePost[1] points to the post-context:
+    std::array<const LocalVariableMap::Context *, 2> PrePost;
+    Point CurrPoint;
+    unsigned CtxIndex;
+
+    void switchContextTo(Point P) {
+      if (!Analyzer.Handler.issueBetaWarnings())
+        return;
+      Analyzer.SxBuilder.setLookupLocalVarExpr(
+          [Ctx = *PrePost[P],
+           Analyzer = &Analyzer](const NamedDecl *D) mutable -> const Expr * {
+            return Analyzer->LocalVarMap.lookupExpr(D, Ctx);
+          });
+      CurrPoint = P;
+    }
+  };
+
+  DualLocalVarContext LVarCtx;
 
   // To update the context used in attr-expr translation.  If `S` is non-null,
   // the context is updated to the program point right after 'S'.
-  void updateLocalVarMapCtx(const Stmt *S) {
-    if (S)
-      LVarCtx = Analyzer->LocalVarMap.getNextContext(CtxIndex, S, LVarCtx);
-    if (!Analyzer->Handler.issueBetaWarnings())
-      return;
-    // The lookup closure needs to be reconstructed with the refreshed LVarCtx.
-    Analyzer->SxBuilder.setLookupLocalVarExpr(
-        [this, Ctx = LVarCtx](const NamedDecl *D) mutable -> const Expr * {
-          return Analyzer->LocalVarMap.lookupExpr(D, Ctx);
-        });
-  }
+  void updateLocalVarMapCtx(const Stmt *S) { LVarCtx.moveToNextContext(S); }
 
   // helper functions
 
@@ -1818,8 +1894,8 @@ public:
   BuildLockset(ThreadSafetyAnalyzer *Anlzr, CFGBlockInfo &Info,
                const FactSet &FunctionExitFSet)
       : ConstStmtVisitor<BuildLockset>(), Analyzer(Anlzr), FSet(Info.EntrySet),
-        FunctionExitFSet(FunctionExitFSet), LVarCtx(Info.EntryContext),
-        CtxIndex(Info.EntryIndex) {
+        FunctionExitFSet(FunctionExitFSet),
+        LVarCtx(*Analyzer, Info.EntryIndex, &Info.EntryContext) {
     updateLocalVarMapCtx(nullptr);
   }
 
@@ -2124,6 +2200,18 @@ void ThreadSafetyAnalyzer::checkPtAccess(const FactSet &FSet, const Expr *Exp,
 /// \param Loc   If \p Exp = nullptr, the location.
 void BuildLockset::handleCall(const Expr *Exp, const NamedDecl *D,
                               til::SExpr *Self, SourceLocation Loc) {
+  // Move to the call Stmt so that both pre- and post-context are available.
+  updateLocalVarMapCtx(Exp);
+
+  // Most function attributes are associated with the pre-context. Exceptions
+  // are AcquireCapability and AssertCapability, which ensure some locks are
+  // held after the call, and thus are associated with the post-context. They
+  // will require a temporary switch to the post-context during handling.
+  //
+  // Parameter attributes are restricted to scoped objects, and thus are NOT
+  // context-sensitive.
+  auto PreContextForThisScope =
+      LVarCtx.switchToContextForScope(DualLocalVarContext::Pre);
   CapExprSet ExclusiveLocksToAdd, SharedLocksToAdd;
   CapExprSet ExclusiveLocksToRemove, SharedLocksToRemove, GenericLocksToRemove;
   CapExprSet ScopedReqsAndExcludes;
@@ -2154,6 +2242,8 @@ void BuildLockset::handleCall(const Expr *Exp, const NamedDecl *D,
       // When we encounter a lock function, we need to add the lock to our
       // lockset.
       case attr::AcquireCapability: {
+        auto PostContextForThisScope =
+            LVarCtx.switchToContextForScope(DualLocalVarContext::Post);
         const auto *A = cast<AcquireCapabilityAttr>(At);
         Analyzer->getMutexIDs(A->isShared() ? SharedLocksToAdd
                                             : ExclusiveLocksToAdd,
@@ -2165,6 +2255,8 @@ void BuildLockset::handleCall(const Expr *Exp, const NamedDecl *D,
       // a warning if it is already there, and will not generate a warning
       // if it is not removed.
       case attr::AssertCapability: {
+        auto PostContextForThisScope =
+            LVarCtx.switchToContextForScope(DualLocalVarContext::Post);
         const auto *A = cast<AssertCapabilityAttr>(At);
         CapExprSet AssertLocks;
         Analyzer->getMutexIDs(AssertLocks, A, Exp, D, Self);
@@ -2487,9 +2579,13 @@ void BuildLockset::VisitCallExpr(const CallExpr *Exp) {
   }
 
   auto *D = dyn_cast_or_null<NamedDecl>(Exp->getCalleeDecl());
+
   if (D)
     handleCall(Exp, D);
-  updateLocalVarMapCtx(Exp);
+  else
+    // Even if we cannot handle the call, we need to update the context for the
+    // Stmt:
+    updateLocalVarMapCtx(Exp);
 }
 
 void BuildLockset::VisitCXXConstructExpr(const CXXConstructExpr *Exp) {

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -7602,6 +7602,112 @@ void testPointerAliasEscapeAndReset(Foo *f) {
   ptr->mu.Unlock();
 }
 
+struct LOCKABLE Entry;
+void getLockedEntry(Entry **entry) EXCLUSIVE_LOCK_FUNCTION(*entry);
+void useLockedEntry(Entry *entry) EXCLUSIVE_LOCKS_REQUIRED(entry);
+void unlockEntry(Entry *entry) UNLOCK_FUNCTION(entry);
+void assertLockedEntry(Entry **entry)   ASSERT_EXCLUSIVE_LOCK(*entry);
+
+void testOutParamAcquireCap(Entry *in) {
+  Entry *entry = in;
+
+  // 'getLockedEntry' guarantees that '*entry' is locked after return:
+  getLockedEntry(&entry);
+  useLockedEntry(entry);
+  if (1) {
+    useLockedEntry(entry);
+  }
+  unlockEntry(entry);
+}
+
+void testOutParamAcquireCap_invalidation(Entry *in) {
+  Entry *entry = in;
+
+  // 'getLockedEntry' invalidates 'entry' at the pre-state and ensures
+  // 'entry' is locked at the post-state. So 'in' is not locked.
+  getLockedEntry(&entry); // expected-note{{mutex acquired here}}
+  useLockedEntry(in); // expected-warning{{calling function 'useLockedEntry' requires holding mutex 'in' exclusively}}
+  unlockEntry(in); // expected-warning{{releasing mutex 'in' that was not held}}
+} // expected-warning{{mutex 'entry' is still held at the end of function}}
+
+void getLockedEntryRef(Entry *&entry) EXCLUSIVE_LOCK_FUNCTION(entry);
+
+void testAcquireCapability_outParamRef(Entry *in) {
+  Entry *entry = in;
+  getLockedEntryRef(entry);
+  // 'entry' has been invalidated. So it holds the lock after the call,
+  // but 'in' does not:
+  useLockedEntry(entry);
+  unlockEntry(entry);
+  useLockedEntry(in); // expected-warning{{calling function 'useLockedEntry' requires holding mutex 'in' exclusively}}
+  unlockEntry(in); // expected-warning{{releasing mutex 'in' that was not held}}
+}
+
+void testAssertCapability_outParam(Entry *in) {
+  Entry *entry = in;
+  assertLockedEntry(&entry);
+  // 'entry' has been invalidated. So it is assumed to hold the lock
+  // after the call, but 'in' does not:
+  useLockedEntry(entry);
+  unlockEntry(entry);
+  useLockedEntry(in); // expected-warning{{calling function 'useLockedEntry' requires holding mutex 'in' exclusively}}
+  unlockEntry(in); // expected-warning{{releasing mutex 'in' that was not held}}
+}
+
+  void getMultiLockedEntries(Entry **e1, Entry **e2, Entry *e3) EXCLUSIVE_LOCK_FUNCTION(*e1, *e2, e3);
+
+void testAcquireCapability_outParmMultiAttrArg(Entry *in1, Entry *in2, Entry *in3) {
+  Entry *entry1 = in1;
+  Entry *entry2 = in2;
+  Entry *entry3 = in3;
+  getMultiLockedEntries(&entry1, &entry2, entry3);
+  useLockedEntry(entry1);
+  useLockedEntry(entry2);
+  unlockEntry(entry1);
+  unlockEntry(entry2);
+
+  useLockedEntry(in1); // expected-warning{{calling function 'useLockedEntry' requires holding mutex 'in1' exclusively}}
+  useLockedEntry(in2); // expected-warning{{calling function 'useLockedEntry' requires holding mutex 'in2' exclusively}}
+  useLockedEntry(in3);
+  unlockEntry(in1); // expected-warning{{releasing mutex 'in1' that was not held}}
+  unlockEntry(in2); // expected-warning{{releasing mutex 'in2' that was not held}}
+  unlockEntry(in3);
+}  
+
+void allActions(Entry **e1, Entry **e2, Entry **e3, Entry **e4, Entry **e5)
+  EXCLUSIVE_LOCK_FUNCTION(*e1) EXCLUSIVE_LOCKS_REQUIRED(*e2)
+  UNLOCK_FUNCTION(*e3) ASSERT_EXCLUSIVE_LOCK(*e4) LOCKS_EXCLUDED(*e5);
+
+// Test pre- and post-state handling involving various kinds of
+// attributes at a single call-site.
+void testAllActions_outParms() {
+  Entry *e1 = nullptr, *e2 = nullptr, *e3 = nullptr,
+    *e4 = nullptr;
+
+  getLockedEntry(&e2);
+  // locks e1, requires then unlocks e2, assumes e3 is locked, requires !e4:
+  allActions(&e1, &e2, &e2, &e3, &e4);
+  useLockedEntry(e1);
+  useLockedEntry(e3);
+  unlockEntry(e1);
+  unlockEntry(e3);
+}
+
+void testAllActions_outParms_negative() {
+  Entry *e1 = nullptr, *e2 = nullptr, *e3 = nullptr,
+    *e4 = nullptr;
+
+  getLockedEntry(&e2);
+  getLockedEntry(&e4); // expected-note{{mutex acquired here}}
+  allActions(&e1, &e2, &e2, &e3, &e4); // expected-warning{{cannot call function 'allActions' while mutex 'e4' is held}} \
+                                       // expected-note{{mutex released here}}
+  useLockedEntry(e1);
+  useLockedEntry(e3);
+  unlockEntry(e1);
+  unlockEntry(e2); // expected-warning{{releasing mutex 'e2' that was not held}}
+} // expected-warning{{mutex 'e4' is still held at the end of function}}
+
+
 // A function that may do anything to the objects referred to by the inputs.
 void escapeAliasMultiple(void *, void *, void *);
 void testPointerAliasEscapeMultiple(Foo *F) {


### PR DESCRIPTION
Previous contributions added alias analysis and strengthened soundness by invalidating out-parameters in beta mode. The latter feature introduced a distinction between the contexts before and after a function call, because the invalidation assumes that an argument passed by pointer or reference may be changed by the function.

This requires two-state semantics for handling function attributes. Specifically, AcquireCapability and AssertCapability, which both ensure that some locks are held after the call, should be associated with the post-state. Other function attributes, like RequireCapability or ReleaseCapability, are associated with the pre-state.

This commit implements these semantics. This change only affects beta mode.

A previous discussion about these semantics:
https://github.com/llvm/llvm-project/pull/190154

rdar://171209196
(cherry picked from commit bd47223f2009fc5d7b997cc3572cbe89b37a6d8c)