### PR TITLE
[lldb] Handle DependentMemberType in TypeSystemSwiftTypeRef::DumpTypeValue

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -5703,6 +5703,9 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       LLVM_FALLTHROUGH;
     case Node::Kind::BuiltinTypeName:
     case Node::Kind::DependentGenericParamType:
+    // An unbound associated type such as `τ_0_0.Element`. Just like a bare
+    // generic parameter this is an opaque archetype, so print its raw value.
+    case Node::Kind::DependentMemberType:
     case Node::Kind::FunctionType:
     case Node::Kind::NoEscapeFunctionType:
     case Node::Kind::CFunctionPointer:

--- a/lldb/test/API/lang/swift/unresolved_associated_type_value/Makefile
+++ b/lldb/test/API/lang/swift/unresolved_associated_type_value/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/unresolved_associated_type_value/TestSwiftUnresolvedAssociatedTypeValue.py
+++ b/lldb/test/API/lang/swift/unresolved_associated_type_value/TestSwiftUnresolvedAssociatedTypeValue.py
@@ -1,0 +1,53 @@
+"""
+Test that a variable whose type is an unbound associated type can be printed.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    # Embedded Swift fully specializes the closure, so its parameter type is
+    # never a dependent member type there.
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        """The parameter of the closure in printAll() has the dependent member
+        type `τ_0_0.Element`. Usually LLDB resolves that archetype to the
+        concrete type via the runtime, but in the closure's epilogue the
+        argument's storage is already gone, so the resolution fails and LLDB
+        has to print the unbound archetype itself."""
+        self.build()
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+
+        # Put a breakpoint on every instruction of the closure so that every
+        # point of its epilogue is visited.
+        instructions = thread.GetFrameAtIndex(0).GetFunction().GetInstructions(
+            target)
+        self.assertTrue(instructions.GetSize() > 0)
+        target.DeleteAllBreakpoints()
+        for i in range(instructions.GetSize()):
+            target.BreakpointCreateBySBAddress(
+                instructions.GetInstructionAtIndex(i).GetAddress())
+
+        # Printing the closure's argument must never crash, and once the
+        # archetype can no longer be bound its raw value is printed instead.
+        saw_unbound_archetype = False
+        while process.GetState() == lldb.eStateStopped:
+            frame = process.GetSelectedThread().GetFrameAtIndex(0)
+            argument = frame.FindVariable("$0")
+            self.assertTrue(argument.IsValid())
+            if argument.GetTypeName() != "a.SpecificClass":
+                self.assertEqual(argument.GetTypeName(), "τ_0_0.Element")
+                self.assertIsNotNone(argument.GetValue())
+                self.assertTrue(argument.GetValue().startswith("0x"))
+                saw_unbound_archetype = True
+            process.Continue()
+
+        self.assertTrue(saw_unbound_archetype,
+                        "never saw the unbound associated type")

--- a/lldb/test/API/lang/swift/unresolved_associated_type_value/main.swift
+++ b/lldb/test/API/lang/swift/unresolved_associated_type_value/main.swift
@@ -1,0 +1,29 @@
+protocol Printable {
+  func describe() -> String
+}
+
+protocol Container {
+  associatedtype Element
+  var items: [Element] { get }
+}
+
+extension Container where Element: Printable {
+  func printAll() -> String {
+    return items.map {
+      $0.describe() // break here
+    }.joined(separator: ", ")
+  }
+}
+
+class SpecificClass: Printable {
+  var name: String
+  init(name: String) { self.name = name }
+  func describe() -> String { return "\(name)" }
+}
+
+struct Stack: Container {
+  var items: [SpecificClass] = []
+}
+
+let stack = Stack(items: [SpecificClass(name: "Rex")])
+print(stack.printAll())


### PR DESCRIPTION
A variable whose type is an associated type of the enclosing protocol's Self (e.g. the parameter of the closure in whose type is the dependent member type `τ_0_0.Element`) is normally resolved to its concrete type by SwiftLanguageRuntime before it is printed.

  extension Container where Element: Printable {
    func printAll() -> String {
      return items.map { $0.describe() }.joined(separator: ", ")
    }
  }

That resolution can legitimately fail, though: in the closure's epilogue the storage of the indirectly passed argument is already gone, so reading the instance fails and LLDB falls back to printing the unbound archetype itself.

`$s7Element4prog9ContainerPQzD` demangles into a
Node::Kind::DependentMemberType, and while CollectTypeInfo() marks that node kind as `eTypeHasValue | eTypeIsPointer | eTypeIsScalar`, it was missing from the node kind switch in DumpTypeValue(). It therefore fell into the `default:` case, which silently printed nothing in a module's type system and tripped the "Unhandled node kind" assertion in TypeSystemSwiftTypeRefForExpressions.

This patch dumps it as a scalar, just like the bare generic parameter DependentGenericParamType right above it. This also matches SwiftASTContext::DumpTypeValue().