### PR TITLE
[lldb] Match embedded Swift's exclusivity SILOptions in the scratch context

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2584,14 +2584,11 @@ ProcessModule(Module &module, std::string m_description,
   }
 }
 
-/// Matches a subset of the SILOptions that the compiler turns on by default
-/// when embedded swift enabled.
+/// Set up \p swift_ast_ctx the same way the compiler sets up an embedded Swift
+/// compilation.
 static void EnableEmbeddedSwift(SwiftASTContext &swift_ast_ctx) {
-  swift_ast_ctx.GetLanguageOptions().enableFeature(swift::Feature::Embedded);
-
-  swift::SILOptions &sil_opts = swift_ast_ctx.GetSILOptions();
-  sil_opts.EnforceExclusivityStatic = true;
-  sil_opts.EnforceExclusivityDynamic = false;
+  swift_ast_ctx.GetCompilerInvocation().setCommonEmbeddedSwiftOptions(
+      swift::CompilerInvocation::EmbeddedSwiftContext::DebuggerExpression);
 }
 
 lldb::TypeSystemSP

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2584,6 +2584,16 @@ ProcessModule(Module &module, std::string m_description,
   }
 }
 
+/// Matches a subset of the SILOptions that the compiler turns on by default
+/// when embedded swift enabled.
+static void EnableEmbeddedSwift(SwiftASTContext &swift_ast_ctx) {
+  swift_ast_ctx.GetLanguageOptions().enableFeature(swift::Feature::Embedded);
+
+  swift::SILOptions &sil_opts = swift_ast_ctx.GetSILOptions();
+  sil_opts.EnforceExclusivityStatic = true;
+  sil_opts.EnforceExclusivityDynamic = false;
+}
+
 lldb::TypeSystemSP
 SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
                                 TypeSystemSwiftTypeRef &typeref_typesystem) {
@@ -2680,7 +2690,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
       module.IsSwiftCxxInteropEnabled();
 
   if (module.IsEmbeddedSwift())
-    swift_ast_sp->GetLanguageOptions().enableFeature(swift::Feature::Embedded);
+    EnableEmbeddedSwift(*swift_ast_sp);
 
   bool found_swift_modules = false;
   SymbolFile *sym_file = module.GetSymbolFile();
@@ -3209,7 +3219,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     auto &lang_opts = swift_ast_sp->GetLanguageOptions();
     lang_opts.EnableCXXInterop = ShouldEnableCXXInterop(cu);
     if (ShouldEnableEmbeddedSwift(cu))
-      lang_opts.enableFeature(swift::Feature::Embedded);
+      EnableEmbeddedSwift(*swift_ast_sp);
   } else {
     // Typesystem fallback context.
     if (!module_sp) {
@@ -3226,7 +3236,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     lang_opts.EnableAccessControl = false;
     lang_opts.EnableCXXInterop = ShouldEnableCXXInterop(cu);
     if (ShouldEnableEmbeddedSwift(cu))
-      lang_opts.enableFeature(swift::Feature::Embedded);
+      EnableEmbeddedSwift(*swift_ast_sp);
   }
   auto defer_log = llvm::make_scope_exit([swift_ast_sp, repl, playground] {
     swift_ast_sp->LogConfiguration(repl, playground);

--- a/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
+++ b/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])


### PR DESCRIPTION
When compiling an embedded swift program, the compiler changes some SILOptions options that we were not mirroring in LLDB.

Assisted-by: claude