### PR TITLE
[lldb] Fix the shadowed variant-exclusion list in the test harness

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1998,32 +1998,6 @@ def _is_excluded_variant_combination(method, variant_name, value_name):
         if combo.get(variant_name) != value_name:
             continue
         if all(
-            getattr(method, k, None) == v
-            for k, v in combo.items()
-            if k != variant_name
-        ):
-            return True
-    return False
-
-
-# Variant value combinations that should never be generated. Each entry maps
-# `variant_name -> value`; a method copy is dropped when its already-set
-# variant attributes plus the new value being added match every key in the
-# entry. Add entries here for crosses that don't exercise anything new and
-# would only inflate the matrix on remote test runs.
-_excluded_variant_combinations = [
-    # Example (uncomment + adapt when registering a real cross to drop):
-    # {"swift_module_importer": "noclang", "swift_embedded": "swiftembed"},
-]
-
-
-def _is_excluded_variant_combination(method, variant_name, value_name):
-    """Return True if assigning *variant_name=value_name* to *method* would
-    produce a combination listed in `_excluded_variant_combinations`."""
-    for combo in _excluded_variant_combinations:
-        if combo.get(variant_name) != value_name:
-            continue
-        if all(
             getattr(method, k, None) == v for k, v in combo.items() if k != variant_name
         ):
             return True


### PR DESCRIPTION
_excluded_variant_combinations and _is_excluded_variant_combination were each defined twice, ~30 lines apart. The first copy carried the real entry:

    # Embedded Swift doesn't go through the ClangImporter, so toggling the
    # importer setting doesn't change anything observable; skip the noclang
    # cross to halve the embedded variant count.
    {"swift_module_importer": "noclang", "swift_embedded": "swiftembed"},

The second was a placeholder with the entry commented out, and being later in the module it shadowed the first. So the exclusion never fired and the noclang x swiftembed cross ran anyway.

This was introduced in the cherry-pick commit b0c8c4e39404dfed09c2e9b974cf1d9387712530