### PR TITLE
[BoundsSafety] Make __single a sugar type

### DIFF
--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -117,6 +117,9 @@ namespace clang {
 class ASTContext;
 template <typename> class CanQual;
 class CXXRecordDecl;
+/* TO_UPSTREAM(BoundsSafety) ON */
+class BoundsSafetyPointerAttributes;
+/* TO_UPSTREAM(BoundsSafety) OFF */
 class DeclContext;
 class EnumDecl;
 class Expr;
@@ -2702,6 +2705,8 @@ public:
   bool isBidiIndexablePointerType() const;
   bool isUnspecifiedPointerType() const;
   bool isSafePointerType() const;
+  std::optional<BoundsSafetyPointerAttributes>
+  getSugarAwareBoundsSafetyPointerAttributes() const;
   /* TO_UPSTREAM(BoundsSafety) OFF */
   bool isSignableType(const ASTContext &Ctx) const;
   bool isSignablePointerType() const;
@@ -3687,12 +3692,16 @@ public:
     return !(FAttr.isUnsafeIndexable() || FAttr.isUnspecified());
   }
 
-  bool isSingle() const { return FAttr.isSingle(); }
   bool isIndexable() const { return FAttr.isIndexable(); }
   bool isBidiIndexable() const { return FAttr.isBidiIndexable(); }
   bool isUnsafeIndexable() const { return FAttr.isUnsafeIndexable(); }
   bool isUnspecified() const { return FAttr.isUnspecified(); }
 
+private:
+  using Type::isSinglePointerType;
+  using Type::isUnsafeIndexablePointerType;
+
+public:
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getPointeeType(), getPointerAttributes());
   }
@@ -9166,43 +9175,45 @@ inline bool Type::isSignablePointerType() const {
 }
 
 /* TO_UPSTREAM(BoundsSafety) ON */
-inline bool Type::isUnsafeIndexablePointerType() const {
+inline std::optional<BoundsSafetyPointerAttributes>
+Type::getSugarAwareBoundsSafetyPointerAttributes() const {
   const auto *PT = dyn_cast<PointerType>(CanonicalType);
   if (!PT)
-    return false;
-  if (PT->isUnsafeIndexable())
-    return true;
-  if (PT->isUnspecified() && hasAttr(attr::PtrUnsafeIndexable))
-    return true;
-  return false;
+    return std::nullopt;
+
+  if (PT->isUnspecified()) {
+    if (hasAttr(attr::PtrSingle))
+      return BoundsSafetyPointerAttributes::single();
+    if (hasAttr(attr::PtrUnsafeIndexable))
+      return BoundsSafetyPointerAttributes::unsafeIndexable();
+  }
+  return PT->getPointerAttributes();
+}
+
+inline bool Type::isUnsafeIndexablePointerType() const {
+  auto Attrs = getSugarAwareBoundsSafetyPointerAttributes();
+  return Attrs && Attrs->isUnsafeIndexable();
 }
 
 inline bool Type::isSinglePointerType() const {
-  const auto *PT = dyn_cast<PointerType>(CanonicalType);
-  if (!PT)
-    return false;
-  if (PT->isSingle())
-    return true;
-  if (PT->isUnspecified() && hasAttr(attr::PtrSingle))
-    return true;
-  return false;
+  auto Attrs = getSugarAwareBoundsSafetyPointerAttributes();
+  return Attrs && Attrs->isSingle();
 }
 
 inline bool Type::isBidiIndexablePointerType() const {
-  const auto *PT = dyn_cast<PointerType>(CanonicalType);
-  return PT && PT->isBidiIndexable();
+  auto Attrs = getSugarAwareBoundsSafetyPointerAttributes();
+  return Attrs && Attrs->isBidiIndexable();
 }
 
 inline bool Type::isIndexablePointerType() const {
-  const auto *PT = dyn_cast<PointerType>(CanonicalType);
-  return PT && PT->isIndexable();
+  auto Attrs = getSugarAwareBoundsSafetyPointerAttributes();
+  return Attrs && Attrs->isIndexable();
 }
 
 inline bool Type::isUnspecifiedPointerType() const {
-  return isPointerType() &&
-         !(isUnsafeIndexablePointerType() || isSinglePointerType() ||
-           isBidiIndexablePointerType() || isIndexablePointerType() ||
-           isBoundsAttributedType() || isValueTerminatedType());
+  auto Attrs = getSugarAwareBoundsSafetyPointerAttributes();
+  return Attrs && Attrs->isUnspecified() && !isBoundsAttributedType() &&
+         !isValueTerminatedType();
 }
 
 inline bool Type::isSafePointerType() const {

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3929,6 +3929,21 @@ QualType ASTContext::getBoundsSafetyPointerType(QualType PointerTy,
   std::function<QualType(QualType)>
   getBoundsSafetyPointerTypeRecurse = [&](QualType Ty) -> QualType {
     if (const auto *AT = Ty->getAs<AttributedType>()) {
+      
+      if (AT->getAttrKind() == attr::PtrSingle ||
+          AT->getAttrKind() == attr::PtrUnsafeIndexable) {
+        QualType Inner =
+            getBoundsSafetyPointerTypeRecurse(AT->getModifiedType());
+        auto QualsOnT = Ty.getQualifiers();
+        auto QualsOnModifTy = AT->getModifiedType().getQualifiers();
+        Qualifiers::removeCommonQualifiers(QualsOnT, QualsOnModifTy);
+        if (!QualsOnT.empty()) {
+          QualifierCollector QC(QualsOnT);
+          Inner = QC.apply(*this, Inner);
+        }
+        return Inner;
+      }
+
       auto ModifiedTy =
           getBoundsSafetyPointerTypeRecurse(AT->getModifiedType());
       auto EquivalentTy =
@@ -4009,6 +4024,22 @@ QualType ASTContext::mergeBoundsSafetyPointerTypes(
 
   const auto *AT = DstTy->getAs<AttributedType>();
   if (AT && !RecoverPtrAuto) {
+        if (AT->getAttrKind() == attr::PtrSingle ||
+        AT->getAttrKind() == attr::PtrUnsafeIndexable) {
+      QualType Inner = mergeBoundsSafetyPointerTypes(
+          AT->getModifiedType(), SrcTy, MergeFunctor, OrigDstTy);
+      if (Inner.isNull())
+        return QualType();
+      auto QualsOnT = DstTy.getQualifiers();
+      auto QualsOnModifTy = AT->getModifiedType().getQualifiers();
+      Qualifiers::removeCommonQualifiers(QualsOnT, QualsOnModifTy);
+      if (!QualsOnT.empty()) {
+        QualifierCollector QC(QualsOnT);
+        Inner = QC.apply(*this, Inner);
+      }
+      return Inner;
+    }
+
     auto ModifiedTy = mergeBoundsSafetyPointerTypes(
         AT->getModifiedType(), SrcTy, MergeFunctor, OrigDstTy);
     if (ModifiedTy.isNull())
@@ -4119,9 +4150,13 @@ public:
 
   RetTy VisitAttributedType(const AttributedType *T) {
     auto SavedAutoPtrAttr = AutoPtrAttr;
-    QualType ModifiedTy = Visit(T->getModifiedType());
+        QualType ModifiedTy = T->getAttrKind() == attr::PtrSingle
+                              ? T->getModifiedType()
+                              : Visit(T->getModifiedType());
     AutoPtrAttr = SavedAutoPtrAttr;
-    QualType EquivalentTy = Visit(T->getEquivalentType());
+    QualType EquivalentTy = T->getAttrKind() == attr::PtrSingle
+                                ? T->getEquivalentType()
+                                : Visit(T->getEquivalentType());
     QualType NewTy =
         Ctx.getAttributedType(T->getAttrKind(), ModifiedTy, EquivalentTy);
     return {NewTy, false};
@@ -6388,7 +6423,7 @@ QualType ASTContext::getAttributedType(attr::Kind attrKind,
   assert(!attr || attr->getKind() == attrKind);
 
   QualType canon = getCanonicalType(equivalentType);
-	type = new (*this, alignof(AttributedType))
+    type = new (*this, alignof(AttributedType))
       AttributedType(canon, attrKind, attr, modifiedType, equivalentType);
 
   Types.push_back(type);
@@ -7958,8 +7993,10 @@ bool ASTContext::hasCompatibleBoundsSafetyPointerLayout(QualType T1, QualType T2
     if (hasSameType(T1, T2))
       return true;
 
-    const auto *PT1 = T1->getBaseElementTypeUnsafe()->getAs<PointerType>();
-    const auto *PT2 = T2->getBaseElementTypeUnsafe()->getAs<PointerType>();
+    QualType BaseT1 = QualType(T1->getBaseElementTypeUnsafe(), 0);
+    QualType BaseT2 = QualType(T2->getBaseElementTypeUnsafe(), 0);
+    const auto *PT1 = BaseT1->getAs<PointerType>();
+    const auto *PT2 = BaseT2->getAs<PointerType>();
 
     if (!PT1 && !PT2)
       return true;
@@ -7974,14 +8011,14 @@ bool ASTContext::hasCompatibleBoundsSafetyPointerLayout(QualType T1, QualType T2
     }
 
     if (PT1) {
-      if (!PT2 && PT1->isSafePointer())
+      if (!PT2 && BaseT1->isSafePointerType())
         return false;
 
       T1 = PT1->getPointeeType();
     }
 
     if (PT2) {
-      if (!PT1 && PT2->isSafePointer())
+      if (!PT1 && BaseT2->isSafePointerType())
         return false;
       T2 = PT2->getPointeeType();
     }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -4161,14 +4161,47 @@ public:
     return {NewTy, false};
   }
 
+  QualType VisitPtrSingleModifiedType(QualType Ty) {
+    if (const auto *AT = Ty->getAs<AttributedType>()) {
+      if (AT->getAttrKind() != attr::PtrSingle &&
+          AT->getAttrKind() != attr::PtrUnsafeIndexable)
+        return Ty;
+
+      QualType NewModifiedTy =
+          VisitPtrSingleModifiedType(AT->getModifiedType());
+      QualType NewEquivalentTy =
+          VisitPtrSingleModifiedType(AT->getEquivalentType());
+      if (NewModifiedTy == AT->getModifiedType() &&
+          NewEquivalentTy == AT->getEquivalentType())
+        return Ty;
+
+      QualType NewTy = Ctx.getAttributedType(AT->getAttrKind(), NewModifiedTy,
+                                              NewEquivalentTy);
+      return copyQuals(Ty, NewTy);
+    }
+
+    const auto *PtrTy = dyn_cast<PointerType>(Ty.getTypePtr());
+    if (!PtrTy)
+      return Ty;
+
+    QualType OrigPointeeTy = PtrTy->getPointeeType();
+    QualType PointeeTy = VisitPtrSingleModifiedType(OrigPointeeTy);
+    if (PointeeTy == OrigPointeeTy)
+      return Ty;
+
+    QualType NewTy =
+        Ctx.getPointerType(PointeeTy, PtrTy->getPointerAttributes());
+    return copyQuals(Ty, NewTy);
+  }
+
   RetTy VisitAttributedType(const AttributedType *T) {
     auto SavedAutoPtrAttr = AutoPtrAttr;
-        QualType ModifiedTy = T->getAttrKind() == attr::PtrSingle
-                              ? T->getModifiedType()
+    QualType ModifiedTy = T->getAttrKind() == attr::PtrSingle
+                              ? VisitPtrSingleModifiedType(T->getModifiedType())
                               : Visit(T->getModifiedType());
     AutoPtrAttr = SavedAutoPtrAttr;
     QualType EquivalentTy = T->getAttrKind() == attr::PtrSingle
-                                ? T->getEquivalentType()
+                                ? VisitPtrSingleModifiedType(T->getEquivalentType())
                                 : Visit(T->getEquivalentType());
     QualType NewTy =
         Ctx.getAttributedType(T->getAttrKind(), ModifiedTy, EquivalentTy);
@@ -8015,11 +8048,14 @@ bool ASTContext::hasCompatibleBoundsSafetyPointerLayout(QualType T1, QualType T2
       return true;
 
     if (PT1 && PT2) {
+      BoundsSafetyPointerAttributes Attr1 =
+          *BaseT1->getSugarAwareBoundsSafetyPointerAttributes();
+      BoundsSafetyPointerAttributes Attr2 =
+          *BaseT2->getSugarAwareBoundsSafetyPointerAttributes();
       if (!ExactCheck) {
-        if (!BoundsSafetyPointerAttributes::areCompatible(
-                PT1->getPointerAttributes(), PT2->getPointerAttributes()))
+        if (!BoundsSafetyPointerAttributes::areCompatible(Attr1, Attr2))
           return false;
-      } else if (PT1->getPointerAttributes() != PT2->getPointerAttributes())
+      } else if (Attr1 != Attr2)
         return false;
     }
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3995,6 +3995,10 @@ static QualType assureMandatorySugarTypesRemain(const ASTContext &Ctx,
           DestTy, DRPT->getStartPointer(), DRPT->getEndPointer(),
           DRPT->getStartPtrDecls(), DRPT->getEndPtrDecls());
     }
+  } else if (SrcTy->hasAttr(attr::PtrSingle)) {
+    if (!DestTy->hasAttr(attr::PtrSingle)) {
+      return Ctx.getAttributedType(attr::PtrSingle, DestTy, DestTy);
+    }
   }
 
   return DestTy;
@@ -4033,11 +4037,19 @@ QualType ASTContext::mergeBoundsSafetyPointerTypes(
       auto QualsOnT = DstTy.getQualifiers();
       auto QualsOnModifTy = AT->getModifiedType().getQualifiers();
       Qualifiers::removeCommonQualifiers(QualsOnT, QualsOnModifTy);
+      bool InnerAlreadyHasAttr = AT->getAttrKind() == attr::PtrSingle
+                                      ? Inner->isSinglePointerType()
+                                      : Inner->isUnsafeIndexablePointerType();
+      bool SrcConveysNoBoundsInfo =
+          SrcTy.isNull() || SrcTy->isUnspecifiedPointerType();
+      QualType NewDstTy = Inner;
+      if (!InnerAlreadyHasAttr && !SrcConveysNoBoundsInfo)
+        NewDstTy = getAttributedType(AT->getAttrKind(), Inner, Inner);
       if (!QualsOnT.empty()) {
         QualifierCollector QC(QualsOnT);
-        Inner = QC.apply(*this, Inner);
+        NewDstTy = QC.apply(*this, NewDstTy);
       }
-      return Inner;
+      return NewDstTy;
     }
 
     auto ModifiedTy = mergeBoundsSafetyPointerTypes(
@@ -4077,6 +4089,7 @@ QualType ASTContext::mergeBoundsSafetyPointerTypes(
       QualifierCollector QC(QualsOnT);
       MergeTy = QC.apply(*this, MergeTy);
     }
+    MergeTy = assureMandatorySugarTypesRemain(*this, MergeTy, DstTy);
   }
   return MergeTy;
 }
@@ -12896,9 +12909,13 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS, bool OfBlockPointer,
     // Merge two pointer types, while trying to preserve typedef info
     const PointerType *LHSPointer = LHS->castAs<PointerType>();
     const PointerType *RHSPointer = RHS->castAs<PointerType>();
-    BoundsSafetyPointerAttributes LHSFA = LHSPointer->getPointerAttributes();
-    BoundsSafetyPointerAttributes RHSFA = RHSPointer->getPointerAttributes();
-    if (!BoundsSafetyPointerAttributes::areCompatible(LHSFA, RHSFA))
+    BoundsSafetyPointerAttributes LHSFA =
+        LHS->getSugarAwareBoundsSafetyPointerAttributes().value_or(
+            BoundsSafetyPointerAttributes::unspecified());
+    BoundsSafetyPointerAttributes RHSFA =
+        RHS->getSugarAwareBoundsSafetyPointerAttributes().value_or(
+            BoundsSafetyPointerAttributes::unspecified());
+    if (!BoundsSafetyPointerAttributes::areEquivalentLayouts(LHSFA, RHSFA))
       return {};
     BoundsSafetyPointerAttributes BestFA = LHSFA;
     if (BestFA.isUnspecified())

--- a/clang/lib/AST/ASTDiagnostic.cpp
+++ b/clang/lib/AST/ASTDiagnostic.cpp
@@ -57,8 +57,18 @@ QualType clang::desugarForDiagnostic(ASTContext &Context, QualType QT,
       QT = ST->desugar();
       continue;
     }
-    // ...or an attributed type...
     if (const AttributedType *AT = dyn_cast<AttributedType>(Ty)) {
+            if (AT->getAttrKind() == attr::PtrSingle ||
+          AT->getAttrKind() == attr::PtrUnsafeIndexable) {
+        bool DesugarModified = false;
+        QualType NewModifiedTy = desugarForDiagnostic(
+            Context, AT->getModifiedType(), DesugarModified);
+        if (DesugarModified)
+          ShouldAKA = true;
+        QT = Context.getAttributedType(AT->getAttrKind(), NewModifiedTy,
+                                        NewModifiedTy);
+        return QC.apply(Context, QT);
+      }
       QT = AT->desugar();
       continue;
     }

--- a/clang/lib/AST/ASTDiagnostic.cpp
+++ b/clang/lib/AST/ASTDiagnostic.cpp
@@ -58,7 +58,7 @@ QualType clang::desugarForDiagnostic(ASTContext &Context, QualType QT,
       continue;
     }
     if (const AttributedType *AT = dyn_cast<AttributedType>(Ty)) {
-            if (AT->getAttrKind() == attr::PtrSingle ||
+      if (AT->getAttrKind() == attr::PtrSingle ||
           AT->getAttrKind() == attr::PtrUnsafeIndexable) {
         bool DesugarModified = false;
         QualType NewModifiedTy = desugarForDiagnostic(

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -10825,6 +10825,11 @@ bool PointerExprEvaluator::VisitCastExpr(const CastExpr *E) {
       if (ObjSize.getQuantity() == 0)
         return true;
 
+      if (SubObj.Invalid &&
+          (Result.isForgeSingle() || Result.isForgeTerminatedBy()) &&
+          !ResultTy->isValueTerminatedType())
+        return true;
+
       ItemCount = APInt(64, 1);
     }
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -10825,8 +10825,7 @@ bool PointerExprEvaluator::VisitCastExpr(const CastExpr *E) {
       if (ObjSize.getQuantity() == 0)
         return true;
 
-      if (SubObj.Invalid &&
-          (Result.isForgeSingle() || Result.isForgeTerminatedBy()) &&
+      if ((Result.isForgeSingle() || Result.isForgeTerminatedBy()) &&
           !ResultTy->isValueTerminatedType())
         return true;
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -10760,8 +10760,12 @@ bool PointerExprEvaluator::VisitCastExpr(const CastExpr *E) {
     // There never is a case where you convert from a counted pointer to
     // something else because no lvalue turns into a counted pointer.
 
-    auto ResultPtrTy = E->getType()->getAs<PointerType>();
-    auto ResultFA = ResultPtrTy->getPointerAttributes();
+    QualType ResultTy = E->getType();
+    auto ResultPtrTy = ResultTy->getAs<PointerType>();
+    bool ResultIsUnsafeOrUnspecified = ResultTy->isUnsafeIndexablePointerType() ||
+                                       ResultTy->isUnspecifiedPointerType();
+    bool ResultIsBidiIndexable = ResultTy->isBidiIndexablePointerType();
+    bool ResultIsIndexable = ResultTy->isIndexablePointerType();
 
     // Evaluate the sub-expression and bail out if that didn't work. We do
     // this first because NULL pointers are always valid constants.
@@ -10771,14 +10775,15 @@ bool PointerExprEvaluator::VisitCastExpr(const CastExpr *E) {
     auto &SubObj = Result.getLValueDesignator();
     // "from unsafe or unspecified" only works if the destination is also
     // unsafe; we can bail out early if that's not the case
-    auto InputPtrTy = E->getSubExpr()->getType()->getAs<PointerType>();
-    auto InputFA = InputPtrTy->getPointerAttributes();
-    auto InputIsUnsafe = InputFA.isUnsafeOrUnspecified() && !Result.IsNullPtr;
-    if (InputIsUnsafe && !ResultFA.isUnsafeOrUnspecified())
+    QualType InputTy = E->getSubExpr()->getType();
+    bool InputIsUnsafeOrUnspecified = InputTy->isUnsafeIndexablePointerType() ||
+                                      InputTy->isUnspecifiedPointerType();
+    auto InputIsUnsafe = InputIsUnsafeOrUnspecified && !Result.IsNullPtr;
+    if (InputIsUnsafe && !ResultIsUnsafeOrUnspecified)
       return false;
 
     // "to unsafe" and "to bidi indexable" require no other checks.
-    if (ResultFA.isUnsafeOrUnspecified() || ResultFA.isBidiIndexable())
+    if (ResultIsUnsafeOrUnspecified || ResultIsBidiIndexable)
       return true;
 
     // "to indexable" requires that the pointer value is not less than the lower
@@ -10786,7 +10791,7 @@ bool PointerExprEvaluator::VisitCastExpr(const CastExpr *E) {
     // upper bound is useless. This gives us a good reason to reject it, which
     // makes the test easy: if the sub-object is invalid, prevent constant
     // evaluation.
-    if (ResultFA.isIndexable()) {
+    if (ResultIsIndexable) {
       return Result.IsNullPtr || SubObj.isValidSubobject();
     }
 

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2103,19 +2103,12 @@ NestedNameSpecifier Type::getPrefix() const {
 
 bool Type::hasAttr(attr::Kind AK) const {
   const Type *Cur = this;
-  while (true) {
-    if (const auto *AT = dyn_cast<AttributedType>(Cur)) {
-      if (AT->getAttrKind() == AK)
-        return true;
-      Cur = AT->getEquivalentType().getTypePtr();
-      continue;
-    }
-    
-    QualType Desugared = Cur->getLocallyUnqualifiedSingleStepDesugaredType();
-    if (Desugared.getTypePtr() == Cur)
-      return false;
-    Cur = Desugared.getTypePtr();
+  while (const auto *AT = Cur->getAs<AttributedType>()) {
+    if (AT->getAttrKind() == AK)
+      return true;
+    Cur = AT->getEquivalentType().getTypePtr();
   }
+  return false;
 }
 
 namespace {

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2103,12 +2103,19 @@ NestedNameSpecifier Type::getPrefix() const {
 
 bool Type::hasAttr(attr::Kind AK) const {
   const Type *Cur = this;
-  while (const auto *AT = Cur->getAs<AttributedType>()) {
-    if (AT->getAttrKind() == AK)
-      return true;
-    Cur = AT->getEquivalentType().getTypePtr();
+  while (true) {
+    if (const auto *AT = dyn_cast<AttributedType>(Cur)) {
+      if (AT->getAttrKind() == AK)
+        return true;
+      Cur = AT->getEquivalentType().getTypePtr();
+      continue;
+    }
+    
+    QualType Desugared = Cur->getLocallyUnqualifiedSingleStepDesugaredType();
+    if (Desugared.getTypePtr() == Cur)
+      return false;
+    Cur = Desugared.getTypePtr();
   }
-  return false;
 }
 
 namespace {

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2085,10 +2085,6 @@ void TypePrinter::printAttributedBefore(const AttributedType *T,
   else
     printBefore(T->getModifiedType(), OS);
 
-    if (T->getAttrKind() == attr::PtrUnsafeIndexable) {
-    OS << "__unsafe_indexable";
-  }
-
   if (T->isMSTypeSpec()) {
     switch (T->getAttrKind()) {
     default: return;
@@ -2170,12 +2166,14 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   if (T->getAttrKind() == attr::PtrAutoNullTerminatedAttr)
     return;
 
-    if (T->getAttrKind() == attr::PtrUnsafeIndexable)
-    return;
   if (T->getAttrKind() == attr::PtrSingle) {
     if (Policy.CountedByInArrayBracket)
       return;
     OS << "__single";
+    return;
+  }
+  if (T->getAttrKind() == attr::PtrUnsafeIndexable) {
+    OS << "__unsafe_indexable";
     return;
   }
   /* TO_UPSTREAM(BoundsSafety) OFF*/

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2031,10 +2031,63 @@ void TypePrinter::printAttributedBefore(const AttributedType *T,
     spaceBeforePlaceHolder(OS);
   }
 
+  
+  if (T->getAttrKind() == attr::PtrSingle && Policy.CountedByInArrayBracket) {
+    QualType Inner = T->getModifiedType();
+    llvm::SmallVector<QualType, 2> Wrappers;
+    for (;;) {
+      if (Inner->getAs<ValueTerminatedType>()) {
+        Wrappers.push_back(Inner);
+        Inner = Inner->getAs<ValueTerminatedType>()->desugar();
+      } else if (const auto *CAT = Inner->getAs<CountAttributedType>()) {
+        Wrappers.push_back(Inner);
+        Inner = CAT->desugar();
+      } else if (const auto *DRT = Inner->getAs<DynamicRangePointerType>()) {
+        Wrappers.push_back(Inner);
+        Inner = DRT->desugar();
+      } else {
+        break;
+      }
+    }
+
+    printBefore(Inner, OS);
+    OS << "__single";
+
+    for (auto It = Wrappers.rbegin(), E = Wrappers.rend(); It != E; ++It) {
+      QualType W = *It;
+      if (const auto *VTT = W->getAs<ValueTerminatedType>()) {
+        
+        assert(VTT->desugar()->isPointerType());
+        OS << ' ';
+        printTerminatedByAttr(VTT, OS, Policy);
+      } else if (const auto *CAT = W->getAs<CountAttributedType>()) {
+        printCountAttributedImpl(CAT, OS, Policy);
+      } else if (const auto *DRT = W->getAs<DynamicRangePointerType>()) {
+        if (const Expr *EndPtr = DRT->getEndPointer()) {
+          OS << " __ended_by(";
+          EndPtr->printPretty(OS, nullptr, Policy);
+          OS << ')';
+        }
+        if (const Expr *StartPtr = DRT->getStartPointer()) {
+          OS << " /* __started_by(";
+          StartPtr->printPretty(OS, nullptr, Policy);
+          OS << ") */ ";
+        }
+      }
+    }
+
+        return;
+  }
+  
+
   if (T->getAttrKind() == attr::AddressSpace)
     printBefore(T->getEquivalentType(), OS);
   else
     printBefore(T->getModifiedType(), OS);
+
+    if (T->getAttrKind() == attr::PtrUnsafeIndexable) {
+    OS << "__unsafe_indexable";
+  }
 
   if (T->isMSTypeSpec()) {
     switch (T->getAttrKind()) {
@@ -2117,12 +2170,12 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   if (T->getAttrKind() == attr::PtrAutoNullTerminatedAttr)
     return;
 
-  if (T->getAttrKind() == attr::PtrSingle) {
-    OS << "__single";
+    if (T->getAttrKind() == attr::PtrUnsafeIndexable)
     return;
-  }
-  if (T->getAttrKind() == attr::PtrUnsafeIndexable) {
-    OS << "__unsafe_indexable";
+  if (T->getAttrKind() == attr::PtrSingle) {
+    if (Policy.CountedByInArrayBracket)
+      return;
+    OS << "__single";
     return;
   }
   /* TO_UPSTREAM(BoundsSafety) OFF*/

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -544,8 +544,10 @@ Sema::deduceCastPointerAttributes(QualType ResultType, QualType SrcType) {
       BoundsSafetyPointerAttributes DstAttr;
       if (!DPTy->isUnspecified()) {
         DstAttr = DPTy->getPointerAttributes();
+      } else if (!OrigDstTy.isNull() && OrigDstTy->isSinglePointerType()) {
+        DstAttr = BoundsSafetyPointerAttributes::single();
       } else if (!SrcTy.isNull() && SrcTy->isSinglePointerType()) {
-                DstAttr = BoundsSafetyPointerAttributes::single();
+        DstAttr = BoundsSafetyPointerAttributes::single();
       } else if (SPTy) {
         DstAttr = SPTy->getPointerAttributes();
       } else {

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -225,7 +225,7 @@ namespace {
         Expr::EvalResult R;
         SrcIsNull = SrcExpr.get()->isNullPointerConstant(Self.Context,
             Expr::NPC_ValueDependentIsNotNull);
-        if (DestPTy->isSafePointer() && !SrcPTy &&
+                if (DestType->isSafePointerType() && !SrcPTy &&
             !DestPTy->getPointeeType().isVolatileQualified() &&
             !SrcIsNull) {
           Self.Diag(OpRange.getBegin(), diag::err_bounds_safety_non_to_pointer);
@@ -384,7 +384,15 @@ namespace {
           }
         }
 
-        if (DestPTy->isSafePointer() && !SrcPTy->isSafePointer() &&
+                bool DestIsSafeForUnsafeToSafe = DestType->isSafePointerType();
+        if (DestIsSafeForUnsafeToSafe && !Self.getLangOpts().BoundsSafety &&
+            (DestType->isValueTerminatedType() ||
+             DestType->isBoundsAttributedType()) &&
+            !DestType->hasAttr(attr::PtrSingle)) {
+          
+          DestIsSafeForUnsafeToSafe = false;
+        }
+        if (DestIsSafeForUnsafeToSafe && !SrcType->isSafePointerType() &&
             !SrcIsNull) {
           if (!SrcPTy->isUnsafeIndexable()) {
             // Ensure that the diagnostic says "unsafe indexable" somewhere.
@@ -397,8 +405,9 @@ namespace {
           return;
         }
 
+        
         if (!SrcIsNull && DestPTy->isPointerTypeWithBounds() &&
-            SrcPTy->isSingle() && !SrcType->isBoundsAttributedType()) {
+            SrcType->isSinglePointerType() && !SrcType->isBoundsAttributedType()) {
           if (SrcPTy->getPointeeType()->isIncompleteOrSizelessType()) {
             Self.Diag(OpRange.getBegin(),
                       diag::err_bounds_safety_incomplete_single_to_indexable)
@@ -483,7 +492,10 @@ namespace {
 /* TO_UPSTREAM(BoundsSafety) ON*/
 QualType
 Sema::deduceCastPointerAttributes(QualType ResultType, QualType SrcType) {
-  if (Context.hasSameBoundsSafetyPointerLayout(ResultType, SrcType))
+    bool NeedsSingleInheritance =
+      SrcType->isSinglePointerType() && ResultType->isUnspecifiedPointerType();
+  if (!NeedsSingleInheritance &&
+      Context.hasSameBoundsSafetyPointerLayout(ResultType, SrcType))
     return ResultType;
 
   // We apply the following type attribute inheritance rules.
@@ -522,7 +534,7 @@ Sema::deduceCastPointerAttributes(QualType ResultType, QualType SrcType) {
                                          MergePointeeTy)) {
         // SrcTy is __terminated_by(), update the pointee and inherit the
         // __terminated_by().
-        assert(!DVTT && SPTy->isSingle());
+        assert(!DVTT && SrcTy->isSinglePointerType());
         QualType Ty = Context.getPointerType(
             MergePointeeTy, BoundsSafetyPointerAttributes::single());
         return Context.getValueTerminatedType(Ty, SVTT->getTerminatorExpr());
@@ -532,6 +544,8 @@ Sema::deduceCastPointerAttributes(QualType ResultType, QualType SrcType) {
       BoundsSafetyPointerAttributes DstAttr;
       if (!DPTy->isUnspecified()) {
         DstAttr = DPTy->getPointerAttributes();
+      } else if (!SrcTy.isNull() && SrcTy->isSinglePointerType()) {
+                DstAttr = BoundsSafetyPointerAttributes::single();
       } else if (SPTy) {
         DstAttr = SPTy->getPointerAttributes();
       } else {

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -225,7 +225,7 @@ namespace {
         Expr::EvalResult R;
         SrcIsNull = SrcExpr.get()->isNullPointerConstant(Self.Context,
             Expr::NPC_ValueDependentIsNotNull);
-                if (DestType->isSafePointerType() && !SrcPTy &&
+        if (DestType->isSafePointerType() && !SrcPTy &&
             !DestPTy->getPointeeType().isVolatileQualified() &&
             !SrcIsNull) {
           Self.Diag(OpRange.getBegin(), diag::err_bounds_safety_non_to_pointer);
@@ -384,12 +384,11 @@ namespace {
           }
         }
 
-                bool DestIsSafeForUnsafeToSafe = DestType->isSafePointerType();
+        bool DestIsSafeForUnsafeToSafe = DestType->isSafePointerType();
         if (DestIsSafeForUnsafeToSafe && !Self.getLangOpts().BoundsSafety &&
             (DestType->isValueTerminatedType() ||
              DestType->isBoundsAttributedType()) &&
             !DestType->hasAttr(attr::PtrSingle)) {
-          
           DestIsSafeForUnsafeToSafe = false;
         }
         if (DestIsSafeForUnsafeToSafe && !SrcType->isSafePointerType() &&
@@ -405,7 +404,6 @@ namespace {
           return;
         }
 
-        
         if (!SrcIsNull && DestPTy->isPointerTypeWithBounds() &&
             SrcType->isSinglePointerType() && !SrcType->isBoundsAttributedType()) {
           if (SrcPTy->getPointeeType()->isIncompleteOrSizelessType()) {
@@ -492,7 +490,7 @@ namespace {
 /* TO_UPSTREAM(BoundsSafety) ON*/
 QualType
 Sema::deduceCastPointerAttributes(QualType ResultType, QualType SrcType) {
-    bool NeedsSingleInheritance =
+  bool NeedsSingleInheritance =
       SrcType->isSinglePointerType() && ResultType->isUnspecifiedPointerType();
   if (!NeedsSingleInheritance &&
       Context.hasSameBoundsSafetyPointerLayout(ResultType, SrcType))

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5411,7 +5411,6 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
     bool IsDBP = ValType->isBoundsAttributedType();
     if (PtrTy || IsDBP) {
       // Check if an AddSub op uses a pointer to __unsafe_indexable pointer.
-      
       if (Form == Arithmetic && (IsDBP || ValType->isSafePointerType())) {
         // Non-AddSub ops require a pointer to an integer, they should have been
         // handled.
@@ -5422,8 +5421,8 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
       }
       // Non-arithmetic ops require a pointer to __unsafe_indexable or __single
       // pointer.
-                if (IsDBP ||
-            (ValType->isSafePointerType() && !ValType->isSinglePointerType())) {
+      if (IsDBP ||
+          (ValType->isSafePointerType() && !ValType->isSinglePointerType())) {
         unsigned DiagIndex;
         if (PtrTy->isIndexable())
           DiagIndex = 0;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5411,7 +5411,8 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
     bool IsDBP = ValType->isBoundsAttributedType();
     if (PtrTy || IsDBP) {
       // Check if an AddSub op uses a pointer to __unsafe_indexable pointer.
-      if (Form == Arithmetic && (IsDBP || PtrTy->isSafePointer())) {
+      
+      if (Form == Arithmetic && (IsDBP || ValType->isSafePointerType())) {
         // Non-AddSub ops require a pointer to an integer, they should have been
         // handled.
         Diag(ExprRange.getBegin(),
@@ -5421,7 +5422,8 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
       }
       // Non-arithmetic ops require a pointer to __unsafe_indexable or __single
       // pointer.
-      if (IsDBP || (PtrTy->isSafePointer() && !PtrTy->isSingle())) {
+                if (IsDBP ||
+            (ValType->isSafePointerType() && !ValType->isSinglePointerType())) {
         unsigned DiagIndex;
         if (PtrTy->isIndexable())
           DiagIndex = 0;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11695,8 +11695,7 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
       if (Param->getType()->isCountAttributedType() ||
           Param->getType()->isDynamicRangePointerType())
         continue; // has a dynamic count, no problem
-      auto FA = Param->getType()->getAs<PointerType>()->getPointerAttributes();
-      if (FA.isSingle()) {
+      if (Param->getType()->isSinglePointerType()) {
         Diag(TSInfo->getTypeLoc().getBeginLoc(),
             diag::err_bounds_safety_array_decay_to_single) << TST;
         Diag(TSInfo->getTypeLoc().getBeginLoc(),
@@ -16609,7 +16608,7 @@ static void checkAtomicAutoPointerAttrs(Sema &S, const Decl *D) {
     if (!PtrTy)
       break;
     if (HasAutoAttr && !PtrTy->isUnspecified() && !PtrTy->isUnsafeIndexable() &&
-        !PtrTy->isSingle()) {
+        !Ty->isSinglePointerType()) {
       assert(PtrTy->isIndexable() || PtrTy->isBidiIndexable());
       unsigned DiagIndex = PtrTy->isIndexable() ? 0 : 1;
       S.Diag(D->getBeginLoc(), diag::err_bounds_safety_atomic_unsupported_attribute)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6877,10 +6877,8 @@ public:
     }
 
     if (Level == 0) {
-      if (S.getLangOpts().BoundsSafetyAttributes && !S.getLangOpts().BoundsSafety)
-        FAttr.setUnspecified();
-      else
-        FAttr.setSingle();
+      
+      FAttr.setUnspecified();
       QualType QTy = (FAttr != T->getPointerAttributes())
                       ? S.Context.getPointerType(T->getPointeeType(), FAttr)
                       : QualType(T, 0);
@@ -6960,11 +6958,19 @@ public:
     if (T->getAttrKind() == attr::PtrAutoAttr)
       AutoPtrAttributed = true;
 
+    
+    unsigned MyLevel = Level;
+
     QualType NewModTy = Visit(T->getModifiedType());
     if (NewModTy.isNull())
       return QualType();
 
     if (T->getAttrKind() == attr::PtrAutoAttr)
+      return NewModTy;
+
+    
+    if (T->getAttrKind() == attr::PtrSingle && MyLevel == 0 &&
+        !S.getLangOpts().isBoundsSafetyAttributeOnlyMode())
       return NewModTy;
 
     if (NewModTy != T->getModifiedType()) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6877,14 +6877,13 @@ public:
     }
 
     if (Level == 0) {
-      
       FAttr.setUnspecified();
       QualType QTy = (FAttr != T->getPointerAttributes())
                       ? S.Context.getPointerType(T->getPointeeType(), FAttr)
                       : QualType(T, 0);
       return getDerived()->BuildDynamicBoundType(QTy);
     }
-    Level--;
+    llvm::SaveAndRestore<unsigned> LevelLocal(Level, Level - 1);
     llvm::SaveAndRestore<bool> AutoPtrAttributedLocal(AutoPtrAttributed, false);
     QualType NewPointeeTy = Visit(T->getPointeeType());
     if (NewPointeeTy.isNull())
@@ -6958,9 +6957,6 @@ public:
     if (T->getAttrKind() == attr::PtrAutoAttr)
       AutoPtrAttributed = true;
 
-    
-    unsigned MyLevel = Level;
-
     QualType NewModTy = Visit(T->getModifiedType());
     if (NewModTy.isNull())
       return QualType();
@@ -6968,8 +6964,7 @@ public:
     if (T->getAttrKind() == attr::PtrAutoAttr)
       return NewModTy;
 
-    
-    if (T->getAttrKind() == attr::PtrSingle && MyLevel == 0 &&
+    if (T->getAttrKind() == attr::PtrSingle && Level == 0 &&
         !S.getLangOpts().isBoundsSafetyAttributeOnlyMode())
       return NewModTy;
 
@@ -7065,7 +7060,7 @@ public:
   }
 
   QualType TraverseArrayType(const ArrayType *T) {
-    Level--;
+    llvm::SaveAndRestore<unsigned> LevelLocal(Level, Level - 1);
     llvm::SaveAndRestore<bool> AutoPtrAttributedLocal(AutoPtrAttributed, false);
     QualType NewElementTy = Visit(T->getElementType());
     if (NewElementTy.isNull())

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8290,8 +8290,8 @@ bool Sema::CheckDynamicCountSizeForAssignment(
     return true;
 
   Expr *CountExpr = LDCPTy->getCountExpr()->IgnoreParenCasts();
-    if (CountExpr->isValueDependent())
-        return false;
+  if (CountExpr->isValueDependent())
+    return false;
 
   // unsafe/unspecified counts as "bounded" because there shouldn't be a warning
   // in manual adoption mode, else no one would be able to use it. In regular
@@ -8302,8 +8302,7 @@ bool Sema::CheckDynamicCountSizeForAssignment(
                       !RHSTy->isCountAttributedType() &&
                       (!RDRPTy || !RDRPTy->getEndPointer()) &&
                       !RHSTy->isPointerTypeWithBounds() &&
-                      !RHSTy->isUnsafeIndexablePointerType() &&
-                      !RHSTy->isUnspecifiedPointerType();
+                      RHSTy->isSafePointerType();
   if (UnboundedRHS)
     // It might still have a flexible array member
     if (auto *RT = RHSTy->getPointeeType()->getAs<RecordType>())
@@ -8858,10 +8857,11 @@ static bool checkDynamicCountPointerAsParameter(Sema &S, FunctionDecl *FDecl,
               DiagTy = ArgDepInfo.getDecl()->getType();
             }
 
-        S.Diag(Call->getExprLoc(),
-           diag::err_bounds_safety_unsynchronized_indirect_param)
-              << ArgInfo.getDecl() << ArgInfo.isAddrOf() << ArgDepInfo.getDecl()
-              << !ArgDepInfo.isDeref() << IsDependent << DiagTy;
+            S.Diag(Call->getExprLoc(),
+                   diag::err_bounds_safety_unsynchronized_indirect_param)
+                << ArgInfo.getDecl() << ArgInfo.isAddrOf()
+                << ArgDepInfo.getDecl() << !ArgDepInfo.isDeref()
+                << IsDependent << DiagTy;
             return false;
           }
         }
@@ -10417,16 +10417,6 @@ static bool checkConditionalNullPointer(Sema &S, ExprResult &NullExpr,
 }
 
 
-static BoundsSafetyPointerAttributes
-getSugarAwareBoundsSafetyPointerAttributes(QualType T) {
-  if (T->isSinglePointerType())
-    return BoundsSafetyPointerAttributes::single();
-  if (T->isUnsafeIndexablePointerType())
-    return BoundsSafetyPointerAttributes::unsafeIndexable();
-  return T->castAs<PointerType>()->getPointerAttributes();
-}
-
-
 /// Checks compatibility between two pointers and return the resulting
 /// type.
 static QualType checkConditionalPointerCompatibility(Sema &S, ExprResult &LHS,
@@ -10477,9 +10467,9 @@ static QualType checkConditionalPointerCompatibility(Sema &S, ExprResult &LHS,
     // 4) __single
     // The operands are considered incompatible if an operand has unsafe pointer
     // type and the other has bounds.
-    
-    auto lFPAttr = getSugarAwareBoundsSafetyPointerAttributes(LHSTy);
-    auto rFPAttr = getSugarAwareBoundsSafetyPointerAttributes(RHSTy);
+
+    auto lFPAttr = *LHSTy->getSugarAwareBoundsSafetyPointerAttributes();
+    auto rFPAttr = *RHSTy->getSugarAwareBoundsSafetyPointerAttributes();
     CompositeFPAttr = BoundsSafetyPointerAttributes::merge(lFPAttr, rFPAttr);
     /* TO_UPSTREAM(BoundsSafety) OFF*/
   }
@@ -10686,9 +10676,9 @@ checkConditionalObjectPointersCompatibility(Sema &S, ExprResult &LHS,
   // we risk doing a BitCast across pointer attributes, which is bad.
   
   BoundsSafetyPointerAttributes lFPAttr =
-      getSugarAwareBoundsSafetyPointerAttributes(LHSTy);
+      *LHSTy->getSugarAwareBoundsSafetyPointerAttributes();
   BoundsSafetyPointerAttributes rFPAttr =
-      getSugarAwareBoundsSafetyPointerAttributes(RHSTy);
+      *RHSTy->getSugarAwareBoundsSafetyPointerAttributes();
   destFPAttr = BoundsSafetyPointerAttributes::merge(lFPAttr, rFPAttr);
 
   // If either type is value terminated, the other also needs to be, meaning
@@ -11544,24 +11534,11 @@ static bool checkBoundsSafetyFunctionPointerForAssignment(Sema &S,
 
   return CheckRemaningParams(LProto) || CheckRemaningParams(RProto);
 }
-/* TO_UPSTREAM(BoundsSafety) OFF*/
 
 
 static bool
 hasCompatibleNestedBoundsSafetyPointerAttributesSugarAware(QualType LHSType,
                                                             QualType RHSType) {
-  auto GetPointerAttrs =
-      [](QualType T) -> std::optional<BoundsSafetyPointerAttributes> {
-    const auto *PT = T->getAs<PointerType>();
-    if (!PT)
-      return std::nullopt;
-    if (T->isSinglePointerType())
-      return BoundsSafetyPointerAttributes::single();
-    if (T->isUnsafeIndexablePointerType())
-      return BoundsSafetyPointerAttributes::unsafeIndexable();
-    return PT->getPointerAttributes();
-  };
-
   const auto *LHSPtr = LHSType->getAs<PointerType>();
   const auto *RHSPtr = RHSType->getAs<PointerType>();
   if (!LHSPtr || !RHSPtr)
@@ -11570,8 +11547,8 @@ hasCompatibleNestedBoundsSafetyPointerAttributesSugarAware(QualType LHSType,
   QualType LPointee = LHSPtr->getPointeeType();
   QualType RPointee = RHSPtr->getPointeeType();
   for (;;) {
-    auto LAttrs = GetPointerAttrs(LPointee);
-    auto RAttrs = GetPointerAttrs(RPointee);
+    auto LAttrs = LPointee->getSugarAwareBoundsSafetyPointerAttributes();
+    auto RAttrs = RPointee->getSugarAwareBoundsSafetyPointerAttributes();
     if (!LAttrs || !RAttrs)
       return true;
     if (!BoundsSafetyPointerAttributes::areCompatible(*LAttrs, *RAttrs))
@@ -11974,7 +11951,6 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
                                                    bool ConvertRHS) {
   QualType RHSType = RHS.get()->getType();
   QualType OrigLHSType = LHSType;
-  
   QualType OrigRHSType = RHSType;
 
   // Get canonical types.  We're not formatting these types, just comparing
@@ -11986,12 +11962,10 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
   if (LHSType == RHSType) {
     Kind = CK_NoOp;
     /* TO_UPSTREAM(BoundsSafety) ON*/
-    
-    bool OuterSingleMismatch = OrigLHSType->isSinglePointerType() !=
-                                OrigRHSType->isSinglePointerType();
     if (getLangOpts().BoundsSafety &&
-        (!Context.canMergeTypeBounds(OrigLHSType, RHS.get()->getType()) ||
-         OuterSingleMismatch)) {
+        (OrigLHSType->isSinglePointerType() !=
+             OrigRHSType->isSinglePointerType() ||
+         !Context.canMergeTypeBounds(OrigLHSType, RHS.get()->getType()))) {
       Kind = CK_BoundsSafetyPointerCast;
     /* TO_UPSTREAM(BoundsSafety) OFF*/
     } else {
@@ -12036,7 +12010,7 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
   // If we have an atomic type, try a non-atomic assignment, then just add an
   // atomic qualification step.
   if (const AtomicType *AtomicTy = dyn_cast<AtomicType>(LHSType)) {
-    
+    /* TO_UPSTREAM(BoundsSafety) ON */
     const AtomicType *OrigAtomicTy = OrigLHSType->getAs<AtomicType>();
     QualType ValueTy =
         OrigAtomicTy ? OrigAtomicTy->getValueType() : AtomicTy->getValueType();
@@ -12298,7 +12272,6 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
       else
         Kind = CK_BitCast;
       /* TO_UPSTREAM(BoundsSafety) ON*/
-      
       if (getLangOpts().BoundsSafety &&
           !hasCompatibleNestedBoundsSafetyPointerAttributesSugarAware(
               OrigLHSType, OrigRHSType))
@@ -12311,7 +12284,6 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
     // int -> T*
     if (RHSType->isIntegerType()) {
       Kind = CK_IntegralToPointer; // FIXME: null?
-      
       return OrigLHSType->isSafePointerType()
                  ? AssignConvertType::IncompatibleIntToSafePointer
                  : AssignConvertType::IntToPointer;
@@ -12946,7 +12918,7 @@ bool Sema::allowBoundsUnsafePointerAssignment(
   // All safe pointers ABI compatible with unsafe pointers (and each other) are
   // __single pointers. Make no exception for ABI incompatible pointer type
   // mismatch.
-    if (!DestTy->isSinglePointerType() && DestSafe)
+  if (!DestTy->isSinglePointerType() && DestSafe)
     return false;
   if (!SourceValue->getType()->isSinglePointerType() && SourceSafe)
     return false;
@@ -14462,7 +14434,7 @@ static bool checkArithmeticBinOpBoundsSafetyPointer(Sema &S, Expr *Base,
     return false;
   }
 
-    if (BaseType->isSinglePointerType() && !BaseType->isBoundsAttributedType()) {
+  if (BaseType->isSinglePointerType() && !BaseType->isBoundsAttributedType()) {
     emitBoundsSafetySinglePointerArithmeticError(S, Base);
     return false;
   }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12222,8 +12222,21 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
         // `int *__single = (char *__bidi)x`) will first BitCast to
         // `int *__bidi` and then FPC to `int *__single`, which will CodeGen
         // the bounds check correctly.
+        bool NeedsBidiIntermediate =
+            OrigLHSType->isBoundsAttributedType() &&
+            OrigRHSType->isSinglePointerType() &&
+            !Context.hasSameUnqualifiedType(LHSPointer->getPointeeType(),
+                                            RHSPointer->getPointeeType());
+        if (NeedsBidiIntermediate)
+          RHS = ImpCastExprToType(
+              RHS.get(),
+              Context.getPointerType(RHSPointer->getPointeeType(),
+                                     BoundsSafetyPointerAttributes::bidiIndexable()),
+              CK_BoundsSafetyPointerCast);
         auto LHSIntermediateType = Context.getPointerType(
-            LHSPointer->getPointeeType(), RHSFA);
+            LHSPointer->getPointeeType(),
+            NeedsBidiIntermediate ? BoundsSafetyPointerAttributes::bidiIndexable()
+                                  : RHSFA);
         auto Result = CheckAssignmentConstraints(LHSIntermediateType, RHS,
                                                  Kind, ConvertRHS);
         bool SkipNoOp = Kind == CK_NoOp &&

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -26402,13 +26402,8 @@ ExprResult Sema::ActOnForgeBidiIndexable(SourceLocation KWLoc,
 
 ExprResult Sema::ActOnForgeSingle(SourceLocation KWLoc, Expr *Addr,
                                   SourceLocation RParenLoc) {
-  QualType ResultType;
-  if (getLangOpts().isBoundsSafetyAttributeOnlyMode()) {
-    ResultType = Context.getAttributedType(attr::PtrSingle, Context.VoidPtrTy,
-                                           Context.VoidPtrTy);
-  } else
-    ResultType = Context.getPointerType(Context.VoidTy,
-                                        BoundsSafetyPointerAttributes::single());
+  QualType ResultType = Context.getAttributedType(
+      attr::PtrSingle, Context.VoidPtrTy, Context.VoidPtrTy);
   return BuildForgePtrExpr(KWLoc, RParenLoc, ResultType, Addr);
 }
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5945,7 +5945,7 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
     // If the base of the array subscript expression is 'counted_by', it should
     // have been promoted to __bidi_indexable.
     assert(!Ty->isBoundsAttributedType());
-    if (PTy->isSingle()) {
+    if (Ty->isSinglePointerType()) {
       Expr::EvalResult RInt;
       if (!RHSExp->EvaluateAsInt(RInt, Context) || RInt.Val.getInt() != 0) {
         Diag(LLoc, diag::err_bounds_safety_pointer_subscript)
@@ -8290,20 +8290,20 @@ bool Sema::CheckDynamicCountSizeForAssignment(
     return true;
 
   Expr *CountExpr = LDCPTy->getCountExpr()->IgnoreParenCasts();
-	if (CountExpr->isValueDependent())
-		return false;
+    if (CountExpr->isValueDependent())
+        return false;
 
-  auto *RHSPTy = RHSTy->getAs<PointerType>();
-  auto FA =
-      RHSPTy ? RHSPTy->getPointerAttributes() : BoundsSafetyPointerAttributes();
   // unsafe/unspecified counts as "bounded" because there shouldn't be a warning
   // in manual adoption mode, else no one would be able to use it. In regular
   // -fbounds-safety mode, some other part of Sema should have already have
   // complained.
   const auto *RDRPTy = RHSTy->getAs<DynamicRangePointerType>();
-  bool UnboundedRHS = !RHSTy->isCountAttributedType() &&
+  bool UnboundedRHS = RHSTy->isPointerType() &&
+                      !RHSTy->isCountAttributedType() &&
                       (!RDRPTy || !RDRPTy->getEndPointer()) &&
-                      !FA.hasUpperBound() && !FA.isUnsafeOrUnspecified();
+                      !RHSTy->isPointerTypeWithBounds() &&
+                      !RHSTy->isUnsafeIndexablePointerType() &&
+                      !RHSTy->isUnspecifiedPointerType();
   if (UnboundedRHS)
     // It might still have a flexible array member
     if (auto *RT = RHSTy->getPointeeType()->getAs<RecordType>())
@@ -8858,8 +8858,8 @@ static bool checkDynamicCountPointerAsParameter(Sema &S, FunctionDecl *FDecl,
               DiagTy = ArgDepInfo.getDecl()->getType();
             }
 
-	    S.Diag(Call->getExprLoc(),
-		   diag::err_bounds_safety_unsynchronized_indirect_param)
+        S.Diag(Call->getExprLoc(),
+           diag::err_bounds_safety_unsynchronized_indirect_param)
               << ArgInfo.getDecl() << ArgInfo.isAddrOf() << ArgDepInfo.getDecl()
               << !ArgDepInfo.isDeref() << IsDependent << DiagTy;
             return false;
@@ -10416,6 +10416,17 @@ static bool checkConditionalNullPointer(Sema &S, ExprResult &NullExpr,
   return false;
 }
 
+
+static BoundsSafetyPointerAttributes
+getSugarAwareBoundsSafetyPointerAttributes(QualType T) {
+  if (T->isSinglePointerType())
+    return BoundsSafetyPointerAttributes::single();
+  if (T->isUnsafeIndexablePointerType())
+    return BoundsSafetyPointerAttributes::unsafeIndexable();
+  return T->castAs<PointerType>()->getPointerAttributes();
+}
+
+
 /// Checks compatibility between two pointers and return the resulting
 /// type.
 static QualType checkConditionalPointerCompatibility(Sema &S, ExprResult &LHS,
@@ -10466,8 +10477,9 @@ static QualType checkConditionalPointerCompatibility(Sema &S, ExprResult &LHS,
     // 4) __single
     // The operands are considered incompatible if an operand has unsafe pointer
     // type and the other has bounds.
-    auto lFPAttr = LHSTy->castAs<PointerType>()->getPointerAttributes();
-    auto rFPAttr = RHSTy->castAs<PointerType>()->getPointerAttributes();
+    
+    auto lFPAttr = getSugarAwareBoundsSafetyPointerAttributes(LHSTy);
+    auto rFPAttr = getSugarAwareBoundsSafetyPointerAttributes(RHSTy);
     CompositeFPAttr = BoundsSafetyPointerAttributes::merge(lFPAttr, rFPAttr);
     /* TO_UPSTREAM(BoundsSafety) OFF*/
   }
@@ -10672,10 +10684,11 @@ checkConditionalObjectPointersCompatibility(Sema &S, ExprResult &LHS,
   BoundsSafetyPointerAttributes destFPAttr;
   // Do -fbounds-safety pointer conversions ahead of any other conversions; otherwise
   // we risk doing a BitCast across pointer attributes, which is bad.
+  
   BoundsSafetyPointerAttributes lFPAttr =
-      LHSTy->castAs<PointerType>()->getPointerAttributes();
+      getSugarAwareBoundsSafetyPointerAttributes(LHSTy);
   BoundsSafetyPointerAttributes rFPAttr =
-      RHSTy->castAs<PointerType>()->getPointerAttributes();
+      getSugarAwareBoundsSafetyPointerAttributes(RHSTy);
   destFPAttr = BoundsSafetyPointerAttributes::merge(lFPAttr, rFPAttr);
 
   // If either type is value terminated, the other also needs to be, meaning
@@ -11533,6 +11546,42 @@ static bool checkBoundsSafetyFunctionPointerForAssignment(Sema &S,
 }
 /* TO_UPSTREAM(BoundsSafety) OFF*/
 
+
+static bool
+hasCompatibleNestedBoundsSafetyPointerAttributesSugarAware(QualType LHSType,
+                                                            QualType RHSType) {
+  auto GetPointerAttrs =
+      [](QualType T) -> std::optional<BoundsSafetyPointerAttributes> {
+    const auto *PT = T->getAs<PointerType>();
+    if (!PT)
+      return std::nullopt;
+    if (T->isSinglePointerType())
+      return BoundsSafetyPointerAttributes::single();
+    if (T->isUnsafeIndexablePointerType())
+      return BoundsSafetyPointerAttributes::unsafeIndexable();
+    return PT->getPointerAttributes();
+  };
+
+  const auto *LHSPtr = LHSType->getAs<PointerType>();
+  const auto *RHSPtr = RHSType->getAs<PointerType>();
+  if (!LHSPtr || !RHSPtr)
+    return true;
+
+  QualType LPointee = LHSPtr->getPointeeType();
+  QualType RPointee = RHSPtr->getPointeeType();
+  for (;;) {
+    auto LAttrs = GetPointerAttrs(LPointee);
+    auto RAttrs = GetPointerAttrs(RPointee);
+    if (!LAttrs || !RAttrs)
+      return true;
+    if (!BoundsSafetyPointerAttributes::areCompatible(*LAttrs, *RAttrs))
+      return false;
+    LPointee = LPointee->getAs<PointerType>()->getPointeeType();
+    RPointee = RPointee->getAs<PointerType>()->getPointeeType();
+  }
+}
+/* TO_UPSTREAM(BoundsSafety) OFF*/
+
 // checkPointerTypesForAssignment - This is a very tricky routine (despite
 // being closely modeled after the C99 spec:-). The odd characteristic of this
 // routine is it effectively iqnores the qualifiers on the top level pointee.
@@ -11925,6 +11974,8 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
                                                    bool ConvertRHS) {
   QualType RHSType = RHS.get()->getType();
   QualType OrigLHSType = LHSType;
+  
+  QualType OrigRHSType = RHSType;
 
   // Get canonical types.  We're not formatting these types, just comparing
   // them.
@@ -11935,8 +11986,12 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
   if (LHSType == RHSType) {
     Kind = CK_NoOp;
     /* TO_UPSTREAM(BoundsSafety) ON*/
+    
+    bool OuterSingleMismatch = OrigLHSType->isSinglePointerType() !=
+                                OrigRHSType->isSinglePointerType();
     if (getLangOpts().BoundsSafety &&
-        !Context.canMergeTypeBounds(OrigLHSType, RHS.get()->getType())) {
+        (!Context.canMergeTypeBounds(OrigLHSType, RHS.get()->getType()) ||
+         OuterSingleMismatch)) {
       Kind = CK_BoundsSafetyPointerCast;
     /* TO_UPSTREAM(BoundsSafety) OFF*/
     } else {
@@ -11981,12 +12036,17 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
   // If we have an atomic type, try a non-atomic assignment, then just add an
   // atomic qualification step.
   if (const AtomicType *AtomicTy = dyn_cast<AtomicType>(LHSType)) {
+    
+    const AtomicType *OrigAtomicTy = OrigLHSType->getAs<AtomicType>();
+    QualType ValueTy =
+        OrigAtomicTy ? OrigAtomicTy->getValueType() : AtomicTy->getValueType();
+    /* TO_UPSTREAM(BoundsSafety) OFF */
     AssignConvertType Result =
-        CheckAssignmentConstraints(AtomicTy->getValueType(), RHS, Kind);
+        CheckAssignmentConstraints(ValueTy, RHS, Kind);
     if (!IsAssignConvertCompatible(Result))
       return Result;
     if (Kind != CK_NoOp && ConvertRHS)
-      RHS = ImpCastExprToType(RHS.get(), AtomicTy->getValueType(), Kind);
+      RHS = ImpCastExprToType(RHS.get(), ValueTy, Kind);
     Kind = CK_NonAtomicToAtomic;
     return Result;
   }
@@ -12134,21 +12194,22 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
       /*TO_UPSTREAM(BoundsSafety) ON*/
       if (getLangOpts().BoundsSafety) {
         bool IsSrcNull = RHS.get()->IgnoreParenCasts()->isNullPointerConstant(Context, Expr::NPC_ValueDependentIsNotNull);
-        if (!IsSrcNull && !RHSType->isSafePointerType() &&
-            !RHS.get()->getType()->isBoundsAttributedType() &&
-            LHSType->isSafePointerType() &&
+        if (!IsSrcNull && !OrigRHSType->isSafePointerType() &&
+            !OrigRHSType->isBoundsAttributedType() &&
+            OrigLHSType->isSafePointerType() &&
             !OrigLHSType->isValueTerminatedType()) {
-          return LHSPointer->isSingle()
+          
+          return OrigLHSType->isSinglePointerType()
                      ? AssignConvertType::IncompatibleUnsafeToSafePointer
                      : AssignConvertType::IncompatibleUnsafeToIndexablePointer;
         }
-        if (!IsSrcNull && RHSPointer->isSingle() &&
+        if (!IsSrcNull && OrigRHSType->isSinglePointerType() &&
             LHSType->isPointerTypeWithBounds() &&
-            !RHS.get()->getType()->isBoundsAttributedType()) {
+            !OrigRHSType->isBoundsAttributedType()) {
           if (RHSPointer->getPointeeType()->isIncompleteOrSizelessType())
             return AssignConvertType::IncompleteSingleToIndexablePointer;
 
-          DiagnoseSingleToWideLosingBounds(LHSType, RHSType, RHS.get());
+          DiagnoseSingleToWideLosingBounds(OrigLHSType, OrigRHSType, RHS.get());
         }
       }
 
@@ -12178,8 +12239,8 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
         // cast logic above to be missed which would change the generated AST.
         bool IsSrcNull = RHS.get()->IgnoreParenCasts()->isNullPointerConstant(
             Context, Expr::NPC_ValueDependentIsNotNull);
-        if (!IsSrcNull && RHSPointer->isSingle() &&
-            !RHS.get()->getType()->isBoundsAttributedType()) {
+        if (!IsSrcNull && OrigRHSType->isSinglePointerType() &&
+            !OrigRHSType->isBoundsAttributedType()) {
           bool IsExplicitlyBoundedPointer = LHSType->isPointerTypeWithBounds();
           if (OrigLHSType->hasAttr(attr::PtrAutoAttr)) {
             // We avoid implicitly indexable (i.e. implicit __bidi_indexable
@@ -12198,12 +12259,12 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
         if (Result != AssignConvertType::Compatible)
           return Result;
       } else if (OrigLHSType->isBoundsAttributedType() &&
-                 RHSType->isSinglePointerType()) {
+                 OrigRHSType->isSinglePointerType()) {
         // Single to dynamic bounds pointer should first create an implicit cast
         // to `__bidi_indexable` and then create any necessary cast such as
         // bitcast in the following example. `void *__sized_by(len) dst = (int
         // *__single)src`
-        assert(!RHS.get()->getType()->isBoundsAttributedType());
+        assert(!OrigRHSType->isBoundsAttributedType());
         if (ConvertRHS) {
           QualType BidiRTy = Context.getPointerType(
               RHSPointer->getPointeeType(),
@@ -12223,6 +12284,13 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
         Kind = CK_NoOp;
       else
         Kind = CK_BitCast;
+      /* TO_UPSTREAM(BoundsSafety) ON*/
+      
+      if (getLangOpts().BoundsSafety &&
+          !hasCompatibleNestedBoundsSafetyPointerAttributesSugarAware(
+              OrigLHSType, OrigRHSType))
+        return AssignConvertType::IncompatibleNestedBoundsSafetyPointerAttributes;
+      /* TO_UPSTREAM(BoundsSafety) OFF*/
       return checkPointerTypesForAssignment(*this, LHSType, RHSType,
                                             RHS.get()->getBeginLoc());
     }
@@ -12230,7 +12298,8 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
     // int -> T*
     if (RHSType->isIntegerType()) {
       Kind = CK_IntegralToPointer; // FIXME: null?
-      return LHSPointer->isSafePointer()
+      
+      return OrigLHSType->isSafePointerType()
                  ? AssignConvertType::IncompatibleIntToSafePointer
                  : AssignConvertType::IntToPointer;
     }
@@ -12854,8 +12923,8 @@ bool Sema::allowBoundsUnsafePointerAssignment(
   if (!SourcePtrTy)
     return false;
 
-  bool DestSafe = DestPtrTy->isSafePointer();
-  bool SourceSafe = SourcePtrTy->isSafePointer();
+  bool DestSafe = DestTy->isSafePointerType();
+  bool SourceSafe = SourceValue->getType()->isSafePointerType();
   // Assignments between unsafe pointers will be allowed regardless, no need to
   // make an exception.
   if (!DestSafe && !SourceSafe)
@@ -12864,9 +12933,9 @@ bool Sema::allowBoundsUnsafePointerAssignment(
   // All safe pointers ABI compatible with unsafe pointers (and each other) are
   // __single pointers. Make no exception for ABI incompatible pointer type
   // mismatch.
-  if (!DestPtrTy->isSingle() && DestSafe)
+    if (!DestTy->isSinglePointerType() && DestSafe)
     return false;
-  if (!SourcePtrTy->isSingle() && SourceSafe)
+  if (!SourceValue->getType()->isSinglePointerType() && SourceSafe)
     return false;
 
   return allowBoundsUnsafeAssignment(AssignmentLoc);
@@ -14380,7 +14449,7 @@ static bool checkArithmeticBinOpBoundsSafetyPointer(Sema &S, Expr *Base,
     return false;
   }
 
-  if (PT->isSingle() && !BaseType->isBoundsAttributedType()) {
+    if (BaseType->isSinglePointerType() && !BaseType->isBoundsAttributedType()) {
     emitBoundsSafetySinglePointerArithmeticError(S, Base);
     return false;
   }
@@ -21246,7 +21315,7 @@ TryFixNestedBoundsSafetyPointerAttributeMismatch(Expr *SrcExpr,
     return std::make_tuple(FixItHint(), nullptr);
 
   StringRef Keyword;
-  if (InnerAttrs.isSingle())
+  if (InnerTy->isSinglePointerType())
     Keyword = "__single ";
   else if (InnerAttrs.isIndexable())
     Keyword = "__indexable ";
@@ -26664,7 +26733,7 @@ static ExprResult makeBoundExpr(Sema& S, Expr *SubExpr,
   const PointerType *PT = T->getAs<PointerType>();
   if (!PT) {
     Reason = 0;
-  } else if (PT->getPointerAttributes().isUnsafeOrUnspecified()) {
+  } else if (T->isUnsafeIndexablePointerType() || T->isUnspecifiedPointerType()) {
     Reason = 1;
   }
 
@@ -26678,7 +26747,7 @@ static ExprResult makeBoundExpr(Sema& S, Expr *SubExpr,
 
   // must implicitly cast original to bidi_indexable if needed
   if (PT->getPointerAttributes() != FA) {
-    if (!PT->isSafePointerType())
+    if (!T->isSafePointerType())
       return ExprError();
     ExprResult ImpCast = S.ImpCastExprToType(
         SubExpr, RT, CK_BoundsSafetyPointerCast);

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6277,7 +6277,18 @@ namespace {
         Sema::GetTypeFromParser(DS.getRepAsType(), &TInfo);
         assert(TInfo);
         // TO_UPSTREAM(BoundsSafety): initializeFullCopy -> copy
-        TL.getValueLoc().copy(TInfo->getTypeLoc());
+        
+        TypeLoc ValueLoc = TL.getValueLoc();
+        QualType TInfoTy = TInfo->getType();
+        while (ValueLoc.getType() != TInfoTy) {
+          AttributedTypeLoc ATL = ValueLoc.getAs<AttributedTypeLoc>();
+          
+          if (!ATL || ATL.getTypePtr()->getAttrKind() != attr::PtrSingle)
+            break;
+          fillAttributedTypeLoc(ATL, State);
+          ValueLoc = ATL.getModifiedLoc();
+        }
+        ValueLoc.copy(TInfo->getTypeLoc());
       } else {
         TL.setKWLoc(DS.getAtomicSpecLoc());
         // No parens, to indicate this was spelled as an _Atomic qualifier.
@@ -9311,9 +9322,12 @@ public:
                diag::err_bounds_safety_conflicting_pointer_attributes)
             << /* pointer */ 1 << /* bound */ 0;
       } else if (shouldWarnRedundantBoundsSafetyAttribute(state, PAttr)) {
+        
+        auto PrevBoundsAttr = BoundsAttrPrev ? BoundsAttrPrev
+                                             : FAttrFromAttributedType.getBoundsAttr();
         S.Diag(PAttr.getLoc(),
                diag::warn_bounds_safety_duplicate_pointer_attributes)
-            << 1 << BoundsAttrPrev - 1;
+            << 1 << PrevBoundsAttr - 1;
       }
       return {};
     }
@@ -9330,6 +9344,15 @@ public:
     QualType AttrOnlyModeType = GetTypeWithAttrForAttributeOnlyMode(PTy);
     if (!AttrOnlyModeType.isNull()) {
       return AttrOnlyModeType;
+    }
+
+    
+    if (Kind == ParsedAttr::AT_PtrSingle) {
+      BoundsSafetyPointerAttributes RawFAttr = FAttr;
+      RawFAttr.setUnspecified();
+      QualType RawTy = Ctx.getPointerType(PTy->getPointeeType(), RawFAttr);
+      return state.getAttributedType(createSimpleAttr<PtrSingleAttr>(Ctx, PAttr),
+                                      RawTy, RawTy);
     }
 
     return Ctx.getPointerType(PTy->getPointeeType(), FAttr);
@@ -9745,7 +9768,7 @@ static bool HandlePtrTerminatedByTypeAttr(TypeProcessingState &state,
 
     // If the pointer is unspecified, we will add __single attribute later in
     // MakeAutoPointer.
-    if (!PT->isUnspecified() && !PT->isSingle()) {
+    if (!PT->isUnspecified() && !T->isSinglePointerType()) {
       S.Diag(PAttr.getLoc(),
              diag::err_bounds_safety_terminated_by_wrong_pointer_type);
       PAttr.setInvalid();
@@ -11929,7 +11952,7 @@ QualType Sema::BuildAtomicType(QualType T, SourceLocation Loc) {
         DiagIndex = 7;
       } else if (const auto *PT = T->getAs<PointerType>()) {
         BoundsSafetyPointerAttributes FAttr = PT->getPointerAttributes();
-        if (!FAttr.isUnspecified() && !FAttr.isSingle() &&
+        if (!FAttr.isUnspecified() && !T->isSinglePointerType() &&
             !FAttr.isUnsafeIndexable()) {
           assert(FAttr.isIndexable() || FAttr.isBidiIndexable());
           DiagIndex = FAttr.isIndexable() ? 0 : 1;

--- a/clang/test/BoundsSafety/AST/SystemHeaders/include/unsafe-global-sys.h
+++ b/clang/test/BoundsSafety/AST/SystemHeaders/include/unsafe-global-sys.h
@@ -58,7 +58,7 @@ void funcInSDK2(int * __single __terminated_by(2) safePointer) {
 // RELAXED: |   |   `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'int *__single __terminated_by(2)':'int *'
 // RELAXED: |   `-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *__single' '='
 // RELAXED: |     |-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *' <LValueToRValue>
 // RELAXED: |       `-DeclRefExpr {{.+}} [[var_safePointer]]
 
 // STRICT: |-FunctionDecl [[func_funcInSDK2:0x[^ ]+]] {{.+}} funcInSDK2
@@ -70,7 +70,7 @@ void funcInSDK2(int * __single __terminated_by(2) safePointer) {
 // STRICT: |   |   `-DeclRefExpr {{.+}} [[var_safePointer]]
 // STRICT: |   `-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *__single' '='
 // STRICT: |     |-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]
-// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
+// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *' <LValueToRValue>
 // STRICT: |       `-DeclRefExpr {{.+}} [[var_safePointer]]
 
 void funcInSDK3(int * unsafePointer) {
@@ -154,7 +154,7 @@ void funcInSDK4(int * __single __terminated_by(2) safePointer) {
 // RELAXED: |-FunctionDecl [[func_funcInSDK4:0x[^ ]+]] {{.+}} funcInSDK4
 // RELAXED: | |-ParmVarDecl [[var_safePointer_1:0x[^ ]+]]
 // RELAXED: | `-CompoundStmt
-// RELAXED: |   |-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *__single' '='
+// RELAXED: |   |-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *' '='
 // RELAXED: |   | |-DeclRefExpr {{.+}} [[var_safePointer_1]]
 // RELAXED: |   | `-MaterializeSequenceExpr {{.+}} <Unbind>
 // RELAXED: |   |   |-MaterializeSequenceExpr {{.+}} <Bind>
@@ -173,7 +173,7 @@ void funcInSDK4(int * __single __terminated_by(2) safePointer) {
 // RELAXED: |   |   |   `-IntegerLiteral {{.+}} 2
 // RELAXED: |   |   |-OpaqueValueExpr [[ove_4]] {{.*}} 'int *__single __sized_by(2)':'int *__single'
 // RELAXED: |   |   `-OpaqueValueExpr [[ove_5]] {{.*}} 'int'
-// RELAXED: |   `-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *__single' '='
+// RELAXED: |   `-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *' '='
 // RELAXED: |     |-DeclRefExpr {{.+}} [[var_safePointer_1]]
 // RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
 // RELAXED: |       `-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]
@@ -185,7 +185,7 @@ void funcInSDK4(int * __single __terminated_by(2) safePointer) {
 // STRICT: |   | `-RecoveryExpr
 // STRICT: |   |   |-DeclRefExpr {{.+}} [[var_safePointer_1]]
 // STRICT: |   |   `-DeclRefExpr {{.+}} [[var_sizedGlobal]]
-// STRICT: |   `-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *__single' '='
+// STRICT: |   `-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *' '='
 // STRICT: |     |-DeclRefExpr {{.+}} [[var_safePointer_1]]
 // STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
 // STRICT: |       `-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]

--- a/clang/test/BoundsSafety/AST/SystemHeaders/include/unsafe-global-sys.h
+++ b/clang/test/BoundsSafety/AST/SystemHeaders/include/unsafe-global-sys.h
@@ -54,7 +54,8 @@ void funcInSDK2(int * __single __terminated_by(2) safePointer) {
 // RELAXED: | `-CompoundStmt
 // RELAXED: |   |-BinaryOperator {{.+}} 'int *__single __sized_by(2)':'int *__single' '='
 // RELAXED: |   | |-DeclRefExpr {{.+}} [[var_sizedGlobal]]
-// RELAXED: |   | `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'int *__single __terminated_by(2)':'int *__single'
+// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single __sized_by(2)':'int *__single' <BoundsSafetyPointerCast>
+// RELAXED: |   |   `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'int *__single __terminated_by(2)':'int *'
 // RELAXED: |   `-BinaryOperator {{.+}} 'int *__single __terminated_by(2)':'int *__single' '='
 // RELAXED: |     |-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]
 // RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
@@ -213,4 +214,3 @@ void funcInSDK4(int * __single __terminated_by(2) safePointer) {
 // MAINCHECK:       | `-DeclRefExpr {{.+}} [[func_funcInSDK4]]
 // MAINCHECK:       `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
 // MAINCHECK:         `-DeclRefExpr {{.+}} [[var_term]]
-

--- a/clang/test/BoundsSafety/AST/SystemHeaders/include/unsafe-inter-sysheader-sys.h
+++ b/clang/test/BoundsSafety/AST/SystemHeaders/include/unsafe-inter-sysheader-sys.h
@@ -27,9 +27,9 @@ void funcInSDK(int * unsafePointer) {
 // RELAXED: |-FunctionDecl [[func_funcInSDK:0x[^ ]+]] {{.+}} funcInSDK
 // RELAXED: | |-ParmVarDecl [[var_unsafePointer:0x[^ ]+]]
 // RELAXED: | `-CompoundStmt
-// RELAXED: |   |-BinaryOperator {{.+}} 'int *__single' '='
+// RELAXED: |   |-BinaryOperator {{.+}} 'int *__single':'int *' '='
 // RELAXED: |   | |-DeclRefExpr {{.+}} [[var_safeGlobal]]
-// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
 // RELAXED: |   |   `-ImplicitCastExpr {{.+}} 'int *' <LValueToRValue>
 // RELAXED: |   |     `-DeclRefExpr {{.+}} [[var_unsafePointer]]
 // RELAXED: |   |-BinaryOperator {{.+}} 'int *' '='
@@ -38,9 +38,8 @@ void funcInSDK(int * unsafePointer) {
 // RELAXED: |   |   `-DeclRefExpr {{.+}} [[var_unsafePointer]]
 // RELAXED: |   |-BinaryOperator {{.+}} 'int *' '='
 // RELAXED: |   | |-DeclRefExpr {{.+}} [[var_unsafePointer]]
-// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// RELAXED: |   |   `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// RELAXED: |   |     `-DeclRefExpr {{.+}} [[var_safeGlobal]]
+// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// RELAXED: |   |   `-DeclRefExpr {{.+}} [[var_safeGlobal]]
 // RELAXED: |   `-BinaryOperator {{.+}} 'int *' '='
 // RELAXED: |     |-DeclRefExpr {{.+}} [[var_unsafePointer]]
 // RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *' <LValueToRValue>
@@ -59,9 +58,8 @@ void funcInSDK(int * unsafePointer) {
 // STRICT: |   |   `-DeclRefExpr {{.+}} [[var_unsafePointer]]
 // STRICT: |   |-BinaryOperator {{.+}} 'int *' '='
 // STRICT: |   | |-DeclRefExpr {{.+}} [[var_unsafePointer]]
-// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// STRICT: |   |   `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// STRICT: |   |     `-DeclRefExpr {{.+}} [[var_safeGlobal]]
+// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// STRICT: |   |   `-DeclRefExpr {{.+}} [[var_safeGlobal]]
 // STRICT: |   `-BinaryOperator {{.+}} 'int *' '='
 // STRICT: |     |-DeclRefExpr {{.+}} [[var_unsafePointer]]
 // STRICT: |     `-ImplicitCastExpr {{.+}} 'int *' <LValueToRValue>
@@ -118,40 +116,38 @@ void funcInSDK3(int * __single safePointer) {
 // RELAXED: |-FunctionDecl [[func_funcInSDK3:0x[^ ]+]] {{.+}} funcInSDK3
 // RELAXED: | |-ParmVarDecl [[var_safePointer:0x[^ ]+]]
 // RELAXED: | `-CompoundStmt
-// RELAXED: |   |-BinaryOperator {{.+}} 'int *__single' '='
+// RELAXED: |   |-BinaryOperator {{.+}} 'int *__single':'int *' '='
 // RELAXED: |   | |-DeclRefExpr {{.+}} [[var_safeGlobal]]
-// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // RELAXED: |   |   `-DeclRefExpr {{.+}} [[var_safePointer]]
 // RELAXED: |   |-BinaryOperator {{.+}} 'int *' '='
 // RELAXED: |   | |-DeclRefExpr {{.+}} [[var_unsafeGlobal]]
-// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// RELAXED: |   |   `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// RELAXED: |   |     `-DeclRefExpr {{.+}} [[var_safePointer]]
-// RELAXED: |   |-BinaryOperator {{.+}} 'int *__single' '='
+// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// RELAXED: |   |   `-DeclRefExpr {{.+}} [[var_safePointer]]
+// RELAXED: |   |-BinaryOperator {{.+}} 'int *__single':'int *' '='
 // RELAXED: |   | |-DeclRefExpr {{.+}} [[var_safePointer]]
-// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // RELAXED: |   |   `-DeclRefExpr {{.+}} [[var_safeGlobal]]
-// RELAXED: |   `-BinaryOperator {{.+}} 'int *__single' '='
+// RELAXED: |   `-BinaryOperator {{.+}} 'int *__single':'int *' '='
 // RELAXED: |     |-DeclRefExpr {{.+}} [[var_safePointer]]
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
 // RELAXED: |       `-ImplicitCastExpr {{.+}} 'int *' <LValueToRValue>
 // RELAXED: |         `-DeclRefExpr {{.+}} [[var_unsafeGlobal]]
 
 // STRICT: |-FunctionDecl [[func_funcInSDK3:0x[^ ]+]] {{.+}} funcInSDK3
 // STRICT: | |-ParmVarDecl [[var_safePointer:0x[^ ]+]]
 // STRICT: | `-CompoundStmt
-// STRICT: |   |-BinaryOperator {{.+}} 'int *__single' '='
+// STRICT: |   |-BinaryOperator {{.+}} 'int *__single':'int *' '='
 // STRICT: |   | |-DeclRefExpr {{.+}} [[var_safeGlobal]]
-// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // STRICT: |   |   `-DeclRefExpr {{.+}} [[var_safePointer]]
 // STRICT: |   |-BinaryOperator {{.+}} 'int *' '='
 // STRICT: |   | |-DeclRefExpr {{.+}} [[var_unsafeGlobal]]
-// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// STRICT: |   |   `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// STRICT: |   |     `-DeclRefExpr {{.+}} [[var_safePointer]]
-// STRICT: |   |-BinaryOperator {{.+}} 'int *__single' '='
+// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// STRICT: |   |   `-DeclRefExpr {{.+}} [[var_safePointer]]
+// STRICT: |   |-BinaryOperator {{.+}} 'int *__single':'int *' '='
 // STRICT: |   | |-DeclRefExpr {{.+}} [[var_safePointer]]
-// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // STRICT: |   |   `-DeclRefExpr {{.+}} [[var_safeGlobal]]
 // STRICT: |   `-ImplicitCastExpr {{.+}} contains-errors <LValueToRValue>
 // STRICT: |     `-RecoveryExpr
@@ -171,17 +167,16 @@ void funcInSDK4(int * __single safePointer) {
 // RELAXED: |   | | |-CallExpr
 // RELAXED: |   | | | |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single __sized_by(4))' <FunctionToPointerDecay>
 // RELAXED: |   | | | | `-DeclRefExpr {{.+}} [[func_funcWithAnnotation]]
-// RELAXED: |   | | | `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'int *__single'
+// RELAXED: |   | | | `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'int *__single':'int *'
 // RELAXED: |   | | `-OpaqueValueExpr [[ove_1]]
-// RELAXED: |   | |   `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// RELAXED: |   | |   `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // RELAXED: |   | |     `-DeclRefExpr {{.+}} [[var_safePointer_1]]
-// RELAXED: |   | `-OpaqueValueExpr [[ove_1]] {{.*}} 'int *__single'
+// RELAXED: |   | `-OpaqueValueExpr [[ove_1]] {{.*}} 'int *__single':'int *'
 // RELAXED: |   `-CallExpr
 // RELAXED: |     |-ImplicitCastExpr {{.+}} 'void (*__single)(int *)' <FunctionToPointerDecay>
 // RELAXED: |     | `-DeclRefExpr {{.+}} [[func_funcWithoutAnnotation]]
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// RELAXED: |       `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// RELAXED: |         `-DeclRefExpr {{.+}} [[var_safePointer_1]]
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// RELAXED: |       `-DeclRefExpr {{.+}} [[var_safePointer_1]]
 
 // STRICT: |-FunctionDecl [[func_funcInSDK4:0x[^ ]+]] {{.+}} funcInSDK4
 // STRICT: | |-ParmVarDecl [[var_safePointer_1:0x[^ ]+]]
@@ -192,21 +187,21 @@ void funcInSDK4(int * __single safePointer) {
 // STRICT: |   | | | |-CallExpr
 // STRICT: |   | | | | |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single __sized_by(4))' <FunctionToPointerDecay>
 // STRICT: |   | | | | | `-DeclRefExpr {{.+}} [[func_funcWithAnnotation]]
-// STRICT: |   | | | | `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'int *__single'
+// STRICT: |   | | | | `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'int *__single':'int *'
 // STRICT: |   | | | `-BinaryOperator {{.+}} 'int' '&&'
 // STRICT: |   | | |   |-BinaryOperator {{.+}} 'int' '&&'
 // STRICT: |   | | |   | |-BinaryOperator {{.+}} 'int' '<='
-// STRICT: |   | | |   | | |-OpaqueValueExpr [[ove]] {{.*}} 'int *__single'
+// STRICT: |   | | |   | | |-OpaqueValueExpr [[ove]] {{.*}} 'int *__single':'int *'
 // STRICT: |   | | |   | | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // STRICT: |   | | |   | |   `-GetBoundExpr {{.+}} upper
 // STRICT: |   | | |   | |     `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// STRICT: |   | | |   | |       `-OpaqueValueExpr [[ove]] {{.*}} 'int *__single'
+// STRICT: |   | | |   | |       `-OpaqueValueExpr [[ove]] {{.*}} 'int *__single':'int *'
 // STRICT: |   | | |   | `-BinaryOperator {{.+}} 'int' '<='
 // STRICT: |   | | |   |   |-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // STRICT: |   | | |   |   | `-GetBoundExpr {{.+}} lower
 // STRICT: |   | | |   |   |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// STRICT: |   | | |   |   |     `-OpaqueValueExpr [[ove]] {{.*}} 'int *__single'
-// STRICT: |   | | |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'int *__single'
+// STRICT: |   | | |   |   |     `-OpaqueValueExpr [[ove]] {{.*}} 'int *__single':'int *'
+// STRICT: |   | | |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'int *__single':'int *'
 // STRICT: |   | | |   `-BinaryOperator {{.+}} 'int' '&&'
 // STRICT: |   | | |     |-BinaryOperator {{.+}} 'int' '<='
 // STRICT: |   | | |     | |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} '__ptrdiff_t':'long'
@@ -215,27 +210,26 @@ void funcInSDK4(int * __single safePointer) {
 // STRICT: |   | | |     |   | `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // STRICT: |   | | |     |   |   `-GetBoundExpr {{.+}} upper
 // STRICT: |   | | |     |   |     `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// STRICT: |   | | |     |   |       `-OpaqueValueExpr [[ove]] {{.*}} 'int *__single'
-// STRICT: |   | | |     |   `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// STRICT: |   | | |     |     `-DeclRefExpr {{.+}} 'int *__single' lvalue ParmVar {{.+}} 'safePointer' 'int *__single'
+// STRICT: |   | | |     |   |       `-OpaqueValueExpr [[ove]] {{.*}} 'int *__single':'int *'
+// STRICT: |   | | |     |   `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// STRICT: |   | | |     |     `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue ParmVar {{.+}} 'safePointer' 'int *__single':'int *'
 // STRICT: |   | | |     `-BinaryOperator {{.+}} 'int' '<='
 // STRICT: |   | | |       |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // STRICT: |   | | |       | `-IntegerLiteral {{.+}} 0
 // STRICT: |   | | |       `-OpaqueValueExpr [[ove_1]] {{.*}} '__ptrdiff_t':'long'
 // STRICT: |   | | |-OpaqueValueExpr [[ove]]
-// STRICT: |   | | | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// STRICT: |   | | | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // STRICT: |   | | |   `-DeclRefExpr {{.+}} [[var_safePointer_1]]
 // STRICT: |   | | `-OpaqueValueExpr [[ove_1]]
 // STRICT: |   | |   `-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // STRICT: |   | |     `-IntegerLiteral {{.+}} 4
-// STRICT: |   | |-OpaqueValueExpr [[ove]] {{.*}} 'int *__single'
+// STRICT: |   | |-OpaqueValueExpr [[ove]] {{.*}} 'int *__single':'int *'
 // STRICT: |   | `-OpaqueValueExpr [[ove_1]] {{.*}} '__ptrdiff_t':'long'
 // STRICT: |   `-CallExpr
 // STRICT: |     |-ImplicitCastExpr {{.+}} 'void (*__single)(int *)' <FunctionToPointerDecay>
 // STRICT: |     | `-DeclRefExpr {{.+}} [[func_funcWithoutAnnotation]]
-// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// STRICT: |       `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// STRICT: |         `-DeclRefExpr {{.+}} [[var_safePointer_1]]
+// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// STRICT: |       `-DeclRefExpr {{.+}} [[var_safePointer_1]]
 
 void funcInSDK5(int * unsafePointer) {
   funcInSDK(unsafePointer);
@@ -254,7 +248,7 @@ void funcInSDK5(int * unsafePointer) {
 // RELAXED: |   `-CallExpr
 // RELAXED: |     |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single)' <FunctionToPointerDecay>
 // RELAXED: |     | `-DeclRefExpr {{.+}} [[func_funcInSDK3]]
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
 // RELAXED: |       `-ImplicitCastExpr {{.+}} 'int *' <LValueToRValue>
 // RELAXED: |         `-DeclRefExpr {{.+}} [[var_unsafePointer_2]]
 
@@ -282,13 +276,12 @@ void funcInSDK6(int * __single safePointer) {
 // RELAXED: |   |-CallExpr
 // RELAXED: |   | |-ImplicitCastExpr {{.+}} 'void (*__single)(int *)' <FunctionToPointerDecay>
 // RELAXED: |   | | `-DeclRefExpr {{.+}} [[func_funcInSDK]]
-// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// RELAXED: |   |   `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// RELAXED: |   |     `-DeclRefExpr {{.+}} [[var_safePointer_2]]
+// RELAXED: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// RELAXED: |   |   `-DeclRefExpr {{.+}} [[var_safePointer_2]]
 // RELAXED: |   `-CallExpr
 // RELAXED: |     |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single)' <FunctionToPointerDecay>
 // RELAXED: |     | `-DeclRefExpr {{.+}} [[func_funcInSDK3]]
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // RELAXED: |       `-DeclRefExpr {{.+}} [[var_safePointer_2]]
 
 // STRICT: |-FunctionDecl [[func_funcInSDK6:0x[^ ]+]] {{.+}} funcInSDK6
@@ -297,12 +290,10 @@ void funcInSDK6(int * __single safePointer) {
 // STRICT: |   |-CallExpr
 // STRICT: |   | |-ImplicitCastExpr {{.+}} 'void (*__single)(int *)' <FunctionToPointerDecay>
 // STRICT: |   | | `-DeclRefExpr {{.+}} [[func_funcInSDK]]
-// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// STRICT: |   |   `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// STRICT: |   |     `-DeclRefExpr {{.+}} [[var_safePointer_2]]
+// STRICT: |   | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// STRICT: |   |   `-DeclRefExpr {{.+}} [[var_safePointer_2]]
 // STRICT: |   `-CallExpr
 // STRICT: |     |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single)' <FunctionToPointerDecay>
 // STRICT: |     | `-DeclRefExpr {{.+}} [[func_funcInSDK3]]
-// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // STRICT: |       `-DeclRefExpr {{.+}} [[var_safePointer_2]]
-

--- a/clang/test/BoundsSafety/AST/SystemHeaders/include/unsafe-return-sys.h
+++ b/clang/test/BoundsSafety/AST/SystemHeaders/include/unsafe-return-sys.h
@@ -36,15 +36,17 @@ int * __unsafe_indexable funcInSDK2(int * __single __terminated_by(2) safePointe
 // RELAXED: | |-ParmVarDecl [[var_safePointer:0x[^ ]+]]
 // RELAXED: | `-CompoundStmt
 // RELAXED: |   `-ReturnStmt
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
-// RELAXED: |       `-DeclRefExpr {{.+}} [[var_safePointer]]
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__unsafe_indexable' <BoundsSafetyPointerCast>
+// RELAXED: |       `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *' <LValueToRValue>
+// RELAXED: |         `-DeclRefExpr {{.+}} [[var_safePointer]]
 
 // STRICT: |-FunctionDecl [[func_funcInSDK2:0x[^ ]+]] {{.+}} funcInSDK2
 // STRICT: | |-ParmVarDecl [[var_safePointer:0x[^ ]+]]
 // STRICT: | `-CompoundStmt
 // STRICT: |   `-ReturnStmt
-// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
-// STRICT: |       `-DeclRefExpr {{.+}} [[var_safePointer]]
+// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__unsafe_indexable' <BoundsSafetyPointerCast>
+// STRICT: |       `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *' <LValueToRValue>
+// STRICT: |         `-DeclRefExpr {{.+}} [[var_safePointer]]
 
 int * __single funcInSDK3(int * __unsafe_indexable unsafePointer) {
     return unsafePointer; // strict-error{{returning 'int *__unsafe_indexable' from a function with incompatible result type 'int *__single' casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
@@ -54,7 +56,7 @@ int * __single funcInSDK3(int * __unsafe_indexable unsafePointer) {
 // RELAXED: | |-ParmVarDecl [[var_unsafePointer_1:0x[^ ]+]]
 // RELAXED: | `-CompoundStmt
 // RELAXED: |   `-ReturnStmt
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
 // RELAXED: |       `-ImplicitCastExpr {{.+}} 'int *__unsafe_indexable' <LValueToRValue>
 // RELAXED: |         `-DeclRefExpr {{.+}} [[var_unsafePointer_1]]
 
@@ -120,14 +122,16 @@ int * __unsafe_indexable funcInSDK5(void) {
 // RELAXED: |-FunctionDecl [[func_funcInSDK5:0x[^ ]+]] {{.+}} funcInSDK5
 // RELAXED: | `-CompoundStmt
 // RELAXED: |   `-ReturnStmt
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
-// RELAXED: |       `-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__unsafe_indexable' <BoundsSafetyPointerCast>
+// RELAXED: |       `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
+// RELAXED: |         `-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]
 
 // STRICT: |-FunctionDecl [[func_funcInSDK5:0x[^ ]+]] {{.+}} funcInSDK5
 // STRICT: | `-CompoundStmt
 // STRICT: |   `-ReturnStmt
-// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
-// STRICT: |       `-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]
+// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__unsafe_indexable' <BoundsSafetyPointerCast>
+// STRICT: |       `-ImplicitCastExpr {{.+}} 'int *__single __terminated_by(2)':'int *__single' <LValueToRValue>
+// STRICT: |         `-DeclRefExpr {{.+}} [[var_valueTerminatedGlobal]]
 
 int * __unsafe_indexable funcInSDK6(void) {
     return bidiGlobal;

--- a/clang/test/BoundsSafety/AST/SystemHeaders/int-to-ptr-main.c
+++ b/clang/test/BoundsSafety/AST/SystemHeaders/int-to-ptr-main.c
@@ -1,4 +1,3 @@
-
 #include <int-to-ptr-sys.h>
 
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s -verify=both -I %S/include | FileCheck %s --implicit-check-not "GetBoundExpr {{.+}} 'char *__single'" --implicit-check-not "GetBoundExpr {{.+}} 'char *'" --check-prefix RELAXED
@@ -15,14 +14,14 @@ int * func(intptr_t y) {
 // RELAXED: | |-ParmVarDecl [[var_p:0x[^ ]+]]
 // RELAXED: | `-CompoundStmt
 // RELAXED: |   `-ReturnStmt
-// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// RELAXED: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // RELAXED: |       `-DeclRefExpr {{.+}} [[var_p]]
 //
 // STRICT: |-FunctionDecl [[func_static:0x[^ ]+]] {{.+}} static
 // STRICT: | |-ParmVarDecl [[var_p:0x[^ ]+]]
 // STRICT: | `-CompoundStmt
 // STRICT: |   `-ReturnStmt
-// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// STRICT: |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // STRICT: |       `-DeclRefExpr {{.+}} [[var_p]]
 
 
@@ -40,14 +39,13 @@ int * func(intptr_t y) {
 // RELAXED: |     |   |-DeclRefExpr {{.+}} [[func_static]]
 // RELAXED: |     |   `-DeclRefExpr {{.+}} [[var_x]]
 // RELAXED: |     `-ReturnStmt
-// RELAXED: |       `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
-// RELAXED: |         `-CallExpr
-// RELAXED: |           |-ImplicitCastExpr {{.+}} 'int *__single(*__single)(int *__single)' <FunctionToPointerDecay>
-// RELAXED: |           | `-DeclRefExpr {{.+}} [[func_static]]
-// RELAXED: |           `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
-// RELAXED: |             `-CStyleCastExpr {{.+}} 'int *' <IntegralToPointer>
-// RELAXED: |               `-ImplicitCastExpr {{.+}} 'intptr_t':'long' <LValueToRValue>
-// RELAXED: |                 `-DeclRefExpr {{.+}} [[var_x]]
+// RELAXED: |       `-CallExpr {{.+}} 'int *__single':'int *'
+// RELAXED: |         |-ImplicitCastExpr {{.+}} 'int *__single(*__single)(int *__single)' <FunctionToPointerDecay>
+// RELAXED: |         | `-DeclRefExpr {{.+}} [[func_static]]
+// RELAXED: |         `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
+// RELAXED: |           `-CStyleCastExpr {{.+}} 'int *' <IntegralToPointer>
+// RELAXED: |             `-ImplicitCastExpr {{.+}} 'intptr_t':'long' <LValueToRValue>
+// RELAXED: |               `-DeclRefExpr {{.+}} [[var_x]]
 //
 // STRICT: |-FunctionDecl [[func_static_1:0x[^ ]+]] {{.+}} static
 // STRICT: | |-ParmVarDecl [[var_x:0x[^ ]+]]

--- a/clang/test/BoundsSafety/AST/SystemHeaders/system-header-func-redecl-single.c
+++ b/clang/test/BoundsSafety/AST/SystemHeaders/system-header-func-redecl-single.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -ast-dump -fbounds-safety -I %S/include %s | FileCheck %s
 // RUN: %clang_cc1 -fsyntax-only -ast-dump -fbounds-safety -I %S/include -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -14,10 +13,10 @@ void bar(void) {
 // CHECK: `-FunctionDecl {{.+}} bar 'void (void)'
 // CHECK:   `-CompoundStmt
 // CHECK:     |-DeclStmt
-// CHECK:     | `-VarDecl {{.+}} used s 'int *__single'
-// CHECK:     `-CallExpr {{.+}} 'int *__single'
-// CHECK:       |-ImplicitCastExpr {{.+}} 'int *__single(*__single)(int *__single*__single)' <FunctionToPointerDecay>
-// CHECK:       | `-DeclRefExpr {{.+}} 'int *__single(int *__single*__single)' Function {{.+}} 'foo' 'int *__single(int *__single*__single)'
-// CHECK:       `-ImplicitCastExpr {{.+}} 'int *__single*__single' <BoundsSafetyPointerCast>
+// CHECK:     | `-VarDecl {{.+}} used s 'int *__single':'int *'
+// CHECK:     `-CallExpr {{.+}} 'int *'
+// CHECK:       |-ImplicitCastExpr {{.+}} 'int *(*__single)(int **)' <FunctionToPointerDecay>
+// CHECK:       | `-DeclRefExpr {{.+}} 'int *(int **)' Function {{.+}} 'foo' 'int *(int **)'
+// CHECK:       `-ImplicitCastExpr {{.+}} 'int **' <BoundsSafetyPointerCast>
 // CHECK:         `-UnaryOperator {{.+}} 'int *__single*__bidi_indexable' prefix '&' cannot overflow
-// CHECK:           `-DeclRefExpr {{.+}} 'int *__single' lvalue Var {{.+}} 's' 'int *__single'
+// CHECK:           `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue Var {{.+}} 's' 'int *__single':'int *'

--- a/clang/test/BoundsSafety/AST/array-to-pointer-decay.c
+++ b/clang/test/BoundsSafety/AST/array-to-pointer-decay.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
 #include <ptrcheck.h>
@@ -32,14 +30,14 @@ void Test() {
     // CHECK-NEXT: DeclRefExpr {{.+}} 'int[7]' lvalue Var {{.+}} 'arrLocal' 'int[7]'
 
     int *__single ptrThinLocal = arrLocal;
-    // CHECK: VarDecl {{.+}} ptrThinLocal 'int *__single' cinit
-    // CHECK-NEXT: ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+    // CHECK: VarDecl {{.+}} ptrThinLocal 'int *__single':'int *' cinit
+    // CHECK-NEXT: ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
     // CHECK-NEXT: ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <ArrayToPointerDecay>
     // CHECK-NEXT: DeclRefExpr {{.+}} 'int[7]' lvalue Var {{.+}} 'arrLocal' 'int[7]'
     ptrThinLocal = arrLocal;
-    // CHECK-NEXT: BinaryOperator {{.+}} 'int *__single' '='
-    // CHECK-NEXT: DeclRefExpr {{.+}} 'int *__single' lvalue Var {{.+}} 'ptrThinLocal' 'int *__single'
-    // CHECK-NEXT: ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+    // CHECK-NEXT: BinaryOperator {{.+}} 'int *__single':'int *' '='
+    // CHECK-NEXT: DeclRefExpr {{.+}} 'int *__single':'int *' lvalue Var {{.+}} 'ptrThinLocal' 'int *__single':'int *'
+    // CHECK-NEXT: ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
     // CHECK-NEXT: ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <ArrayToPointerDecay>
     // CHECK-NEXT: DeclRefExpr {{.+}} 'int[7]' lvalue Var {{.+}} 'arrLocal' 'int[7]'
 
@@ -55,4 +53,3 @@ void Test() {
 
     int *__bidi_indexable ptrFromArraySub = &arrLocal[0];
 }
-

--- a/clang/test/BoundsSafety/AST/atomic-ops-c11-casts.c
+++ b/clang/test/BoundsSafety/AST/atomic-ops-c11-casts.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
 
@@ -69,7 +68,7 @@ void single(void) {
   // CHECK: DeclStmt {{.+}}
   // CHECK: `-VarDecl {{.+}} p1 '_Atomic(int *__single)' cinit
   // CHECK:   `-ImplicitCastExpr {{.+}} '_Atomic(int *__single)' <NonAtomicToAtomic>
-  // CHECK:     `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+  // CHECK:     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
   // CHECK:       `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <LValueToRValue>
   // CHECK:         `-DeclRefExpr {{.+}} 'int *__bidi_indexable' lvalue Var {{.+}} 'q1' 'int *__bidi_indexable'
   int *__bidi_indexable q1;
@@ -78,7 +77,7 @@ void single(void) {
   // CHECK: AtomicExpr {{.+}} 'void'
   // CHECK: |-UnaryOperator {{.+}} '_Atomic(int *__single) *__bidi_indexable' prefix '&' cannot overflow
   // CHECK: | `-DeclRefExpr {{.+}} '_Atomic(int *__single)' lvalue Var {{.+}} 'p2' '_Atomic(int *__single)'
-  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
   // CHECK:   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <LValueToRValue>
   // CHECK:     `-DeclRefExpr {{.+}} 'int *__bidi_indexable' lvalue Var {{.+}} 'q2' 'int *__bidi_indexable'
   int *_Atomic __single p2;
@@ -89,18 +88,18 @@ void single(void) {
   // CHECK: |-UnaryOperator {{.+}} '_Atomic(int *__single) *__bidi_indexable' prefix '&' cannot overflow
   // CHECK: | `-DeclRefExpr {{.+}} '_Atomic(int *__single)' lvalue Var {{.+}} 'p3' '_Atomic(int *__single)'
   // CHECK: |-IntegerLiteral {{.+}} 'int' 5
-  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
   // CHECK:   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <LValueToRValue>
   // CHECK:     `-DeclRefExpr {{.+}} 'int *__bidi_indexable' lvalue Var {{.+}} 'q3' 'int *__bidi_indexable'
   int *_Atomic __single p3;
   int *__bidi_indexable q3;
   __c11_atomic_store(&p3, q3, __ATOMIC_SEQ_CST);
 
-  // CHECK: AtomicExpr {{.+}} 'int *__single'
+  // CHECK: AtomicExpr {{.+}} 'int *__single':'int *'
   // CHECK: |-UnaryOperator {{.+}} '_Atomic(int *__single) *__bidi_indexable' prefix '&' cannot overflow
   // CHECK: | `-DeclRefExpr {{.+}} '_Atomic(int *__single)' lvalue Var {{.+}} 'p4' '_Atomic(int *__single)'
   // CHECK: |-IntegerLiteral {{.+}} 'int' 5
-  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
   // CHECK:   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <LValueToRValue>
   // CHECK:     `-DeclRefExpr {{.+}} 'int *__bidi_indexable' lvalue Var {{.+}} 'q4' 'int *__bidi_indexable'
   int *_Atomic __single p4;
@@ -113,9 +112,9 @@ void single(void) {
   // CHECK: |-IntegerLiteral {{.+}} 'int' 5
   // CHECK: |-ImplicitCastExpr {{.+}} 'int *__single*' <BoundsSafetyPointerCast>
   // CHECK: | `-UnaryOperator {{.+}} 'int *__single*__bidi_indexable' prefix '&' cannot overflow
-  // CHECK: |   `-DeclRefExpr {{.+}} 'int *__single' lvalue Var {{.+}} 'q5' 'int *__single'
+  // CHECK: |   `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue Var {{.+}} 'q5' 'int *__single':'int *'
   // CHECK: |-IntegerLiteral {{.+}} 'int' 5
-  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
   // CHECK:   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <LValueToRValue>
   // CHECK:     `-DeclRefExpr {{.+}} 'int *__bidi_indexable' lvalue Var {{.+}} 'r5' 'int *__bidi_indexable'
   int *_Atomic __single p5;

--- a/clang/test/BoundsSafety/AST/atomic-ops-gnu-casts.c
+++ b/clang/test/BoundsSafety/AST/atomic-ops-gnu-casts.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
 
@@ -51,20 +50,20 @@ void unsafe_indexable(void) {
 void single(void) {
   // CHECK: AtomicExpr {{.+}} 'void'
   // CHECK: |-UnaryOperator {{.+}} 'int *__single*__bidi_indexable' prefix '&' cannot overflow
-  // CHECK: | `-DeclRefExpr {{.+}} 'int *__single' lvalue Var {{.+}} 'p1' 'int *__single'
+  // CHECK: | `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue Var {{.+}} 'p1' 'int *__single':'int *'
   // CHECK: |-IntegerLiteral {{.+}} 'int' 5
-  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
   // CHECK:   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <LValueToRValue>
   // CHECK:     `-DeclRefExpr {{.+}} 'int *__bidi_indexable' lvalue Var {{.+}} 'q1' 'int *__bidi_indexable'
   int *__single p1;
   int *__bidi_indexable q1;
   __atomic_store_n(&p1, q1, __ATOMIC_SEQ_CST);
 
-  // CHECK: AtomicExpr {{.+}} 'int *__single'
+  // CHECK: AtomicExpr {{.+}} 'int *__single':'int *'
   // CHECK: |-UnaryOperator {{.+}} 'int *__single*__bidi_indexable' prefix '&' cannot overflow
-  // CHECK: | `-DeclRefExpr {{.+}} 'int *__single' lvalue Var {{.+}} 'p2' 'int *__single'
+  // CHECK: | `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue Var {{.+}} 'p2' 'int *__single':'int *'
   // CHECK: |-IntegerLiteral {{.+}} 'int' 5
-  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+  // CHECK: `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
   // CHECK:   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <LValueToRValue>
   // CHECK:     `-DeclRefExpr {{.+}} 'int *__bidi_indexable' lvalue Var {{.+}} 'q2' 'int *__bidi_indexable'
   int *__single p2;
@@ -73,13 +72,13 @@ void single(void) {
 
   // CHECK: `-AtomicExpr {{.+}} '_Bool'
   // CHECK:   |-UnaryOperator {{.+}} 'int *__single*__bidi_indexable' prefix '&' cannot overflow
-  // CHECK:   | `-DeclRefExpr {{.+}} 'int *__single' lvalue Var {{.+}} 'p3' 'int *__single'
+  // CHECK:   | `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue Var {{.+}} 'p3' 'int *__single':'int *'
   // CHECK:   |-IntegerLiteral {{.+}} 'int' 5
   // CHECK:   |-ImplicitCastExpr {{.+}} 'int *__single*' <BoundsSafetyPointerCast>
   // CHECK:   | `-UnaryOperator {{.+}} 'int *__single*__bidi_indexable' prefix '&' cannot overflow
-  // CHECK:   |   `-DeclRefExpr {{.+}} 'int *__single' lvalue Var {{.+}} 'q3' 'int *__single'
+  // CHECK:   |   `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue Var {{.+}} 'q3' 'int *__single':'int *'
   // CHECK:   |-IntegerLiteral {{.+}} 'int' 5
-  // CHECK:   |-ImplicitCastExpr {{.+}} 'int *__single' <BoundsSafetyPointerCast>
+  // CHECK:   |-ImplicitCastExpr {{.+}} 'int *__single':'int *' <BoundsSafetyPointerCast>
   // CHECK:   | `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <LValueToRValue>
   // CHECK:   |   `-DeclRefExpr {{.+}} 'int *__bidi_indexable' lvalue Var {{.+}} 'r3' 'int *__bidi_indexable'
   // CHECK:   `-ImplicitCastExpr {{.+}} '_Bool' <IntegralToBoolean>

--- a/clang/test/BoundsSafety/AST/attr-applied-twice.c
+++ b/clang/test/BoundsSafety/AST/attr-applied-twice.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
 
 // When processing the type for `b`, the types are processed from the beginning of the declaration,
@@ -18,8 +16,8 @@ void foo() {
 // CHECK: -FunctionDecl {{.*}} foo 'void ()'
 // CHECK-NEXT:  `-CompoundStmt
 // CHECK-NEXT:    |-DeclStmt
-// CHECK-NEXT:    | |-VarDecl {{.*}} a 'int_ptr_t __single':'int *__single'
-// CHECK-NEXT:    | `-VarDecl {{.*}} b 'int_ptr_t __single':'int *__single'
+// CHECK-NEXT:    | |-VarDecl {{.*}} a 'int_ptr_t __single':'int *'
+// CHECK-NEXT:    | `-VarDecl {{.*}} b 'int_ptr_t __single':'int *'
 // CHECK-NEXT:    |-DeclStmt
 // CHECK-NEXT:    | |-VarDecl {{.*}} c 'int_ptr_t __bidi_indexable':'int *__bidi_indexable'
 // CHECK-NEXT:    | `-VarDecl {{.*}} d 'int_ptr_t __bidi_indexable':'int *__bidi_indexable'
@@ -29,4 +27,3 @@ void foo() {
 // CHECK-NEXT:    `-DeclStmt
 // CHECK-NEXT:      |-VarDecl {{.*}} g 'int_ptr_t __indexable':'int *__indexable'
 // CHECK-NEXT:      `-VarDecl {{.*}} h 'int_ptr_t __indexable':'int *__indexable'
-

--- a/clang/test/BoundsSafety/AST/auto-bound-atomic.c
+++ b/clang/test/BoundsSafety/AST/auto-bound-atomic.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
 
@@ -22,9 +21,9 @@ void parm1(int *_Atomic p1);
 void parm2(_Atomic(int *) p2);
 
 void locals(void) {
-  // CHECK: VarDecl {{.+}} l1 '_Atomic(_Atomic(int *__single) *__single)'
+  // CHECK: VarDecl {{.+}} l1 '_Atomic(_Atomic(int *) *__single)'
   int *_Atomic *_Atomic __single l1;
-  // CHECK: VarDecl {{.+}} l2 '_Atomic(_Atomic(int *__single) *__single)'
+  // CHECK: VarDecl {{.+}} l2 '_Atomic(_Atomic(int *) *__single)'
   _Atomic(int *) *_Atomic __single l2;
 
   // CHECK: VarDecl {{.+}} l3 '_Atomic(_Atomic(int *__single) *__unsafe_indexable)'

--- a/clang/test/BoundsSafety/AST/auto-bound-const-char-pointer-param.c
+++ b/clang/test/BoundsSafety/AST/auto-bound-const-char-pointer-param.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -ast-dump -x objective-c -fexperimental-bounds-safety-objc %s 2>&1 | FileCheck %s
 
@@ -109,11 +108,11 @@ void bidi_parm(const char *__bidi_indexable bidi_parm);
 // CHECK: ParmVarDecl {{.+}} counted_parm 'const char *__single __counted_by(8)'
 void counted_parm(const char *__counted_by(8) counted_parm);
 
-// CHECK: ParmVarDecl {{.+}} ended_parm 'const char *__single __ended_by(end)'
-// CHECK: ParmVarDecl {{.+}} end 'const char *__single /* __started_by(ended_parm) */ ':'const char *__single'
+// CHECK: ParmVarDecl {{.+}} ended_parm 'const char *__single __ended_by(end)':'const char *__single'
+// CHECK: ParmVarDecl {{.+}} end 'const char *__single /* __started_by(ended_parm) */ ':'const char *'
 void ended_parm_single(const char *__ended_by(end) ended_parm, const char *__single end);
 
-// CHECK: ParmVarDecl {{.+}} ended_parm 'const char *__single __ended_by(end)'
+// CHECK: ParmVarDecl {{.+}} ended_parm 'const char *__single __ended_by(end)':'const char *__single'
 // CHECK: ParmVarDecl {{.+}} end 'const char *__single /* __started_by(ended_parm) */ ':'const char *__single'
 void ended_parm_unspec(const char *__ended_by(end) ended_parm, const char *end);
 

--- a/clang/test/BoundsSafety/AST/auto-type-from-decayed.c
+++ b/clang/test/BoundsSafety/AST/auto-type-from-decayed.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s | FileCheck %s
 
@@ -28,35 +26,35 @@ void Test() {
   __auto_type local_from_unsafe = unsafe_ptr;   /* int *__unsafe_indexable */
 }
 
-// CHECK:     `-FunctionDecl {{.*}} <line:17:1, line:29:1> line:17:6 Test 'void ()'
-// CHECK:         |-DeclStmt {{.*}} <line:22:3, col:40>
+// CHECK:     `-FunctionDecl {{.*}} <line:15:1, line:27:1> line:15:6 Test 'void ()'
+// CHECK:         |-DeclStmt {{.*}} <line:20:3, col:40>
 // CHECK-NEXT:    | `-VarDecl {{.*}} <col:3, col:37> col:15 local_from_arrdecay 'int *__bidi_indexable' cinit
 // CHECK-NEXT:    |   `-ImplicitCastExpr {{.*}} <col:37> 'int *__bidi_indexable' <ArrayToPointerDecay>
 // CHECK-NEXT:    |     `-DeclRefExpr {{.*}} <col:37> 'int[2]' lvalue Var {{.*}} 'arr' 'int[2]'
-// CHECK-NEXT:    |-DeclStmt {{.*}} <line:23:3, col:37>
+// CHECK-NEXT:    |-DeclStmt {{.*}} <line:21:3, col:37>
 // CHECK-NEXT:    | `-VarDecl {{.*}} <col:3, col:36> col:15 local_from_addrof 'int *__bidi_indexable' cinit
 // CHECK-NEXT:    |   `-UnaryOperator {{.*}} <col:35, col:36> 'int *__bidi_indexable' prefix '&' cannot overflow
 // CHECK-NEXT:    |     `-DeclRefExpr {{.*}} <col:36> 'int' lvalue Var {{.*}} 'i' 'int'
-// CHECK-NEXT:    |-DeclStmt {{.*}} <line:24:3, col:47>
+// CHECK-NEXT:    |-DeclStmt {{.*}} <line:22:3, col:47>
 // CHECK-NEXT:    | `-VarDecl {{.*}} <col:3, col:46> col:15 local_from_addr_of_arr 'int *__bidi_indexable' cinit
 // CHECK-NEXT:    |   `-UnaryOperator {{.*}} <col:40, col:46> 'int *__bidi_indexable' prefix '&' cannot overflow
 // CHECK-NEXT:    |     `-ArraySubscriptExpr {{.*}} <col:41, col:46> 'int' lvalue
 // CHECK-NEXT:    |       |-ImplicitCastExpr {{.*}} <col:41> 'int *__bidi_indexable' <ArrayToPointerDecay>
 // CHECK-NEXT:    |       | `-DeclRefExpr {{.*}} <col:41> 'int[2]' lvalue Var {{.*}} 'arr' 'int[2]'
 // CHECK-NEXT:    |       `-IntegerLiteral {{.*}} <col:45> 'int' 0
-// CHECK-NEXT:    |-DeclStmt {{.*}} <line:25:3, col:40>
+// CHECK-NEXT:    |-DeclStmt {{.*}} <line:23:3, col:40>
 // CHECK-NEXT:    | `-VarDecl {{.*}} <col:3, col:37> col:15 local_from_fundecay 'void (*__single)(int *__single __counted_by(len), unsigned int)' cinit
 // CHECK-NEXT:    |   `-ImplicitCastExpr {{.*}} <col:37> 'void (*__single)(int *__single __counted_by(len), unsigned int)' <FunctionToPointerDecay>
 // CHECK-NEXT:    |     `-DeclRefExpr {{.*}} <col:37> 'void (int *__single __counted_by(len), unsigned int)' Function {{.*}} 'Foo' 'void (int *__single __counted_by(len), unsigned int)'
-// CHECK-NEXT:    |-DeclStmt {{.*}} <line:26:3, col:45>
-// CHECK-NEXT:    | `-VarDecl {{.*}} <col:3, col:35> col:15 local_from_single 'int *__single' cinit
-// CHECK-NEXT:    |   `-ImplicitCastExpr {{.*}} <col:35> 'int *__single' <LValueToRValue>
-// CHECK-NEXT:    |     `-DeclRefExpr {{.*}} <col:35> 'int *__single' lvalue Var {{.*}} 'single_ptr' 'int *__single'
-// CHECK-NEXT:    |-DeclStmt {{.*}} <line:27:3, col:43>
+// CHECK-NEXT:    |-DeclStmt {{.*}} <line:24:3, col:45>
+// CHECK-NEXT:    | `-VarDecl {{.*}} <col:3, col:35> col:15 local_from_single 'int *__single':'int *' cinit
+// CHECK-NEXT:    |   `-ImplicitCastExpr {{.*}} <col:35> 'int *__single':'int *' <LValueToRValue>
+// CHECK-NEXT:    |     `-DeclRefExpr {{.*}} <col:35> 'int *__single':'int *' lvalue Var {{.*}} 'single_ptr' 'int *__single':'int *'
+// CHECK-NEXT:    |-DeclStmt {{.*}} <line:25:3, col:43>
 // CHECK-NEXT:    | `-VarDecl {{.*}} <col:3, col:34> col:15 local_from_index 'int *__indexable' cinit
 // CHECK-NEXT:    |   `-ImplicitCastExpr {{.*}} <col:34> 'int *__indexable' <LValueToRValue>
 // CHECK-NEXT:    |     `-DeclRefExpr {{.*}} <col:34> 'int *__indexable' lvalue Var {{.*}} 'index_ptr' 'int *__indexable'
-// CHECK-NEXT:    `-DeclStmt {{.*}} <line:28:3, col:45>
+// CHECK-NEXT:    `-DeclStmt {{.*}} <line:26:3, col:45>
 // CHECK-NEXT:      `-VarDecl {{.*}} <col:3, col:35> col:15 local_from_unsafe 'int *__unsafe_indexable' cinit
 // CHECK-NEXT:        `-ImplicitCastExpr {{.*}} <col:35> 'int *__unsafe_indexable' <LValueToRValue>
 // CHECK-NEXT:          `-DeclRefExpr {{.*}} <col:35> 'int *__unsafe_indexable' lvalue Var {{.*}} 'unsafe_ptr' 'int *__unsafe_indexable'

--- a/clang/test/BoundsSafety/AST/bitcast-to-counted_by.c
+++ b/clang/test/BoundsSafety/AST/bitcast-to-counted_by.c
@@ -51,7 +51,7 @@ void Test(void) {
 // CHECK: {{^}}    |     |-OpaqueValueExpr [[ove]]
 // CHECK: {{^}}    |     | `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK: {{^}}    |     |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: {{^}}    |     |     `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK: {{^}}    |     |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK: {{^}}    |     |       `-DeclRefExpr {{.+}} [[var_iptr]]
 // CHECK: {{^}}    |     `-OpaqueValueExpr [[ove_1]]
 // CHECK: {{^}}    |       `-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>

--- a/clang/test/BoundsSafety/AST/bounds-attributed-in-return.c
+++ b/clang/test/BoundsSafety/AST/bounds-attributed-in-return.c
@@ -125,7 +125,7 @@ int *__counted_by(count) cb_in_from_indexable(int count, int *__indexable p) {
 // CHECK:       |     |-IntegerLiteral {{.+}} 0
 // CHECK:       |     `-OpaqueValueExpr [[ove_5]] {{.*}} 'int'
 // CHECK:       |-OpaqueValueExpr [[ove_4]]
-// CHECK:       | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK:       | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK:       |   `-DeclRefExpr {{.+}} [[var_p_2]]
 // CHECK:       `-OpaqueValueExpr [[ove_5]]
 // CHECK:         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -169,11 +169,11 @@ int *__counted_by(count) cb_in_from_single(int count, int *__single p) {
 // CHECK:       |     `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK:       |       `-OpaqueValueExpr [[ove_7]] {{.*}} lvalue
 // CHECK:       |-OpaqueValueExpr [[ove_6]]
-// CHECK:       | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK:       | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK:       |   `-DeclRefExpr {{.+}} [[var_p_3]]
 // CHECK:       `-OpaqueValueExpr [[ove_7]]
 // CHECK:         `-UnaryOperator {{.+}} cannot overflow
-// CHECK:           `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK:           `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK:             `-DeclRefExpr {{.+}} [[var_count_3]]
 int *__counted_by(*count) cb_out_from_single(int *__single count, int *__single p) {
   return p;
@@ -216,7 +216,7 @@ int *__counted_by(*count) cb_out_from_single(int *__single count, int *__single 
 // CHECK:       |-OpaqueValueExpr [[ove_8]]
 // CHECK:       | `-ImplicitCastExpr {{.+}} 'void *__bidi_indexable' <BitCast>
 // CHECK:       |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK:       |     `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK:       |     `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK:       |       `-DeclRefExpr {{.+}} [[var_p_4]]
 // CHECK:       `-OpaqueValueExpr [[ove_9]]
 // CHECK:         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -261,7 +261,7 @@ void *__sized_by(size) sb_from_single(int size, int *__single p) {
 // CHECK:       |       |-IntegerLiteral {{.+}} 0
 // CHECK:       |       `-OpaqueValueExpr [[ove_11]] {{.*}} 'int'
 // CHECK:       |-OpaqueValueExpr [[ove_10]]
-// CHECK:       | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK:       | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK:       |   `-DeclRefExpr {{.+}} [[var_p_5]]
 // CHECK:       `-OpaqueValueExpr [[ove_11]]
 // CHECK:         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -288,10 +288,10 @@ int *__counted_by_or_null(count) cbn_in_from_single(int count, int *__single p) 
 // CHECK:       |   |-OpaqueValueExpr [[ove_12]] {{.*}} 'int *__single'
 // CHECK:       |   `-OpaqueValueExpr [[ove_13]] {{.*}} 'int *__single'
 // CHECK:       |-OpaqueValueExpr [[ove_12]]
-// CHECK:       | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK:       | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK:       |   `-DeclRefExpr {{.+}} [[var_p_6]]
 // CHECK:       `-OpaqueValueExpr [[ove_13]]
-// CHECK:         `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK:         `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK:           `-DeclRefExpr {{.+}} [[var_end]]
 int *__ended_by(end) eb_in_from_single(int *__single end, int *__single p) {
   return p;

--- a/clang/test/BoundsSafety/AST/complex-typespecs-with-bounds.c
+++ b/clang/test/BoundsSafety/AST/complex-typespecs-with-bounds.c
@@ -1,4 +1,3 @@
-
 // RUN: not %clang_cc1 -fsyntax-only -fbounds-safety -ast-dump %s | FileCheck %s
 // RUN: not %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s | FileCheck %s
 
@@ -150,14 +149,14 @@ void typeof_autotype2() {
 // CHECK: |   |-DeclStmt
 // CHECK: |   | `-VarDecl [[var_p1_2:0x[^ ]+]]
 // CHECK: |   |   `-ImplicitCastExpr {{.+}} 'char *__unsafe_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |     `-ImplicitCastExpr {{.+}} 'char *__single _Nullable':'char *__single' <LValueToRValue>
+// CHECK: |   |     `-ImplicitCastExpr {{.+}} 'char *__single _Nullable':'char *' <LValueToRValue>
 // CHECK: |   |       `-DeclRefExpr {{.+}} [[var_p]]
 // CHECK: |   `-DeclStmt
 // CHECK: |     `-VarDecl [[var_p2_2:0x[^ ]+]]
 // CHECK: |       `-ImplicitCastExpr {{.+}} 'char *__unsafe_indexable' <BoundsSafetyPointerCast>
 // CHECK: |         `-UnaryOperator {{.+}} cannot overflow
 // CHECK: |           `-UnaryOperator {{.+}} cannot overflow
-// CHECK: |             `-ImplicitCastExpr {{.+}} 'char *__single _Nullable':'char *__single' <LValueToRValue>
+// CHECK: |             `-ImplicitCastExpr {{.+}} 'char *__single _Nullable':'char *' <LValueToRValue>
 // CHECK: |               `-DeclRefExpr {{.+}} [[var_p]]
 // CHECK: |-FunctionDecl [[func_typeofexpr_typeofexpr:0x[^ ]+]] {{.+}} typeofexpr_typeofexpr
 // CHECK: | `-CompoundStmt
@@ -187,4 +186,3 @@ void typeof_autotype2() {
 // CHECK:     |     `-DeclRefExpr {{.+}} [[var_bar]]
 // CHECK:     `-DeclStmt
 // CHECK:       `-VarDecl [[var_p2_6:0x[^ ]+]]
-

--- a/clang/test/BoundsSafety/AST/counted_by_or_null_call.c
+++ b/clang/test/BoundsSafety/AST/counted_by_or_null_call.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -Wno-bounds-safety-init-list %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -Wno-bounds-safety-init-list %s | FileCheck %s
 
@@ -417,25 +416,28 @@ void caller_7(int *__bidi_indexable p, int len) {
 // CHECK-NEXT: {{^}}|     | | |-CallExpr
 // CHECK-NEXT: {{^}}|     | | | |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single __counted_by_or_null(len), int)' <FunctionToPointerDecay>
 // CHECK-NEXT: {{^}}|     | | | | `-DeclRefExpr {{.+}} [[func_foo]]
-// CHECK-NEXT: {{^}}|     | | | |-OpaqueValueExpr [[ove_18:0x[^ ]+]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | | | |-ImplicitCastExpr {{.+}} 'int *__single __counted_by_or_null(len)':'int *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}|     | | | | `-OpaqueValueExpr [[ove_18:0x[^ ]+]] {{.*}} 'int *__single':'int *'
+// CHECK-NEXT: {{^}}|     | | | |   `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// CHECK-NEXT: {{^}}|     | | | |     `-DeclRefExpr {{.+}} [[var_p_4]]
 // CHECK:      {{^}}|     | | | `-OpaqueValueExpr [[ove_19:0x[^ ]+]] {{.*}} 'int'
 // CHECK:      {{^}}|     | | `-BinaryOperator {{.+}} 'int' '&&'
 // CHECK-NEXT: {{^}}|     | |   |-BinaryOperator {{.+}} 'int' '&&'
 // CHECK-NEXT: {{^}}|     | |   | |-BinaryOperator {{.+}} 'int' '<='
-// CHECK-NEXT: {{^}}|     | |   | | |-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |   | | |-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |   | | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}|     | |   | |   `-GetBoundExpr {{.+}} upper
 // CHECK-NEXT: {{^}}|     | |   | |     `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK-NEXT: {{^}}|     | |   | |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |   | |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |   | `-BinaryOperator {{.+}} 'int' '<='
 // CHECK-NEXT: {{^}}|     | |   |   |-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}|     | |   |   | `-GetBoundExpr {{.+}} lower
 // CHECK-NEXT: {{^}}|     | |   |   |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK-NEXT: {{^}}|     | |   |   |     `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
-// CHECK:      {{^}}|     | |   |   `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |   |   |     `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
+// CHECK:      {{^}}|     | |   |   `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |   `-BinaryOperator {{.+}} 'int' '||'
 // CHECK-NEXT: {{^}}|     | |     |-UnaryOperator {{.+}} cannot overflow
-// CHECK-NEXT: {{^}}|     | |     | `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |     | `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |     `-BinaryOperator {{.+}} 'int' '&&'
 // CHECK-NEXT: {{^}}|     | |       |-BinaryOperator {{.+}} 'int' '<='
 // CHECK-NEXT: {{^}}|     | |       | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -444,18 +446,18 @@ void caller_7(int *__bidi_indexable p, int len) {
 // CHECK-NEXT: {{^}}|     | |       |   |-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}|     | |       |   | `-GetBoundExpr {{.+}} upper
 // CHECK-NEXT: {{^}}|     | |       |   |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK-NEXT: {{^}}|     | |       |   |     `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
-// CHECK:      {{^}}|     | |       |   `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |       |   |     `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
+// CHECK:      {{^}}|     | |       |   `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |       `-BinaryOperator {{.+}} 'int' '<='
 // CHECK-NEXT: {{^}}|     | |         |-IntegerLiteral {{.+}} 0
 // CHECK-NEXT: {{^}}|     | |         `-OpaqueValueExpr [[ove_19]] {{.*}} 'int'
 // CHECK:      {{^}}|     | |-OpaqueValueExpr [[ove_18]]
-// CHECK-NEXT: {{^}}|     | | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}|     | | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK-NEXT: {{^}}|     | |   `-DeclRefExpr {{.+}} [[var_p_4]]
 // CHECK-NEXT: {{^}}|     | `-OpaqueValueExpr [[ove_19]]
 // CHECK-NEXT: {{^}}|     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: {{^}}|     |     `-DeclRefExpr {{.+}} [[var_len_4]]
-// CHECK-NEXT: {{^}}|     |-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     |-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     `-OpaqueValueExpr [[ove_19]] {{.*}} 'int'
 void caller_8(int *__single p, int len) {
   foo(p, len);

--- a/clang/test/BoundsSafety/AST/default-attributes-in-preprocessed.c
+++ b/clang/test/BoundsSafety/AST/default-attributes-in-preprocessed.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -verify -fbounds-safety -isystem %S/SystemHeaders/include %s | FileCheck %s
 // RUN: %clang_cc1 -E -verify -fbounds-safety -isystem %S/SystemHeaders/include -o %t.pp.c %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %t.pp.c | FileCheck %s
@@ -23,5 +21,6 @@ int *__single return_to_single_p(int *p) {
 // CHECK-NEXT:   |-ParmVarDecl {{.*}} used p 'int *__single'
 // CHECK-NEXT:   `-CompoundStmt
 // CHECK-NEXT:     `-ReturnStmt
-// CHECK-NEXT:       `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-// CHECK-NEXT:         `-DeclRefExpr {{.*}} 'int *__single' lvalue ParmVar {{.*}} 'p' 'int *__single'
+// CHECK-NEXT:       `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <BoundsSafetyPointerCast>
+// CHECK-NEXT:         `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
+// CHECK-NEXT:           `-DeclRefExpr {{.*}} 'int *__single' lvalue ParmVar {{.*}} 'p' 'int *__single'

--- a/clang/test/BoundsSafety/AST/flexible-array-member-assign-null.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-assign-null.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -16,8 +14,8 @@ void init_null(void) {
 }
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: `-DeclStmt
-// CHECK-NEXT:   `-VarDecl {{.*}} s 'flex_t *__single' cinit
-// CHECK-NEXT:     `-ImplicitCastExpr {{.*}} 'flex_t *__single' <NullToPointer>
+// CHECK-NEXT:   `-VarDecl {{.*}} s 'flex_t *__single':'flex_t *' cinit
+// CHECK-NEXT:     `-ImplicitCastExpr {{.*}} 'flex_t *__single':'flex_t *' <NullToPointer>
 // CHECK-NEXT:       `-IntegerLiteral {{.*}} 'int' 0
 
 
@@ -27,10 +25,9 @@ void init_casted_null(void) {
 }
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: `-DeclStmt
-// CHECK-NEXT:   `-VarDecl {{.*}} s 'flex_t *__single' cinit
-// CHECK-NEXT:     `-ImplicitCastExpr {{.*}} 'flex_t *__single' <BoundsSafetyPointerCast>
-// CHECK-NEXT:       `-CStyleCastExpr {{.*}} 'flex_t *' <NullToPointer>
-// CHECK-NEXT:         `-IntegerLiteral {{.*}} 'int' 0
+// CHECK-NEXT:   `-VarDecl {{.*}} s 'flex_t *__single':'flex_t *' cinit
+// CHECK-NEXT:     `-CStyleCastExpr {{.*}} 'flex_t *' <NullToPointer>
+// CHECK-NEXT:       `-IntegerLiteral {{.*}} 'int' 0
 
 
 // CHECK-LABEL: assign_null 'void (void)'
@@ -40,10 +37,10 @@ void assign_null(void) {
 }
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: |-DeclStmt
-// CHECK-NEXT: | `-VarDecl {{.*}} used s 'flex_t *__single'
-// CHECK-NEXT: `-BinaryOperator {{.*}} 'flex_t *__single' '='
-// CHECK-NEXT:   |-DeclRefExpr {{.*}} 'flex_t *__single' lvalue Var {{.*}} 's' 'flex_t *__single'
-// CHECK-NEXT:   `-ImplicitCastExpr {{.*}} 'flex_t *__single' <NullToPointer>
+// CHECK-NEXT: | `-VarDecl {{.*}} used s 'flex_t *__single':'flex_t *'
+// CHECK-NEXT: `-BinaryOperator {{.*}} 'flex_t *__single':'flex_t *' '='
+// CHECK-NEXT:   |-DeclRefExpr {{.*}} 'flex_t *__single':'flex_t *' lvalue Var {{.*}} 's' 'flex_t *__single':'flex_t *'
+// CHECK-NEXT:   `-ImplicitCastExpr {{.*}} 'flex_t *__single':'flex_t *' <NullToPointer>
 // CHECK-NEXT:     `-IntegerLiteral {{.*}} 'int' 0
 
 
@@ -54,9 +51,8 @@ void assign_casted_null(void) {
 }
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: |-DeclStmt
-// CHECK-NEXT: | `-VarDecl {{.*}} used s 'flex_t *__single'
-// CHECK-NEXT: `-BinaryOperator {{.*}} 'flex_t *__single' '='
-// CHECK-NEXT:   |-DeclRefExpr {{.*}} 'flex_t *__single' lvalue Var {{.*}} 's' 'flex_t *__single'
-// CHECK-NEXT:   `-ImplicitCastExpr {{.*}} 'flex_t *__single' <BoundsSafetyPointerCast>
-// CHECK-NEXT:     `-CStyleCastExpr {{.*}} 'flex_t *' <NullToPointer>
-// CHECK-NEXT:       `-IntegerLiteral {{.*}} 'int' 0
+// CHECK-NEXT: | `-VarDecl {{.*}} used s 'flex_t *__single':'flex_t *'
+// CHECK-NEXT: `-BinaryOperator {{.*}} 'flex_t *__single':'flex_t *' '='
+// CHECK-NEXT:   |-DeclRefExpr {{.*}} 'flex_t *__single':'flex_t *' lvalue Var {{.*}} 's' 'flex_t *__single':'flex_t *'
+// CHECK-NEXT:   `-CStyleCastExpr {{.*}} 'flex_t *' <NullToPointer>
+// CHECK-NEXT:     `-IntegerLiteral {{.*}} 'int' 0

--- a/clang/test/BoundsSafety/AST/flexible-array-member-assign-with-single.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-assign-with-single.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -18,9 +16,10 @@ void init_single(void *p) {
 // CHECK-NEXT: | `-CompoundStmt
 // CHECK-NEXT: |   `-DeclStmt
 // CHECK-NEXT: |     `-VarDecl [[var_s:0x[^ ]+]]
-// CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BitCast>
-// CHECK-NEXT: |         `-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue>
-// CHECK-NEXT: |           `-DeclRefExpr {{.+}} [[var_p]]
+// CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |         `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BitCast>
+// CHECK-NEXT: |           `-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue>
+// CHECK-NEXT: |             `-DeclRefExpr {{.+}} [[var_p]]
 
 // CHECK-LABEL: init_casted_single
 void init_casted_single(void *p) {
@@ -30,9 +29,10 @@ void init_casted_single(void *p) {
 // CHECK-NEXT: | `-CompoundStmt
 // CHECK-NEXT: |   `-DeclStmt
 // CHECK-NEXT: |     `-VarDecl [[var_s_1:0x[^ ]+]]
-// CHECK-NEXT: |       `-CStyleCastExpr {{.+}} 'struct flexible *__single' <BitCast>
-// CHECK-NEXT: |         `-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue>
-// CHECK-NEXT: |           `-DeclRefExpr {{.+}} [[var_p_1]]
+// CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |         `-CStyleCastExpr {{.+}} 'struct flexible *__single' <BitCast>
+// CHECK-NEXT: |           `-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue> part_of_explicit_cast
+// CHECK-NEXT: |             `-DeclRefExpr {{.+}} [[var_p_1]]
 
 // CHECK-LABEL: assign_single
 void assign_single(void *p) {
@@ -43,11 +43,12 @@ void assign_single(void *p) {
 // CHECK-NEXT: | `-CompoundStmt
 // CHECK-NEXT: |   |-DeclStmt
 // CHECK-NEXT: |   | `-VarDecl [[var_s_2:0x[^ ]+]]
-// CHECK-NEXT: |   `-BinaryOperator {{.+}} 'struct flexible *__single' '='
+// CHECK-NEXT: |   `-BinaryOperator {{.+}} 'struct flexible *__single':'struct flexible *' '='
 // CHECK-NEXT: |     |-DeclRefExpr {{.+}} [[var_s_2]]
-// CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BitCast>
-// CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue>
-// CHECK-NEXT: |         `-DeclRefExpr {{.+}} [[var_p_2]]
+// CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BitCast>
+// CHECK-NEXT: |         `-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue>
+// CHECK-NEXT: |           `-DeclRefExpr {{.+}} [[var_p_2]]
 
 // CHECK-LABEL: assign_casted_single
 void assign_casted_single(void *p) {
@@ -58,8 +59,9 @@ void assign_casted_single(void *p) {
 // CHECK-NEXT: `-CompoundStmt
 // CHECK-NEXT:   |-DeclStmt
 // CHECK-NEXT:   | `-VarDecl [[var_s_3:0x[^ ]+]]
-// CHECK-NEXT:   `-BinaryOperator {{.+}} 'struct flexible *__single' '='
+// CHECK-NEXT:   `-BinaryOperator {{.+}} 'struct flexible *__single':'struct flexible *' '='
 // CHECK-NEXT:     |-DeclRefExpr {{.+}} [[var_s_3]]
-// CHECK-NEXT:     `-CStyleCastExpr {{.+}} 'struct flexible *__single' <BitCast>
-// CHECK-NEXT:       `-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue>
-// CHECK-NEXT:         `-DeclRefExpr {{.+}} [[var_p_3]]
+// CHECK-NEXT:     `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK-NEXT:       `-CStyleCastExpr {{.+}} 'struct flexible *__single' <BitCast>
+// CHECK-NEXT:         `-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue> part_of_explicit_cast
+// CHECK-NEXT:           `-DeclRefExpr {{.+}} [[var_p_3]]

--- a/clang/test/BoundsSafety/AST/flexible-array-member-assignments-no-count.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-assignments-no-count.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -62,7 +60,7 @@ void test_fam_base_init(void *__bidi_indexable buf) {
 // CHECK: `-CompoundStmt
 // CHECK:   `-DeclStmt
 // CHECK:     `-VarDecl [[var_f_2:0x[^ ]+]]
-// CHECK:       `-ImplicitCastExpr {{.+}} 'flex_t *__single' <BoundsSafetyPointerCast>
+// CHECK:       `-ImplicitCastExpr {{.+}} 'flex_t *__single':'flex_t *' <BoundsSafetyPointerCast>
 // CHECK:         `-ImplicitCastExpr {{.+}} 'flex_t *__bidi_indexable' <BitCast>
 // CHECK:           `-ImplicitCastExpr {{.+}} 'void *__bidi_indexable' <LValueToRValue>
 // CHECK:             `-DeclRefExpr {{.+}} [[var_buf_2]]
@@ -77,14 +75,14 @@ void test_fam_base_init_with_count(void *__bidi_indexable buf) {
 // CHECK: `-CompoundStmt
 // CHECK:   |-DeclStmt
 // CHECK:   | `-VarDecl [[var_f_3:0x[^ ]+]]
-// CHECK:   |   `-ImplicitCastExpr {{.+}} 'flex_t *__single' <BoundsSafetyPointerCast>
+// CHECK:   |   `-ImplicitCastExpr {{.+}} 'flex_t *__single':'flex_t *' <BoundsSafetyPointerCast>
 // CHECK:   |     `-ImplicitCastExpr {{.+}} 'flex_t *__bidi_indexable' <BitCast>
 // CHECK:   |       `-ImplicitCastExpr {{.+}} 'void *__bidi_indexable' <LValueToRValue>
 // CHECK:   |         `-DeclRefExpr {{.+}} [[var_buf_3]]
 // CHECK:   `-BinaryOperator {{.+}} 'int' '='
 // CHECK:     |-MemberExpr {{.+}} .count
 // CHECK:     | `-MemberExpr {{.+}} ->flex
-// CHECK:     |   `-ImplicitCastExpr {{.+}} 'flex_t *__single' <LValueToRValue>
+// CHECK:     |   `-ImplicitCastExpr {{.+}} 'flex_t *__single':'flex_t *' <LValueToRValue>
 // CHECK:     |     `-DeclRefExpr {{.+}} [[var_f_3]]
 // CHECK:     `-IntegerLiteral {{.+}} 10
 

--- a/clang/test/BoundsSafety/AST/flexible-array-member-checks-assignments.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-checks-assignments.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -93,7 +91,7 @@ void test_fam_base_init(void *__bidi_indexable buf) {
 // CHECK:       `-VarDecl [[var_f_2:0x[^ ]+]]
 // CHECK:         `-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK:           |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK:           | |-ImplicitCastExpr {{.+}} 'flex_t *__single' <BoundsSafetyPointerCast>
+// CHECK:           | |-ImplicitCastExpr {{.+}} 'flex_t *__single':'flex_t *' <BoundsSafetyPointerCast>
 // CHECK:           | | `-PredefinedBoundsCheckExpr {{.+}} 'flex_t *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:           | |   |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'flex_t *__bidi_indexable'
 // CHECK:           | |   |-OpaqueValueExpr [[ove_3]] {{.*}} 'flex_t *__bidi_indexable'
@@ -121,7 +119,7 @@ void test_fam_base_init_with_count(void *__bidi_indexable buf) {
 // CHECK:   |-DeclStmt
 // CHECK:   | `-VarDecl [[var_f_3:0x[^ ]+]]
 // CHECK:   |   `-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:   |     |-ImplicitCastExpr {{.+}} 'flex_t *__single' <BoundsSafetyPointerCast>
+// CHECK:   |     |-ImplicitCastExpr {{.+}} 'flex_t *__single':'flex_t *' <BoundsSafetyPointerCast>
 // CHECK:   |     | `-PredefinedBoundsCheckExpr {{.+}} 'flex_t *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:   |     |   |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'flex_t *__bidi_indexable'
 // CHECK:   |     |   |-OpaqueValueExpr [[ove_4]] {{.*}} 'flex_t *__bidi_indexable'
@@ -140,7 +138,7 @@ void test_fam_base_init_with_count(void *__bidi_indexable buf) {
 // CHECK:     |-BinaryOperator {{.+}} 'int' '='
 // CHECK:     | |-MemberExpr {{.+}} .count
 // CHECK:     | | `-MemberExpr {{.+}} ->flex
-// CHECK:     | |   `-ImplicitCastExpr {{.+}} 'flex_t *__single' <LValueToRValue>
+// CHECK:     | |   `-ImplicitCastExpr {{.+}} 'flex_t *__single':'flex_t *' <LValueToRValue>
 // CHECK:     | |     `-DeclRefExpr {{.+}} [[var_f_3]]
 // CHECK:     | `-OpaqueValueExpr [[ove_5]] {{.*}} 'int'
 // CHECK:     |-OpaqueValueExpr [[ove_4]] {{.*}} 'flex_t *__bidi_indexable'
@@ -159,7 +157,7 @@ void test_fam_base_init_deref_with_count(void *__bidi_indexable buf) {
 // CHECK:   | `-VarDecl [[var_f_4:0x[^ ]+]]
 // CHECK:   |   `-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK:   |     |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK:   |     | |-ImplicitCastExpr {{.+}} 'flex_t *__single' <BoundsSafetyPointerCast>
+// CHECK:   |     | |-ImplicitCastExpr {{.+}} 'flex_t *__single':'flex_t *' <BoundsSafetyPointerCast>
 // CHECK:   |     | | `-PredefinedBoundsCheckExpr {{.+}} 'flex_t *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:   |     | |   |-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'flex_t *__bidi_indexable'
 // CHECK:   |     | |   |-OpaqueValueExpr [[ove_6]] {{.*}} 'flex_t *__bidi_indexable'

--- a/clang/test/BoundsSafety/AST/flexible-array-member-checks-deref-no-count.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-checks-deref-no-count.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -23,7 +21,7 @@ int not_checking_count_single(struct flexible *__single flex) {
 // CHECK: |         | `-MemberExpr {{.+}} .elems
 // CHECK: |         |   `-ParenExpr
 // CHECK: |         |     `-UnaryOperator {{.+}} cannot overflow
-// CHECK: |         |       `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <LValueToRValue>
+// CHECK: |         |       `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <LValueToRValue>
 // CHECK: |         |         `-DeclRefExpr {{.+}} [[var_flex]]
 // CHECK: |         `-IntegerLiteral {{.+}} 12
 

--- a/clang/test/BoundsSafety/AST/flexible-array-member-checks-deref.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-checks-deref.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -57,7 +55,7 @@ int not_checking_count_single(struct flexible *__single flex) {
 // CHECK: |         | |         | | |     `-MemberExpr {{.+}} ->count
 // CHECK: |         | |         | | |       `-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single'
 // CHECK: |         | |         | `-OpaqueValueExpr [[ove_1]]
-// CHECK: |         | |         |   `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <LValueToRValue>
+// CHECK: |         | |         |   `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <LValueToRValue>
 // CHECK: |         | |         |     `-DeclRefExpr {{.+}} [[var_flex]]
 // CHECK: |         | |         `-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single'
 // CHECK: |         | `-OpaqueValueExpr [[ove]] {{.*}} lvalue

--- a/clang/test/BoundsSafety/AST/flexible-array-member-checks-to-single.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-checks-to-single.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -20,26 +18,22 @@ void checking_count_single(struct flexible *__single flex) {
 // CHECK: |   |-CallExpr
 // CHECK: |   | |-ImplicitCastExpr {{.+}} 'void (*__single)(struct flexible *__single)' <FunctionToPointerDecay>
 // CHECK: |   | | `-DeclRefExpr {{.+}} [[func_sink]]
-// CHECK: |   | | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
-// CHECK: |   | | |   `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | | |       | | |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'struct flexible *__single'
-// CHECK: |   | | `-OpaqueValueExpr [[ove]]
-// CHECK: |   | |   `-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK: |   | |     |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | |     | | |-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single'
-// CHECK: |   | |     | | |-BinaryOperator {{.+}} 'int *' '+'
-// CHECK: |   | |     | | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
-// CHECK: |   | |     | | | | `-MemberExpr {{.+}} ->elems
-// CHECK: |   | |     | | | |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single'
-// CHECK: |   | |     | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK: |   | |     | | |   `-MemberExpr {{.+}} ->count
-// CHECK: |   | |     | | |     `-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single'
-// CHECK: |   | |     | `-OpaqueValueExpr [[ove_1]]
-// CHECK: |   | |     |   `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <LValueToRValue>
-// CHECK: |   | |     |     `-DeclRefExpr {{.+}} [[var_flex_1]]
-// CHECK: |   | |     `-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single'
-// CHECK: |   | `-OpaqueValueExpr [[ove]] {{.*}} 'struct flexible *__bidi_indexable'
+// CHECK: |   | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK: |   |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK: |   |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK: |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'struct flexible *__bidi_indexable'
+// CHECK: |   |     | | |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'struct flexible *__single':'struct flexible *'
+// CHECK: |   |     | | |-BinaryOperator {{.+}} 'int *' '+'
+// CHECK: |   |     | | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
+// CHECK: |   |     | | | | `-MemberExpr {{.+}} ->elems
+// CHECK: |   |     | | | |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single':'struct flexible *'
+// CHECK: |   |     | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK: |   |     | | |   `-MemberExpr {{.+}} ->count
+// CHECK: |   |     | | |     `-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single':'struct flexible *'
+// CHECK: |   |     | `-OpaqueValueExpr [[ove_1]]
+// CHECK: |   |     |   `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <LValueToRValue>
+// CHECK: |   |     |     `-DeclRefExpr {{.+}} [[var_flex_1]]
+// CHECK: |   |     `-OpaqueValueExpr [[ove_1]] {{.*}} 'struct flexible *__single':'struct flexible *'
 
     (void)(struct flexible *__single)flex;
 // CHECK: |   `-CStyleCastExpr {{.+}} 'void' <ToVoid>
@@ -47,18 +41,18 @@ void checking_count_single(struct flexible *__single flex) {
 // CHECK: |       `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: |         |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'struct flexible *__bidi_indexable'
-// CHECK: |         | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'struct flexible *__single'
+// CHECK: |         | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'struct flexible *__single':'struct flexible *'
 // CHECK: |         | | |-BinaryOperator {{.+}} 'int *' '+'
 // CHECK: |         | | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
 // CHECK: |         | | | | `-MemberExpr {{.+}} ->elems
-// CHECK: |         | | | |   `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct flexible *__single'
+// CHECK: |         | | | |   `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct flexible *__single':'struct flexible *'
 // CHECK: |         | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK: |         | | |   `-MemberExpr {{.+}} ->count
-// CHECK: |         | | |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct flexible *__single'
+// CHECK: |         | | |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct flexible *__single':'struct flexible *'
 // CHECK: |         | `-OpaqueValueExpr [[ove_2]]
-// CHECK: |         |   `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <LValueToRValue>
+// CHECK: |         |   `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <LValueToRValue>
 // CHECK: |         |     `-DeclRefExpr {{.+}} [[var_flex_1]]
-// CHECK: |         `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct flexible *__single'
+// CHECK: |         `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct flexible *__single':'struct flexible *'
 
 }
 
@@ -66,31 +60,25 @@ void checking_count_single(struct flexible *__single flex) {
 void checking_count_indexable(struct flexible *__indexable flex) {
 // CHECK: | |-ParmVarDecl [[var_flex_2:0x[^ ]+]]
     sink(flex);
-// CHECK:  |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK:  | |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: |   |-CallExpr
 // CHECK: |   | |-ImplicitCastExpr {{.+}} 'void (*__single)(struct flexible *__single)' <FunctionToPointerDecay>
 // CHECK: |   | | `-DeclRefExpr {{.+}} [[func_sink]]
-// CHECK: |   | | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
-// CHECK: |   | | |   `-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | | |       | | |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | | `-OpaqueValueExpr [[ove_3]]
-// CHECK: |   | |   `-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK: |   | |     |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | |     | |-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__indexable' <FlexibleArrayCountCast(BasePtr, FamPtr, Count)>
-// CHECK: |   | |     | | |-OpaqueValueExpr [[ove_4]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | |     | | |-OpaqueValueExpr [[ove_4]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | |     | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
-// CHECK: |   | |     | | | `-MemberExpr {{.+}} ->elems
-// CHECK: |   | |     | | |   `-OpaqueValueExpr [[ove_4]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK: |   | |     | |   `-MemberExpr {{.+}} ->count
-// CHECK: |   | |     | |     `-OpaqueValueExpr [[ove_4]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | |     | `-OpaqueValueExpr [[ove_4]]
-// CHECK: |   | |     |   `-ImplicitCastExpr {{.+}} 'struct flexible *__indexable' <LValueToRValue>
-// CHECK: |   | |     |     `-DeclRefExpr {{.+}} [[var_flex_2]]
-// CHECK: |   | |     `-OpaqueValueExpr [[ove_4]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK: |   |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK: |   |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK: |   |     | |-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__indexable' <FlexibleArrayCountCast(BasePtr, FamPtr, Count)>
+// CHECK: |   |     | | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |     | | |-OpaqueValueExpr [[ove_3]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |     | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
+// CHECK: |   |     | | | `-MemberExpr {{.+}} ->elems
+// CHECK: |   |     | | |   `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK: |   |     | |   `-MemberExpr {{.+}} ->count
+// CHECK: |   |     | |     `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |     | `-OpaqueValueExpr [[ove_3]]
+// CHECK: |   |     |   `-ImplicitCastExpr {{.+}} 'struct flexible *__indexable' <LValueToRValue>
+// CHECK: |   |     |     `-DeclRefExpr {{.+}} [[var_flex_2]]
+// CHECK: |   |     `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct flexible *__indexable'
 
     (void)(struct flexible *__single)flex;
 // CHECK: |   `-CStyleCastExpr {{.+}} 'void' <ToVoid>
@@ -104,31 +92,25 @@ void checking_count_bidi_indexable(struct flexible *__indexable flex) {
 // CHECK: {{^}}| |-ParmVarDecl [[var_flex_3:0x[^ ]+]]
     sink(flex);
 // CHECK: | `-CompoundStmt
-// CHECK: |   |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK: |   | |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | | |-CallExpr
-// CHECK: |   | | | |-ImplicitCastExpr {{.+}} 'void (*__single)(struct flexible *__single)' <FunctionToPointerDecay>
-// CHECK: |   | | | | `-DeclRefExpr {{.+}} [[func_sink]]
-// CHECK: |   | | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
-// CHECK: |   | | |   `-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | | |       | | |-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | | `-OpaqueValueExpr [[ove_5]]
-// CHECK: |   | |   `-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK: |   | |     |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | |     | |-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__indexable' <FlexibleArrayCountCast(BasePtr, FamPtr, Count)>
-// CHECK: |   | |     | | |-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | |     | | |-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | |     | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
-// CHECK: |   | |     | | | `-MemberExpr {{.+}} ->elems
-// CHECK: |   | |     | | |   `-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK: |   | |     | |   `-MemberExpr {{.+}} ->count
-// CHECK: |   | |     | |     `-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | |     | `-OpaqueValueExpr [[ove_6]]
-// CHECK: |   | |     |   `-ImplicitCastExpr {{.+}} 'struct flexible *__indexable' <LValueToRValue>
-// CHECK: |   | |     |     `-DeclRefExpr {{.+}} [[var_flex_3]]
-// CHECK: |   | |     `-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__indexable'
-// CHECK: |   | `-OpaqueValueExpr [[ove_5]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |-CallExpr
+// CHECK: |   | |-ImplicitCastExpr {{.+}} 'void (*__single)(struct flexible *__single)' <FunctionToPointerDecay>
+// CHECK: |   | | `-DeclRefExpr {{.+}} [[func_sink]]
+// CHECK: |   | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK: |   |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK: |   |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK: |   |     | |-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__indexable' <FlexibleArrayCountCast(BasePtr, FamPtr, Count)>
+// CHECK: |   |     | | |-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |     | | |-OpaqueValueExpr [[ove_5]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |     | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
+// CHECK: |   |     | | | `-MemberExpr {{.+}} ->elems
+// CHECK: |   |     | | |   `-OpaqueValueExpr [[ove_5]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK: |   |     | |   `-MemberExpr {{.+}} ->count
+// CHECK: |   |     | |     `-OpaqueValueExpr [[ove_5]] {{.*}} 'struct flexible *__indexable'
+// CHECK: |   |     | `-OpaqueValueExpr [[ove_5]]
+// CHECK: |   |     |   `-ImplicitCastExpr {{.+}} 'struct flexible *__indexable' <LValueToRValue>
+// CHECK: |   |     |     `-DeclRefExpr {{.+}} [[var_flex_3]]
+// CHECK: |   |     `-OpaqueValueExpr [[ove_5]] {{.*}} 'struct flexible *__indexable'
 
     (void)(struct flexible *__single)flex;
 // CHECK: |   `-CStyleCastExpr {{.+}} 'void' <ToVoid>
@@ -143,49 +125,40 @@ void checking_count_sized_by(struct flexible *__sized_by(size) flex, int size) {
 // CHECK: {{^}}| |-ParmVarDecl [[var_size:0x[^ ]+]]
     sink(flex);
 // CHECK: | `-CompoundStmt
-// CHECK: |   |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK: |   | |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | | |-CallExpr
-// CHECK: |   | | | |-ImplicitCastExpr {{.+}} 'void (*__single)(struct flexible *__single)' <FunctionToPointerDecay>
-// CHECK: |   | | | | `-DeclRefExpr {{.+}} [[func_sink]]
-// CHECK: |   | | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
-// CHECK: |   | | |   `-OpaqueValueExpr [[ove_7:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | | |       | | |-OpaqueValueExpr [[ove_8:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | | |       | | |   | | |-OpaqueValueExpr [[ove_9:0x[^ ]+]] {{.*}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single'
-// CHECK: |   | | |       | | |   | | |   `-OpaqueValueExpr [[ove_10:0x[^ ]+]] {{.*}} 'int'
-// CHECK: |   | | `-OpaqueValueExpr [[ove_7]]
-// CHECK: |   | |   `-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK: |   | |     |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | |     | |-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountCast(BasePtr, FamPtr, Count)>
-// CHECK: |   | |     | | |-OpaqueValueExpr [[ove_8]] {{.*}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | |     | | |-OpaqueValueExpr [[ove_8]] {{.*}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | |     | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
-// CHECK: |   | |     | | | `-MemberExpr {{.+}} ->elems
-// CHECK: |   | |     | | |   `-OpaqueValueExpr [[ove_8]] {{.*}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK: |   | |     | |   `-MemberExpr {{.+}} ->count
-// CHECK: |   | |     | |     `-OpaqueValueExpr [[ove_8]] {{.*}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | |     | `-OpaqueValueExpr [[ove_8]]
-// CHECK: |   | |     |   `-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK: |   | |     |     |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | |     |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | |     |     | | |-OpaqueValueExpr [[ove_9]] {{.*}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single'
-// CHECK: |   | |     |     | | |-ImplicitCastExpr {{.+}} 'struct flexible *' <BitCast>
-// CHECK: |   | |     |     | | | `-BinaryOperator {{.+}} 'char *' '+'
-// CHECK: |   | |     |     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
-// CHECK: |   | |     |     | | |   | `-ImplicitCastExpr {{.+}} 'struct flexible *' <BoundsSafetyPointerCast>
-// CHECK: |   | |     |     | | |   |   `-OpaqueValueExpr [[ove_9]] {{.*}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single'
-// CHECK: |   | |     |     | | |   `-OpaqueValueExpr [[ove_10]] {{.*}} 'int'
-// CHECK: |   | |     |     | |-OpaqueValueExpr [[ove_9]]
-// CHECK: |   | |     |     | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single' <LValueToRValue>
-// CHECK: |   | |     |     | |   `-DeclRefExpr {{.+}} [[var_flex_4]]
-// CHECK: |   | |     |     | `-OpaqueValueExpr [[ove_10]]
-// CHECK: |   | |     |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK: |   | |     |     |     `-DeclRefExpr {{.+}} [[var_size]]
-// CHECK: |   | |     |     |-OpaqueValueExpr [[ove_9]] {{.*}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single'
-// CHECK: |   | |     |     `-OpaqueValueExpr [[ove_10]] {{.*}} 'int'
-// CHECK: |   | |     `-OpaqueValueExpr [[ove_8]] {{.*}} 'struct flexible *__bidi_indexable'
-// CHECK: |   | `-OpaqueValueExpr [[ove_7]] {{.*}} 'struct flexible *__bidi_indexable'
+// CHECK: |   |-CallExpr
+// CHECK: |   | |-ImplicitCastExpr {{.+}} 'void (*__single)(struct flexible *__single)' <FunctionToPointerDecay>
+// CHECK: |   | | `-DeclRefExpr {{.+}} [[func_sink]]
+// CHECK: |   | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK: |   |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK: |   |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK: |   |     | |-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountCast(BasePtr, FamPtr, Count)>
+// CHECK: |   |     | | |-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
+// CHECK: |   |     | | | `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK: |   |     | | |   |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK: |   |     | | |   | |-BoundsSafetyPointerPromotionExpr {{.+}} 'struct flexible *__bidi_indexable'
+// CHECK: |   |     | | |   | | |-OpaqueValueExpr [[ove_7:0x[^ ]+]] {{.*}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single'
+// CHECK: |   |     | | |   | | |-ImplicitCastExpr {{.+}} 'struct flexible *' <BitCast>
+// CHECK: |   |     | | |   | | | `-BinaryOperator {{.+}} 'char *' '+'
+// CHECK: |   |     | | |   | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK: |   |     | | |   | | |   | `-ImplicitCastExpr {{.+}} 'struct flexible *' <BoundsSafetyPointerCast>
+// CHECK: |   |     | | |   | | |   |   `-OpaqueValueExpr [[ove_7]] {{.*}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single'
+// CHECK: |   |     | | |   | | |   `-OpaqueValueExpr [[ove_8:0x[^ ]+]] {{.*}} 'int'
+// CHECK: |   |     | | |   | |-OpaqueValueExpr [[ove_7]]
+// CHECK: |   |     | | |   | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single' <LValueToRValue>
+// CHECK: |   |     | | |   | |   `-DeclRefExpr {{.+}} [[var_flex_4]]
+// CHECK: |   |     | | |   | `-OpaqueValueExpr [[ove_8]]
+// CHECK: |   |     | | |   |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK: |   |     | | |   |     `-DeclRefExpr {{.+}} [[var_size]]
+// CHECK: |   |     | | |   |-OpaqueValueExpr [[ove_7]] {{.*}} 'struct flexible *__single __sized_by(size)':'struct flexible *__single'
+// CHECK: |   |     | | |   `-OpaqueValueExpr [[ove_8]] {{.*}} 'int'
+// CHECK: |   |     | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
+// CHECK: |   |     | | | `-MemberExpr {{.+}} ->elems
+// CHECK: |   |     | | |   `-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__bidi_indexable'
+// CHECK: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK: |   |     | |   `-MemberExpr {{.+}} ->count
+// CHECK: |   |     | |     `-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__bidi_indexable'
+// CHECK: |   |     | `-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__bidi_indexable'
+// CHECK: |   |     `-OpaqueValueExpr [[ove_6]] {{.*}} 'struct flexible *__bidi_indexable'
 
 
     (void)(struct flexible *__single)flex;
@@ -231,7 +204,7 @@ struct flexible *checking_count_single_return(struct flexible *__single flex) {
 // CHECK: |         | | |   `-MemberExpr {{.+}} ->count
 // CHECK: |         | | |     `-OpaqueValueExpr [[ove_13]] {{.*}} 'struct flexible *__single'
 // CHECK: |         | `-OpaqueValueExpr [[ove_13]]
-// CHECK: |         |   `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <LValueToRValue>
+// CHECK: |         |   `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <LValueToRValue>
 // CHECK: |         |     `-DeclRefExpr {{.+}} [[var_flex_5]]
 // CHECK: |         `-OpaqueValueExpr [[ove_13]] {{.*}} 'struct flexible *__single'
   return flex;

--- a/clang/test/BoundsSafety/AST/flexible-array-member-promotion-assignment-uint64.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-promotion-assignment-uint64.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -61,9 +59,8 @@ void promote_null_to_single() {
 // CHECK: | `-CompoundStmt
 // CHECK: |   `-DeclStmt
 // CHECK: |     `-VarDecl [[var_b_2:0x[^ ]+]]
-// CHECK: |       `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
-// CHECK: |         `-CStyleCastExpr {{.+}} 'struct flexible *' <NullToPointer>
-// CHECK: |           `-IntegerLiteral {{.+}} 0
+// CHECK: |       `-CStyleCastExpr {{.+}} 'struct flexible *' <NullToPointer>
+// CHECK: |         `-IntegerLiteral {{.+}} 0
 
 // CHECK-LABEL: promote_to_single
 void promote_to_single(struct flexible *flex) {
@@ -75,7 +72,7 @@ void promote_to_single(struct flexible *flex) {
 // CHECK:     `-VarDecl [[var_s:0x[^ ]+]]
 // CHECK:       `-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK:         |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK:         | |-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
+// CHECK:         | |-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
 // CHECK:         | | `-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:         | |   |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:         | |   |   | | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'struct flexible *__single'
@@ -237,7 +234,7 @@ void promote_to_single_assign(struct flexible *flex) {
 // CHECK:   |-DeclStmt
 // CHECK:   | `-VarDecl [[var_s_2:0x[^ ]+]]
 // CHECK:   |   `-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:   |     |-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
+// CHECK:   |     |-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
 // CHECK:   |     | `-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:   |     |   |-OpaqueValueExpr [[ove_9:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:   |     |   |   | | |-OpaqueValueExpr [[ove_10:0x[^ ]+]] {{.*}} 'struct flexible *__single'
@@ -278,7 +275,7 @@ void promote_to_single_assign(struct flexible *flex) {
 // CHECK:   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK:     |-BinaryOperator {{.+}} 'unsigned long long' '='
 // CHECK:     | |-MemberExpr {{.+}} ->count
-// CHECK:     | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <LValueToRValue>
+// CHECK:     | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <LValueToRValue>
 // CHECK:     | |   `-DeclRefExpr {{.+}} [[var_s_2]]
 // CHECK:     | `-OpaqueValueExpr [[ove_11]] {{.*}} 'unsigned long long'
 // CHECK:     |-OpaqueValueExpr [[ove_9]] {{.*}} 'struct flexible *__bidi_indexable'

--- a/clang/test/BoundsSafety/AST/flexible-array-member-promotion-assignment.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-promotion-assignment.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -52,9 +50,8 @@ void promote_null_to_single() {
 // CHECK: | `-CompoundStmt
 // CHECK: |   `-DeclStmt
 // CHECK: |     `-VarDecl [[var_b_2:0x[^ ]+]]
-// CHECK: |       `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
-// CHECK: |         `-CStyleCastExpr {{.+}} 'struct flexible *' <NullToPointer>
-// CHECK: |           `-IntegerLiteral {{.+}} 0
+// CHECK: |       `-CStyleCastExpr {{.+}} 'struct flexible *' <NullToPointer>
+// CHECK: |         `-IntegerLiteral {{.+}} 0
 
 // CHECK-LABEL: promote_to_single
 void promote_to_single(struct flexible *flex) {
@@ -66,7 +63,7 @@ void promote_to_single(struct flexible *flex) {
 // CHECK:     `-VarDecl [[var_s:0x[^ ]+]]
 // CHECK:       `-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK:         |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK:         | |-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
+// CHECK:         | |-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
 // CHECK:         | | `-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:         | |   |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:         | |   |   | | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'struct flexible *__single'
@@ -212,7 +209,7 @@ void promote_to_single_assign(struct flexible *flex) {
 // CHECK:   |-DeclStmt
 // CHECK:   | `-VarDecl [[var_s_2:0x[^ ]+]]
 // CHECK:   |   `-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:   |     |-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
+// CHECK:   |     |-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
 // CHECK:   |     | `-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:   |     |   |-OpaqueValueExpr [[ove_9:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:   |     |   |   | | |-OpaqueValueExpr [[ove_10:0x[^ ]+]] {{.*}} 'struct flexible *__single'
@@ -245,7 +242,7 @@ void promote_to_single_assign(struct flexible *flex) {
 // CHECK:   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK:     |-BinaryOperator {{.+}} 'int' '='
 // CHECK:     | |-MemberExpr {{.+}} ->count
-// CHECK:     | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <LValueToRValue>
+// CHECK:     | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <LValueToRValue>
 // CHECK:     | |   `-DeclRefExpr {{.+}} [[var_s_2]]
 // CHECK:     | `-OpaqueValueExpr [[ove_11]] {{.*}} 'int'
 // CHECK:     |-OpaqueValueExpr [[ove_9]] {{.*}} 'struct flexible *__bidi_indexable'

--- a/clang/test/BoundsSafety/AST/flexible-array-member-promotion-returns.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-promotion-returns.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s | FileCheck %s
 
@@ -22,7 +20,7 @@ void single_init() {
 // CHECK:     `-VarDecl [[var_s:0x[^ ]+]]
 // CHECK:       `-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK:         |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK:         | |-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
+// CHECK:         | |-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
 // CHECK:         | | `-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:         | |   |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:         | |   |   | | |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'struct flexible *__single'
@@ -63,9 +61,9 @@ void single_assign() {
 // CHECK: | `-VarDecl [[var_s_1:0x[^ ]+]]
 // CHECK: `-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK:   |-MaterializeSequenceExpr {{.+}} <Unbind>
-// CHECK:   | |-BinaryOperator {{.+}} 'struct flexible *__single' '='
+// CHECK:   | |-BinaryOperator {{.+}} 'struct flexible *__single':'struct flexible *' '='
 // CHECK:   | | |-DeclRefExpr {{.+}} [[var_s_1]]
-// CHECK:   | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
+// CHECK:   | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
 // CHECK:   | |   `-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:   | |     |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:   | |     |   | | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'struct flexible *__single'
@@ -105,9 +103,9 @@ void single_assign_with_count() {
 // CHECK: |-DeclStmt
 // CHECK: | `-VarDecl [[var_s_2:0x[^ ]+]]
 // CHECK: |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: | |-BinaryOperator {{.+}} 'struct flexible *__single' '='
+// CHECK: | |-BinaryOperator {{.+}} 'struct flexible *__single':'struct flexible *' '='
 // CHECK: | | |-DeclRefExpr {{.+}} [[var_s_2]]
-// CHECK: | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <BoundsSafetyPointerCast>
+// CHECK: | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <BoundsSafetyPointerCast>
 // CHECK: | |   `-PredefinedBoundsCheckExpr {{.+}} 'struct flexible *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK: | |     |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK: | |     |   | | |-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'struct flexible *__single'
@@ -138,7 +136,7 @@ void single_assign_with_count() {
 // CHECK: `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK:   |-BinaryOperator {{.+}} 'int' '='
 // CHECK:   | |-MemberExpr {{.+}} ->count
-// CHECK:   | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single' <LValueToRValue>
+// CHECK:   | | `-ImplicitCastExpr {{.+}} 'struct flexible *__single':'struct flexible *' <LValueToRValue>
 // CHECK:   | |   `-DeclRefExpr {{.+}} [[var_s_2]]
 // CHECK:   | `-OpaqueValueExpr [[ove_6]] {{.*}} 'int'
 // CHECK:   |-OpaqueValueExpr [[ove_4]] {{.*}} 'struct flexible *__bidi_indexable'

--- a/clang/test/BoundsSafety/AST/flexible-array-member-shared-decls.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-shared-decls.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
 // RN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
 
@@ -56,7 +54,7 @@ struct Outer *foo(int len) {
 // CHECK-NEXT: {{^}}|   | `-VarDecl [[var_p:0x[^ ]+]]
 // CHECK-NEXT: {{^}}|   |   `-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK-NEXT: {{^}}|   |     |-BoundsCheckExpr {{.+}} 'p2 <= __builtin_get_pointer_upper_bound(p2) && __builtin_get_pointer_lower_bound(p2) <= p2 && len <= __builtin_get_pointer_upper_bound(p2) - p2 && 0 <= len'
-// CHECK-NEXT: {{^}}|   |     | |-ImplicitCastExpr {{.+}} 'struct Outer *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}|   |     | |-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}|   |     | | `-PredefinedBoundsCheckExpr {{.+}} 'struct Outer *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK-NEXT: {{^}}|   |     | |   |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'struct Outer *__bidi_indexable'
 // CHECK:      {{^}}|   |     | |   |   | | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'struct Outer *__single __sized_by(16UL + 4UL * len)':'struct Outer *__single'
@@ -135,14 +133,14 @@ struct Outer *foo(int len) {
 // CHECK-NEXT: {{^}}|   |-BinaryOperator {{.+}} 'int' '='
 // CHECK-NEXT: {{^}}|   | |-MemberExpr {{.+}} .len
 // CHECK-NEXT: {{^}}|   | | `-MemberExpr {{.+}} ->hdr
-// CHECK-NEXT: {{^}}|   | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}|   | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <LValueToRValue>
 // CHECK-NEXT: {{^}}|   | |     `-DeclRefExpr {{.+}} [[var_p]]
 // CHECK-NEXT: {{^}}|   | `-OpaqueValueExpr [[ove_6]] {{.*}} 'int'
 // CHECK:      {{^}}|   |-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK-NEXT: {{^}}|   | |-BinaryOperator {{.+}} 'int *__single __counted_by(len)':'int *__single' '='
 // CHECK-NEXT: {{^}}|   | | |-MemberExpr {{.+}} .ptr
 // CHECK-NEXT: {{^}}|   | | | `-MemberExpr {{.+}} ->hdr
-// CHECK-NEXT: {{^}}|   | | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}|   | | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <LValueToRValue>
 // CHECK-NEXT: {{^}}|   | | |     `-DeclRefExpr {{.+}} [[var_p]]
 // CHECK-NEXT: {{^}}|   | | `-ImplicitCastExpr {{.+}} 'int *__single __counted_by(len)':'int *__single' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}|   | |   `-OpaqueValueExpr [[ove_7]] {{.*}} 'int *__bidi_indexable'
@@ -164,7 +162,7 @@ struct Outer *foo(int len) {
 // CHECK-NEXT: {{^}}|         | | |     `-MemberExpr {{.+}} ->hdr
 // CHECK-NEXT: {{^}}|         | | |       `-OpaqueValueExpr [[ove_8]] {{.*}} 'struct Outer *__single'
 // CHECK:      {{^}}|         | `-OpaqueValueExpr [[ove_8]]
-// CHECK-NEXT: {{^}}|         |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}|         |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <LValueToRValue>
 // CHECK-NEXT: {{^}}|         |     `-DeclRefExpr {{.+}} [[var_p]]
 // CHECK-NEXT: {{^}}|         `-OpaqueValueExpr [[ove_8]] {{.*}} 'struct Outer *__single'
 
@@ -204,7 +202,7 @@ struct Outer *foo2(int len) {
 // CHECK-NEXT: {{^}}    | `-VarDecl [[var_p_1:0x[^ ]+]]
 // CHECK-NEXT: {{^}}    |   `-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK-NEXT: {{^}}    |     |-BoundsCheckExpr {{.+}} 'p2 <= __builtin_get_pointer_upper_bound(p2) && __builtin_get_pointer_lower_bound(p2) <= p2 && len <= __builtin_get_pointer_upper_bound(p2) - p2 && 0 <= len'
-// CHECK-NEXT: {{^}}    |     | |-ImplicitCastExpr {{.+}} 'struct Outer *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}    |     | |-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}    |     | | `-PredefinedBoundsCheckExpr {{.+}} 'struct Outer *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK-NEXT: {{^}}    |     | |   |-OpaqueValueExpr [[ove_11:0x[^ ]+]] {{.*}} 'struct Outer *__bidi_indexable'
 // CHECK:      {{^}}    |     | |   |   | | |-OpaqueValueExpr [[ove_12:0x[^ ]+]] {{.*}} 'struct Outer *__single __sized_by(16UL + 4UL * len)':'struct Outer *__single'
@@ -283,7 +281,7 @@ struct Outer *foo2(int len) {
 // CHECK-NEXT: {{^}}    |-BinaryOperator {{.+}} 'int *__single __counted_by(len)':'int *__single' '='
 // CHECK-NEXT: {{^}}    | |-MemberExpr {{.+}} .ptr
 // CHECK-NEXT: {{^}}    | | `-MemberExpr {{.+}} ->hdr
-// CHECK-NEXT: {{^}}    | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}    | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <LValueToRValue>
 // CHECK-NEXT: {{^}}    | |     `-DeclRefExpr {{.+}} [[var_p_1]]
 // CHECK-NEXT: {{^}}    | `-ImplicitCastExpr {{.+}} 'int *__single __counted_by(len)':'int *__single' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}    |   `-OpaqueValueExpr [[ove_16]] {{.*}} 'int *__bidi_indexable'
@@ -291,7 +289,7 @@ struct Outer *foo2(int len) {
 // CHECK-NEXT: {{^}}    | |-BinaryOperator {{.+}} 'int' '='
 // CHECK-NEXT: {{^}}    | | |-MemberExpr {{.+}} .len
 // CHECK-NEXT: {{^}}    | | | `-MemberExpr {{.+}} ->hdr
-// CHECK-NEXT: {{^}}    | | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}    | | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <LValueToRValue>
 // CHECK-NEXT: {{^}}    | | |     `-DeclRefExpr {{.+}} [[var_p_1]]
 // CHECK-NEXT: {{^}}    | | `-OpaqueValueExpr [[ove_15]] {{.*}} 'int'
 // CHECK:      {{^}}    | |-OpaqueValueExpr [[ove_11]] {{.*}} 'struct Outer *__bidi_indexable'
@@ -312,7 +310,6 @@ struct Outer *foo2(int len) {
 // CHECK-NEXT: {{^}}          | | |     `-MemberExpr {{.+}} ->hdr
 // CHECK-NEXT: {{^}}          | | |       `-OpaqueValueExpr [[ove_17]] {{.*}} 'struct Outer *__single'
 // CHECK:      {{^}}          | `-OpaqueValueExpr [[ove_17]]
-// CHECK-NEXT: {{^}}          |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}          |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <LValueToRValue>
 // CHECK-NEXT: {{^}}          |     `-DeclRefExpr {{.+}} [[var_p_1]]
 // CHECK-NEXT: {{^}}          `-OpaqueValueExpr [[ove_17]] {{.*}} 'struct Outer *__single'
-

--- a/clang/test/BoundsSafety/AST/forward-declared-type.c
+++ b/clang/test/BoundsSafety/AST/forward-declared-type.c
@@ -230,7 +230,7 @@ void unsizedSizedByToSingle(struct unsized * __sized_by(len) p, int len) {
 // CHECK: | `-CompoundStmt
 // CHECK: |   `-DeclStmt
 // CHECK: |     `-VarDecl [[var_p2_1:0x[^ ]+]]
-// CHECK: |       `-ImplicitCastExpr {{.+}} 'struct unsized *__single' <BoundsSafetyPointerCast>
+// CHECK: |       `-ImplicitCastExpr {{.+}} 'struct unsized *__single':'struct unsized *' <BoundsSafetyPointerCast>
 // CHECK: |         `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: |           |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'struct unsized *__bidi_indexable'
@@ -785,4 +785,3 @@ void unsizedSingleToSizedByToBidiVoid(void * p) { // rdar://112462891
 // CHECK:           `-OpaqueValueExpr [[ove_39]] {{.*}} 'int'
     void * __bidi_indexable p3 = p2;
 }
-

--- a/clang/test/BoundsSafety/AST/forward-declared-type.c
+++ b/clang/test/BoundsSafety/AST/forward-declared-type.c
@@ -582,7 +582,7 @@ void unsizedSingleForgedNull() {
 // CHECK: |   `-DeclStmt
 // CHECK: |     `-VarDecl [[var_p2_10:0x[^ ]+]]
 // CHECK: |       `-ParenExpr
-// CHECK: |         `-CStyleCastExpr {{.+}} 'struct unsized *__single' <BitCast>
+// CHECK: |         `-CStyleCastExpr {{.+}} 'struct unsized *__single':'struct unsized *' <BitCast>
 // CHECK: |           `-ForgePtrExpr
 // CHECK: |             |-ParenExpr
 // CHECK: |             | `-IntegerLiteral {{.+}} 0
@@ -596,7 +596,7 @@ void unsizedSingleForgedDyn(int p) {
 // CHECK: |   `-DeclStmt
 // CHECK: |     `-VarDecl [[var_p2_11:0x[^ ]+]]
 // CHECK: |       `-ParenExpr
-// CHECK: |         `-CStyleCastExpr {{.+}} 'struct unsized *__single' <BitCast>
+// CHECK: |         `-CStyleCastExpr {{.+}} 'struct unsized *__single':'struct unsized *' <BitCast>
 // CHECK: |           `-ForgePtrExpr
 // CHECK: |             |-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK: |             | `-ParenExpr
@@ -612,7 +612,7 @@ void unsizedSingleForgedToBidi(int p) {
 // CHECK:       `-VarDecl [[var_p2_12:0x[^ ]+]]
 // CHECK:         `-RecoveryExpr
 // CHECK:           `-ParenExpr
-// CHECK:             `-CStyleCastExpr {{.+}} 'struct unsized *__single' <BitCast>
+// CHECK:             `-CStyleCastExpr {{.+}} 'struct unsized *__single':'struct unsized *' <BitCast>
 // CHECK:               `-ForgePtrExpr
 // CHECK:                 |-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK:                 | `-ParenExpr
@@ -634,9 +634,10 @@ void unsizedSingleForgedToSizedBy(int p, int len) {
     int size = len; // expected-note{{size initialized here}}
 // CHECK:    `-DeclStmt
 // CHECK:      `-VarDecl [[var_p2_13:0x[^ ]+]]
-// CHECK:        `-BoundsCheckExpr {{.+}} '(struct unsized *__single)__builtin_unsafe_forge_single((p)) <= __builtin_get_pointer_upper_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) && __builtin_get_pointer_lower_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) <= (struct unsized *__single)__builtin_unsafe_forge_single((p)) && size <= (char *)__builtin_get_pointer_upper_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) - (char *__single)(struct unsized *__single)__builtin_unsafe_forge_single((p)) && 0 <= size'
-// CHECK:          |-ParenExpr
-// CHECK:          | `-OpaqueValueExpr [[ove_32:0x[^ ]+]] {{.*}} 'struct unsized *__single'
+// CHECK:        `-BoundsCheckExpr {{.+}} '((struct unsized *__single)__builtin_unsafe_forge_single((p))) <= __builtin_get_pointer_upper_bound(((struct unsized *__single)__builtin_unsafe_forge_single((p)))) && __builtin_get_pointer_lower_bound(((struct unsized *__single)__builtin_unsafe_forge_single((p)))) <= ((struct unsized *__single)__builtin_unsafe_forge_single((p))) && size <= (char *)__builtin_get_pointer_upper_bound(((struct unsized *__single)__builtin_unsafe_forge_single((p)))) - (char *)((struct unsized *__single)__builtin_unsafe_forge_single((p))) && 0 <= size'
+// CHECK:          |-ImplicitCastExpr {{.+}} 'struct unsized *__single __sized_by(size)':'struct unsized *__single' <BoundsSafetyPointerCast>
+// CHECK:          | `-OpaqueValueExpr [[ove_32:0x[^ ]+]] {{.*}} 'struct unsized *__single':'struct unsized *'
+// CHECK:          |   `-ParenExpr
 // CHECK:          |-BinaryOperator {{.+}} 'int' '&&'
 // CHECK:          | |-BinaryOperator {{.+}} 'int' '&&'
 // CHECK:          | | |-BinaryOperator {{.+}} 'int' '<='
@@ -657,14 +658,15 @@ void unsizedSingleForgedToSizedBy(int p, int len) {
 // CHECK:          |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:          |   |   |   `-ImplicitCastExpr {{.+}} 'struct unsized *__bidi_indexable' <BoundsSafetyPointerCast>
 // CHECK:          |   |   |     `-OpaqueValueExpr [[ove_32]] {{.*}} 'struct unsized *__single'
-// CHECK:          |   |   `-CStyleCastExpr {{.+}} 'char *__single' <BitCast>
-// CHECK:          |   |     `-OpaqueValueExpr [[ove_32]] {{.*}} 'struct unsized *__single'
+// CHECK:          |   |   `-CStyleCastExpr {{.+}} 'char *__single' <BoundsSafetyPointerCast>
+// CHECK:          |   |     `-ImplicitCastExpr {{.+}} 'char *' <BitCast> part_of_explicit_cast
+// CHECK:          |   |       `-OpaqueValueExpr [[ove_32]] {{.*}} 'struct unsized *__single'
 // CHECK:          |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:          |     |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // CHECK:          |     | `-IntegerLiteral {{.+}} 0
 // CHECK:          |     `-OpaqueValueExpr [[ove_33]] {{.*}} '__ptrdiff_t':'long'
 // CHECK:          |-OpaqueValueExpr [[ove_32]]
-// CHECK:          | `-CStyleCastExpr {{.+}} 'struct unsized *__single' <BitCast>
+// CHECK:          | `-CStyleCastExpr {{.+}} 'struct unsized *__single':'struct unsized *' <BitCast>
 // CHECK:          |   `-ForgePtrExpr
 // CHECK:          |     |-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK:          |     | `-ParenExpr
@@ -673,7 +675,7 @@ void unsizedSingleForgedToSizedBy(int p, int len) {
 // CHECK:            `-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // CHECK:              `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK:                `-DeclRefExpr {{.+}} [[var_size_4]]
-    struct unsized * __single __sized_by(size) p2 = __unsafe_forge_single(struct unsized *, p); // expected-warning{{size value is not statically known: initializing 'p2' of type 'struct unsized *__single __sized_by(size)' (aka 'struct unsized *__single') with 'struct unsized *__single' is invalid for any size greater than 0}}
+    struct unsized * __single __sized_by(size) p2 = __unsafe_forge_single(struct unsized *, p); // expected-warning{{size value is not statically known: initializing 'p2' of type 'struct unsized *__single __sized_by(size)' (aka 'struct unsized *__single') with 'struct unsized *__single' (aka 'struct unsized *') is invalid for any size greater than 0}}
 }
 
 // CHECK: |-FunctionDecl [[func_unsizedSingleForgedToBidiVoid:0x[^ ]+]] {{.+}} unsizedSingleForgedToBidiVoid
@@ -684,7 +686,7 @@ void unsizedSingleForgedToBidiVoid(int p) {
 // CHECK: |     `-VarDecl [[var_p2_14:0x[^ ]+]]
 // CHECK: |       `-RecoveryExpr
 // CHECK: |         `-ParenExpr
-// CHECK: |           `-CStyleCastExpr {{.+}} 'void *__single' <NoOp>
+// CHECK: |           `-CStyleCastExpr {{.+}} 'void *__single':'void *' <NoOp>
 // CHECK: |             `-ForgePtrExpr
 // CHECK: |               |-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK: |               | `-ParenExpr

--- a/clang/test/BoundsSafety/AST/get-pointer-bound.c
+++ b/clang/test/BoundsSafety/AST/get-pointer-bound.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s 2>&1 | FileCheck %s
 #include <ptrcheck.h>
@@ -47,14 +45,14 @@ void single(int *__single p) {
 // CHECK: |   | `-VarDecl {{.+}} q 'int *__bidi_indexable' cinit
 // CHECK: |   |   `-GetBoundExpr {{.+}} 'int *__bidi_indexable' lower
 // CHECK: |   |     `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |       `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// CHECK: |   |         `-DeclRefExpr {{.+}} 'int *__single' lvalue ParmVar {{.+}} 'p' 'int *__single'
+// CHECK: |   |       `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// CHECK: |   |         `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue ParmVar {{.+}} 'p' 'int *__single':'int *'
 // CHECK: |   `-DeclStmt
 // CHECK: |     `-VarDecl {{.+}} r 'int *__bidi_indexable' cinit
 // CHECK: |       `-GetBoundExpr {{.+}} 'int *__bidi_indexable' upper
 // CHECK: |         `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |           `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
-// CHECK: |             `-DeclRefExpr {{.+}} 'int *__single' lvalue ParmVar {{.+}} 'p' 'int *__single'
+// CHECK: |           `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// CHECK: |             `-DeclRefExpr {{.+}} 'int *__single':'int *' lvalue ParmVar {{.+}} 'p' 'int *__single':'int *'
 
 void array(void) {
     int array[10];

--- a/clang/test/BoundsSafety/AST/implicit-cast-attributes-and-storage-type.c
+++ b/clang/test/BoundsSafety/AST/implicit-cast-attributes-and-storage-type.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s 2>&1 | FileCheck %s
 #include <ptrcheck.h>
 
@@ -10,6 +8,7 @@ void foo(void) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincompatible-pointer-types"
 #pragma clang diagnostic ignored "-Wbounds-attributes-implicit-conversion-single-to-explicit-indexable"
+#pragma clang diagnostic ignored "-Wbounds-safety-single-to-indexable-bounds-truncated"
   char *__bidi_indexable b = extern_ptr;
 #pragma clang diagnostic pop
 }
@@ -19,7 +18,7 @@ void foo(void) {
 // warning doesn't break the requirement that the above implicit conversion is
 // split into a BitCast then BoundsSafetyPointerCast.
 
-// CHECK:|-VarDecl {{.*}} used extern_ptr 'int *__single' extern
+// CHECK:|-VarDecl {{.*}} used extern_ptr 'int *__single':'int *' extern
 // CHECK-NEXT:`-FunctionDecl {{.*}} foo 'void (void)'
 // CHECK-NEXT:  `-CompoundStmt {{.*}}
 // CHECK-NEXT:    `-DeclStmt {{.*}}
@@ -28,7 +27,7 @@ void foo(void) {
 // Make sure the `(int* __single) -> (char* __bidi_indexable) gets split into two
 // separate implicit casts.
 // CHECK-NEXT:        `-ImplicitCastExpr {{.*}} 'char *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK-NEXT:          `-ImplicitCastExpr {{.*}} 'char *__single' <BitCast>
+// CHECK-NEXT:          `-ImplicitCastExpr {{.*}} 'char *' <BitCast>
 
-// CHECK-NEXT:            `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-// CHECK-NEXT:              `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'extern_ptr' 'int *__single'
+// CHECK-NEXT:            `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+// CHECK-NEXT:              `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'extern_ptr' 'int *__single':'int *'

--- a/clang/test/BoundsSafety/AST/incomplete-single-to-indexable-bitcast.c
+++ b/clang/test/BoundsSafety/AST/incomplete-single-to-indexable-bitcast.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s | FileCheck %s
 
@@ -11,19 +10,20 @@
 // CHECK: |-DeclStmt
 // CHECK: | `-VarDecl {{.*}} impl_bidi_ptr 'int *__bidi_indexable' cinit
 // CHECK: |   `-CStyleCastExpr {{.*}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |     `-ImplicitCastExpr {{.*}} 'int *__single' <BitCast> part_of_explicit_cast
-// CHECK: |       `-ParenExpr {{.*}} 'void *__single'
-// CHECK: |         `-CStyleCastExpr {{.*}} 'void *__single' <NullToPointer>
+// CHECK: |     `-ImplicitCastExpr {{.*}} 'int *' <BitCast> part_of_explicit_cast
+// CHECK: |       `-ParenExpr {{.*}} 'void *__single':'void *'
+// CHECK: |         `-CStyleCastExpr {{.*}} 'void *__single':'void *' <NullToPointer>
 // CHECK: |           `-IntegerLiteral {{.*}} 'int' 0
 // CHECK: `-DeclStmt
 // CHECK:   `-VarDecl {{.*}} impl_bidi_ptr2 'int *__bidi_indexable' cinit
 // CHECK:     `-ImplicitCastExpr {{.*}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
 // CHECK:       `-ImplicitCastExpr {{.*}} 'int *__single' <BitCast>
 // CHECK:         `-CStyleCastExpr {{.*}} 'void *__single' <BitCast>
-// CHECK:           `-CStyleCastExpr {{.*}} 'char *__single' <BitCast>
-// CHECK:             `-ParenExpr {{.*}} 'void *__single'
-// CHECK:               `-CStyleCastExpr {{.*}} 'void *__single' <NullToPointer>
-// CHECK:                 `-IntegerLiteral {{.*}} 'int' 0
+// CHECK:           `-CStyleCastExpr {{.*}} 'char *__single' <BoundsSafetyPointerCast>
+// CHECK:             `-ImplicitCastExpr {{.*}} 'char *' <BitCast> part_of_explicit_cast
+// CHECK:               `-ParenExpr {{.*}} 'void *__single':'void *'
+// CHECK:                 `-CStyleCastExpr {{.*}} 'void *__single':'void *' <NullToPointer>
+// CHECK:                   `-IntegerLiteral {{.*}} 'int' 0
 void test_null_to_bidi() {
   int *impl_bidi_ptr = (int *__bidi_indexable)NULL;
   int *impl_bidi_ptr2 = (void *)(char *)NULL;

--- a/clang/test/BoundsSafety/AST/nested-struct-member-count.c
+++ b/clang/test/BoundsSafety/AST/nested-struct-member-count.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s 2>&1 | FileCheck %s
 
@@ -62,7 +61,7 @@ struct Outer * assign(void * __bidi_indexable bar, int len) {
 // CHECK:    |-DeclStmt
 // CHECK:    | `-VarDecl [[var_s:0x[^ ]+]]
 // CHECK:    |   `-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:    |     |-ImplicitCastExpr {{.+}} 'struct Outer *__single' <BoundsSafetyPointerCast>
+// CHECK:    |     |-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <BoundsSafetyPointerCast>
 // CHECK:    |     | `-PredefinedBoundsCheckExpr {{.+}} 'struct Outer *__bidi_indexable' <FlexibleArrayCountAssign(BasePtr, FamPtr, Count)>
 // CHECK:    |     |   |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'struct Outer *__bidi_indexable'
 // CHECK:    |     |   |-OpaqueValueExpr [[ove_1]] {{.*}} 'struct Outer *__bidi_indexable'
@@ -81,7 +80,7 @@ struct Outer * assign(void * __bidi_indexable bar, int len) {
 // CHECK:    | |-BinaryOperator {{.+}} 'int' '='
 // CHECK:    | | |-MemberExpr {{.+}} .len
 // CHECK:    | | | `-MemberExpr {{.+}} ->hdr
-// CHECK:    | | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK:    | | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <LValueToRValue>
 // CHECK:    | | |     `-DeclRefExpr {{.+}} [[var_s]]
 // CHECK:    | | `-OpaqueValueExpr [[ove_2]] {{.*}} 'int'
 // CHECK:    | |-OpaqueValueExpr [[ove_1]] {{.*}} 'struct Outer *__bidi_indexable'
@@ -91,17 +90,16 @@ struct Outer * assign(void * __bidi_indexable bar, int len) {
 // CHECK:        `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK:          |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK:          | |-BoundsSafetyPointerPromotionExpr {{.+}} 'struct Outer *__bidi_indexable'
-// CHECK:          | | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'struct Outer *__single'
+// CHECK:          | | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'struct Outer *__single':'struct Outer *'
 // CHECK:          | | |-BinaryOperator {{.+}} 'char *' '+'
 // CHECK:          | | | |-ImplicitCastExpr {{.+}} 'char *' <ArrayToPointerDecay>
 // CHECK:          | | | | `-MemberExpr {{.+}} ->fam
-// CHECK:          | | | |   `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct Outer *__single'
+// CHECK:          | | | |   `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct Outer *__single':'struct Outer *'
 // CHECK:          | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK:          | | |   `-MemberExpr {{.+}} .len
 // CHECK:          | | |     `-MemberExpr {{.+}} ->hdr
-// CHECK:          | | |       `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct Outer *__single'
+// CHECK:          | | |       `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct Outer *__single':'struct Outer *'
 // CHECK:          | `-OpaqueValueExpr [[ove_3]]
-// CHECK:          |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK:          |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single':'struct Outer *' <LValueToRValue>
 // CHECK:          |     `-DeclRefExpr {{.+}} [[var_s]]
-// CHECK:          `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct Outer *__single'
-
+// CHECK:          `-OpaqueValueExpr [[ove_3]] {{.*}} 'struct Outer *__single':'struct Outer *'

--- a/clang/test/BoundsSafety/AST/sized_by_or_null_call.c
+++ b/clang/test/BoundsSafety/AST/sized_by_or_null_call.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -Wno-bounds-safety-init-list %s | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -Wno-bounds-safety-init-list %s | FileCheck %s
 
@@ -435,25 +434,26 @@ void caller_7(int *__bidi_indexable p, int len) {
 // CHECK-NEXT: {{^}}|     | | |-CallExpr
 // CHECK-NEXT: {{^}}|     | | | |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single __sized_by_or_null(len), int)' <FunctionToPointerDecay>
 // CHECK-NEXT: {{^}}|     | | | | `-DeclRefExpr {{.+}} [[func_foo]]
-// CHECK-NEXT: {{^}}|     | | | |-OpaqueValueExpr [[ove_18:0x[^ ]+]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | | | |-ImplicitCastExpr {{.+}} 'int *__single __sized_by_or_null(len)':'int *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}|     | | | | `-OpaqueValueExpr [[ove_18:0x[^ ]+]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | | | `-OpaqueValueExpr [[ove_19:0x[^ ]+]] {{.*}} 'int'
 // CHECK:      {{^}}|     | | `-BinaryOperator {{.+}} 'int' '&&'
 // CHECK-NEXT: {{^}}|     | |   |-BinaryOperator {{.+}} 'int' '&&'
 // CHECK-NEXT: {{^}}|     | |   | |-BinaryOperator {{.+}} 'int' '<='
-// CHECK-NEXT: {{^}}|     | |   | | |-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |   | | |-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |   | | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}|     | |   | |   `-GetBoundExpr {{.+}} upper
 // CHECK-NEXT: {{^}}|     | |   | |     `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK-NEXT: {{^}}|     | |   | |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |   | |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |   | `-BinaryOperator {{.+}} 'int' '<='
 // CHECK-NEXT: {{^}}|     | |   |   |-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}|     | |   |   | `-GetBoundExpr {{.+}} lower
 // CHECK-NEXT: {{^}}|     | |   |   |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK-NEXT: {{^}}|     | |   |   |     `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
-// CHECK:      {{^}}|     | |   |   `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |   |   |     `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
+// CHECK:      {{^}}|     | |   |   `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |   `-BinaryOperator {{.+}} 'int' '||'
 // CHECK-NEXT: {{^}}|     | |     |-UnaryOperator {{.+}} cannot overflow
-// CHECK-NEXT: {{^}}|     | |     | `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |     | `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |     `-BinaryOperator {{.+}} 'int' '&&'
 // CHECK-NEXT: {{^}}|     | |       |-BinaryOperator {{.+}} 'int' '<='
 // CHECK-NEXT: {{^}}|     | |       | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -463,19 +463,20 @@ void caller_7(int *__bidi_indexable p, int len) {
 // CHECK-NEXT: {{^}}|     | |       |   | `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK-NEXT: {{^}}|     | |       |   |   `-GetBoundExpr {{.+}} upper
 // CHECK-NEXT: {{^}}|     | |       |   |     `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK-NEXT: {{^}}|     | |       |   |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
-// CHECK:      {{^}}|     | |       |   `-CStyleCastExpr {{.+}} 'char *__single' <BitCast>
-// CHECK-NEXT: {{^}}|     | |       |     `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     | |       |   |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
+// CHECK:      {{^}}|     | |       |   `-CStyleCastExpr {{.+}} 'char *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}|     | |       |     `-ImplicitCastExpr {{.+}} 'char *' <BitCast> part_of_explicit_cast
+// CHECK-NEXT: {{^}}|     | |       |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     | |       `-BinaryOperator {{.+}} 'int' '<='
 // CHECK-NEXT: {{^}}|     | |         |-IntegerLiteral {{.+}} 0
 // CHECK-NEXT: {{^}}|     | |         `-OpaqueValueExpr [[ove_19]] {{.*}} 'int'
 // CHECK:      {{^}}|     | |-OpaqueValueExpr [[ove_18]]
-// CHECK-NEXT: {{^}}|     | | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}|     | | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK-NEXT: {{^}}|     | |   `-DeclRefExpr {{.+}} [[var_p_4]]
 // CHECK-NEXT: {{^}}|     | `-OpaqueValueExpr [[ove_19]]
 // CHECK-NEXT: {{^}}|     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: {{^}}|     |     `-DeclRefExpr {{.+}} [[var_len_4]]
-// CHECK-NEXT: {{^}}|     |-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single'
+// CHECK-NEXT: {{^}}|     |-OpaqueValueExpr [[ove_18]] {{.*}} 'int *__single':'int *'
 // CHECK:      {{^}}|     `-OpaqueValueExpr [[ove_19]] {{.*}} 'int'
 void caller_8(int *__single p, int len) {
   foo(p, len);

--- a/clang/test/BoundsSafety/AST/terminated-by-redecl.c
+++ b/clang/test/BoundsSafety/AST/terminated-by-redecl.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc %s 2>&1 | FileCheck %s
 
@@ -38,8 +37,8 @@ void test_system_nt_argument_implicit_3(const char *__null_terminated p);
 // CHECK-NEXT:| `-ParmVarDecl {{.*}} p 'int *__single __terminated_by(0)':'int *__single'
 // CHECK-NEXT:|-FunctionDecl {{.*}} prev {{.*}} test_system_nt_argument_implicit_1 'void (const char *__single __terminated_by(0))'
 // CHECK-NEXT:| `-ParmVarDecl {{.*}} p 'const char *__single __terminated_by(0)':'const char *__single'
-// CHECK-NEXT:|-FunctionDecl {{.*}} prev {{.*}} test_system_nt_argument_implicit_2 'void (const char *__single)'
-// CHECK-NEXT:| `-ParmVarDecl {{.*}} p 'const char *__single'
+// CHECK-NEXT:|-FunctionDecl {{.*}} prev {{.*}} test_system_nt_argument_implicit_2 'void (const char *)'
+// CHECK-NEXT:| `-ParmVarDecl {{.*}} p 'const char *'
 // CHECK-NEXT:|-FunctionDecl {{.*}} prev {{.*}} test_system_nt_argument_implicit_3 'void (const char *__single __terminated_by(0))'
 // CHECK-NEXT:| `-ParmVarDecl {{.*}} p 'const char *__single __terminated_by(0)':'const char *__single'
 

--- a/clang/test/BoundsSafety/AST/ternary-on-indexables.c
+++ b/clang/test/BoundsSafety/AST/ternary-on-indexables.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fbounds-safety -Wno-bounds-safety-single-to-indexable-bounds-truncated -ast-dump  %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -Wno-bounds-safety-single-to-indexable-bounds-truncated -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
 #include <ptrcheck.h>
@@ -68,14 +67,14 @@ void Test(int sel) {
     int *__single y_sg = &a;
     int *__single z_sg = sel ? x_sg : y_sg;
     // CHECK: |-DeclStmt
-    // CHECK: | `-VarDecl {{.*}} z_sg 'int *__single' cinit
-    // CHECK: |   `-ConditionalOperator {{.*}} 'int *__single'
+    // CHECK: | `-VarDecl {{.*}} z_sg 'int *__single':'int *' cinit
+    // CHECK: |   `-ConditionalOperator {{.*}} 'int *__single':'int *'
     // CHECK: |     |-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
     // CHECK: |     | `-DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'sel' 'int'
-    // CHECK: |     |-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |     | `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
-    // CHECK: |     `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |       `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'y_sg' 'int *__single'
+    // CHECK: |     |-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |     | `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
+    // CHECK: |     `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |       `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'y_sg' 'int *__single':'int *'
 
     int *__unsafe_indexable x_uix = &a;
     int *__unsafe_indexable y_uix = &a;
@@ -139,8 +138,8 @@ void Test(int sel) {
     // CHECK: |   | `-ImplicitCastExpr {{.*}} 'int *__bidi_indexable' <LValueToRValue>
     // CHECK: |   |   `-DeclRefExpr {{.*}} 'int *__bidi_indexable' lvalue Var {{.*}} 'x' 'int *__bidi_indexable'
     // CHECK: |   `-ImplicitCastExpr {{.*}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-    // CHECK: |     `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |       `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'y_sg' 'int *__single'
+    // CHECK: |     `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |       `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'y_sg' 'int *__single':'int *'
     
     z = x ?: y_ix_void;
     // CHECK: |-BinaryOperator {{.*}} 'int *__bidi_indexable' '='
@@ -182,8 +181,8 @@ void Test(int sel) {
     // CHECK: |   |-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
     // CHECK: |   | `-DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'sel' 'int'
     // CHECK: |   |-ImplicitCastExpr {{.*}} 'int *__indexable' <BoundsSafetyPointerCast>
-    // CHECK: |   | `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |   |   `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
+    // CHECK: |   | `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |   |   `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
     // CHECK: |   `-ImplicitCastExpr {{.*}} 'int *__indexable' <LValueToRValue>
     // CHECK: |     `-DeclRefExpr {{.*}} 'int *__indexable' lvalue Var {{.*}} 'y_ix' 'int *__indexable'
 
@@ -192,16 +191,16 @@ void Test(int sel) {
     // CHECK: | |-DeclRefExpr {{.*}} 'int *__indexable' lvalue Var {{.*}} 'z_ix' 'int *__indexable'
     // CHECK: | `-ImplicitCastExpr {{.*}} 'int *__indexable' <BitCast>
     // CHECK: |   `-BinaryConditionalOperator {{.*}} 'void *__indexable'
-    // CHECK: |     |-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |     | `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
-    // CHECK: |     |-OpaqueValueExpr {{.*}} 'int *__single'
-    // CHECK: |     | `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |     |   `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
+    // CHECK: |     |-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |     | `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
+    // CHECK: |     |-OpaqueValueExpr {{.*}} 'int *__single':'int *'
+    // CHECK: |     | `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |     |   `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
     // CHECK: |     |-ImplicitCastExpr {{.*}} 'void *__indexable' <BitCast>
     // CHECK: |     | `-ImplicitCastExpr {{.*}} 'int *__indexable' <BoundsSafetyPointerCast>
-    // CHECK: |     |   `-OpaqueValueExpr {{.*}} 'int *__single'
-    // CHECK: |     |     `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |     |       `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
+    // CHECK: |     |   `-OpaqueValueExpr {{.*}} 'int *__single':'int *'
+    // CHECK: |     |     `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |     |       `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
     // CHECK: |     `-ImplicitCastExpr {{.*}} 'void *__indexable' <LValueToRValue>
     // CHECK: |       `-DeclRefExpr {{.*}} 'void *__indexable' lvalue Var {{.*}} 'y_ix_void' 'void *__indexable'
 
@@ -214,8 +213,8 @@ void Test(int sel) {
     // CHECK: |       |-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
     // CHECK: |       | `-DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'sel' 'int'
     // CHECK: |       |-ImplicitCastExpr {{.*}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-    // CHECK: |       | `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |       |   `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
+    // CHECK: |       | `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |       |   `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
     // CHECK: |       `-ImplicitCastExpr {{.*}} 'int *__bidi_indexable' <LValueToRValue>
     // CHECK: |         `-DeclRefExpr {{.*}} 'int *__bidi_indexable' lvalue Var {{.*}} 'y' 'int *__bidi_indexable'
 
@@ -227,8 +226,8 @@ void Test(int sel) {
     // CHECK: |     |-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
     // CHECK: |     | `-DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'sel' 'int'
     // CHECK: |     |-ImplicitCastExpr {{.*}} 'int *__indexable' <BoundsSafetyPointerCast>
-    // CHECK: |     | `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |     |   `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
+    // CHECK: |     | `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |     |   `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
     // CHECK: |     `-ImplicitCastExpr {{.*}} 'int *__indexable' <LValueToRValue>
     // CHECK: |       `-DeclRefExpr {{.*}} 'int *__indexable' lvalue Var {{.*}} 'y_ix' 'int *__indexable'
 
@@ -239,14 +238,14 @@ void Test(int sel) {
     // CHECK: |-BinaryOperator {{.*}} 'void *__indexable' '='
     // CHECK: | |-DeclRefExpr {{.*}} 'void *__indexable' lvalue Var {{.*}} 'z_ix_void' 'void *__indexable'
     // CHECK: | `-ImplicitCastExpr {{.+}} 'void *__indexable' <BoundsSafetyPointerCast>
-    // CHECK: |   `-ImplicitCastExpr {{.+}} 'void *__single' <BitCast>
-    // CHECK: |     `-ConditionalOperator {{.*}} 'int *__single'
+    // CHECK: |   `-ImplicitCastExpr {{.+}} 'void *' <BitCast>
+    // CHECK: |     `-ConditionalOperator {{.*}} 'int *__single':'int *'
     // CHECK: |       |-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
     // CHECK: |       | `-DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'sel' 'int'
-    // CHECK: |       |-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |       | `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
-    // CHECK: |       `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |         `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'y_sg' 'int *__single'
+    // CHECK: |       |-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |       | `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
+    // CHECK: |       `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |         `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'y_sg' 'int *__single':'int *'
 
     z_char = sel ? x_ix : y_ix_void;
     // CHECK: |-BinaryOperator {{.*}} 'char *__bidi_indexable' '='
@@ -268,16 +267,16 @@ void Test(int sel) {
     // CHECK: | `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BoundsSafetyPointerCast>
     // CHECK: |   `-ImplicitCastExpr {{.+}} 'char *__indexable' <BitCast>
     // CHECK: |     `-BinaryConditionalOperator {{.*}} 'void *__indexable'
-    // CHECK: |       |-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |       | `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
-    // CHECK: |       |-OpaqueValueExpr {{.*}} 'int *__single'
-    // CHECK: |       | `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |       |   `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
+    // CHECK: |       |-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |       | `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
+    // CHECK: |       |-OpaqueValueExpr {{.*}} 'int *__single':'int *'
+    // CHECK: |       | `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |       |   `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
     // CHECK: |       |-ImplicitCastExpr {{.*}} 'void *__indexable' <BitCast>
     // CHECK: |       | `-ImplicitCastExpr {{.*}} 'int *__indexable' <BoundsSafetyPointerCast>
-    // CHECK: |       |   `-OpaqueValueExpr {{.*}} 'int *__single'
-    // CHECK: |       |     `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |       |       `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
+    // CHECK: |       |   `-OpaqueValueExpr {{.*}} 'int *__single':'int *'
+    // CHECK: |       |     `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |       |       `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
     // CHECK: |       `-ImplicitCastExpr {{.*}} 'void *__indexable' <LValueToRValue>
     // CHECK: |         `-DeclRefExpr {{.*}} 'void *__indexable' lvalue Var {{.*}} 'y_ix_void' 'void *__indexable'
 
@@ -291,8 +290,8 @@ void Test(int sel) {
     // CHECK: |       | `-DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'sel' 'int'
     // CHECK: |       |-ImplicitCastExpr {{.*}} 'void *__indexable' <BitCast>
     // CHECK: |       | `-ImplicitCastExpr {{.*}} 'int *__indexable' <BoundsSafetyPointerCast>
-    // CHECK: |       |   `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |       |     `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'x_sg' 'int *__single'
+    // CHECK: |       |   `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |       |     `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'x_sg' 'int *__single':'int *'
     // CHECK: |       `-ImplicitCastExpr {{.*}} 'void *__indexable' <LValueToRValue>
     // CHECK: |         `-DeclRefExpr {{.*}} 'void *__indexable' lvalue Var {{.*}} 'y_ix_void' 'void *__indexable'
 
@@ -340,8 +339,8 @@ void Test(int sel) {
     // CHECK: |       | `-DeclRefExpr {{.*}} 'void *__indexable' lvalue Var {{.*}} 'x_ix_void' 'void *__indexable'
     // CHECK: |       `-ImplicitCastExpr {{.*}} 'void *__indexable' <BitCast>
     // CHECK: |         `-ImplicitCastExpr {{.*}} 'int *__indexable' <BoundsSafetyPointerCast>
-    // CHECK: |           `-ImplicitCastExpr {{.*}} 'int *__single' <LValueToRValue>
-    // CHECK: |             `-DeclRefExpr {{.*}} 'int *__single' lvalue Var {{.*}} 'y_sg' 'int *__single'
+    // CHECK: |           `-ImplicitCastExpr {{.*}} 'int *__single':'int *' <LValueToRValue>
+    // CHECK: |             `-DeclRefExpr {{.*}} 'int *__single':'int *' lvalue Var {{.*}} 'y_sg' 'int *__single':'int *'
 
     z_char = x_ix_void ?: y_ix_void;
     // CHECK: `-BinaryOperator {{.*}} 'char *__bidi_indexable' '='

--- a/clang/test/BoundsSafety/AST/typedef-pointer-attrs-explicit.c
+++ b/clang/test/BoundsSafety/AST/typedef-pointer-attrs-explicit.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
 
@@ -46,9 +44,10 @@ void foo(unspecified_ptr_t a_single1,
 // CHECK: |-TypedefDecl {{.*}} referenced unspecified_ptr_t 'int *'
 // CHECK: | `-PointerType {{.*}} 'int *'
 // CHECK: |   `-BuiltinType {{.*}} 'int'
-// CHECK: |-TypedefDecl {{.*}} referenced single_ptr_t 'int *__single'
-// CHECK: | `-PointerType {{.*}} 'int *__single'
-// CHECK: |   `-BuiltinType {{.*}} 'int'
+// CHECK: |-TypedefDecl {{.*}} referenced single_ptr_t 'int *__single':'int *'
+// CHECK: | `-AttributedType {{.*}} 'int *__single' sugar
+// CHECK: |   `-PointerType {{.*}} 'int *'
+// CHECK: |     `-BuiltinType {{.*}} 'int'
 // CHECK: |-TypedefDecl {{.*}} referenced bidi_ptr_t 'int *__bidi_indexable'
 // CHECK: | `-PointerType {{.*}} 'int *__bidi_indexable'
 // CHECK: |   `-BuiltinType {{.*}} 'int'
@@ -63,8 +62,9 @@ void foo(unspecified_ptr_t a_single1,
 // CHECK: | `-PointerType {{.*}} 'single_ptr_t *'
 // CHECK: |   `-TypedefType {{.*}} 'single_ptr_t' sugar
 // CHECK: |     |-Typedef {{.*}} 'single_ptr_t'
-// CHECK: |     `-PointerType {{.*}} 'int *__single'
-// CHECK: |       `-BuiltinType {{.*}} 'int'
+// CHECK: |     `-AttributedType {{.*}} 'int *__single' sugar
+// CHECK: |       `-PointerType {{.*}} 'int *'
+// CHECK: |         `-BuiltinType {{.*}} 'int'
 // CHECK: |-TypedefDecl {{.*}} referenced unspecified_ptr_ptr_t 'unspecified_ptr_t *'
 // CHECK: | `-PointerType {{.*}} 'unspecified_ptr_t *'
 // CHECK: |   `-TypedefType {{.*}} 'unspecified_ptr_t' sugar
@@ -76,14 +76,14 @@ void foo(unspecified_ptr_t a_single1,
 // CHECK: |   `-PointerType {{.*}} 'int *'
 // CHECK: |     `-BuiltinType {{.*}} 'int'
 // CHECK: |-VarDecl {{.*}} g_single1 'int *__single'
-// CHECK: |-VarDecl {{.*}} g_single2 'single_ptr_t':'int *__single'
+// CHECK: |-VarDecl {{.*}} g_single2 'single_ptr_t':'int *'
 // CHECK: |-VarDecl {{.*}} g_bidi 'bidi_ptr_t':'int *__bidi_indexable'
 // CHECK: |-VarDecl {{.*}} g_unsafe 'unsafe_ptr_t':'int *__unsafe_indexable'
 // CHECK: |-VarDecl {{.*}} g_single_single 'int *__single*__single'
 // CHECK: |-VarDecl {{.*}} g_term 'int *__single __terminated_by(0)':'int *__single'
 // CHECK: `-FunctionDecl {{.*}} foo 'void (int *__single, single_ptr_t, bidi_ptr_t, unsafe_ptr_t, int *__single __terminated_by(0))'
 // CHECK:   |-ParmVarDecl {{.*}} a_single1 'int *__single'
-// CHECK:   |-ParmVarDecl {{.*}} a_single2 'single_ptr_t':'int *__single'
+// CHECK:   |-ParmVarDecl {{.*}} a_single2 'single_ptr_t':'int *'
 // CHECK:   |-ParmVarDecl {{.*}} a_bidi 'bidi_ptr_t':'int *__bidi_indexable'
 // CHECK:   |-ParmVarDecl {{.*}} a_unsafe 'unsafe_ptr_t':'int *__unsafe_indexable'
 // CHECK:   |-ParmVarDecl {{.*}} a_term 'int *__single __terminated_by(0)':'int *__single'
@@ -91,13 +91,13 @@ void foo(unspecified_ptr_t a_single1,
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl {{.*}} l_bidi1 'int *__bidi_indexable'
 // CHECK:     |-DeclStmt
-// CHECK:     | `-VarDecl {{.*}} l_single 'single_ptr_t':'int *__single'
+// CHECK:     | `-VarDecl {{.*}} l_single 'single_ptr_t':'int *'
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl {{.*}} l_bidi2 'bidi_ptr_t':'int *__bidi_indexable'
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl {{.*}} l_unsafe 'unsafe_ptr_t':'int *__unsafe_indexable'
 // CHECK:     |-DeclStmt
-// CHECK:     | `-VarDecl {{.*}} l_single2 'unspecified_ptr_t __single':'int *__single'
+// CHECK:     | `-VarDecl {{.*}} l_single2 'unspecified_ptr_t __single':'int *'
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl {{.*}} l_unsafe2 'unspecified_ptr_t __unsafe_indexable':'int *__unsafe_indexable'
 // CHECK:     |-DeclStmt

--- a/clang/test/BoundsSafety/AST/unify-conditional-expr-types.c
+++ b/clang/test/BoundsSafety/AST/unify-conditional-expr-types.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -verify %s | FileCheck %s
 #include <ptrcheck.h>
 
@@ -102,7 +100,7 @@ char testFunc2(int pred, char * __counted_by(cc) c, char * __single d, int cc, i
 // CHECK: |   |     |   | |-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__single __counted_by(cc)':'char *__single'
 // CHECK: |   |     |   | `-OpaqueValueExpr [[ove_2]] {{.*}} 'int'
 // CHECK: |   |     |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |     |     `-ImplicitCastExpr {{.+}} 'char *__single' <LValueToRValue>
+// CHECK: |   |     |     `-ImplicitCastExpr {{.+}} 'char *__single':'char *' <LValueToRValue>
 // CHECK: |   |     |       `-DeclRefExpr {{.+}} [[var_d]]
 // CHECK: |   |     `-OpaqueValueExpr [[ove_3]]
 // CHECK: |   |       `-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -362,7 +360,6 @@ char testFunc6(int pred, char * __bidi_indexable * __indexable c, char * __bidi_
 // CHECK: |       `-OpaqueValueExpr [[ove_19]] {{.*}} '__ptrdiff_t':'long'
 
 char testFunc7(int pred, char * __unsafe_indexable * __single c, char * __single * __indexable d) {
-    // expected-error@+1{{conditional expression evaluates values with incompatible pointee types 'char *__unsafe_indexable*__indexable' and 'char *__single*__indexable'; use explicit casts to perform this conversion}}
     char * __unsafe_indexable *__indexable tmp = pred ? c : d;
     return tmp[9][2];
 }
@@ -517,8 +514,9 @@ char testFunc14(int pred, const char *__single _Nullable __null_terminated c, co
 // CHECK: |   |   `-ConditionalOperator {{.+}} <col:41, col:52> 'const char *__single __terminated_by(0) _Nullable':'const char *__single'
 // CHECK: |   |     |-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK: |   |     | `-DeclRefExpr {{.+}} [[var_pred_13]]
-// CHECK: |   |     |-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0) _Nullable':'const char *__single' <LValueToRValue>
-// CHECK: |   |     | `-DeclRefExpr {{.+}} [[var_c_10]]
+// CHECK: |   |     |-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0)':'const char *__single' <BitCast>
+// CHECK: |   |     | `-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0) _Nullable':'const char *' <LValueToRValue>
+// CHECK: |   |     |   `-DeclRefExpr {{.+}} [[var_c_10]]
 // CHECK: |   |     `-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0) _Nullable':'const char *__single' <LValueToRValue>
 // CHECK: |   |       `-DeclRefExpr {{.+}} [[var_d_10]]
 // CHECK: |   `-ReturnStmt
@@ -542,8 +540,9 @@ char testFunc15(int pred, const char *__single _Nullable __null_terminated c, co
 // CHECK: |   |   `-ConditionalOperator {{.+}} <col:41, col:52> 'const char *__single __terminated_by(0) _Nullable':'const char *__single'
 // CHECK: |   |     |-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK: |   |     | `-DeclRefExpr {{.+}} [[var_pred_14]]
-// CHECK: |   |     |-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0) _Nullable':'const char *__single' <LValueToRValue>
-// CHECK: |   |     | `-DeclRefExpr {{.+}} [[var_c_11]]
+// CHECK: |   |     |-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0)':'const char *__single' <BitCast>
+// CHECK: |   |     | `-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0) _Nullable':'const char *' <LValueToRValue>
+// CHECK: |   |     |   `-DeclRefExpr {{.+}} [[var_c_11]]
 // CHECK: |   |     `-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0) _Nullable':'const char *__single' <LValueToRValue>
 // CHECK: |   |       `-DeclRefExpr {{.+}} [[var_d_11]]
 // CHECK: |   `-ReturnStmt
@@ -576,4 +575,3 @@ char testFunc16(int pred, const char * _Nullable __null_terminated c, const char
 // CHECK:         `-UnaryOperator {{.+}} cannot overflow
 // CHECK:           `-ImplicitCastExpr {{.+}} 'const char *__single __terminated_by(0)':'const char *__single' <LValueToRValue>
 // CHECK:             `-DeclRefExpr {{.+}} [[var_foo_11]]
-

--- a/clang/test/BoundsSafety/AST/wide-to-counted-pointer-arg.c
+++ b/clang/test/BoundsSafety/AST/wide-to-counted-pointer-arg.c
@@ -1,5 +1,3 @@
-
-
 // RUN: not %clang_cc1 -fbounds-safety -ast-dump %s 2> /dev/null | FileCheck %s
 // RUN: %clang_cc1 -fbounds-safety -verify %s
 // RUN: not %clang_cc1 -fbounds-safety -ast-dump %s 2> /dev/null | FileCheck %s
@@ -579,6 +577,6 @@ Lbar_sbuf_11:
 void TestError(void) {
     int value = 0;
     int *__single p = &value;
-    // expected-error@+1{{passing 'int *__single' to parameter 'buf' of type 'int *__single __counted_by(len)' (aka 'int *__single') with count value of 5 always fails}}
+    // expected-error@+1{{passing 'int *__single' (aka 'int *') to parameter 'buf' of type 'int *__single __counted_by(len)' (aka 'int *__single') with count value of 5 always fails}}
     Foo(p, 5);
 }

--- a/clang/test/BoundsSafety/AST/wide-to-counted-pointer-arg.c
+++ b/clang/test/BoundsSafety/AST/wide-to-counted-pointer-arg.c
@@ -290,22 +290,26 @@ Lfoo_p_0:
 // CHECK: |   |   | | |-CallExpr
 // CHECK: |   |   | | | |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single __counted_by(len), int)' <FunctionToPointerDecay>
 // CHECK: |   |   | | | | `-DeclRefExpr {{.+}} [[func_Foo]]
-// CHECK: |   |   | | | |-OpaqueValueExpr [[ove_17:0x[^ ]+]] {{.*}} 'int *__single'
+// CHECK: |   |   | | | |-ImplicitCastExpr {{.+}} 'int *__single __counted_by(len)':'int *__single' <BoundsSafetyPointerCast>
+// CHECK: |   |   | | | | `-OpaqueValueExpr [[ove_17:0x[^ ]+]] {{.*}} 'int *__single':'int *'
+// CHECK: |   |   | | | |   `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// CHECK: |   |   | | | |     `-DeclRefExpr {{.+}} [[var_p]]
 // CHECK: |   |   | | | `-OpaqueValueExpr [[ove_18:0x[^ ]+]] {{.*}} 'int'
+// CHECK: |   |   | | |   `-IntegerLiteral {{.+}} 0
 // CHECK: |   |   | | `-BinaryOperator {{.+}} 'int' '&&'
 // CHECK: |   |   | |   |-BinaryOperator {{.+}} 'int' '&&'
 // CHECK: |   |   | |   | |-BinaryOperator {{.+}} 'int' '<='
-// CHECK: |   |   | |   | | |-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single'
+// CHECK: |   |   | |   | | |-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single':'int *'
 // CHECK: |   |   | |   | | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK: |   |   | |   | |   `-GetBoundExpr {{.+}} upper
 // CHECK: |   |   | |   | |     `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |   | |   | |       `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single'
+// CHECK: |   |   | |   | |       `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single':'int *'
 // CHECK: |   |   | |   | `-BinaryOperator {{.+}} 'int' '<='
 // CHECK: |   |   | |   |   |-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK: |   |   | |   |   | `-GetBoundExpr {{.+}} lower
 // CHECK: |   |   | |   |   |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |   | |   |   |     `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single'
-// CHECK: |   |   | |   |   `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single'
+// CHECK: |   |   | |   |   |     `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single':'int *'
+// CHECK: |   |   | |   |   `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single':'int *'
 // CHECK: |   |   | |   `-BinaryOperator {{.+}} 'int' '&&'
 // CHECK: |   |   | |     |-BinaryOperator {{.+}} 'int' '<='
 // CHECK: |   |   | |     | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -314,18 +318,16 @@ Lfoo_p_0:
 // CHECK: |   |   | |     |   |-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK: |   |   | |     |   | `-GetBoundExpr {{.+}} upper
 // CHECK: |   |   | |     |   |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |   | |     |   |     `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single'
-// CHECK: |   |   | |     |   `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single'
+// CHECK: |   |   | |     |   |     `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single':'int *'
+// CHECK: |   |   | |     |   `-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single':'int *'
 // CHECK: |   |   | |     `-BinaryOperator {{.+}} 'int' '<='
 // CHECK: |   |   | |       |-IntegerLiteral {{.+}} 0
 // CHECK: |   |   | |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'int'
-// CHECK: |   |   | |-OpaqueValueExpr [[ove_17]]
-// CHECK: |   |   | | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK: |   |   | |-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single':'int *'
+// CHECK: |   |   | | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK: |   |   | |   `-DeclRefExpr {{.+}} [[var_p]]
-// CHECK: |   |   | `-OpaqueValueExpr [[ove_18]]
+// CHECK: |   |   | `-OpaqueValueExpr [[ove_18]] {{.*}} 'int'
 // CHECK: |   |   |   `-IntegerLiteral {{.+}} 0
-// CHECK: |   |   |-OpaqueValueExpr [[ove_17]] {{.*}} 'int *__single'
-// CHECK: |   |   `-OpaqueValueExpr [[ove_18]] {{.*}} 'int'
 
 Lfoo_p_1:
     Foo(p, 1);
@@ -336,22 +338,26 @@ Lfoo_p_1:
 // CHECK: |   |   | | |-CallExpr
 // CHECK: |   |   | | | |-ImplicitCastExpr {{.+}} 'void (*__single)(int *__single __counted_by(len), int)' <FunctionToPointerDecay>
 // CHECK: |   |   | | | | `-DeclRefExpr {{.+}} [[func_Foo]]
-// CHECK: |   |   | | | |-OpaqueValueExpr [[ove_19:0x[^ ]+]] {{.*}} 'int *__single'
+// CHECK: |   |   | | | |-ImplicitCastExpr {{.+}} 'int *__single __counted_by(len)':'int *__single' <BoundsSafetyPointerCast>
+// CHECK: |   |   | | | | `-OpaqueValueExpr [[ove_19:0x[^ ]+]] {{.*}} 'int *__single':'int *'
+// CHECK: |   |   | | | |   `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
+// CHECK: |   |   | | | |     `-DeclRefExpr {{.+}} [[var_p]]
 // CHECK: |   |   | | | `-OpaqueValueExpr [[ove_20:0x[^ ]+]] {{.*}} 'int'
+// CHECK: |   |   | | |   `-IntegerLiteral {{.+}} 1
 // CHECK: |   |   | | `-BinaryOperator {{.+}} 'int' '&&'
 // CHECK: |   |   | |   |-BinaryOperator {{.+}} 'int' '&&'
 // CHECK: |   |   | |   | |-BinaryOperator {{.+}} 'int' '<='
-// CHECK: |   |   | |   | | |-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single'
+// CHECK: |   |   | |   | | |-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single':'int *'
 // CHECK: |   |   | |   | | `-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK: |   |   | |   | |   `-GetBoundExpr {{.+}} upper
 // CHECK: |   |   | |   | |     `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |   | |   | |       `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single'
+// CHECK: |   |   | |   | |       `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single':'int *'
 // CHECK: |   |   | |   | `-BinaryOperator {{.+}} 'int' '<='
 // CHECK: |   |   | |   |   |-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK: |   |   | |   |   | `-GetBoundExpr {{.+}} lower
 // CHECK: |   |   | |   |   |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |   | |   |   |     `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single'
-// CHECK: |   |   | |   |   `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single'
+// CHECK: |   |   | |   |   |     `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single':'int *'
+// CHECK: |   |   | |   |   `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single':'int *'
 // CHECK: |   |   | |   `-BinaryOperator {{.+}} 'int' '&&'
 // CHECK: |   |   | |     |-BinaryOperator {{.+}} 'int' '<='
 // CHECK: |   |   | |     | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -360,18 +366,16 @@ Lfoo_p_1:
 // CHECK: |   |   | |     |   |-ImplicitCastExpr {{.+}} 'int *' <BoundsSafetyPointerCast>
 // CHECK: |   |   | |     |   | `-GetBoundExpr {{.+}} upper
 // CHECK: |   |   | |     |   |   `-ImplicitCastExpr {{.+}} 'int *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   |   | |     |   |     `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single'
-// CHECK: |   |   | |     |   `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single'
+// CHECK: |   |   | |     |   |     `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single':'int *'
+// CHECK: |   |   | |     |   `-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single':'int *'
 // CHECK: |   |   | |     `-BinaryOperator {{.+}} 'int' '<='
 // CHECK: |   |   | |       |-IntegerLiteral {{.+}} 0
 // CHECK: |   |   | |       `-OpaqueValueExpr [[ove_20]] {{.*}} 'int'
-// CHECK: |   |   | |-OpaqueValueExpr [[ove_19]]
-// CHECK: |   |   | | `-ImplicitCastExpr {{.+}} 'int *__single' <LValueToRValue>
+// CHECK: |   |   | |-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single':'int *'
+// CHECK: |   |   | | `-ImplicitCastExpr {{.+}} 'int *__single':'int *' <LValueToRValue>
 // CHECK: |   |   | |   `-DeclRefExpr {{.+}} [[var_p]]
-// CHECK: |   |   | `-OpaqueValueExpr [[ove_20]]
+// CHECK: |   |   | `-OpaqueValueExpr [[ove_20]] {{.*}} 'int'
 // CHECK: |   |   |   `-IntegerLiteral {{.+}} 1
-// CHECK: |   |   |-OpaqueValueExpr [[ove_19]] {{.*}} 'int *__single'
-// CHECK: |   |   `-OpaqueValueExpr [[ove_20]] {{.*}} 'int'
 
 Lfoo_q_5:
     Foo(q, 5);

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations-constexpr-geps.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations-constexpr-geps.c
@@ -355,38 +355,32 @@ void concat_to_separate_clobals(hdr_t *p_buf) {
 // CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[TMP8]], getelementptr inbounds nuw (i8, ptr @b, i64 16), {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[TMP10:%.*]] = icmp ule ptr [[ARRAYIDX77]], [[TMP8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND120:%.*]] = and i1 [[TMP9]], [[TMP10]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP11:%.*]] = icmp uge ptr [[ARRAYIDX77]], @b, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND121:%.*]] = and i1 [[TMP11]], [[OR_COND120]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND121]], label %[[CONT80:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND120]], label %[[CONT80:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT80]]:
 // CHECK-NEXT:    [[ARRAYIDX68:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0142]], i64 1
-// CHECK-NEXT:    [[TMP12:%.*]] = load i8, ptr [[ARRAYIDX68]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV75:%.*]] = zext i8 [[TMP12]] to i32
+// CHECK-NEXT:    [[TMP11:%.*]] = load i8, ptr [[ARRAYIDX68]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV75:%.*]] = zext i8 [[TMP11]] to i32
 // CHECK-NEXT:    store i32 [[CONV75]], ptr [[ARRAYIDX77]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX94:%.*]] = getelementptr [4 x i8], ptr @c, i64 [[IDXPROM]]
-// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[ARRAYIDX94]], i64 4, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], getelementptr inbounds nuw (i8, ptr @c, i64 16), {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX94]], [[TMP13]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND123:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP16:%.*]] = icmp uge ptr [[ARRAYIDX94]], @c, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND124:%.*]] = and i1 [[TMP16]], [[OR_COND123]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND124]], label %[[CONT97:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP12:%.*]] = getelementptr i8, ptr [[ARRAYIDX94]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP13:%.*]] = icmp ule ptr [[TMP12]], getelementptr inbounds nuw (i8, ptr @c, i64 16), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[ARRAYIDX94]], [[TMP12]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND123:%.*]] = and i1 [[TMP13]], [[TMP14]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND123]], label %[[CONT97:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT97]]:
 // CHECK-NEXT:    [[ARRAYIDX85:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0142]], i64 2
-// CHECK-NEXT:    [[TMP17:%.*]] = load i8, ptr [[ARRAYIDX85]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV92:%.*]] = zext i8 [[TMP17]] to i32
+// CHECK-NEXT:    [[TMP15:%.*]] = load i8, ptr [[ARRAYIDX85]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV92:%.*]] = zext i8 [[TMP15]] to i32
 // CHECK-NEXT:    store i32 [[CONV92]], ptr [[ARRAYIDX94]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX111:%.*]] = getelementptr [4 x i8], ptr @d, i64 [[IDXPROM]]
-// CHECK-NEXT:    [[TMP18:%.*]] = getelementptr i8, ptr [[ARRAYIDX111]], i64 4, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP19:%.*]] = icmp ule ptr [[TMP18]], getelementptr inbounds nuw (i8, ptr @d, i64 16), {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP20:%.*]] = icmp ule ptr [[ARRAYIDX111]], [[TMP18]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND126:%.*]] = and i1 [[TMP19]], [[TMP20]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP21:%.*]] = icmp uge ptr [[ARRAYIDX111]], @d, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND127:%.*]] = and i1 [[TMP21]], [[OR_COND126]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND127]], label %[[CONT114]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP16:%.*]] = getelementptr i8, ptr [[ARRAYIDX111]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP17:%.*]] = icmp ule ptr [[TMP16]], getelementptr inbounds nuw (i8, ptr @d, i64 16), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[ARRAYIDX111]], [[TMP16]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND126:%.*]] = and i1 [[TMP17]], [[TMP18]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND126]], label %[[CONT114]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT114]]:
-// CHECK-NEXT:    [[TMP22:%.*]] = load i8, ptr [[PARAMS_SROA_0_0142]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV109:%.*]] = zext i8 [[TMP22]] to i32
+// CHECK-NEXT:    [[TMP19:%.*]] = load i8, ptr [[PARAMS_SROA_0_0142]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV109:%.*]] = zext i8 [[TMP19]] to i32
 // CHECK-NEXT:    store i32 [[CONV109]], ptr [[ARRAYIDX111]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[INC]] = add i8 [[I_0141]], 1, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[CONV4:%.*]] = zext i8 [[INC]] to i32
@@ -596,34 +590,32 @@ void concat_to_arrays_struct_can_remove_arrays_check(struct arrays *arrays, hdr_
 // CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[TMP8]], [[UPPER78]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[TMP10:%.*]] = icmp ule ptr [[ARRAYIDX80]], [[TMP8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND127:%.*]] = and i1 [[TMP9]], [[TMP10]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP11:%.*]] = icmp uge ptr [[ARRAYIDX80]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND128:%.*]] = and i1 [[TMP11]], [[OR_COND127]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND128]], label %[[CONT83:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND127]], label %[[CONT83:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT83]]:
 // CHECK-NEXT:    [[ARRAYIDX69:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 1
-// CHECK-NEXT:    [[TMP12:%.*]] = load i8, ptr [[ARRAYIDX69]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV76:%.*]] = zext i8 [[TMP12]] to i32
+// CHECK-NEXT:    [[TMP11:%.*]] = load i8, ptr [[ARRAYIDX69]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV76:%.*]] = zext i8 [[TMP11]] to i32
 // CHECK-NEXT:    store i32 [[CONV76]], ptr [[ARRAYIDX80]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX99:%.*]] = getelementptr [4 x i8], ptr [[UPPER78]], i64 [[IDXPROM]]
-// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[ARRAYIDX99]], i64 4, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], [[UPPER97]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX99]], [[TMP13]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND130:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP12:%.*]] = getelementptr i8, ptr [[ARRAYIDX99]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP13:%.*]] = icmp ule ptr [[TMP12]], [[UPPER97]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[ARRAYIDX99]], [[TMP12]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND130:%.*]] = and i1 [[TMP13]], [[TMP14]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND130]], label %[[CONT102:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT102]]:
 // CHECK-NEXT:    [[ARRAYIDX88:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 2
-// CHECK-NEXT:    [[TMP16:%.*]] = load i8, ptr [[ARRAYIDX88]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV95:%.*]] = zext i8 [[TMP16]] to i32
+// CHECK-NEXT:    [[TMP15:%.*]] = load i8, ptr [[ARRAYIDX88]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV95:%.*]] = zext i8 [[TMP15]] to i32
 // CHECK-NEXT:    store i32 [[CONV95]], ptr [[ARRAYIDX99]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX118:%.*]] = getelementptr [4 x i8], ptr [[UPPER97]], i64 [[IDXPROM]]
-// CHECK-NEXT:    [[TMP17:%.*]] = getelementptr i8, ptr [[ARRAYIDX118]], i64 4, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[TMP17]], [[UPPER116]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP19:%.*]] = icmp ule ptr [[ARRAYIDX118]], [[TMP17]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND133:%.*]] = and i1 [[TMP18]], [[TMP19]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP16:%.*]] = getelementptr i8, ptr [[ARRAYIDX118]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP17:%.*]] = icmp ule ptr [[TMP16]], [[UPPER116]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[ARRAYIDX118]], [[TMP16]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND133:%.*]] = and i1 [[TMP17]], [[TMP18]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND133]], label %[[CONT121]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT121]]:
-// CHECK-NEXT:    [[TMP20:%.*]] = load i8, ptr [[PARAMS_SROA_0_0152]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV114:%.*]] = zext i8 [[TMP20]] to i32
+// CHECK-NEXT:    [[TMP19:%.*]] = load i8, ptr [[PARAMS_SROA_0_0152]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV114:%.*]] = zext i8 [[TMP19]] to i32
 // CHECK-NEXT:    store i32 [[CONV114]], ptr [[ARRAYIDX118]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[INC]] = add i8 [[I_0151]], 1, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[CONV4:%.*]] = zext i8 [[INC]] to i32
@@ -834,34 +826,32 @@ void concat_to_arrays_struct_trap_on_last_iter(struct arrays *arrays, hdr_t *p_b
 // CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[TMP8]], [[UPPER78]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[TMP10:%.*]] = icmp ule ptr [[ARRAYIDX80]], [[TMP8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND127:%.*]] = and i1 [[TMP9]], [[TMP10]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP11:%.*]] = icmp uge ptr [[ARRAYIDX80]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND128:%.*]] = and i1 [[TMP11]], [[OR_COND127]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND128]], label %[[CONT83:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND127]], label %[[CONT83:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT83]]:
 // CHECK-NEXT:    [[ARRAYIDX69:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 1
-// CHECK-NEXT:    [[TMP12:%.*]] = load i8, ptr [[ARRAYIDX69]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV76:%.*]] = zext i8 [[TMP12]] to i32
+// CHECK-NEXT:    [[TMP11:%.*]] = load i8, ptr [[ARRAYIDX69]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV76:%.*]] = zext i8 [[TMP11]] to i32
 // CHECK-NEXT:    store i32 [[CONV76]], ptr [[ARRAYIDX80]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX99:%.*]] = getelementptr [4 x i8], ptr [[UPPER78]], i64 [[IDXPROM]]
-// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[ARRAYIDX99]], i64 4, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], [[UPPER97]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX99]], [[TMP13]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND130:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP12:%.*]] = getelementptr i8, ptr [[ARRAYIDX99]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP13:%.*]] = icmp ule ptr [[TMP12]], [[UPPER97]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[ARRAYIDX99]], [[TMP12]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND130:%.*]] = and i1 [[TMP13]], [[TMP14]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND130]], label %[[CONT102:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT102]]:
 // CHECK-NEXT:    [[ARRAYIDX88:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0152]], i64 2
-// CHECK-NEXT:    [[TMP16:%.*]] = load i8, ptr [[ARRAYIDX88]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV95:%.*]] = zext i8 [[TMP16]] to i32
+// CHECK-NEXT:    [[TMP15:%.*]] = load i8, ptr [[ARRAYIDX88]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV95:%.*]] = zext i8 [[TMP15]] to i32
 // CHECK-NEXT:    store i32 [[CONV95]], ptr [[ARRAYIDX99]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX118:%.*]] = getelementptr [4 x i8], ptr [[UPPER97]], i64 [[IDXPROM]]
-// CHECK-NEXT:    [[TMP17:%.*]] = getelementptr i8, ptr [[ARRAYIDX118]], i64 4, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[TMP17]], [[UPPER116]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP19:%.*]] = icmp ule ptr [[ARRAYIDX118]], [[TMP17]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND133:%.*]] = and i1 [[TMP18]], [[TMP19]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP16:%.*]] = getelementptr i8, ptr [[ARRAYIDX118]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP17:%.*]] = icmp ule ptr [[TMP16]], [[UPPER116]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[ARRAYIDX118]], [[TMP16]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND133:%.*]] = and i1 [[TMP17]], [[TMP18]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND133]], label %[[CONT121]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT121]]:
-// CHECK-NEXT:    [[TMP20:%.*]] = load i8, ptr [[PARAMS_SROA_0_0152]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV114:%.*]] = zext i8 [[TMP20]] to i32
+// CHECK-NEXT:    [[TMP19:%.*]] = load i8, ptr [[PARAMS_SROA_0_0152]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV114:%.*]] = zext i8 [[TMP19]] to i32
 // CHECK-NEXT:    store i32 [[CONV114]], ptr [[ARRAYIDX118]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[INC]] = add i8 [[I_0151]], 1, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[CONV4:%.*]] = zext i8 [[INC]] to i32
@@ -940,34 +930,32 @@ void concat_to_arrays_struct_trap_on_last_iter_opaque(struct arrays *arrays, hdr
 // CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[TMP8]], [[UPPER78]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[TMP10:%.*]] = icmp ule ptr [[ARRAYIDX80]], [[TMP8]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND127:%.*]] = and i1 [[TMP9]], [[TMP10]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP11:%.*]] = icmp uge ptr [[ARRAYIDX80]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND128:%.*]] = and i1 [[TMP11]], [[OR_COND127]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND128]], label %[[CONT83:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND127]], label %[[CONT83:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT83]]:
 // CHECK-NEXT:    [[ARRAYIDX69:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0151]], i64 1
-// CHECK-NEXT:    [[TMP12:%.*]] = load i8, ptr [[ARRAYIDX69]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV76:%.*]] = zext i8 [[TMP12]] to i32
+// CHECK-NEXT:    [[TMP11:%.*]] = load i8, ptr [[ARRAYIDX69]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV76:%.*]] = zext i8 [[TMP11]] to i32
 // CHECK-NEXT:    store i32 [[CONV76]], ptr [[ARRAYIDX80]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX99:%.*]] = getelementptr [4 x i8], ptr [[UPPER78]], i64 [[IDXPROM]]
-// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[ARRAYIDX99]], i64 4, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], [[UPPER97]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX99]], [[TMP13]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND130:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP12:%.*]] = getelementptr i8, ptr [[ARRAYIDX99]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP13:%.*]] = icmp ule ptr [[TMP12]], [[UPPER97]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[ARRAYIDX99]], [[TMP12]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND130:%.*]] = and i1 [[TMP13]], [[TMP14]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND130]], label %[[CONT102:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT102]]:
 // CHECK-NEXT:    [[ARRAYIDX88:%.*]] = getelementptr i8, ptr [[PARAMS_SROA_0_0151]], i64 2
-// CHECK-NEXT:    [[TMP16:%.*]] = load i8, ptr [[ARRAYIDX88]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV95:%.*]] = zext i8 [[TMP16]] to i32
+// CHECK-NEXT:    [[TMP15:%.*]] = load i8, ptr [[ARRAYIDX88]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV95:%.*]] = zext i8 [[TMP15]] to i32
 // CHECK-NEXT:    store i32 [[CONV95]], ptr [[ARRAYIDX99]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX118:%.*]] = getelementptr [4 x i8], ptr [[UPPER97]], i64 [[IDXPROM]]
-// CHECK-NEXT:    [[TMP17:%.*]] = getelementptr i8, ptr [[ARRAYIDX118]], i64 4, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[TMP17]], [[UPPER116]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP19:%.*]] = icmp ule ptr [[ARRAYIDX118]], [[TMP17]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND133:%.*]] = and i1 [[TMP18]], [[TMP19]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP16:%.*]] = getelementptr i8, ptr [[ARRAYIDX118]], i64 4, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP17:%.*]] = icmp ule ptr [[TMP16]], [[UPPER116]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[ARRAYIDX118]], [[TMP16]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND133:%.*]] = and i1 [[TMP17]], [[TMP18]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND133]], label %[[CONT121]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT121]]:
-// CHECK-NEXT:    [[TMP20:%.*]] = load i8, ptr [[PARAMS_SROA_0_0151]], align 1, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[CONV114:%.*]] = zext i8 [[TMP20]] to i32
+// CHECK-NEXT:    [[TMP19:%.*]] = load i8, ptr [[PARAMS_SROA_0_0151]], align 1, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[CONV114:%.*]] = zext i8 [[TMP19]] to i32
 // CHECK-NEXT:    store i32 [[CONV114]], ptr [[ARRAYIDX118]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[INC]] = add i8 [[I_0150]], 1, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[CONV4:%.*]] = zext i8 [[INC]] to i32

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations.c
@@ -572,17 +572,9 @@ void loop_accesses_eliminate_later_checks(int* __counted_by(n) dst, unsigned n) 
 // CHECK-NEXT:    [[OR_COND56:%.*]] = and i1 [[TMP6]], [[TMP5]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[TMP7:%.*]] = icmp uge ptr [[ARRAYIDX8]], [[DST]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND57:%.*]] = and i1 [[TMP7]], [[OR_COND56]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND57]], label %[[CONT15:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
-// CHECK:       [[CONT15]]:
-// CHECK-NEXT:    store i32 0, ptr [[ARRAYIDX8]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[ARRAYIDX8]], [[ADD_PTR]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[DOTNOT]], label %[[TRAP]], label %[[CONT54:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND57]], label %[[CONT54:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT54]]:
-// CHECK-NEXT:    [[ARRAYIDX21:%.*]] = getelementptr i8, ptr [[DST]], i64 16
-// CHECK-NEXT:    store i32 0, ptr [[ARRAYIDX21]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX34:%.*]] = getelementptr i8, ptr [[DST]], i64 12
-// CHECK-NEXT:    store i32 0, ptr [[ARRAYIDX34]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    store i32 0, ptr [[TMP0]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    tail call void @llvm.memset.p0.i64(ptr noundef nonnull align 4 dereferenceable(16) [[TMP0]], i8 0, i64 16, i1 false)
 // CHECK-NEXT:    ret void
 //
 void elim_consecutive_writes(int* __counted_by(n) dst, unsigned n) {
@@ -620,12 +612,9 @@ void elim_consecutive_writes(int* __counted_by(n) dst, unsigned n) {
 // CHECK-NEXT:    [[TMP5:%.*]] = icmp ule ptr [[TMP4]], [[ADD_PTR]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[TMP6:%.*]] = icmp ule ptr [[ARRAYIDX8]], [[TMP4]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND56:%.*]] = and i1 [[TMP6]], [[TMP5]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND56]], label %[[CONT15:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
-// CHECK:       [[CONT15]]:
-// CHECK-NEXT:    store i32 0, ptr [[ARRAYIDX8]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[ARRAYIDX8]], [[ADD_PTR]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[DOTNOT]], label %[[TRAP]], label %[[CONT41:.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND56]], label %[[CONT41:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT41]]:
+// CHECK-NEXT:    store i32 0, ptr [[ARRAYIDX8]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX21:%.*]] = getelementptr i8, ptr [[DST]], i64 12
 // CHECK-NEXT:    store i32 0, ptr [[ARRAYIDX21]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX34:%.*]] = getelementptr i8, ptr [[DST]], i64 8
@@ -634,9 +623,7 @@ void elim_consecutive_writes(int* __counted_by(n) dst, unsigned n) {
 // CHECK-NEXT:    [[TMP8:%.*]] = icmp ule ptr [[TMP7]], [[ADD_PTR]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[TMP4]], [[TMP7]], {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[OR_COND62:%.*]] = and i1 [[TMP9]], [[TMP8]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP10:%.*]] = icmp uge ptr [[TMP4]], [[DST]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND63:%.*]] = and i1 [[TMP10]], [[OR_COND62]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND63]], label %[[CONT54:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND62]], label %[[CONT54:.*]], label %[[TRAP]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK:       [[CONT54]]:
 // CHECK-NEXT:    store i32 0, ptr [[TMP4]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    br label %[[IF_END]]

--- a/clang/test/BoundsSafety/Sema/address-taken-dynamic-range-decls.c
+++ b/clang/test/BoundsSafety/Sema/address-taken-dynamic-range-decls.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 
 #include <ptrcheck.h>
@@ -43,7 +42,7 @@ void test() {
   *ptr_to_end = 0;
 
   fun_out_end(&s.end, &s.start);
-  // expected-error@+1{{type of 'local_end', 'int *__single', is incompatible with parameter of type 'int *__single /* __started_by(*out_start) */ ' (aka 'int *__single')}}
+  // expected-error@+1{{type of 'local_end', 'int *__single' (aka 'int *'), is incompatible with parameter of type 'int *__single /* __started_by(*out_start) */ ' (aka 'int *__single')}}
   fun_out_end(&local_end, &s.start);
   // expected-error@+1{{passing address of 'end' as an indirect parameter; must also pass 'iter' or its address because the type of 'iter', 'int *__single __ended_by(end) /* __started_by(start) */ ' (aka 'int *__single'), refers to 'end'}}
   fun_out_end(&u.end, &u.start);

--- a/clang/test/BoundsSafety/Sema/constant-forge-ptr-expr.c
+++ b/clang/test/BoundsSafety/Sema/constant-forge-ptr-expr.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
@@ -33,7 +32,7 @@ int *__single ptrSingle13 = __unsafe_forge_single(int *, arr);
 int *__terminated_by(5) ptrTerminated = __unsafe_forge_terminated_by(int *, arr, 5);
 int *__terminated_by(5) ptrTerminated2 = __unsafe_forge_terminated_by(int *, arr, 6); // expected-error{{pointers with incompatible terminators initializing 'int *__single __terminated_by(5)' (aka 'int *__single') with an expression of incompatible type 'int *__single __terminated_by(6)' (aka 'int *__single')}}
 int *__terminated_by(5) ptrTerminated3 = __unsafe_forge_terminated_by(int *, 7, 5);
-// The attribute on cast is missing macro identifer info. 
+// The attribute on cast is missing macro identifer info.
 // expected-error@+2{{'__terminated_by__' attribute requires an integer constant}}
 // expected-error@+1{{initializing 'int *__single __terminated_by(4)' (aka 'int *__single') with an expression of incompatible type 'int *__single' is an unsafe operation; use '__unsafe_terminated_by_from_indexable()' or '__unsafe_forge_terminated_by()' to perform this conversion}}
 int *__terminated_by(4) ptrTerminated4 = __unsafe_forge_terminated_by(int *, arr, len);
@@ -61,7 +60,7 @@ char *__null_terminated ptrNt1 = __unsafe_forge_bidi_indexable(char *, arr, 10);
 char *__null_terminated ptrNt2 = __unsafe_forge_bidi_indexable(char *, arr+12, 10);
 
 // expected-error@+2{{initializer element is not a compile-time constant}}
-// expected-error@+1{{initializing 'char *__single __terminated_by(0)' (aka 'char *__single') with an expression of incompatible type 'char *__single' is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+// expected-error@+1{{initializing 'char *__single __terminated_by(0)' (aka 'char *__single') with an expression of incompatible type 'char *__single' (aka 'char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
 char *__null_terminated ptrNt3 = __unsafe_forge_single(char *, arr+12);
 
 // expected-error@+1{{initializer element is not a compile-time constant}}

--- a/clang/test/BoundsSafety/Sema/counted_by_type_incomplete_completable_struct.c
+++ b/clang/test/BoundsSafety/Sema/counted_by_type_incomplete_completable_struct.c
@@ -241,7 +241,7 @@ struct IncompleteStructTy* __counted_by(1) // expected-note 2{{consider using '_
 // expected-error@+1{{cannot apply '__counted_by' attribute to return type 'struct IncompleteStructTy *__single __counted_by(size)' (aka 'struct IncompleteStructTy *__single') on a function definition because the pointee type 'struct IncompleteStructTy' is incomplete}}
 struct IncompleteStructTy* __counted_by(size) // expected-note 2{{consider using '__sized_by' instead of '__counted_by'}}
 consume_param_and_return_cb_single_forge(int size) {
-  // rs-warning@+2{{count value is not statically known: returning 'struct IncompleteStructTy *__single' from a function with result type 'struct IncompleteStructTy *__single __counted_by(size)' (aka 'struct IncompleteStructTy *__single') is invalid for any count other than 0 or 1}}
+  // rs-warning@+2{{count value is not statically known: returning 'struct IncompleteStructTy *__single' (aka 'struct IncompleteStructTy *') from a function with result type 'struct IncompleteStructTy *__single __counted_by(size)' (aka 'struct IncompleteStructTy *__single') is invalid for any count other than 0 or 1}}
   // expected-error@+1{{cannot return '__counted_by' attributed type 'struct IncompleteStructTy *__single __counted_by(size)' (aka 'struct IncompleteStructTy *__single') because the pointee type 'struct IncompleteStructTy' is incomplete}}
   return __unsafe_forge_single(struct IncompleteStructTy*, 0x0);
 }
@@ -265,7 +265,7 @@ struct IncompleteStructTy* __counted_by_or_null(size) // expected-note 2{{consid
 // expected-error@+1{{cannot apply '__counted_by_or_null' attribute to return type 'struct IncompleteStructTy *__single __counted_by_or_null(size)' (aka 'struct IncompleteStructTy *__single') on a function definition because the pointee type 'struct IncompleteStructTy' is incomplete}}
 struct IncompleteStructTy* __counted_by_or_null(size) // expected-note 2{{consider using '__sized_by_or_null' instead of '__counted_by_or_null'}}
 consume_param_and_return_cbon_single_forge(int size) {
-  // rs-warning@+2{{count value is not statically known: returning 'struct IncompleteStructTy *__single' from a function with result type 'struct IncompleteStructTy *__single __counted_by_or_null(size)' (aka 'struct IncompleteStructTy *__single') is invalid for any count other than 0 or 1 unless the pointer is null}}
+  // rs-warning@+2{{count value is not statically known: returning 'struct IncompleteStructTy *__single' (aka 'struct IncompleteStructTy *') from a function with result type 'struct IncompleteStructTy *__single __counted_by_or_null(size)' (aka 'struct IncompleteStructTy *__single') is invalid for any count other than 0 or 1 unless the pointer is null}}
   // expected-error@+1{{cannot return '__counted_by_or_null' attributed type 'struct IncompleteStructTy *__single __counted_by_or_null(size)' (aka 'struct IncompleteStructTy *__single') because the pointee type 'struct IncompleteStructTy' is incomplete}}
   return __unsafe_forge_single(struct IncompleteStructTy*, 0x0);
 }

--- a/clang/test/BoundsSafety/Sema/implicit-single-to-explicit-indexable-conversion-nested.c
+++ b/clang/test/BoundsSafety/Sema/implicit-single-to-explicit-indexable-conversion-nested.c
@@ -20,6 +20,7 @@
 void take_bidi0(int **__bidi_indexable b_arg0);
 // expected-note@+1{{passing argument to parameter 'b_arg1' here}}
 void take_bidi1(int **__bidi_indexable b_arg1);
+// expected-note@+1{{passing argument to parameter 'b_arg2' here}}
 void take_bidi2(int **__bidi_indexable b_arg2);
 // expected-note@+1{{passing argument to parameter 'b_arg3' here}}
 void take_bidi3(int **__bidi_indexable b_arg3);
@@ -38,6 +39,7 @@ void take_bidi5(int **__bidi_indexable b_arg5);
 void take_idx0(int **__indexable i_arg0);
 // expected-note@+1{{passing argument to parameter 'i_arg1' here}}
 void take_idx1(int **__indexable i_arg1);
+// expected-note@+1{{passing argument to parameter 'i_arg2' here}}
 void take_idx2(int **__indexable i_arg2);
 // expected-note@+1{{passing argument to parameter 'i_arg3' here}}
 void take_idx3(int **__indexable i_arg3);
@@ -233,6 +235,7 @@ void use(void) {
   int **__bidi_indexable explicit_bidi = explicitly_single1;
   // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single1'}}
   int **__bidi_indexable explicit_bidi2 = implicitly_single1;
+  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   int **__bidi_indexable explicit_bidi3 = SINGLE_EXPR;
   // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single1'}}
   int **__bidi_indexable explicit_bidi4 = bigger_explicit_single1;
@@ -248,6 +251,7 @@ void use(void) {
   int **__indexable explicit_idx = explicitly_single3;
   // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single3'}}
   int **__indexable explicit_idx2 = implicitly_single3;
+  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   int **__indexable explicit_idx3 = SINGLE_EXPR;
   // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single3'}}
   int **__indexable explicit_idx4 = bigger_explicit_single3;
@@ -263,6 +267,7 @@ void use(void) {
   BidiStruct_t bidiStruct = {.field = explicitly_single5};
   // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single5'}}
   BidiStruct_t bidiStruct2 = {.field = implicitly_single5};
+  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   BidiStruct_t bidiStruct3 = {.field = SINGLE_EXPR};
   // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single5'}}
   BidiStruct_t bidiStruct4 = {.field = bigger_explicit_single5};
@@ -278,6 +283,7 @@ void use(void) {
   IdxStruct_t idxStruct = {.field = explicitly_single7};
   // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single7'}}
   IdxStruct_t idxStruct2 = {.field = implicitly_single7};
+  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   IdxStruct_t idxStruct3 = {.field = SINGLE_EXPR};
   // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single7'}}
   IdxStruct_t idxStruct4 = {.field = bigger_explicit_single7};
@@ -305,6 +311,7 @@ void use(void) {
   explicit_bidi = implicitly_single10;
   // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single10'}}
   explicit_bidi = explicitly_single10;
+  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   explicit_bidi = SINGLE_EXPR;
   // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single10'}}
   explicit_bidi = bigger_explicit_single10;
@@ -321,6 +328,7 @@ void use(void) {
   explicit_idx = implicitly_single24;
   // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single24'}}
   explicit_idx = explicitly_single24;
+  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   explicit_idx = SINGLE_EXPR;
   // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single24'}}
   explicit_idx = bigger_explicit_single24;
@@ -337,6 +345,7 @@ void use(void) {
   bidiStruct.field = implicitly_single12;
   // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single12'}}
   bidiStruct.field = explicitly_single12;
+  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   bidiStruct.field = SINGLE_EXPR;
   // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single12'}}
   bidiStruct.field = bigger_explicit_single12;
@@ -352,6 +361,7 @@ void use(void) {
   idxStruct.field = implicitly_single14;
   // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single14'}}
   idxStruct.field = explicitly_single14;
+  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   idxStruct.field = SINGLE_EXPR;
   // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single14'}}
   idxStruct.field = bigger_explicit_single14;
@@ -370,6 +380,7 @@ void use(void) {
   take_bidi0(implicitly_single16);
   // expected-warning@+1{{passing __single type 'int **__single' to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single16'}}
   take_bidi1(explicitly_single16);
+  // expected-warning@+1{{passing __single type 'int *__single*__single' to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   take_bidi2(SINGLE_EXPR);
   // expected-warning@+1{{passing __single type 'uint64_t **__single' (aka 'unsigned long **__single') to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single16'}}
   take_bidi3(bigger_explicit_single16);
@@ -386,6 +397,7 @@ void use(void) {
   take_idx0(implicitly_single18);
   // expected-warning@+1{{passing __single type 'int **__single' to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single18'}}
   take_idx1(explicitly_single18);
+  // expected-warning@+1{{passing __single type 'int *__single*__single' to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   take_idx2(SINGLE_EXPR);
   // expected-warning@+1{{passing __single type 'uint64_t **__single' (aka 'unsigned long **__single') to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single18'}}
   take_idx3(bigger_explicit_single18);
@@ -413,6 +425,7 @@ int **__bidi_indexable warn_ret_bidi_impl(void) {
 }
 
 int **__bidi_indexable warn_ret_bidi_single_expr(void) {
+  // expected-warning@+1{{returning __single type 'int *__single*__single' from a function with __bidi_indexable result type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   return SINGLE_EXPR;
 }
 
@@ -457,6 +470,7 @@ int **__indexable warn_ret_idx_impl(void) {
 }
 
 int **__indexable warn_ret_idx_single_expr(void) {
+  // expected-warning@+1{{returning __single type 'int *__single*__single' from a function with __indexable result type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   return SINGLE_EXPR;
 }
 

--- a/clang/test/BoundsSafety/Sema/implicit-single-to-explicit-indexable-conversion-nested.c
+++ b/clang/test/BoundsSafety/Sema/implicit-single-to-explicit-indexable-conversion-nested.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 
 #include <ptrcheck.h>
@@ -21,7 +20,6 @@
 void take_bidi0(int **__bidi_indexable b_arg0);
 // expected-note@+1{{passing argument to parameter 'b_arg1' here}}
 void take_bidi1(int **__bidi_indexable b_arg1);
-// expected-note@+1{{passing argument to parameter 'b_arg2' here}}
 void take_bidi2(int **__bidi_indexable b_arg2);
 // expected-note@+1{{passing argument to parameter 'b_arg3' here}}
 void take_bidi3(int **__bidi_indexable b_arg3);
@@ -40,7 +38,6 @@ void take_bidi5(int **__bidi_indexable b_arg5);
 void take_idx0(int **__indexable i_arg0);
 // expected-note@+1{{passing argument to parameter 'i_arg1' here}}
 void take_idx1(int **__indexable i_arg1);
-// expected-note@+1{{passing argument to parameter 'i_arg2' here}}
 void take_idx2(int **__indexable i_arg2);
 // expected-note@+1{{passing argument to parameter 'i_arg3' here}}
 void take_idx3(int **__indexable i_arg3);
@@ -228,19 +225,18 @@ void use(void) {
   int **implicit_bidi3 = SINGLE_EXPR;        // no warning
   // Note: This is a different warning than this test is really intended to test
   // but we test it here for completeness.
-  // expected-error@+1{{incompatible pointer types initializing 'int *__single*__bidi_indexable' with an expression of type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single')}}
+  // expected-error@+1{{incompatible pointer types initializing 'int *__single*__bidi_indexable' with an expression of type 'uint64_t **__single' (aka 'unsigned long **__single')}}
   int **implicit_bidi4 = bigger_explicit_single0;
   int **implicit_bidi5 = returns_explicit_single(); // no warning
 
-  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single1'}}
+  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single1'}}
   int **__bidi_indexable explicit_bidi = explicitly_single1;
   // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single1'}}
   int **__bidi_indexable explicit_bidi2 = implicitly_single1;
-  // expected-warning-re@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   int **__bidi_indexable explicit_bidi3 = SINGLE_EXPR;
-  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single1'}}
+  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single1'}}
   int **__bidi_indexable explicit_bidi4 = bigger_explicit_single1;
-  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   int **__bidi_indexable explicit_bidi5 = returns_explicit_single();
   int **__bidi_indexable explicit_bidi6 = (int **__bidi_indexable)explicitly_single2;         // no warning
   int **__bidi_indexable explicit_bidi7 = (int **__bidi_indexable)implicitly_single2;         // no warning
@@ -248,15 +244,14 @@ void use(void) {
   int **__bidi_indexable explicit_bidi9 = (int **__bidi_indexable)bigger_explicit_single2;    // no warning
   int **__bidi_indexable explicit_bidi10 = (int **__bidi_indexable)returns_explicit_single(); // no warning
 
-  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single3'}}
+  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single3'}}
   int **__indexable explicit_idx = explicitly_single3;
   // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single3'}}
   int **__indexable explicit_idx2 = implicitly_single3;
-  // expected-warning-re@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   int **__indexable explicit_idx3 = SINGLE_EXPR;
-  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single3'}}
+  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single3'}}
   int **__indexable explicit_idx4 = bigger_explicit_single3;
-  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   int **__indexable explicit_idx5 = returns_explicit_single();
   int **__indexable explicit_idx6 = (int **__indexable)explicitly_single4;         // no warning
   int **__indexable explicit_idx7 = (int **__indexable)implicitly_single4;         // no warning
@@ -264,15 +259,14 @@ void use(void) {
   int **__indexable explicit_idx9 = (int **__indexable)bigger_explicit_single4;    // no warning
   int **__indexable explicit_idx10 = (int **__indexable)returns_explicit_single(); // no warning
 
-  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single5'}}
+  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single5'}}
   BidiStruct_t bidiStruct = {.field = explicitly_single5};
   // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single5'}}
   BidiStruct_t bidiStruct2 = {.field = implicitly_single5};
-  // expected-warning-re@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   BidiStruct_t bidiStruct3 = {.field = SINGLE_EXPR};
-  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single5'}}
+  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single5'}}
   BidiStruct_t bidiStruct4 = {.field = bigger_explicit_single5};
-  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{initializing __bidi_indexable type 'int *__single*__bidi_indexable' with an expression of __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   BidiStruct_t bidiStruct5 = {.field = returns_explicit_single()};
   BidiStruct_t bidiStruct6 = {.field = (int **__bidi_indexable)explicitly_single6};         // no warning
   BidiStruct_t bidiStruct7 = {.field = (int **__bidi_indexable)implicitly_single6};         // no warning
@@ -280,15 +274,14 @@ void use(void) {
   BidiStruct_t bidiStruct9 = {.field = (int **__bidi_indexable)bigger_explicit_single6};    // no warning
   BidiStruct_t bidiStruct10 = {.field = (int **__bidi_indexable)returns_explicit_single()}; // no warning
 
-  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single7'}}
+  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single7'}}
   IdxStruct_t idxStruct = {.field = explicitly_single7};
   // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single7'}}
   IdxStruct_t idxStruct2 = {.field = implicitly_single7};
-  // expected-warning-re@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   IdxStruct_t idxStruct3 = {.field = SINGLE_EXPR};
-  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single7'}}
+  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single7'}}
   IdxStruct_t idxStruct4 = {.field = bigger_explicit_single7};
-  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{initializing __indexable type 'int *__single*__indexable' with an expression of __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   IdxStruct_t idxStruct5 = {.field = returns_explicit_single()};
   IdxStruct_t idxStruct6 = {.field = (int **__indexable)explicitly_single8};         // no warning
   IdxStruct_t idxStruct7 = {.field = (int **__indexable)implicitly_single8};         // no warning
@@ -304,19 +297,18 @@ void use(void) {
   implicit_bidi = SINGLE_EXPR;        // no warning
   // Note: This is a different warning than this test is really intended to test
   // but we test it here for completeness.
-  // expected-error@+1{{incompatible pointer types assigning to 'int *__single*__bidi_indexable' from 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single')}}
+  // expected-error@+1{{incompatible pointer types assigning to 'int *__single*__bidi_indexable' from 'uint64_t **__single' (aka 'unsigned long **__single')}}
   implicit_bidi = bigger_explicit_single9;
   implicit_bidi = returns_explicit_single(); // no warning
 
   // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single10'}}
   explicit_bidi = implicitly_single10;
-  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single10'}}
+  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single10'}}
   explicit_bidi = explicitly_single10;
-  // expected-warning-re@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   explicit_bidi = SINGLE_EXPR;
-  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single10'}}
+  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single10'}}
   explicit_bidi = bigger_explicit_single10;
-  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   explicit_bidi = returns_explicit_single();
 
   explicit_bidi = (int **__bidi_indexable)implicitly_single11;       // no warning
@@ -327,13 +319,12 @@ void use(void) {
 
   // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single24'}}
   explicit_idx = implicitly_single24;
-  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single24'}}
+  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single24'}}
   explicit_idx = explicitly_single24;
-  // expected-warning-re@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   explicit_idx = SINGLE_EXPR;
-  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single24'}}
+  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single24'}}
   explicit_idx = bigger_explicit_single24;
-  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   explicit_idx = returns_explicit_single();
 
   explicit_idx = (int **__indexable)implicitly_single25;       // no warning
@@ -344,13 +335,12 @@ void use(void) {
 
   // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single12'}}
   bidiStruct.field = implicitly_single12;
-  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single12'}}
+  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single12'}}
   bidiStruct.field = explicitly_single12;
-  // expected-warning-re@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   bidiStruct.field = SINGLE_EXPR;
-  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single12'}}
+  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single12'}}
   bidiStruct.field = bigger_explicit_single12;
-  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int *__single*__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{assigning to __bidi_indexable type 'int *__single*__bidi_indexable' from __single type 'int **__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   bidiStruct.field = returns_explicit_single();
   bidiStruct.field = (int **__bidi_indexable)implicitly_single13;       // no warning
   bidiStruct.field = (int **__bidi_indexable)explicitly_single13;       // no warning
@@ -360,13 +350,12 @@ void use(void) {
 
   // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single14'}}
   idxStruct.field = implicitly_single14;
-  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single14'}}
+  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single14'}}
   idxStruct.field = explicitly_single14;
-  // expected-warning-re@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   idxStruct.field = SINGLE_EXPR;
-  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single14'}}
+  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'uint64_t **__single' (aka 'unsigned long **__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single14'}}
   idxStruct.field = bigger_explicit_single14;
-  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int *__single*__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{assigning to __indexable type 'int *__single*__indexable' from __single type 'int **__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   idxStruct.field = returns_explicit_single();
   idxStruct.field = (int **__indexable)implicitly_single15;       // no warning
   idxStruct.field = (int **__indexable)explicitly_single15;       // no warning
@@ -379,13 +368,12 @@ void use(void) {
   //--------------------------------------------------------------------------
   // expected-warning@+1{{passing __single type 'int *__single*__single' to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single16'}}
   take_bidi0(implicitly_single16);
-  // expected-warning@+1{{passing __single type 'int *__single*__single' to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single16'}}
+  // expected-warning@+1{{passing __single type 'int **__single' to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single16'}}
   take_bidi1(explicitly_single16);
-  // expected-warning-re@+1{{passing __single type 'int *__single*__single' to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   take_bidi2(SINGLE_EXPR);
-  // expected-warning@+1{{passing __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single16'}}
+  // expected-warning@+1{{passing __single type 'uint64_t **__single' (aka 'unsigned long **__single') to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single16'}}
   take_bidi3(bigger_explicit_single16);
-  // expected-warning@+1{{passing __single type 'int *__single*__single' to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{passing __single type 'int **__single' to parameter of __bidi_indexable type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   take_bidi4(returns_explicit_single());
 
   take_bidi5((int **__bidi_indexable)implicitly_single17);       // no warning
@@ -396,13 +384,12 @@ void use(void) {
 
   // expected-warning@+1{{passing __single type 'int *__single*__single' to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single18'}}
   take_idx0(implicitly_single18);
-  // expected-warning@+1{{passing __single type 'int *__single*__single' to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single18'}}
+  // expected-warning@+1{{passing __single type 'int **__single' to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single18'}}
   take_idx1(explicitly_single18);
-  // expected-warning-re@+1{{passing __single type 'int *__single*__single' to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   take_idx2(SINGLE_EXPR);
-  // expected-warning@+1{{passing __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single18'}}
+  // expected-warning@+1{{passing __single type 'uint64_t **__single' (aka 'unsigned long **__single') to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single18'}}
   take_idx3(bigger_explicit_single18);
-  // expected-warning@+1{{passing __single type 'int *__single*__single' to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{passing __single type 'int **__single' to parameter of __indexable type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   take_idx4(returns_explicit_single());
 
   take_idx5((int **__indexable)implicitly_single19);       // no warning
@@ -416,7 +403,7 @@ void use(void) {
 // Implicit conversion on return
 //--------------------------------------------------------------------------
 int **__bidi_indexable warn_ret_bidi_expl(void) {
-  // expected-warning@+1{{returning __single type 'int *__single*__single' from a function with __bidi_indexable result type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single20'}}
+  // expected-warning@+1{{returning __single type 'int **__single' from a function with __bidi_indexable result type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single20'}}
   return explicitly_single20;
 }
 
@@ -426,17 +413,16 @@ int **__bidi_indexable warn_ret_bidi_impl(void) {
 }
 
 int **__bidi_indexable warn_ret_bidi_single_expr(void) {
-  // expected-warning-re@+1{{returning __single type 'int *__single*__single' from a function with __bidi_indexable result type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   return SINGLE_EXPR;
 }
 
 int **__bidi_indexable warn_ret_bidi_bigger_explicit(void) {
-  // expected-warning@+1{{returning __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') from a function with __bidi_indexable result type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single20'}}
+  // expected-warning@+1{{returning __single type 'uint64_t **__single' (aka 'unsigned long **__single') from a function with __bidi_indexable result type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single20'}}
   return bigger_explicit_single20;
 }
 
 int **__bidi_indexable warn_ret_bidi_tail_call_ret_single(void) {
-  // expected-warning@+1{{returning __single type 'int *__single*__single' from a function with __bidi_indexable result type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{returning __single type 'int **__single' from a function with __bidi_indexable result type 'int *__single*__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   return returns_explicit_single();
 }
 
@@ -461,7 +447,7 @@ int **__bidi_indexable no_warn_ret_bidi_tail_call_ret_single(void) {
 }
 
 int **__indexable warn_ret_idx_expl(void) {
-  // expected-warning@+1{{returning __single type 'int *__single*__single' from a function with __indexable result type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single22'}}
+  // expected-warning@+1{{returning __single type 'int **__single' from a function with __indexable result type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single22'}}
   return explicitly_single22;
 }
 
@@ -471,17 +457,16 @@ int **__indexable warn_ret_idx_impl(void) {
 }
 
 int **__indexable warn_ret_idx_single_expr(void) {
-  // expected-warning-re@+1{{returning __single type 'int *__single*__single' from a function with __indexable result type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   return SINGLE_EXPR;
 }
 
 int **__indexable warn_ret_idx_bigger_explicit(void) {
-  // expected-warning@+1{{returning __single type 'uint64_t *__single*__single' (aka 'unsigned long *__single*__single') from a function with __indexable result type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single22'}}
+  // expected-warning@+1{{returning __single type 'uint64_t **__single' (aka 'unsigned long **__single') from a function with __indexable result type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single22'}}
   return bigger_explicit_single22;
 }
 
 int **__indexable warn_ret_idx_tail_call_ret_single(void) {
-  // expected-warning@+1{{eturning __single type 'int *__single*__single' from a function with __indexable result type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
+  // expected-warning@+1{{returning __single type 'int **__single' from a function with __indexable result type 'int *__single*__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   return returns_explicit_single();
 }
 

--- a/clang/test/BoundsSafety/Sema/implicit-single-to-explicit-indexable-conversion.c
+++ b/clang/test/BoundsSafety/Sema/implicit-single-to-explicit-indexable-conversion.c
@@ -13,6 +13,7 @@
 void take_bidi0(int *__bidi_indexable b_arg0);
 // expected-note@+1{{passing argument to parameter 'b_arg1' here}}
 void take_bidi1(int *__bidi_indexable b_arg1);
+// expected-note@+1{{passing argument to parameter 'b_arg2' here}}
 void take_bidi2(int *__bidi_indexable b_arg2);
 // expected-note@+1{{passing argument to parameter 'b_arg3' here}}
 void take_bidi3(int *__bidi_indexable b_arg3);
@@ -31,6 +32,7 @@ void take_bidi5(int *__bidi_indexable b_arg5);
 void take_idx0(int *__indexable i_arg0);
 // expected-note@+1{{passing argument to parameter 'i_arg1' here}}
 void take_idx1(int *__indexable i_arg1);
+// expected-note@+1{{passing argument to parameter 'i_arg2' here}}
 void take_idx2(int *__indexable i_arg2);
 // expected-note@+1{{passing argument to parameter 'i_arg3' here}}
 void take_idx3(int *__indexable i_arg3);
@@ -223,6 +225,7 @@ void use(void) {
   int *__bidi_indexable explicit_bidi = explicitly_single1;
   // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single1}}
   int *__bidi_indexable explicit_bidi2 = implicitly_single1;
+  // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   int *__bidi_indexable explicit_bidi3 = SINGLE_EXPR;
   // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'uint64_t *__single' (aka 'unsigned long *__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single1'}}
   int *__bidi_indexable explicit_bidi4 = bigger_explicit_single1;
@@ -238,6 +241,7 @@ void use(void) {
   int *__indexable explicit_idx = explicitly_single3;
   // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single3'}}
   int *__indexable explicit_idx2 = implicitly_single3;
+  // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   int *__indexable explicit_idx3 = SINGLE_EXPR;
   // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'uint64_t *__single' (aka 'unsigned long *__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single3'}}
   int *__indexable explicit_idx4 = bigger_explicit_single3;
@@ -253,6 +257,7 @@ void use(void) {
   BidiStruct_t bidiStruct = {.field = explicitly_single5};
   // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single5'}}
   BidiStruct_t bidiStruct2 = {.field = implicitly_single5};
+  // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   BidiStruct_t bidiStruct3 = {.field = SINGLE_EXPR};
   // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'uint64_t *__single' (aka 'unsigned long *__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single5'}}
   BidiStruct_t bidiStruct4 = {.field = bigger_explicit_single5};
@@ -268,6 +273,7 @@ void use(void) {
   IdxStruct_t idxStruct = {.field = explicitly_single7};
   // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single7'}}
   IdxStruct_t idxStruct2 = {.field = implicitly_single7};
+  // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   IdxStruct_t idxStruct3 = {.field = SINGLE_EXPR};
   // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'uint64_t *__single' (aka 'unsigned long *__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single7'}}
   IdxStruct_t idxStruct4 = {.field = bigger_explicit_single7};
@@ -295,6 +301,7 @@ void use(void) {
   explicit_bidi = implicitly_single10;
   // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single10'}}
   explicit_bidi = explicitly_single10;
+  // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   explicit_bidi = SINGLE_EXPR;
   // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'uint64_t *__single' (aka 'unsigned long *__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single10'}}
   explicit_bidi = bigger_explicit_single10;
@@ -311,6 +318,7 @@ void use(void) {
   explicit_idx = implicitly_single24;
   // expected-warning@+1{{assigning to type 'int *__indexable' from type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single24'}}
   explicit_idx = explicitly_single24;
+  // expected-warning@+1{{assigning to type 'int *__indexable' from type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   explicit_idx = SINGLE_EXPR;
   // expected-warning@+1{{assigning to type 'int *__indexable' from type 'uint64_t *__single' (aka 'unsigned long *__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single24'}}
   explicit_idx = bigger_explicit_single24;
@@ -327,6 +335,7 @@ void use(void) {
   bidiStruct.field = implicitly_single12;
   // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single12'}}
   bidiStruct.field = explicitly_single12;
+  // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   bidiStruct.field = SINGLE_EXPR;
   // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'uint64_t *__single' (aka 'unsigned long *__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single12'}}
   bidiStruct.field = bigger_explicit_single12;
@@ -342,6 +351,7 @@ void use(void) {
   idxStruct.field = implicitly_single14;
   // expected-warning@+1{{assigning to type 'int *__indexable' from type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single14'}}
   idxStruct.field = explicitly_single14;
+  // expected-warning@+1{{assigning to type 'int *__indexable' from type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   idxStruct.field = SINGLE_EXPR;
   // expected-warning@+1{{assigning to type 'int *__indexable' from type 'uint64_t *__single' (aka 'unsigned long *__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single14'}}
   idxStruct.field = bigger_explicit_single14;
@@ -360,6 +370,7 @@ void use(void) {
   take_bidi0(implicitly_single16);
   // expected-warning@+1{{passing type 'int *__single' to parameter of type 'int *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single16'}}
   take_bidi1(explicitly_single16);
+  // expected-warning@+1{{passing type 'int *__single' to parameter of type 'int *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   take_bidi2(SINGLE_EXPR);
   // expected-warning@+1{{passing type 'uint64_t *__single' (aka 'unsigned long *__single') to parameter of type 'int *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single16'}}
   take_bidi3(bigger_explicit_single16);
@@ -376,6 +387,7 @@ void use(void) {
   take_idx0(implicitly_single18);
   // expected-warning@+1{{passing type 'int *__single' to parameter of type 'int *__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single18'}}
   take_idx1(explicitly_single18);
+  // expected-warning@+1{{passing type 'int *__single' to parameter of type 'int *__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   take_idx2(SINGLE_EXPR);
   // expected-warning@+1{{passing type 'uint64_t *__single' (aka 'unsigned long *__single') to parameter of type 'int *__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single18'}}
   take_idx3(bigger_explicit_single18);
@@ -403,6 +415,7 @@ int *__bidi_indexable warn_ret_bidi_impl(void) {
 }
 
 int *__bidi_indexable warn_ret_bidi_single_expr(void) {
+  // expected-warning@+1{{returning type 'int *__single' from a function with result type 'int *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced}}
   return SINGLE_EXPR;
 }
 
@@ -447,6 +460,7 @@ int *__indexable warn_ret_idx_impl(void) {
 }
 
 int *__indexable warn_ret_idx_single_expr(void) {
+  // expected-warning@+1{{returning type 'int *__single' from a function with result type 'int *__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced}}
   return SINGLE_EXPR;
 }
 

--- a/clang/test/BoundsSafety/Sema/implicit-single-to-explicit-indexable-conversion.c
+++ b/clang/test/BoundsSafety/Sema/implicit-single-to-explicit-indexable-conversion.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-bounds-safety-single-to-indexable-bounds-truncated -verify %s
 
 #include <ptrcheck.h>
@@ -14,7 +13,6 @@
 void take_bidi0(int *__bidi_indexable b_arg0);
 // expected-note@+1{{passing argument to parameter 'b_arg1' here}}
 void take_bidi1(int *__bidi_indexable b_arg1);
-// expected-note@+1{{passing argument to parameter 'b_arg2' here}}
 void take_bidi2(int *__bidi_indexable b_arg2);
 // expected-note@+1{{passing argument to parameter 'b_arg3' here}}
 void take_bidi3(int *__bidi_indexable b_arg3);
@@ -33,7 +31,6 @@ void take_bidi5(int *__bidi_indexable b_arg5);
 void take_idx0(int *__indexable i_arg0);
 // expected-note@+1{{passing argument to parameter 'i_arg1' here}}
 void take_idx1(int *__indexable i_arg1);
-// expected-note@+1{{passing argument to parameter 'i_arg2' here}}
 void take_idx2(int *__indexable i_arg2);
 // expected-note@+1{{passing argument to parameter 'i_arg3' here}}
 void take_idx3(int *__indexable i_arg3);
@@ -226,7 +223,6 @@ void use(void) {
   int *__bidi_indexable explicit_bidi = explicitly_single1;
   // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single1}}
   int *__bidi_indexable explicit_bidi2 = implicitly_single1;
-  // expected-warning-re@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   int *__bidi_indexable explicit_bidi3 = SINGLE_EXPR;
   // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'uint64_t *__single' (aka 'unsigned long *__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single1'}}
   int *__bidi_indexable explicit_bidi4 = bigger_explicit_single1;
@@ -242,7 +238,6 @@ void use(void) {
   int *__indexable explicit_idx = explicitly_single3;
   // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single3'}}
   int *__indexable explicit_idx2 = implicitly_single3;
-  // expected-warning-re@+1{{initializing type 'int *__indexable' with an expression of type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   int *__indexable explicit_idx3 = SINGLE_EXPR;
   // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'uint64_t *__single' (aka 'unsigned long *__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single3'}}
   int *__indexable explicit_idx4 = bigger_explicit_single3;
@@ -258,7 +253,6 @@ void use(void) {
   BidiStruct_t bidiStruct = {.field = explicitly_single5};
   // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single5'}}
   BidiStruct_t bidiStruct2 = {.field = implicitly_single5};
-  // expected-warning-re@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   BidiStruct_t bidiStruct3 = {.field = SINGLE_EXPR};
   // expected-warning@+1{{initializing type 'int *__bidi_indexable' with an expression of type 'uint64_t *__single' (aka 'unsigned long *__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single5'}}
   BidiStruct_t bidiStruct4 = {.field = bigger_explicit_single5};
@@ -274,7 +268,6 @@ void use(void) {
   IdxStruct_t idxStruct = {.field = explicitly_single7};
   // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'implicitly_single7'}}
   IdxStruct_t idxStruct2 = {.field = implicitly_single7};
-  // expected-warning-re@+1{{initializing type 'int *__indexable' with an expression of type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   IdxStruct_t idxStruct3 = {.field = SINGLE_EXPR};
   // expected-warning@+1{{initializing type 'int *__indexable' with an expression of type 'uint64_t *__single' (aka 'unsigned long *__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single7'}}
   IdxStruct_t idxStruct4 = {.field = bigger_explicit_single7};
@@ -302,7 +295,6 @@ void use(void) {
   explicit_bidi = implicitly_single10;
   // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single10'}}
   explicit_bidi = explicitly_single10;
-  // expected-warning-re@+1{{assigning to type 'int *__bidi_indexable' from type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   explicit_bidi = SINGLE_EXPR;
   // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'uint64_t *__single' (aka 'unsigned long *__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single10'}}
   explicit_bidi = bigger_explicit_single10;
@@ -319,7 +311,6 @@ void use(void) {
   explicit_idx = implicitly_single24;
   // expected-warning@+1{{assigning to type 'int *__indexable' from type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single24'}}
   explicit_idx = explicitly_single24;
-  // expected-warning-re@+1{{assigning to type 'int *__indexable' from type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   explicit_idx = SINGLE_EXPR;
   // expected-warning@+1{{assigning to type 'int *__indexable' from type 'uint64_t *__single' (aka 'unsigned long *__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single24'}}
   explicit_idx = bigger_explicit_single24;
@@ -336,7 +327,6 @@ void use(void) {
   bidiStruct.field = implicitly_single12;
   // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single12'}}
   bidiStruct.field = explicitly_single12;
-  // expected-warning-re@+1{{assigning to type 'int *__bidi_indexable' from type 'int *__single' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   bidiStruct.field = SINGLE_EXPR;
   // expected-warning@+1{{assigning to type 'int *__bidi_indexable' from type 'uint64_t *__single' (aka 'unsigned long *__single') results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single12'}}
   bidiStruct.field = bigger_explicit_single12;
@@ -352,7 +342,6 @@ void use(void) {
   idxStruct.field = implicitly_single14;
   // expected-warning@+1{{assigning to type 'int *__indexable' from type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single14'}}
   idxStruct.field = explicitly_single14;
-  // expected-warning-re@+1{{assigning to type 'int *__indexable' from type 'int *__single' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   idxStruct.field = SINGLE_EXPR;
   // expected-warning@+1{{assigning to type 'int *__indexable' from type 'uint64_t *__single' (aka 'unsigned long *__single') results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single14'}}
   idxStruct.field = bigger_explicit_single14;
@@ -371,7 +360,6 @@ void use(void) {
   take_bidi0(implicitly_single16);
   // expected-warning@+1{{passing type 'int *__single' to parameter of type 'int *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single16'}}
   take_bidi1(explicitly_single16);
-  // expected-warning-re@+1{{passing type 'int *__single' to parameter of type 'int *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   take_bidi2(SINGLE_EXPR);
   // expected-warning@+1{{passing type 'uint64_t *__single' (aka 'unsigned long *__single') to parameter of type 'int *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single16'}}
   take_bidi3(bigger_explicit_single16);
@@ -388,7 +376,6 @@ void use(void) {
   take_idx0(implicitly_single18);
   // expected-warning@+1{{passing type 'int *__single' to parameter of type 'int *__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'explicitly_single18'}}
   take_idx1(explicitly_single18);
-  // expected-warning-re@+1{{passing type 'int *__single' to parameter of type 'int *__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   take_idx2(SINGLE_EXPR);
   // expected-warning@+1{{passing type 'uint64_t *__single' (aka 'unsigned long *__single') to parameter of type 'int *__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'bigger_explicit_single18'}}
   take_idx3(bigger_explicit_single18);
@@ -416,7 +403,6 @@ int *__bidi_indexable warn_ret_bidi_impl(void) {
 }
 
 int *__bidi_indexable warn_ret_bidi_single_expr(void) {
-  // expected-warning-re@+1{{returning type 'int *__single' from a function with result type 'int *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   return SINGLE_EXPR;
 }
 
@@ -461,7 +447,6 @@ int *__indexable warn_ret_idx_impl(void) {
 }
 
 int *__indexable warn_ret_idx_single_expr(void) {
-  // expected-warning-re@+1{{returning type 'int *__single' from a function with result type 'int *__indexable' results in an __indexable pointer that will trap if a non-zero offset is dereferenced{{$}}}}
   return SINGLE_EXPR;
 }
 

--- a/clang/test/BoundsSafety/Sema/incompatible-ptr-casts-no-implicit-bound.c
+++ b/clang/test/BoundsSafety/Sema/incompatible-ptr-casts-no-implicit-bound.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 #include <ptrcheck.h>
@@ -47,6 +46,5 @@ void Test () {
 
     // expected-error@+1{{conversion between pointers to functions with incompatible bound attributes}}
     bar_t fp1 = foo;
-    // expected-error@+1{{conversion between pointers to functions with incompatible bound attributes}}
     baz_t fp2 = foo;
 }

--- a/clang/test/BoundsSafety/Sema/incomplete-single-to-indexable.c
+++ b/clang/test/BoundsSafety/Sema/incomplete-single-to-indexable.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -triple aarch64-none-linux-gnu -target-feature +sve -mvscale-min=4 -mvscale-max=4 -flax-vector-conversions=none -ffreestanding -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -triple aarch64-none-linux-gnu -target-feature +sve -mvscale-min=4 -mvscale-max=4 -flax-vector-conversions=none -ffreestanding -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
@@ -13,7 +12,7 @@ oq_struct_t __unsafe_indexable foo();
 
 oq_struct_t test() {
   oq_struct_t local = 0; // expected-note{{pointer 'local' declared here}}
-  // expected-error@+1{{cannot assign to indexable pointer with type 'struct oq_struct *__bidi_indexable' from __single pointer to incomplete type 'oq_struct_t __single' (aka 'struct oq_struct *__single'); consider declaring pointer 'local' as '__single'}}
+  // expected-error@+1{{cannot assign to indexable pointer with type 'struct oq_struct *__bidi_indexable' from __single pointer to incomplete type 'struct oq_struct *__single'; consider declaring pointer 'local' as '__single'}}
   local = __unsafe_forge_single(oq_struct_t, foo());
   return local;
 }

--- a/clang/test/BoundsSafety/Sema/incomplete-single-to-indexable.c
+++ b/clang/test/BoundsSafety/Sema/incomplete-single-to-indexable.c
@@ -12,7 +12,7 @@ oq_struct_t __unsafe_indexable foo();
 
 oq_struct_t test() {
   oq_struct_t local = 0; // expected-note{{pointer 'local' declared here}}
-  // expected-error@+1{{cannot assign to indexable pointer with type 'struct oq_struct *__bidi_indexable' from __single pointer to incomplete type 'struct oq_struct *__single'; consider declaring pointer 'local' as '__single'}}
+  // expected-error@+1{{cannot assign to indexable pointer with type 'struct oq_struct *__bidi_indexable' from __single pointer to incomplete type 'oq_struct_t __single' (aka 'struct oq_struct *__single'); consider declaring pointer 'local' as '__single'}}
   local = __unsafe_forge_single(oq_struct_t, foo());
   return local;
 }

--- a/clang/test/BoundsSafety/Sema/non-bounds-safety-attrs/attrs_and_qualifiers.c
+++ b/clang/test/BoundsSafety/Sema/non-bounds-safety-attrs/attrs_and_qualifiers.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-intrinsics -fbounds-safety -fsyntax-only -ast-dump %s | FileCheck %s
 // RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-intrinsics -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -fsyntax-only -ast-dump %s | FileCheck %s
 #include <ptrcheck.h>
@@ -14,66 +12,66 @@ const int * __ptrauth(2, 0, 0) auto_global_var3;
 // CHECK: auto_global_var3 'const int *__single__ptrauth(2,0,0)'
 
 const int * __single global_var1;
-// CHECK: global_var1 'const int *__single'
+// CHECK: global_var1 'const int *__single':'const int *'
 
 const int * _Nullable __single global_var2;
-// CHECK: global_var2 'const int *__single _Nullable':'const int *__single'
+// CHECK: global_var2 'const int *__single _Nullable':'const int *'
 
 const int * __ptrauth(2, 0, 0) __single global_var3;
-// CHECK: global_var3 'const int *__single__ptrauth(2,0,0)'
+// CHECK: global_var3 'const int *__single__ptrauth(2,0,0)':'const int *__ptrauth(2,0,0)'
 
 
 const int * _Nullable __ptrauth(2, 0, 0) __single c1_global_var1;
-// CHECK: c1_global_var1 'const int *__single _Nullable __ptrauth(2,0,0)':'const int *__single__ptrauth(2,0,0)'
+// CHECK: c1_global_var1 'const int *__single _Nullable __ptrauth(2,0,0)':'const int *__ptrauth(2,0,0)'
 
 const int * _Nullable __single __ptrauth(2, 0, 0) c1_global_var2;
-// CHECK: c1_global_var2 'const int *__single _Nullable __ptrauth(2,0,0)':'const int *__single__ptrauth(2,0,0)'
+// CHECK: c1_global_var2 'const int *__single _Nullable __ptrauth(2,0,0)':'const int *__ptrauth(2,0,0)'
 
 const int * __ptrauth(2, 0, 0) _Nullable __single c1_global_var3;
-// CHECK: c1_global_var3 'const int *__single__ptrauth(2,0,0) _Nullable':'const int *__single__ptrauth(2,0,0)'
+// CHECK: c1_global_var3 'const int *__single__ptrauth(2,0,0) _Nullable':'const int *__ptrauth(2,0,0)'
 
 const int * __ptrauth(2, 0, 0) __single _Nullable c1_global_var4;
-// CHECK: c1_global_var4 'const int *__single__ptrauth(2,0,0) _Nullable':'const int *__single__ptrauth(2,0,0)'
+// CHECK: c1_global_var4 'const int *__single__ptrauth(2,0,0) _Nullable':'const int *__ptrauth(2,0,0)'
 
 const int * __single __ptrauth(2, 0, 0) _Nullable c1_global_var5;
-// CHECK: c1_global_var5 'const int *__single__ptrauth(2,0,0) _Nullable':'const int *__single__ptrauth(2,0,0)'
+// CHECK: c1_global_var5 'const int *__single__ptrauth(2,0,0) _Nullable':'const int *__ptrauth(2,0,0)'
 
 const int * __single _Nullable __ptrauth(2, 0, 0) c1_global_var6;
-// CHECK: c1_global_var6 'const int *__single _Nullable __ptrauth(2,0,0)':'const int *__single__ptrauth(2,0,0)'
+// CHECK: c1_global_var6 'const int *__single _Nullable __ptrauth(2,0,0)':'const int *__ptrauth(2,0,0)'
 
 
 int * const _Nullable __ptrauth(2, 0, 0) __single c2_global_var1;
-// CHECK: c2_global_var1 'int *__singleconst  _Nullable __ptrauth(2,0,0)':'int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c2_global_var1 'int *__singleconst  _Nullable __ptrauth(2,0,0)':'int *const __ptrauth(2,0,0)'
 
 int * const _Nullable __single __ptrauth(2, 0, 0) c2_global_var2;
-// CHECK: c2_global_var2 'int *__singleconst  _Nullable __ptrauth(2,0,0)':'int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c2_global_var2 'int *__singleconst  _Nullable __ptrauth(2,0,0)':'int *const __ptrauth(2,0,0)'
 
 int * const __ptrauth(2, 0, 0) _Nullable __single c2_global_var3;
-// CHECK: c2_global_var3 'int *__singleconst __ptrauth(2,0,0) _Nullable':'int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c2_global_var3 'int *__singleconst __ptrauth(2,0,0) _Nullable':'int *const __ptrauth(2,0,0)'
 
 int * const __ptrauth(2, 0, 0) __single _Nullable c2_global_var4;
-// CHECK: c2_global_var4 'int *__singleconst __ptrauth(2,0,0) _Nullable':'int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c2_global_var4 'int *__singleconst __ptrauth(2,0,0) _Nullable':'int *const __ptrauth(2,0,0)'
 
 int * const __single __ptrauth(2, 0, 0) _Nullable c2_global_var5;
-// CHECK: c2_global_var5 'int *__singleconst __ptrauth(2,0,0) _Nullable':'int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c2_global_var5 'int *__singleconst __ptrauth(2,0,0) _Nullable':'int *const __ptrauth(2,0,0)'
 
 int * const __single _Nullable __ptrauth(2, 0, 0) c2_global_var6;
-// CHECK: c2_global_var6 'int *__singleconst _Nullable __ptrauth(2,0,0)':'int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c2_global_var6 'int *__singleconst _Nullable __ptrauth(2,0,0)':'int *const __ptrauth(2,0,0)'
 
 
 const int * const _Nullable __ptrauth(2, 0, 0) __single c12_global_var1;
-// CHECK: c12_global_var1 'const int *__singleconst _Nullable __ptrauth(2,0,0)':'const int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c12_global_var1 'const int *__singleconst _Nullable __ptrauth(2,0,0)':'const int *const __ptrauth(2,0,0)'
 const int * const _Nullable __single __ptrauth(2, 0, 0) c12_global_var2;
-// CHECK: c12_global_var2 'const int *__singleconst  _Nullable __ptrauth(2,0,0)':'const int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c12_global_var2 'const int *__singleconst  _Nullable __ptrauth(2,0,0)':'const int *const __ptrauth(2,0,0)'
 
 const int * const __ptrauth(2, 0, 0) _Nullable __single c12_global_var3;
-// CHECK: c12_global_var3 'const int *__singleconst __ptrauth(2,0,0) _Nullable':'const int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c12_global_var3 'const int *__singleconst __ptrauth(2,0,0) _Nullable':'const int *const __ptrauth(2,0,0)'
 
 const int * const __ptrauth(2, 0, 0) __single _Nullable c12_global_var4;
-// CHECK: c12_global_var4 'const int *__singleconst __ptrauth(2,0,0) _Nullable':'const int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c12_global_var4 'const int *__singleconst __ptrauth(2,0,0) _Nullable':'const int *const __ptrauth(2,0,0)'
 
 const int * const __single __ptrauth(2, 0, 0) _Nullable c12_global_var5;
-// CHECK: c12_global_var5 'const int *__singleconst __ptrauth(2,0,0) _Nullable':'const int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c12_global_var5 'const int *__singleconst __ptrauth(2,0,0) _Nullable':'const int *const __ptrauth(2,0,0)'
 
 const int * const __single _Nullable __ptrauth(2, 0, 0) c12_global_var6;
-// CHECK: c12_global_var6 'const int *__singleconst _Nullable __ptrauth(2,0,0)':'const int *__singleconst __ptrauth(2,0,0)'
+// CHECK: c12_global_var6 'const int *__singleconst _Nullable __ptrauth(2,0,0)':'const int *const __ptrauth(2,0,0)'

--- a/clang/test/BoundsSafety/Sema/non-bounds-safety-attrs/nullability_and_bounds-safety.c
+++ b/clang/test/BoundsSafety/Sema/non-bounds-safety-attrs/nullability_and_bounds-safety.c
@@ -1,14 +1,12 @@
-
-
 // RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-intrinsics -fbounds-safety -fsyntax-only -ast-dump %s | FileCheck %s
 // RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-intrinsics -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -fsyntax-only -ast-dump %s | FileCheck %s
 #include <ptrcheck.h>
 
 int * _Nullable __single global_var1;
-// CHECK: global_var1 'int *__single _Nullable':'int *__single'
+// CHECK: global_var1 'int *__single _Nullable':'int *'
 
 int * __single _Nullable global_var2;
-// CHECK: global_var2 'int *__single _Nullable':'int *__single'
+// CHECK: global_var2 'int *__single _Nullable':'int *'
 
 void f(void) {
   int * _Nullable __bidi_indexable local_var1;
@@ -28,18 +26,18 @@ void f(void) {
 
 struct S {
   int * __single _Nullable member_var1;
-  // CHECK: member_var1 'int *__single _Nullable':'int *__single'
+  // CHECK: member_var1 'int *__single _Nullable':'int *'
 
   int * _Nullable __single member_var2;
-  // CHECK: member_var2 'int *__single _Nullable':'int *__single'
+  // CHECK: member_var2 'int *__single _Nullable':'int *'
 };
 
 union U {
   int * __single _Nullable union_var1;
-  // CHECK: union_var1 'int *__single _Nullable':'int *__single'
+  // CHECK: union_var1 'int *__single _Nullable':'int *'
 
   int * _Nullable __single union_var2;
-  // CHECK: union_var2 'int *__single _Nullable':'int *__single'
+  // CHECK: union_var2 'int *__single _Nullable':'int *'
 };
 
 void foo1(int * _Nonnull __single __counted_by(n) ptr1, unsigned n);

--- a/clang/test/BoundsSafety/Sema/non-bounds-safety-attrs/ptrauth_nullability_bounds-safety.c
+++ b/clang/test/BoundsSafety/Sema/non-bounds-safety-attrs/ptrauth_nullability_bounds-safety.c
@@ -1,26 +1,24 @@
-
-
 // RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-intrinsics -fbounds-safety -fsyntax-only -ast-dump %s | FileCheck %s
 // RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-intrinsics -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -fsyntax-only -ast-dump %s | FileCheck %s
 #include <ptrcheck.h>
 
 int * _Nullable __ptrauth(2, 0, 0) __single global_var1;
-// CHECK: global_var1 'int *__single _Nullable __ptrauth(2,0,0)':'int *__single__ptrauth(2,0,0)'
+// CHECK: global_var1 'int *__single _Nullable __ptrauth(2,0,0)':'int *__ptrauth(2,0,0)'
 
 int * _Nullable __single __ptrauth(2, 0, 0) global_var2;
-// CHECK: global_var2 'int *__single _Nullable __ptrauth(2,0,0)':'int *__single__ptrauth(2,0,0)'
+// CHECK: global_var2 'int *__single _Nullable __ptrauth(2,0,0)':'int *__ptrauth(2,0,0)'
 
 int * __ptrauth(2, 0, 0) _Nullable __single global_var3;
-// CHECK: global_var3 'int *__single__ptrauth(2,0,0) _Nullable':'int *__single__ptrauth(2,0,0)'
+// CHECK: global_var3 'int *__single__ptrauth(2,0,0) _Nullable':'int *__ptrauth(2,0,0)'
 
 int * __ptrauth(2, 0, 0) __single _Nullable global_var4;
-// CHECK: global_var4 'int *__single__ptrauth(2,0,0) _Nullable':'int *__single__ptrauth(2,0,0)'
+// CHECK: global_var4 'int *__single__ptrauth(2,0,0) _Nullable':'int *__ptrauth(2,0,0)'
 
 int * __single __ptrauth(2, 0, 0) _Nullable global_var5;
-// CHECK: global_var5 'int *__single__ptrauth(2,0,0) _Nullable':'int *__single__ptrauth(2,0,0)'
+// CHECK: global_var5 'int *__single__ptrauth(2,0,0) _Nullable':'int *__ptrauth(2,0,0)'
 
 int * __single _Nullable __ptrauth(2, 0, 0) global_var6;
-// CHECK: global_var6 'int *__single _Nullable __ptrauth(2,0,0)':'int *__single__ptrauth(2,0,0)'
+// CHECK: global_var6 'int *__single _Nullable __ptrauth(2,0,0)':'int *__ptrauth(2,0,0)'
 
 void foo() {
     int n1 = 0;

--- a/clang/test/BoundsSafety/Sema/single-to-count-ptr-promotion.c
+++ b/clang/test/BoundsSafety/Sema/single-to-count-ptr-promotion.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify=bounds-safety %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify=bounds-safety %s
 
@@ -50,7 +49,7 @@ void bar(int *ptr, int len) {
 void baz(int *__counted_by(len) ptr1, int *__counted_by(1) ptr2, int len) {
   int *__single sp;
   int *__unsafe_indexable up;
-  // bounds-safety-warning@+1{{count value is not statically known: assigning to 'ptr1' of type 'int *__single __counted_by(len)' (aka 'int *__single') from 'int *__single' is invalid for any count other than 0 or 1}}
+  // bounds-safety-warning@+1{{count value is not statically known: assigning to 'ptr1' of type 'int *__single __counted_by(len)' (aka 'int *__single') from 'int *__single' (aka 'int *') is invalid for any count other than 0 or 1}}
   ptr1 = sp;
   // bounds-safety-note@+1{{count assigned here}}
   len = len;
@@ -100,7 +99,7 @@ void bar_nullable(int *ptr, int len) {
 void baz_nullable(int *__counted_by_or_null(len) ptr1, int *__counted_by_or_null(1) ptr2, int len) {
   int *__single sp;
   int *__unsafe_indexable up;
-  // bounds-safety-warning@+1{{count value is not statically known: assigning to 'ptr1' of type 'int *__single __counted_by_or_null(len)' (aka 'int *__single') from 'int *__single' is invalid for any count other than 0 or 1 unless the pointer is null}}
+  // bounds-safety-warning@+1{{count value is not statically known: assigning to 'ptr1' of type 'int *__single __counted_by_or_null(len)' (aka 'int *__single') from 'int *__single' (aka 'int *') is invalid for any count other than 0 or 1 unless the pointer is null}}
   ptr1 = sp;
   // bounds-safety-note@+1{{count assigned here}}
   len = len;

--- a/clang/test/BoundsSafety/Sema/single-to-sized-ptr-promotion.c
+++ b/clang/test/BoundsSafety/Sema/single-to-sized-ptr-promotion.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-bounds-safety-single-to-indexable-bounds-truncated -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-bounds-safety-single-to-indexable-bounds-truncated -x objective-c -fexperimental-bounds-safety-objc -verify %s
 #include <ptrcheck.h>
@@ -55,7 +54,7 @@ void bar(int *ptr, int len) {
 void baz(int *__sized_by(len) ptr1, int *__sized_by(4) ptr2, int len) {
     int *__single sp;
     int *__unsafe_indexable up;
-    // expected-warning@+1{{size value is not statically known: assigning to 'ptr1' of type 'int *__single __sized_by(len)' (aka 'int *__single') from 'int *__single' is invalid for any size greater than 4}}
+    // expected-warning@+1{{size value is not statically known: assigning to 'ptr1' of type 'int *__single __sized_by(len)' (aka 'int *__single') from 'int *__single' (aka 'int *') is invalid for any size greater than 4}}
     ptr1 = sp;
     // expected-note@+1{{size assigned here}}
     len = len;
@@ -88,15 +87,15 @@ void external(struct unsized *__sized_by(size) p, int size);
 void convert_unsized(struct unsized *__single p, int size) {
   // expected-error@+1{{argument of '__sized_by' attribute cannot refer to declaration of a different lifetime}}
   struct unsized *__single __sized_by(size) a = p; // requires explicit __single because of rdar://112196572
-  // expected-warning@+1{{size value is not statically known: passing 'struct unsized *__single' to parameter 'p' of type 'struct unsized *__single __sized_by(size)' (aka 'struct unsized *__single') is invalid for any size greater than 0}}
+  // expected-warning@+1{{size value is not statically known: passing 'struct unsized *__single' (aka 'struct unsized *') to parameter 'p' of type 'struct unsized *__single __sized_by(size)' (aka 'struct unsized *__single') is invalid for any size greater than 0}}
   external(p, size); // expected-note{{size passed here}}
 }
 
 void convert_unsized2(struct unsized *__single p, int size) {
   // expected-note@+1{{size initialized here}}
   int s = size;
-  // expected-warning@+1{{size value is not statically known: initializing 'a' of type 'struct unsized *__single __sized_by(s)' (aka 'struct unsized *__single') with 'struct unsized *__single' is invalid for any size greater than 0}}
+  // expected-warning@+1{{size value is not statically known: initializing 'a' of type 'struct unsized *__single __sized_by(s)' (aka 'struct unsized *__single') with 'struct unsized *__single' (aka 'struct unsized *') is invalid for any size greater than 0}}
   struct unsized *__single __sized_by(s) a = p; // requires explicit __single because of rdar://112196572
-  // expected-warning@+1{{size value is not statically known: passing 'struct unsized *__single' to parameter 'p' of type 'struct unsized *__single __sized_by(size)' (aka 'struct unsized *__single') is invalid for any size greater than 0}}
+  // expected-warning@+1{{size value is not statically known: passing 'struct unsized *__single' (aka 'struct unsized *') to parameter 'p' of type 'struct unsized *__single __sized_by(size)' (aka 'struct unsized *__single') is invalid for any size greater than 0}}
   external(p, size); // expected-note{{size passed here}}
 }

--- a/clang/test/BoundsSafety/Sema/terminated-by-explicit-casts.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-explicit-casts.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
@@ -22,7 +20,7 @@ void dont_inherit(const char *__null_terminated p) {
   // expected-error@+1{{pointers with incompatible terminators casting 'const char *__single __terminated_by(0)' (aka 'const char *__single') to incompatible type 'const char * __terminated_by(42)' (aka 'const char *')}}
   const char *__null_terminated q3 = (const char *__terminated_by(42))p;
 
-  // expected-error@+1{{casting 'const char *__single __terminated_by(0)' (aka 'const char *__single') to incompatible type 'const char *__single' requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
+  // expected-error@+1{{casting 'const char *__single __terminated_by(0)' (aka 'const char *__single') to incompatible type 'const char *__single' (aka 'const char *') requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
   const char *__null_terminated q4 = (const char *__single)p;
 
   // expected-error@+3{{casting 'const char *__single __terminated_by(0)' (aka 'const char *__single') to incompatible type 'const char *__bidi_indexable' requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}

--- a/clang/test/BoundsSafety/Sema/terminated-by-ptr-assign-unsafe.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-ptr-assign-unsafe.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
@@ -32,7 +31,8 @@ char *__null_terminated unsafe_indexable_to_null_terminated_char(char *__unsafe_
   // expected-error@+1{{returning 'char *__unsafe_indexable' from a function with incompatible result type 'char *__single __terminated_by(0)' (aka 'char *__single') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
   return p;
 
-  // expected-error@+1{{casting 'char *__unsafe_indexable' to incompatible type 'char * __terminated_by(0)' (aka 'char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+  // expected-error@+2{{casting 'char *__unsafe_indexable' to incompatible type 'char * __terminated_by(0)' (aka 'char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+  // expected-error@+1{{casting 'char *__unsafe_indexable' to incompatible type 'char * __terminated_by(0)' (aka 'char *') casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
   (void)((char *__null_terminated)p);
 }
 
@@ -68,7 +68,8 @@ char *__terminated_by('X') unsafe_indexable_to_terminated_by_char(char *__unsafe
   // expected-error@+1{{returning 'char *__unsafe_indexable' from a function with incompatible result type 'char *__single __terminated_by('X')' (aka 'char *__single') is an unsafe operation; use '__unsafe_terminated_by_from_indexable()' or '__unsafe_forge_terminated_by()' to perform this conversion}}
   return p;
 
-  // expected-error@+1{{casting 'char *__unsafe_indexable' to incompatible type 'char * __terminated_by('X')' (aka 'char *') is an unsafe operation; use '__unsafe_terminated_by_from_indexable()' or '__unsafe_forge_terminated_by()' to perform this conversion}}
+  // expected-error@+2{{casting 'char *__unsafe_indexable' to incompatible type 'char * __terminated_by('X')' (aka 'char *') is an unsafe operation; use '__unsafe_terminated_by_from_indexable()' or '__unsafe_forge_terminated_by()' to perform this conversion}}
+  // expected-error@+1{{casting 'char *__unsafe_indexable' to incompatible type 'char * __terminated_by('X')' (aka 'char *') casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
   (void)((char *__terminated_by('X'))p);
 }
 
@@ -99,7 +100,8 @@ int *__null_terminated unsafe_indexable_to_null_terminated_int(int *__unsafe_ind
   // expected-error@+1{{returning 'int *__unsafe_indexable' from a function with incompatible result type 'int *__single __terminated_by(0)' (aka 'int *__single') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
   return p;
 
-  // expected-error@+1{{casting 'int *__unsafe_indexable' to incompatible type 'int * __terminated_by(0)' (aka 'int *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+  // expected-error@+2{{casting 'int *__unsafe_indexable' to incompatible type 'int * __terminated_by(0)' (aka 'int *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+  // expected-error@+1{{casting 'int *__unsafe_indexable' to incompatible type 'int * __terminated_by(0)' (aka 'int *') casts away '__unsafe_indexable' qualifier; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable' to perform this conversion}}
   (void)((int *__null_terminated)p);
 }
 

--- a/clang/test/BoundsSafety/Sema/terminated-by-ptr-assign.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-ptr-assign.c
@@ -571,11 +571,11 @@ char *const __null_terminated quals_nc_to_c(char *__null_terminated p) {
 
 char *__null_terminated single_to_terminated_by(char *__single p) {
   // ubu-warning@+2{{initializing 'char * __terminated_by(0)' (aka 'char *') with an expression of incompatible type 'char *__single' is an unsafe operation}}
-  // bs-error@+1{{initializing 'char *__single __terminated_by(0)' (aka 'char *__single') with an expression of incompatible type 'char *__single' is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+  // bs-error@+1{{initializing 'char *__single __terminated_by(0)' (aka 'char *__single') with an expression of incompatible type 'char *__single' (aka 'char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
   char *__null_terminated q = p;
 
   // ubu-warning@+2{{assigning to 'char * __terminated_by(0)' (aka 'char *') from incompatible type 'char *__single' is an unsafe operation}}
-  // bs-error@+1{{assigning to 'char *__single __terminated_by(0)' (aka 'char *__single') from incompatible type 'char *__single' is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+  // bs-error@+1{{assigning to 'char *__single __terminated_by(0)' (aka 'char *__single') from incompatible type 'char *__single' (aka 'char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
   q = p;
 
   // ubu-warning@+2{{passing 'char *__single' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
@@ -583,7 +583,7 @@ char *__null_terminated single_to_terminated_by(char *__single p) {
   nul(p);
 
   // ubu-warning@+2{{returning 'char *__single' from a function with incompatible result type 'char * __terminated_by(0)' (aka 'char *') is an unsafe operation}}
-  // bs-error@+1{{returning 'char *__single' from a function with incompatible result type 'char *__single __terminated_by(0)' (aka 'char *__single') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+  // bs-error@+1{{returning 'char *__single' (aka 'char *') from a function with incompatible result type 'char *__single __terminated_by(0)' (aka 'char *__single') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
   return p;
 
   // ubu-warning@+2{{casting 'char *__single' to incompatible type 'char * __terminated_by(0)' (aka 'char *') is an unsafe operation}}
@@ -621,23 +621,23 @@ char *__null_terminated indexable_to_terminated_by(char *__indexable p) {
 #endif
 
 char *__null_terminated *__null_terminated nested_to_terminated_by(char *__single *__null_terminated p) {
-  // ubu-warning@+2{{initializing 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') with an expression of incompatible type 'char ** __terminated_by(0)__single' (aka 'char **') that adds '__terminated_by' attribute}}
+  // ubu-warning@+2{{initializing 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') with an expression of incompatible type 'char ** __terminated_by(0)__single' (aka 'char **__single') that adds '__terminated_by' attribute}}
   // bs-error@+1{{initializing 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') with an expression of incompatible type 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') that adds '__terminated_by' attribute is not allowed}}
   char *__null_terminated *__null_terminated q = p;
 
-  // ubu-warning@+2{{assigning to 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') from incompatible type 'char ** __terminated_by(0)__single' (aka 'char **') that adds '__terminated_by' attribute}}
+  // ubu-warning@+2{{assigning to 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') from incompatible type 'char ** __terminated_by(0)__single' (aka 'char **__single') that adds '__terminated_by' attribute}}
   // bs-error@+1{{assigning to 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') from incompatible type 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') that adds '__terminated_by' attribute is not allowed}}
   q = p;
 
-  // ubu-warning@+2{{passing 'char ** __terminated_by(0)__single' (aka 'char **') to parameter of incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that adds '__terminated_by' attribute}}
+  // ubu-warning@+2{{passing 'char ** __terminated_by(0)__single' (aka 'char **__single') to parameter of incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that adds '__terminated_by' attribute}}
   // bs-error@+1{{passing 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') to parameter of incompatible type 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') that adds '__terminated_by' attribute is not allowed}}
   nul_nested(p);
 
-  // ubu-warning@+2{{returning 'char ** __terminated_by(0)__single' (aka 'char **') from a function with incompatible result type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that adds '__terminated_by' attribute}}
+  // ubu-warning@+2{{returning 'char ** __terminated_by(0)__single' (aka 'char **__single') from a function with incompatible result type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that adds '__terminated_by' attribute}}
   // bs-error@+1{{returning 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') from a function with incompatible result type 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') that adds '__terminated_by' attribute is not allowed}}
   return p;
 
-  // ubu-warning@+2{{casting 'char ** __terminated_by(0)__single' (aka 'char **') to incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that adds '__terminated_by' attribute}}
+  // ubu-warning@+2{{casting 'char ** __terminated_by(0)__single' (aka 'char **__single') to incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that adds '__terminated_by' attribute}}
   // bs-error@+1{{casting 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') to incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that adds '__terminated_by' attribute is not allowed}}
   (void)((char *__null_terminated *__null_terminated)p);
 }
@@ -649,23 +649,23 @@ void foo_single(char *__single);
 
 char *__single single_from_terminated_by(char *__null_terminated p) {
   // ubu-warning@+2{{initializing 'char *__single' with an expression of incompatible type 'char * __terminated_by(0)' (aka 'char *') requires a linear search for the terminator}}
-  // bs-error@+1{{initializing 'char *__single' with an expression of incompatible type 'char *__single __terminated_by(0)' (aka 'char *__single') requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
+  // bs-error@+1{{initializing 'char *__single' (aka 'char *') with an expression of incompatible type 'char *__single __terminated_by(0)' (aka 'char *__single') requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
   char *__single q = p;
 
   // ubu-warning@+2{{assigning to 'char *__single' from incompatible type 'char * __terminated_by(0)' (aka 'char *') requires a linear search for the terminator}}
-  // bs-error@+1{{assigning to 'char *__single' from incompatible type 'char *__single __terminated_by(0)' (aka 'char *__single') requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
+  // bs-error@+1{{assigning to 'char *__single' (aka 'char *') from incompatible type 'char *__single __terminated_by(0)' (aka 'char *__single') requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
   q = p;
 
   // ubu-warning@+2{{passing 'char * __terminated_by(0)' (aka 'char *') to parameter of incompatible type 'char *__single' requires a linear search for the terminator}}
-  // bs-error@+1{{passing 'char *__single __terminated_by(0)' (aka 'char *__single') to parameter of incompatible type 'char *__single' requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
+  // bs-error@+1{{passing 'char *__single __terminated_by(0)' (aka 'char *__single') to parameter of incompatible type 'char *__single' (aka 'char *') requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
   foo_single(p);
 
   // ubu-warning@+2{{returning 'char * __terminated_by(0)' (aka 'char *') from a function with incompatible result type 'char *__single' requires a linear search for the terminator}}
-  // bs-error@+1{{returning 'char *__single __terminated_by(0)' (aka 'char *__single') from a function with incompatible result type 'char *__single' requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
+  // bs-error@+1{{returning 'char *__single __terminated_by(0)' (aka 'char *__single') from a function with incompatible result type 'char *__single' (aka 'char *') requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
   return p;
 
   // ubu-warning@+2{{casting 'char * __terminated_by(0)' (aka 'char *') to incompatible type 'char *__single' requires a linear search for the terminator}}
-  // bs-error@+1{{casting 'char *__single __terminated_by(0)' (aka 'char *__single') to incompatible type 'char *__single' requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
+  // bs-error@+1{{casting 'char *__single __terminated_by(0)' (aka 'char *__single') to incompatible type 'char *__single' (aka 'char *') requires a linear search for the terminator; use '__null_terminated_to_indexable()' to perform this conversion explicitly}}
   (void)((char *__single)p);
 }
 
@@ -705,23 +705,23 @@ char *__indexable indexable_from_terminated_by(char *__null_terminated p) {
 void bar(char *__single *__null_terminated);
 
 char *__single *__null_terminated nested_from_terminated_by(char *__null_terminated *__null_terminated p) {
-  // ubu-warning@+2{{initializing 'char ** __terminated_by(0)__single' (aka 'char **') with an expression of incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that discards '__terminated_by' attribute}}
+  // ubu-warning@+2{{initializing 'char ** __terminated_by(0)__single' (aka 'char **__single') with an expression of incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that discards '__terminated_by' attribute}}
   // bs-error@+1{{initializing 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') with an expression of incompatible type 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') that discards '__terminated_by' attribute is not allowed}}
   char *__single *__null_terminated q = p;
 
-  // ubu-warning@+2{{assigning to 'char ** __terminated_by(0)__single' (aka 'char **') from incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that discards '__terminated_by' attribute}}
+  // ubu-warning@+2{{assigning to 'char ** __terminated_by(0)__single' (aka 'char **__single') from incompatible type 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') that discards '__terminated_by' attribute}}
   // bs-error@+1{{assigning to 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') from incompatible type 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') that discards '__terminated_by' attribute is not allowed}}
   q = p;
 
-  // ubu-warning@+2{{passing 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') to parameter of incompatible type 'char ** __terminated_by(0)__single' (aka 'char **') that discards '__terminated_by' attribute}}
+  // ubu-warning@+2{{passing 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') to parameter of incompatible type 'char ** __terminated_by(0)__single' (aka 'char **__single') that discards '__terminated_by' attribute}}
   // bs-error@+1{{passing 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') to parameter of incompatible type 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') that discards '__terminated_by' attribute is not allowed}}
   bar(p);
 
-  // ubu-warning@+2{{returning 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') from a function with incompatible result type 'char ** __terminated_by(0)__single' (aka 'char **') that discards '__terminated_by' attribute}}
+  // ubu-warning@+2{{returning 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') from a function with incompatible result type 'char ** __terminated_by(0)__single' (aka 'char **__single') that discards '__terminated_by' attribute}}
   // bs-error@+1{{returning 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') from a function with incompatible result type 'char *__single*__single __terminated_by(0)' (aka 'char *__single*__single') that discards '__terminated_by' attribute is not allowed}}
   return p;
 
-  // ubu-warning@+2{{casting 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') to incompatible type 'char ** __terminated_by(0)__single' (aka 'char **') that discards '__terminated_by' attribute}}
+  // ubu-warning@+2{{casting 'char * __terminated_by(0)* __terminated_by(0)' (aka 'char **') to incompatible type 'char ** __terminated_by(0)__single' (aka 'char **__single') that discards '__terminated_by' attribute}}
   // bs-error@+1{{casting 'char *__single __terminated_by(0)*__single __terminated_by(0)' (aka 'char *__single*__single') to incompatible type 'char *__single* __terminated_by(0)' (aka 'char *__single*') that discards '__terminated_by' attribute is not allowed}}
   (void)((char *__single *__null_terminated)p);
 }
@@ -866,7 +866,8 @@ const int *__null_terminated cond_op_different_type(int cond) {
   p = cond ? i : l;
   // bs-error@+1{{conditional expression evaluates values with incompatible pointee types 'const int *__bidi_indexable' and 'const long *__bidi_indexable'; use explicit casts to perform this conversion}}
   nul_int(cond ? i : l);
-  // bs-error@+1{{conditional expression evaluates values with incompatible pointee types 'const int *__bidi_indexable' and 'const long *__bidi_indexable'; use explicit casts to perform this conversion}}
+  // bs-error@+2{{conditional expression evaluates values with incompatible pointee types 'const int *__bidi_indexable' and 'const long *__bidi_indexable'; use explicit casts to perform this conversion}}
+  // bs-error@+1{{non-pointer to safe pointer conversion is not allowed with -fbounds-safety; use '__unsafe_forge_single' or '__unsafe_forge_bidi_indexable'}}
   (void)((const int *__null_terminated) (cond ? i : l));
   // bs-error@+1{{conditional expression evaluates values with incompatible pointee types 'const int *__bidi_indexable' and 'const long *__bidi_indexable'; use explicit casts to perform this conversion}}
   return cond ? i : l;

--- a/clang/test/BoundsSafety/Sema/terminated-by-ptr-relaxed-casting.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-ptr-relaxed-casting.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify=strict,both %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify=relaxed,both -Wno-error=bounds-safety-strict-terminated-by-cast -Wno-error %s
 
@@ -10,23 +9,23 @@ void foo(const char * __null_terminated); // both-note{{passing argument to para
 void bar(const char * __null_terminated * __single); // both-note{{passing argument to parameter here}}
 
 void test(const char * __single sp) {
-    // strict-error@+2{{initializing 'const char *__single __terminated_by(0)' (aka 'const char *__single') with an expression of incompatible type 'const char *__single' is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()}}
-    // relaxed-warning@+1{{initializing 'const char *__single __terminated_by(0)' (aka 'const char *__single') with an expression of incompatible type 'const char *__single' is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()}}
+    // strict-error@+2{{initializing 'const char *__single __terminated_by(0)' (aka 'const char *__single') with an expression of incompatible type 'const char *__single' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()}}
+    // relaxed-warning@+1{{initializing 'const char *__single __terminated_by(0)' (aka 'const char *__single') with an expression of incompatible type 'const char *__single' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()}}
     const char * __null_terminated ntp = sp;
     // strict-error@+2{{casting 'const char *__single' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
     // relaxed-warning@+1{{casting 'const char *__single' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
     const char * __null_terminated ntp2 = (const char * __null_terminated) sp;
 
-    // strict-error@+2{{passing 'const char *__single' to parameter of incompatible type 'const char *__single __terminated_by(0)' (aka 'const char *__single') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
-    // relaxed-warning@+1{{passing 'const char *__single' to parameter of incompatible type 'const char *__single __terminated_by(0)' (aka 'const char *__single') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+    // strict-error@+2{{passing 'const char *__single' (aka 'const char *') to parameter of incompatible type 'const char *__single __terminated_by(0)' (aka 'const char *__single') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+    // relaxed-warning@+1{{passing 'const char *__single' (aka 'const char *') to parameter of incompatible type 'const char *__single __terminated_by(0)' (aka 'const char *__single') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
     foo(sp);
     // strict-error@+2{{casting 'const char *__single' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
     // relaxed-warning@+1{{casting 'const char *__single' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
     foo((const char * __null_terminated) sp);
 
     const char * __null_terminated ntp3 = ntp;
-    // strict-error@+2{{assigning to 'const char *__single __terminated_by(0)' (aka 'const char *__single') from incompatible type 'const char *__single' is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
-    // relaxed-warning@+1{{assigning to 'const char *__single __terminated_by(0)' (aka 'const char *__single') from incompatible type 'const char *__single' is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+    // strict-error@+2{{assigning to 'const char *__single __terminated_by(0)' (aka 'const char *__single') from incompatible type 'const char *__single' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
+    // relaxed-warning@+1{{assigning to 'const char *__single __terminated_by(0)' (aka 'const char *__single') from incompatible type 'const char *__single' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
     ntp3 = sp;
     // strict-error@+2{{casting 'const char *__single' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
     // relaxed-warning@+1{{casting 'const char *__single' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion}}
@@ -36,23 +35,23 @@ void test(const char * __single sp) {
     /* --- Nested --- */
 
     const char * __single * __single spp = &sp;
-    // strict-error@+2{{initializing 'const char *__single __terminated_by(0)*__single' (aka 'const char *__single*__single') with an expression of incompatible type 'const char *__single*__single' that adds '__terminated_by' attribute is not allowed}}
-    // relaxed-warning@+1{{initializing 'const char *__single __terminated_by(0)*__single' (aka 'const char *__single*__single') with an expression of incompatible type 'const char *__single*__single' that adds '__terminated_by' attribute is not allowed}}
+    // strict-error@+2{{initializing 'const char * __terminated_by(0)*__single' (aka 'const char **__single') with an expression of incompatible type 'const char *__single*__single' that adds '__terminated_by' attribute is not allowed}}
+    // relaxed-warning@+1{{initializing 'const char * __terminated_by(0)*__single' (aka 'const char **__single') with an expression of incompatible type 'const char *__single*__single' that adds '__terminated_by' attribute is not allowed}}
     const char * __null_terminated * __single ntpp = spp;
     // strict-error@+2{{casting 'const char *__single*__single' to incompatible type 'const char * __terminated_by(0)*__single' (aka 'const char **__single') that adds '__terminated_by' attribute is not allowed}}
     // relaxed-warning@+1{{casting 'const char *__single*__single' to incompatible type 'const char * __terminated_by(0)*__single' (aka 'const char **__single') that adds '__terminated_by' attribute is not allowed}}
     const char * __null_terminated * __single ntpp2 = (const char * __null_terminated * __single) spp;
 
-    // strict-error@+2{{passing 'const char *__single*__single' to parameter of incompatible type 'const char *__single __terminated_by(0)*__single' (aka 'const char *__single*__single') that adds '__terminated_by' attribute is not allowed}}
-    // relaxed-warning@+1{{passing 'const char *__single*__single' to parameter of incompatible type 'const char *__single __terminated_by(0)*__single' (aka 'const char *__single*__single') that adds '__terminated_by' attribute is not allowed}}
+    // strict-error@+2{{passing 'const char *__single*__single' to parameter of incompatible type 'const char * __terminated_by(0)*__single' (aka 'const char **__single') that adds '__terminated_by' attribute is not allowed}}
+    // relaxed-warning@+1{{passing 'const char *__single*__single' to parameter of incompatible type 'const char * __terminated_by(0)*__single' (aka 'const char **__single') that adds '__terminated_by' attribute is not allowed}}
     bar(spp);
     // strict-error@+2{{casting 'const char *__single*__single' to incompatible type 'const char * __terminated_by(0)*__single' (aka 'const char **__single') that adds '__terminated_by' attribute is not allowed}}
     // relaxed-warning@+1{{casting 'const char *__single*__single' to incompatible type 'const char * __terminated_by(0)*__single' (aka 'const char **__single') that adds '__terminated_by' attribute is not allowed}}
     bar((const char * __null_terminated * __single) spp);
 
     const char * __null_terminated * __single ntpp3 = ntpp;
-    // strict-error@+2{{assigning to 'const char *__single __terminated_by(0)*__single' (aka 'const char *__single*__single') from incompatible type 'const char *__single*__single' that adds '__terminated_by' attribute is not allowed}}
-    // relaxed-warning@+1{{assigning to 'const char *__single __terminated_by(0)*__single' (aka 'const char *__single*__single') from incompatible type 'const char *__single*__single' that adds '__terminated_by' attribute is not allowed}}
+    // strict-error@+2{{assigning to 'const char * __terminated_by(0)*__single' (aka 'const char **__single') from incompatible type 'const char *__single*__single' that adds '__terminated_by' attribute is not allowed}}
+    // relaxed-warning@+1{{assigning to 'const char * __terminated_by(0)*__single' (aka 'const char **__single') from incompatible type 'const char *__single*__single' that adds '__terminated_by' attribute is not allowed}}
     ntpp3 = spp;
     // strict-error@+2{{casting 'const char *__single*__single' to incompatible type 'const char * __terminated_by(0)*__single' (aka 'const char **__single') that adds '__terminated_by' attribute is not allowed}}
     // relaxed-warning@+1{{casting 'const char *__single*__single' to incompatible type 'const char * __terminated_by(0)*__single' (aka 'const char **__single') that adds '__terminated_by' attribute is not allowed}}

--- a/clang/test/BoundsSafety/Sema/ternary-on-terminated-by.c
+++ b/clang/test/BoundsSafety/Sema/ternary-on-terminated-by.c
@@ -1,4 +1,3 @@
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-bounds-safety-single-to-indexable-bounds-truncated -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-bounds-safety-single-to-indexable-bounds-truncated -x objective-c -fexperimental-bounds-safety-objc -verify %s
 #include <ptrcheck.h>
@@ -30,7 +29,7 @@ void Test(int sel) {
     char * __single y_single = &c;
     char * __single x_single = &c;
     z_nt = sel ? x_nt : y_single; // expected-error{{conditional expression evaluates values with mismatching __terminated_by attributes 'char *__single __terminated_by(0)' (aka 'char *__single') and 'char *__single'}}
-    z_nt = sel ? x_single : y_nt; // expected-error{{conditional expression evaluates values with mismatching __terminated_by attributes 'char *__single' and 'char *__single __terminated_by(0)' (aka 'char *__single')}}
+    z_nt = sel ? x_single : y_nt; // expected-error{{conditional expression evaluates values with mismatching __terminated_by attributes 'char *__single' (aka 'char *') and 'char *__single __terminated_by(0)' (aka 'char *__single')}}
 
     char * __terminated_by(2) x_2t = __unsafe_forge_terminated_by(char *, x, 2);
     z_nt = sel ? x_2t : y_nt; // expected-error{{conditional expression evaluates values with mismatching __terminated_by attributes 'char *__single __terminated_by(2)' (aka 'char *__single') and 'char *__single __terminated_by(0)' (aka 'char *__single')}}


### PR DESCRIPTION
This change implements the approach discussed in #13065 .

Fixes #13065

## Changes

- Represent `__single` as `AttributedType` sugar.
- Preserve the existing canonical pointer type.
- Update AST and Sema consumers to inspect `AttributedType` where appropriate.
- Update type construction, merging, diagnostics, and type printing.
- Update BoundsSafety tests.

## Tests
All tests passed.
- Total discovered: **924**
- Passed: **913**
- Expected failures: **11**