### PR TITLE
[Embedded Swift concurrency] Link the single-threaded platform library

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -201,6 +201,7 @@ ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
 	SWIFT_EMBEDDED_LIB_DIR = $(shell dirname $(SWIFTC))/../lib/swift/embedded/$(SWIFT_EMBEDDED_TRIPLE)
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_Concurrency.a
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_ConcurrencyDefaultExecutor.a
+	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswiftEmbeddedPlatformSingleThreaded.a
 	LD_EXTRAS += -lc++
 	LD_EXTRAS += -Xlinker -dead_strip
 endif


### PR DESCRIPTION
As part of our replatforming of Embedded Swift concurrency on top of the platform abstraction layer, clients will need to link in a platform library to use concurrency. Use the single-threaded one because it's the simplest.

(cherry picked from commit c9d15e888b9d8a4792636199670444ede976c80e)