### PR TITLE
[clang][RISCV] Support the Swift calling convention

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -612,7 +612,10 @@ RISCVTargetInfo::checkCallingConvention(CallingConv CC) const {
   case CC_RISCVVLSCall_16384:
   case CC_RISCVVLSCall_32768:
   case CC_RISCVVLSCall_65536:
+  case CC_Swift:
     return CCCR_OK;
+  case CC_SwiftAsync:
+    return CCCR_Error;
   }
 }
 

--- a/clang/test/Sema/riscv-swiftcall.c
+++ b/clang/test/Sema/riscv-swiftcall.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple riscv32-unknown-elf -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple riscv64-unknown-linux-gnu -fsyntax-only -verify %s
+
+// swiftcall is supported on RISC-V; swiftasynccall is not, because lowering
+// it needs guaranteed tail calls the backend does not provide.
+
+void __attribute__((swiftcall)) f(void *__attribute__((swift_context)) ctx) {}
+
+#if !__has_extension(swiftcc)
+#error swiftcc should be available on RISC-V
+#endif
+
+#if __has_extension(swiftasynccc)
+#error swiftasynccc should not be available on RISC-V
+#endif
+
+// expected-error@+1 {{'swiftasynccall' calling convention is not supported for this target}}
+void __attribute__((swiftasynccall)) g(void *__attribute__((swift_async_context)) ctx) {}

--- a/clang/test/Sema/swift-call-conv.c
+++ b/clang/test/Sema/swift-call-conv.c
@@ -1,8 +1,6 @@
 // RUN: %clang_cc1 -triple aarch64-unknown-windows-msvc -fsyntax-only %s -verify
 // RUN: %clang_cc1 -triple thumbv7-unknown-windows-msvc -fsyntax-only %s -verify
 // RUN: %clang_cc1 -triple x86_64-unknown-windows-msvc -fsyntax-only %s -verify
-// RISC-V does not support swiftcall
-// RUN: %clang_cc1 -triple riscv32-unknown-elf -fsyntax-only %s -verify
 
 #if __has_extension(swiftcc)
 // expected-no-diagnostics

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -25738,6 +25738,7 @@ SDValue RISCVTargetLowering::LowerFormalArguments(
   case CallingConv::PreserveMost:
   case CallingConv::GRAAL:
   case CallingConv::RISCV_VectorCall:
+  case CallingConv::Swift:
 #define CC_VLS_CASE(ABI_VLEN) case CallingConv::RISCV_VLSCall_##ABI_VLEN:
     CC_VLS_CASE(32)
     CC_VLS_CASE(64)

--- a/llvm/test/CodeGen/RISCV/swiftcc.ll
+++ b/llvm/test/CodeGen/RISCV/swiftcc.ll
@@ -1,0 +1,26 @@
+; RUN: llc -mtriple=riscv32 -verify-machineinstrs < %s | FileCheck %s
+; RUN: llc -mtriple=riscv64 -verify-machineinstrs < %s | FileCheck %s
+
+; swiftcc is lowered like the C convention on RISC-V. Check that it is
+; accepted at all: LowerFormalArguments used to reject it with
+; "Unsupported calling convention".
+
+define swiftcc i32 @swiftcc_param(i32 %a, i32 %b) {
+; CHECK-LABEL: swiftcc_param:
+; CHECK: ret
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+define swiftcc i32 @call_swiftcc(i32 %a, i32 %b) {
+; CHECK-LABEL: call_swiftcc:
+; CHECK: call swiftcc_param
+  %r = call swiftcc i32 @swiftcc_param(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+define swiftcc ptr @swiftself_param(ptr swiftself %addr) {
+; CHECK-LABEL: swiftself_param:
+; CHECK: ret
+  ret ptr %addr
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/llvm/llvm-project/pull/213448, filed upstream first per the guidance on #5551. This branch is the identical commit, so it stays a clean cherry-pick once upstream merges.

`RISCVTargetCodeGenInfo` already registers a `SwiftABIInfo`, but `RISCVTargetInfo::checkCallingConvention` does not accept `CC_Swift`, so sema drops the attribute and substitutes the default convention before CodeGen is reached. Every `swift_context` parameter then fails with `'swift_context' parameter can only be used with swiftcall or swiftasynccall calling convention`, which is where building the Swift standard library for riscv64 stops. `RISCVTargetLowering::LowerFormalArguments` also has no case for `CallingConv::Swift`.

`CC_SwiftAsync` is refused, as SystemZ and PPC64 refuse it, so `__has_extension(swiftasynccc)` stays false and `Config.h` falls back to `SWIFT_CC(swift)`.

Replaces #5551, which was scoped wider (swifterror in a register, dedicated s-registers for swiftself/swifterror/swiftasync/swiftcoro) and was filed only against the fork.