### PR TITLE
[IncludeTree] Record modules needed by textually-included modular headers

### DIFF
--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -14,6 +14,8 @@
 #include "clang/DependencyScanning/ScanAndUpdateArgs.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/PrefixMappingFileSystem.h"
@@ -134,6 +136,8 @@ private:
   std::optional<cas::ObjectRef> ModuleIncludesBufferRef;
   std::optional<cas::ObjectRef> ModuleMapRef;
   std::optional<cas::ObjectRef> APINotesRef;
+  /// Top-level modules of the submodule names recorded in the include-tree.
+  llvm::SmallSetVector<Module *, 2> EnteredModules;
   /// When the builder is created from an existing tree, the main include tree.
   std::optional<cas::ObjectRef> MainIncludeTreeRef;
   SmallVector<FilePPState> IncludeStack;
@@ -570,6 +574,7 @@ void IncludeTreeBuilder::enteredSubmodule(Preprocessor &PP, Module *M,
   assert(!IncludeStack.back().SubmoduleName && "repeated enteredSubmodule");
   auto Ref = check(DB.storeFromString({}, M->getFullModuleName()));
   IncludeStack.back().SubmoduleName = Ref;
+  EnteredModules.insert(M->getTopLevelModule());
 }
 void IncludeTreeBuilder::exitedSubmodule(Preprocessor &PP, Module *M,
                                          SourceLocation ImportLoc,
@@ -737,16 +742,20 @@ Expected<cas::IncludeTreeRoot> IncludeTreeBuilder::finishIncludeTree(
   if (!MainIncludeTree)
     return MainIncludeTree.takeError();
 
-  if (!ScanInstance.getLangOpts().CurrentModule.empty()) {
-    SmallVector<cas::ObjectRef> Modules;
-    SmallVector<cas::ObjectRef> APINotes;
-    auto AddModule = [&](Module *M) -> llvm::Error {
-      Expected<cas::IncludeTree::Module> Mod = getIncludeTreeModule(DB, M);
-      if (!Mod)
-        return Mod.takeError();
-      Modules.push_back(Mod->getRef());
+  SmallVector<cas::ObjectRef> Modules;
+  SmallVector<cas::ObjectRef> APINotes;
+  llvm::SmallPtrSet<Module *, 4> AddedModules;
+  auto AddModule = [&](Module *M) -> llvm::Error {
+    if (!AddedModules.insert(M).second)
       return Error::success();
-    };
+    Expected<cas::IncludeTree::Module> Mod = getIncludeTreeModule(DB, M);
+    if (!Mod)
+      return Mod.takeError();
+    Modules.push_back(Mod->getRef());
+    return Error::success();
+  };
+
+  if (!ScanInstance.getLangOpts().CurrentModule.empty()) {
     if (Module *M = ScanInstance.getPreprocessor().getCurrentModule()) {
       if (Error E = AddModule(M))
         return std::move(E);
@@ -781,18 +790,26 @@ Expected<cas::IncludeTreeRoot> IncludeTreeBuilder::finishIncludeTree(
         if (Error E = AddModule(PM))
           return std::move(E);
     }
+  }
 
+  // Modules referenced by a recorded submodule name must be resolvable when
+  // replaying the include-tree.
+  for (Module *M : EnteredModules)
+    if (Error E = AddModule(M))
+      return std::move(E);
+
+  if (!Modules.empty()) {
     auto ModMap = cas::IncludeTree::ModuleMap::create(DB, Modules);
     if (!ModMap)
       return ModMap.takeError();
     ModuleMapRef = ModMap->getRef();
+  }
 
-    if (!APINotes.empty()) {
-      auto ModAPINotes = cas::IncludeTree::APINotes::create(DB, APINotes);
-      if (!ModAPINotes)
-        return ModAPINotes.takeError();
-      APINotesRef = ModAPINotes->getRef();
-    }
+  if (!APINotes.empty()) {
+    auto ModAPINotes = cas::IncludeTree::APINotes::create(DB, APINotes);
+    if (!ModAPINotes)
+      return ModAPINotes.takeError();
+    APINotesRef = ModAPINotes->getRef();
   }
 
   auto FileList =

--- a/clang/test/ClangScanDeps/include-tree-module-map-file-without-modules.c
+++ b/clang/test/ClangScanDeps/include-tree-module-map-file-without-modules.c
@@ -1,0 +1,49 @@
+// Headers covered by a module map loaded with -fmodule-map-file belong to that
+// module even when modules are disabled, so the include-tree records a
+// submodule name for them. Check the module declaration is recorded too, so
+// replaying the include-tree can resolve that name.
+
+// REQUIRES: ondisk_cas
+// RUN: rm -rf %t
+// RUN: split-file --leading-lines %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-include-tree-full -cas-path %t/cas > %t/deps.json
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp
+
+// RUN: FileCheck %s -input-file %t/tu.rsp -check-prefix=RSP
+// RSP-NOT: -fmodule-map-file
+
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid > %t/tree.txt
+// RUN: FileCheck %s -input-file %t/tree.txt -DPREFIX=%/t
+
+// CHECK: [[PREFIX]]{{[/\\]}}tu.c llvmcas://
+// CHECK: [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}foo.h llvmcas://
+// CHECK-NEXT: Submodule: Foo
+// CHECK: Module Map:
+// CHECK-NEXT: Foo
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/tu.c -IDIR/Inputs -fmodule-map-file=DIR/module.modulemap",
+    "file": "DIR/tu.c"
+  }
+]
+
+//--- module.modulemap
+module Foo {
+  umbrella "Inputs"
+  export *
+}
+
+//--- Inputs/foo.h
+void foo(void);
+
+//--- tu.c
+#include "foo.h"
+void tu(void) { foo(); }


### PR DESCRIPTION
Headers covered by a module map loaded with -fmodule-map-file belong to
that module even when modules are disabled, so the include-tree records a
submodule name for them. The module declaration itself was only recorded
when building or implementing a module, so replaying such an include-tree
failed with:

  error: unable to load a node from the CAS include-tree:
  'failed to find module 'Foo''

Record the modules referenced by the submodule names in the tree.

rdar://183963783

