### PR TITLE
[lldb] Handle ThinFunctionType in TypeSystemSwiftTypeRef::DumpTypeValue

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -5705,6 +5705,11 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::DependentGenericParamType:
     case Node::Kind::FunctionType:
     case Node::Kind::NoEscapeFunctionType:
+    // A thin function type is the type reflection uses to describe the
+    // function pointer inside of a thick function. It is a scalar just
+    // like all the other function types.
+    case Node::Kind::ThinFunctionType:
+    case Node::Kind::BoundGenericFunction:
     case Node::Kind::CFunctionPointer:
     case Node::Kind::ObjCBlock:
     case Node::Kind::ImplFunctionType: {

--- a/lldb/test/API/lang/swift/thick_function_children/Makefile
+++ b/lldb/test/API/lang/swift/thick_function_children/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/thick_function_children/TestSwiftThickFunctionChildren.py
+++ b/lldb/test/API/lang/swift/thick_function_children/TestSwiftThickFunctionChildren.py
@@ -1,0 +1,35 @@
+"""
+Test that the synthetic children of a thick function (closure) can be printed.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TestSwiftThickFunctionChildren(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    def test(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+        frame = thread.GetSelectedFrame()
+
+        self.expect(
+            "frame variable -T --ptr-depth 1 fn",
+            substrs=[
+                "((Int) -> Int) fn = 0x",
+                "(@convention(thin) () -> ()) function = 0x",
+                "(Builtin.NativeObject) context = 0x",
+            ],
+        )
+
+        fn = frame.FindVariable("fn")
+        self.assertTrue(fn.IsValid())
+        function = fn.GetChildMemberWithName("function")
+        self.assertTrue(function.IsValid())
+        self.assertEqual(function.GetTypeName(), "@convention(thin) () -> ()")
+        self.assertTrue(function.GetValue().startswith("0x"))

--- a/lldb/test/API/lang/swift/thick_function_children/main.swift
+++ b/lldb/test/API/lang/swift/thick_function_children/main.swift
@@ -1,0 +1,6 @@
+func use(_ fn: (Int) -> Int) {
+  print(fn(1)) // break here
+}
+
+var captured = 42
+use { $0 + captured }


### PR DESCRIPTION
A thick Swift function (a closure) is described by reflection as a record with two fields: "function", whose type is the reflection- internal builtin `yyXf` (`@convention(thin) () -> ()`), and "context", a `Builtin.NativeObject` (see TypeConverter::getThickFunctionTypeInfo() in TypeLowering.cpp).

Whenever those synthetic children get materialized -- e.g. by `frame variable --ptr-depth 1 someClosure` -- LLDB has to print a value for the "function" child. `$syyXfD` demangles into a `Node::Kind::ThinFunctionType`, and while that node kind is already treated as a scalar function type by CollectTypeInfo() (it is marked eTypeIsPointer | eTypeHasValue) and by IsFunctionType(), it was missing from the node kind switch in DumpTypeValue(). It therefore fell into the `default:` case, which silently printed nothing in a module's type system and tripped the "Unhandled node kind" assertion in TypeSystemSwiftTypeRefForExpressions.

Add ThinFunctionType (and, for the same reason, BoundGenericFunction, which CollectTypeInfo() groups with the other function types) to the list of function types that are dumped as a scalar. This matches SwiftASTContext::DumpTypeValue(), which handles the reconstructed type under swift::TypeKind::Function/GenericFunction.