### PR TITLE
[lldb] Wrap reconstructed constraint types in an ExistentialType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5225,6 +5225,23 @@ static swift::Type ConvertSILFunctionTypesToASTFunctionTypes(swift::Type t) {
   });
 }
 
+/// Reconstruct a Swift type from a mangled type name.
+///
+/// This wraps swift::Demangle::getTypeForMangling(), which decodes the
+/// outermost type as if it appeared in a generic requirement. A mangled
+/// existential such as $s4main1P_pD ("any P") is therefore handed back as the
+/// bare constraint type ProtocolType "P" instead of an ExistentialType. LLDB
+/// only ever reconstructs the types of values, so re-wrap constraint types in
+/// an ExistentialType to get the same type the Swift compiler would produce
+/// for the equivalent source code.
+static swift::Type GetTypeForMangling(swift::ASTContext &ast_ctx,
+                                      llvm::StringRef mangled_name) {
+  swift::Type type = swift::Demangle::getTypeForMangling(ast_ctx, mangled_name);
+  if (type && type->isConstraintType())
+    return swift::ExistentialType::get(type);
+  return type;
+}
+
 CompilerType
 SwiftASTContext::GetTypeFromMangledTypename(ConstString mangled_typename) {
   if (llvm::isa<SwiftASTContextForExpressions>(this))
@@ -5350,8 +5367,7 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
 
   // Avoid type reconstruction compiling additional implicit modules.
   DisableImplicitImportsRAII no_imports(*this);
-  found_type = swift::Demangle::getTypeForMangling(
-                   **ast_ctx, mangled_typename.GetStringRef())
+  found_type = GetTypeForMangling(**ast_ctx, mangled_typename.GetStringRef())
                    .getPointer();
   assert(!found_type || &found_type->getASTContext() == *ast_ctx);
 
@@ -5362,8 +5378,7 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
     auto adjusted =
         GetTypeSystemSwiftTypeRef()->AdjustTypeForOriginallyDefinedInModule(
             mangled_typename);
-    found_type =
-        swift::Demangle::getTypeForMangling(**ast_ctx, adjusted).getPointer();
+    found_type = GetTypeForMangling(**ast_ctx, adjusted).getPointer();
   }
   // Objective-C classes sometimes have private subclasses that are invisible
   // to the Swift compiler because they are declared and defined in a .m file.

--- a/lldb/test/API/lang/swift/existential_dynamic_type/Makefile
+++ b/lldb/test/API/lang/swift/existential_dynamic_type/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/existential_dynamic_type/TestSwiftExistentialDynamicType.py
+++ b/lldb/test/API/lang/swift/existential_dynamic_type/TestSwiftExistentialDynamicType.py
@@ -1,0 +1,37 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(lldbtest.TestBase):
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        """Test that type(of:) works on variables of existential type."""
+
+        self.build()
+        filespec = lldb.SBFileSpec("main.swift")
+        lldbutil.run_to_source_breakpoint(self, "break here", filespec)
+
+        dynamic = lldb.SBExpressionOptions()
+        dynamic.SetFetchDynamicValue(lldb.eDynamicCanRunTarget)
+
+        static = lldb.SBExpressionOptions()
+        static.SetFetchDynamicValue(lldb.eNoDynamicValues)
+
+        # With dynamic type resolution the existential is replaced by the
+        # concrete type it holds.
+        self.expect_expr("type(of: single)", result_summary="a.S", options=dynamic)
+        self.expect_expr("type(of: composition)", result_summary="a.S", options=dynamic)
+        self.expect_expr("type(of: inherited)", result_summary="a.S", options=dynamic)
+        self.expect_expr("type(of: anything)", result_summary="Int", options=dynamic)
+
+        # Without dynamic type resolution the static existential type is used.
+        self.expect_expr("type(of: single)", result_type="a.P1.Type", options=static)
+        self.expect_expr(
+            "type(of: composition)", result_type="a.P1 & a.P2.Type", options=static
+        )
+        self.expect_expr(
+            "type(of: inherited)", result_type="a.Composed.Type", options=static
+        )

--- a/lldb/test/API/lang/swift/existential_dynamic_type/main.swift
+++ b/lldb/test/API/lang/swift/existential_dynamic_type/main.swift
@@ -1,0 +1,25 @@
+protocol P1 {
+  var a: Int { get }
+}
+
+protocol P2 {
+  var b: Int { get }
+}
+
+protocol Composed: P1 & P2 {
+  var c: Int { get }
+}
+
+struct S: Composed {
+  var a = 1
+  var b = 2
+  var c = 3
+}
+
+// The parameter types below are implicit existentials, i.e. they are the same
+// as `any P1`, `any P1 & P2` and `any Composed`.
+func f(single: P1, composition: P1 & P2, inherited: Composed, anything: Any) {
+  print(single.a, composition.b, inherited.c, anything) // break here
+}
+
+f(single: S(), composition: S(), inherited: S(), anything: 42)


### PR DESCRIPTION
Evaluating an expression that mentions a variable of existential type, such as

  protocol P { var x: Int { get } }
  func f(p: P) { ... }   // p has type `any P`

with `expression -- type(of: p)` aborted LLDB in the Swift AST verifier:

  different types for base type of .Type expression: P vs. any P

SwiftASTContext::ReconstructType() reconstructs a variable's type from its mangled name using swift::Demangle::getTypeForMangling(), which forwards to ASTBuilder::decodeMangledType() with its default `forRequirement=true`. In that mode the outermost type is decoded as if it appeared in a generic requirement, so ASTBuilder:: createProtocolCompositionType() returns the bare constraint type (a ProtocolType/ProtocolCompositionType) instead of wrapping it in an ExistentialType. LLDB then declares the local variable in the $__lldb_expr wrapper with the constraint type `P`, while Sema computes the metatype of the DynamicTypeExpr as `any P.Type`, and the two no longer agree.

LLDB only ever reconstructs the types of values, never constraints in requirement position (nested types are already decoded with forRequirement=false by TypeDecoder), and TypeSystemSwiftTypeRef:: IsExistentialType() already treats an outermost Protocol/ProtocolList node as an existential. Re-wrap outermost constraint types in an ExistentialType so that reconstruction produces the same type the Swift compiler would produce for the equivalent source code.