### PR TITLE
[lldb] Enable embedded String-expression tests

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/objc-interop/TestSwiftObjCInterop.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc-interop/TestSwiftObjCInterop.py
@@ -12,5 +12,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift,
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[
         swiftTest,skipUnlessObjCInterop])

--- a/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -70,8 +70,8 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         self.filecheck_log(log, __file__, "--check-prefix=CHECK-TYPEINFO")
         # CHECK-TYPEINFO: [LLDBTypeInfoProvider] Looking up debug type info for So4CMYKV
 
-    @skipEmbeddedSwift
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_dwarf_importer_exprs(self):
         self.build()

--- a/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
@@ -23,7 +23,6 @@ class TestSwiftSubmoduleImport(TestBase):
     # Have to find some submodule that is present on both Darwin & Linux for this
     # test to run on both systems...
 
-    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test_swift_submodule_import(self):

--- a/lldb/test/API/lang/swift/generic_tuple/TestSwiftGenericTuple.py
+++ b/lldb/test/API/lang/swift/generic_tuple/TestSwiftGenericTuple.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest]
+)

--- a/lldb/test/API/lang/swift/local_types/TestSwiftLocalTypes.py
+++ b/lldb/test/API/lang/swift/local_types/TestSwiftLocalTypes.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest]
+)

--- a/lldb/test/API/lang/swift/macCatalystFramework/TestSwiftMacCatalystFramework.py
+++ b/lldb/test/API/lang/swift/macCatalystFramework/TestSwiftMacCatalystFramework.py
@@ -8,7 +8,6 @@ class TestSwiftMacCatalystFramework(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
     @swiftTest
     @skipIf(macos_version=["<", "26"])
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/missing_sdk/Makefile
+++ b/lldb/test/API/lang/swift/missing_sdk/Makefile
@@ -7,7 +7,13 @@ include Makefile.rules
 fakesdk:
 	$(call LN_SF,$(SDKROOT),$@)
 
+# On platforms with no SDK (e.g. Linux) SDKROOT is empty, and $(subst) with an
+# empty pattern appends the replacement to SWIFTFLAGS rather than substituting
+# anything, corrupting the last flag. There is no SDK path to redirect there
+# anyway, so only substitute when SDKROOT is set.
+ifneq "$(SDKROOT)" ""
 SWIFTFLAGS := $(subst $(SDKROOT),$(shell pwd)/fakesdk,$(SWIFTFLAGS))
+endif
 
 clean::
 	$(call RM_F,fakesdk a.out *.dSYM)

--- a/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
+++ b/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
@@ -14,7 +14,6 @@ class TestSwiftMissingSDK(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
-    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=['windows'])
     @skipIfDarwinEmbedded # swift crash inspecting swift stdlib with little other swift loaded <rdar://problem/55079456> 

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -22,7 +22,6 @@ import shutil
 
 class TestSwiftStructChangeRerun(TestBase):
     @expectedFailureWindows  # https://github.com/swiftlang/llvm-project/issues/13444
-    @skipEmbeddedSwift
     @swiftTest
     @skipIf(
         oslist=["windows"],


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/91151 fixes a bug in the embedded runtime's swift_bridgeObjectRetain, which caused these tests to fail.

Now that the bug is fixed, enable the tests.

Assisted-by: claude