### PR TITLE
🍒 [Verifier] Allow too big unused sectioned global variables with local linkage

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -855,10 +855,14 @@ void Verifier::visitGlobalVariable(const GlobalVariable &GV) {
         "Global @" + GV.getName() + " has illegal target extension type",
         GVType);
 
-  // Check that the the address space can hold all bits of the type, recognized
+  // Check that the address space can hold all bits of the type, recognized
   // by an access in the address space being able to reach all bytes of the
   // type.
+  // An exemption to this is sectioned global variables with local linkage
+  // and no uses. These are usually used for metadata.
   Check(!GVType->isSized() ||
+            (GV.hasLocalLinkage() && GV.hasSection() &&
+             GV.materialized_use_empty()) ||
             isUIntN(DL.getAddressSizeInBits(GV.getAddressSpace()),
                     GV.getGlobalSize(DL)),
         "Global variable is too large to fit into the address space", &GV,

--- a/llvm/test/Verifier/global-var-too-big.ll
+++ b/llvm/test/Verifier/global-var-too-big.ll
@@ -12,10 +12,27 @@ target datalayout = "e-m:e-p1:16:16-p2:32:32-p3:64:64-i8:8-i32:32-i64:64"
 @G3 = internal addrspace(1) global [65535 x i8] zeroinitializer, align 4
 @G4 = internal addrspace(2) global [2147483647 x i16] zeroinitializer, align 4
 
+; Too large but exempt: unreferenced, local linkage, has a section.
+@G5 = internal addrspace(1) global [65536 x i8] zeroinitializer, section "some_section_1", align 4
+@G6 = private addrspace(1) global [65536 x i8] zeroinitializer, section "some_section_2", align 4
+
+; Too large, has a section, but has a use so not exempt.
+@G7 = internal addrspace(1) global [65536 x i8] zeroinitializer, section "some_section_3", align 4
+@G7_user = global ptr addrspace(1) @G7
+
+; Too large, unreferenced, has a section, but external linkage so not exempt.
+@G8 = addrspace(1) global [65536 x i8] zeroinitializer, section "some_section_4", align 4
+
 ; CHECK: Global variable is too large to fit into the address space
 ; CHECK-NEXT: ptr addrspace(1) @G1
 ; CHECK-NEXT: [65536 x i8]
 ; CHECK: Global variable is too large to fit into the address space
 ; CHECK-NEXT: ptr addrspace(2) @G2
 ; CHECK-NEXT: [2147483648 x i16]
+; CHECK: Global variable is too large to fit into the address space
+; CHECK-NEXT: ptr addrspace(1) @G7
+; CHECK-NEXT: [65536 x i8]
+; CHECK: Global variable is too large to fit into the address space
+; CHECK-NEXT: ptr addrspace(1) @G8
+; CHECK-NEXT: [65536 x i8]
 ; CHECK-NOT: Global variable is too large to fit into the address space


### PR DESCRIPTION
This commit adjusts the check added in
https://github.com/llvm/llvm-project/pull/179625 to allow global variables that are too big for their address space if they are unused, have local linkage, and have a section. This allows metadata embedded in global variables, like __clang_ast, to exceed the limits.

This is an interim measure to unblock Swift stdlib builds. A better approach is being discussed in
https://github.com/llvm/llvm-project/pull/212733.

Problem context:

Building the embedded Swift stdlib for `avr-none-none-elf`, the Swift compiler aborts in the LLVM verify pass:
```
Global variable is too large to fit into the address space
ptr @__clang_ast   ; [136164 x i8]
````
AVR's data address space (addr space 0) is 16-bit → max 65535 bytes; the __clang_ast blob is 136164 bytes.