### PR TITLE
[clang][APINotes] Do not duplicate Escapable and Copyable attributes

### DIFF
--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -807,6 +807,14 @@ static void ProcessAPINotes(Sema &S, ObjCMethodDecl *D,
                   static_cast<const api_notes::FunctionInfo &>(Info), Metadata);
 }
 
+static void addSwiftAttrIfAbsent(Sema &S, Decl *D, StringRef Attribute) {
+  for (const auto *A : D->specific_attrs<SwiftAttrAttr>())
+    if (A->getAttribute() == Attribute)
+      return;
+
+  D->addAttr(SwiftAttrAttr::Create(S.Context, Attribute));
+}
+
 /// Process API notes for a tag.
 static void ProcessAPINotes(Sema &S, TagDecl *D, const api_notes::TagInfo &Info,
                             VersionedInfoMetadata Metadata) {
@@ -828,12 +836,11 @@ static void ProcessAPINotes(Sema &S, TagDecl *D, const api_notes::TagInfo &Info,
 
   if (auto Copyable = Info.isSwiftCopyable()) {
     if (!*Copyable)
-      D->addAttr(SwiftAttrAttr::Create(S.Context, "~Copyable"));
+      addSwiftAttrIfAbsent(S, D, "~Copyable");
   }
 
   if (auto Escapable = Info.isSwiftEscapable()) {
-    D->addAttr(SwiftAttrAttr::Create(S.Context,
-                                     *Escapable ? "Escapable" : "~Escapable"));
+    addSwiftAttrIfAbsent(S, D, *Escapable ? "Escapable" : "~Escapable");
   }
 
   if (auto Extensibility = Info.EnumExtensibility) {

--- a/clang/test/APINotes/Inputs/Headers/SwiftImportAs.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/SwiftImportAs.apinotes
@@ -32,6 +32,12 @@ Tags:
   SwiftEscapable: false
 - Name: EscapableType
   SwiftEscapable: true
+- Name: EscapableAnnotatedInHeader
+  SwiftEscapable: true
+- Name: NoncopyableAnnotatedInHeader
+  SwiftCopyable: false
+- Name: EscapabilityConflict
+  SwiftEscapable: false
 - Name: NoncopyableWithDestroyType
   SwiftCopyable: false
   SwiftDestroyOp: NCDDestroy

--- a/clang/test/APINotes/Inputs/Headers/SwiftImportAs.h
+++ b/clang/test/APINotes/Inputs/Headers/SwiftImportAs.h
@@ -20,6 +20,10 @@ struct CopyableType { int value; };
 struct NonEscapableType { int value; };
 struct EscapableType { int value; };
 
+struct __attribute__((swift_attr("Escapable"))) EscapableAnnotatedInHeader { int value; };
+struct __attribute__((swift_attr("~Copyable"))) NoncopyableAnnotatedInHeader { int value; };
+struct __attribute__((swift_attr("Escapable"))) EscapabilityConflict { int value; };
+
 struct RefCountedTypeWithDefaultConvention {};
 inline void retain(RefCountedType *x) {}
 inline void release(RefCountedType *x) {}

--- a/clang/test/APINotes/swift-import-as.cpp
+++ b/clang/test/APINotes/swift-import-as.cpp
@@ -8,6 +8,9 @@
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter CopyableType | FileCheck -check-prefix=CHECK-COPYABLE %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter NonEscapableType | FileCheck -check-prefix=CHECK-NON-ESCAPABLE %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter EscapableType | FileCheck -check-prefix=CHECK-ESCAPABLE %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter EscapableAnnotatedInHeader | FileCheck -check-prefix=CHECK-ESCAPABLE-IN-HEADER %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter NoncopyableAnnotatedInHeader | FileCheck -check-prefix=CHECK-NONCOPYABLE-IN-HEADER %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter EscapabilityConflict | FileCheck -check-prefix=CHECK-ESCAPABILITY-CONFLICT %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter functionReturningFrt__ | FileCheck -check-prefix=CHECK-FUNCTION-RETURNING-FRT %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter functionReturningFrt_returns_unretained | FileCheck -check-prefix=CHECK-FUNCTION-RETURNING-FRT-UNRETAINED %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers %s -x c++ -ast-dump -ast-dump-filter functionReturningFrt_returns_retained | FileCheck -check-prefix=CHECK-FUNCTION-RETURNING-FRT-RETAINED %s
@@ -68,6 +71,23 @@
 // CHECK-ESCAPABLE: Dumping EscapableType:
 // CHECK-ESCAPABLE-NEXT: CXXRecordDecl {{.+}} imported in SwiftImportAs {{.+}} struct EscapableType
 // CHECK-ESCAPABLE: SwiftAttrAttr {{.+}} "Escapable"
+
+// An annotation from API notes does not repeat one that the header already has.
+// CHECK-ESCAPABLE-IN-HEADER: Dumping EscapableAnnotatedInHeader:
+// CHECK-ESCAPABLE-IN-HEADER-NEXT: CXXRecordDecl {{.+}} imported in SwiftImportAs {{.+}} struct EscapableAnnotatedInHeader
+// CHECK-ESCAPABLE-IN-HEADER: SwiftAttrAttr {{.+}} "Escapable"
+// CHECK-ESCAPABLE-IN-HEADER-NOT: SwiftAttrAttr {{.+}} "Escapable"
+
+// CHECK-NONCOPYABLE-IN-HEADER: Dumping NoncopyableAnnotatedInHeader:
+// CHECK-NONCOPYABLE-IN-HEADER-NEXT: CXXRecordDecl {{.+}} imported in SwiftImportAs {{.+}} struct NoncopyableAnnotatedInHeader
+// CHECK-NONCOPYABLE-IN-HEADER: SwiftAttrAttr {{.+}} "~Copyable"
+// CHECK-NONCOPYABLE-IN-HEADER-NOT: SwiftAttrAttr {{.+}} "~Copyable"
+
+// An annotation that disagrees with the header is still added.
+// CHECK-ESCAPABILITY-CONFLICT: Dumping EscapabilityConflict:
+// CHECK-ESCAPABILITY-CONFLICT-NEXT: CXXRecordDecl {{.+}} imported in SwiftImportAs {{.+}} struct EscapabilityConflict
+// CHECK-ESCAPABILITY-CONFLICT: SwiftAttrAttr {{.+}} "Escapable"
+// CHECK-ESCAPABILITY-CONFLICT: SwiftAttrAttr {{.+}} "~Escapable"
 
 // CHECK-FUNCTION-RETURNING-FRT: Dumping functionReturningFrt__:
 // CHECK-FUNCTION-RETURNING-FRT: FunctionDecl {{.+}} imported in SwiftImportAs functionReturningFrt__ 'ImmortalRefType *()'


### PR DESCRIPTION
Applying them when they already present is a wasted allocation and can also cause trouble in the Swift compiler that can complain about duplicated attributes.

rdar://174868727
(cherry picked from commit d8952cde88ae46e2824dc12fefa2eb87c49686ca)