### PR TITLE
[lldb] Enable concurrency tests to run in the embedded variant

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1509,6 +1509,23 @@ class Base(unittest.TestCase):
     def getSwiftModuleImporterVariant(self):
         return self.getVariant("swift_module_importer")
 
+    def getSwiftEmbeddedVariant(self):
+        return self.getVariant("swift_embedded")
+
+    def isEmbeddedSwift(self):
+        """Return True when running the embedded Swift variant of this test."""
+        return self.getSwiftEmbeddedVariant() == "swiftembed"
+
+    def swiftMangledName(self, mangled_name):
+        """Return *mangled_name* in the mangling flavor of the current variant.
+
+        Embedded Swift prefixes every mangled symbol with `$e` where regular
+        Swift uses `$s`. A test that hardcodes a mangled name should pass it
+        through here instead of spelling both flavors out."""
+        if self.isEmbeddedSwift() and mangled_name.startswith("$s"):
+            return "$e" + mangled_name[2:]
+        return mangled_name
+
     def build(
         self,
         debug_info=None,

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -164,13 +164,6 @@ ifeq "$(SWIFT_CXX_INTEROP)" "1"
 endif
 
 #----------------------------------------------------------------------
-# SWIFT_EMBEDDED_CONCURRENCY implies SWIFT_EMBEDDED_MODE
-#----------------------------------------------------------------------
-ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
-	SWIFT_EMBEDDED_MODE = 1
-endif
-
-#----------------------------------------------------------------------
 # Check if we should compile in Swift embedded mode
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
@@ -195,15 +188,26 @@ ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
 endif
 
 #----------------------------------------------------------------------
-# Check if we need embedded Swift concurrency support
+# Check if we need embedded Swift concurrency support.
+#
+# A test whose sources use async/await or actors sets SWIFT_CONCURRENCY := 1.
+# Regular Swift needs nothing extra, so this only has an effect on an embedded
+# build, and it never turns embedded mode on by itself: an embedded-only test
+# sets both SWIFT_CONCURRENCY and SWIFT_EMBEDDED_MODE.
 #----------------------------------------------------------------------
-ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
+ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
+ifeq "$(SWIFT_CONCURRENCY)" "1"
+  # Embedded Swift disables the implicit _Concurrency import on every target
+  # except WASI. We inject it via the swift flags so the tests that compile in
+  # both variants can stay unchanged.
+	SWIFTFLAGS += -Xfrontend -import-module -Xfrontend _Concurrency
 	SWIFT_EMBEDDED_LIB_DIR = $(shell dirname $(SWIFTC))/../lib/swift/embedded/$(SWIFT_EMBEDDED_TRIPLE)
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_Concurrency.a
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_ConcurrencyDefaultExecutor.a
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswiftEmbeddedPlatformSingleThreaded.a
 	LD_EXTRAS += -lc++
 	LD_EXTRAS += -Xlinker -dead_strip
+endif
 endif
 
 #----------------------------------------------------------------------

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -190,13 +190,14 @@ endif
 #----------------------------------------------------------------------
 # Check if we need embedded Swift concurrency support.
 #
-# A test whose sources use async/await or actors sets SWIFT_CONCURRENCY := 1.
+# A test whose sources use async/await or actors sets SWIFT_CONCURRENCY to any
+# non-empty value.
 # Regular Swift needs nothing extra, so this only has an effect on an embedded
 # build, and it never turns embedded mode on by itself: an embedded-only test
 # sets both SWIFT_CONCURRENCY and SWIFT_EMBEDDED_MODE.
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
-ifeq "$(SWIFT_CONCURRENCY)" "1"
+ifneq "$(SWIFT_CONCURRENCY)" ""
   # Embedded Swift disables the implicit _Concurrency import on every target
   # except WASI. We inject it via the swift flags so the tests that compile in
   # both variants can stay unchanged.

--- a/lldb/test/API/lang/swift/async/continuations/Makefile
+++ b/lldb/test/API/lang/swift/async/continuations/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/expr/Makefile
+++ b/lldb/test/API/lang/swift/async/expr/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
+++ b/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
@@ -8,6 +8,8 @@ class TestSwiftAsyncExpressions(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     @skipIf(archs=no_match(["aarch", "arm64", "arm64e", "arm64_32", "x86_64"]))
     def test_actor(self):

--- a/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
+++ b/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
@@ -8,7 +8,6 @@ class TestSwiftAsyncExpressions(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(archs=no_match(["aarch", "arm64", "arm64e", "arm64_32", "x86_64"]))
     def test_actor(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -7,7 +7,6 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -7,6 +7,8 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/parent/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/parent/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -6,6 +6,8 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test summary formatter for TaskPriority."""

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -6,7 +6,6 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test(self):
         """Test summary formatter for TaskPriority."""

--- a/lldb/test/API/lang/swift/async/frame/variable/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/variable/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/queues/Makefile
+++ b/lldb/test/API/lang/swift/async/queues/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -15,9 +15,14 @@ class TestCase(lldbtest.TestBase):
 
         src = lldb.SBFileSpec("main.swift")
         target, _, thread, _ = lldbutil.run_to_source_breakpoint(self, "await f()", src)
-        self.assertEqual(thread.frame[0].function.mangled, "$s1a5entryO4mainyyYaFZ")
+        self.assertEqual(
+            thread.frame[0].function.mangled,
+            self.swiftMangledName("$s1a5entryO4mainyyYaFZ"),
+        )
 
-        sym_ctx_list = target.FindFunctions("$s1a5entryO4mainyyYaFZTQ0_")
+        sym_ctx_list = target.FindFunctions(
+            self.swiftMangledName("$s1a5entryO4mainyyYaFZTQ0_")
+        )
         self.assertEqual(sym_ctx_list.GetSize(), 1)
         function = sym_ctx_list[0].function
         self.assertIsNotNone(function)

--- a/lldb/test/API/lang/swift/async/stepping/step_out/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
@@ -28,7 +28,6 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.assertEqual(thread.frames[0].GetFunctionName(), expected_func_name)
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
@@ -28,6 +28,7 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.assertEqual(thread.frames[0].GetFunctionName(), expected_func_name)
 
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step_over/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -17,7 +17,6 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):
@@ -40,7 +39,6 @@ class TestCase(lldbtest.TestBase):
             self.check_is_in_line(thread, expected_line_num)
             self.check_x_is_available(thread.frames[0])
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @skipIfOutOfTreeDebugserver
     @swiftTest
     @skipIf(oslist=["windows", "linux"])

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -17,6 +17,7 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):
@@ -39,6 +40,7 @@ class TestCase(lldbtest.TestBase):
             self.check_is_in_line(thread, expected_line_num)
             self.check_x_is_available(thread.frames[0])
 
+    @skipEmbeddedSwift
     @skipIfOutOfTreeDebugserver
     @swiftTest
     @skipIf(oslist=["windows", "linux"])

--- a/lldb/test/API/lang/swift/async/tasks/info/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/info/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
+++ b/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
@@ -28,7 +28,6 @@ class TestCase(TestBase):
         task_info_output = self.res.GetOutput()
         self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @skipUnlessPlatform(["macosx", "linux"])
     @swiftTest
     def test_compare_printed_task_variable_to_task_info_with_address(self):

--- a/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
+++ b/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
@@ -28,6 +28,7 @@ class TestCase(TestBase):
         task_info_output = self.res.GetOutput()
         self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))
 
+    @skipEmbeddedSwiftOnLinux
     @skipUnlessPlatform(["macosx", "linux"])
     @swiftTest
     def test_compare_printed_task_variable_to_task_info_with_address(self):

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestDisableLanguageUnwinder(lldbtest.TestBase):
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=['windows',])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestDisableLanguageUnwinder(lldbtest.TestBase):
 
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=['windows',])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/hidden_frames/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/hidden_frames/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -32,14 +32,17 @@ class TestCase(lldbtest.TestBase):
 
     def set_breakpoints_all_funclets(self, target):
         funclet_names = [
-            "$s1a12ASYNC___1___4condS2i_tYaF",
-            "$s1a12ASYNC___1___4condS2i_tYaFTY0_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTQ1_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTY2_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTQ3_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTY4_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTQ5_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTY6_",
+            self.swiftMangledName(name)
+            for name in [
+                "$s1a12ASYNC___1___4condS2i_tYaF",
+                "$s1a12ASYNC___1___4condS2i_tYaFTY0_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTQ1_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTY2_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTQ3_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTY4_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTQ5_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTY6_",
+            ]
         ]
 
         breakpoints = set()

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
@@ -10,7 +10,6 @@ class TestCase(lldbtest.TestBase):
 
     unwind_fail_range_cache = dict()
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows",])
     @skipIf(archs=["arm64e"])
@@ -20,7 +19,7 @@ class TestCase(lldbtest.TestBase):
 
         source_file = lldb.SBFileSpec("main.swift")
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
-            self, "$s1a9factorialyS2iYaFTQ1_"
+            self, self.swiftMangledName("$s1a9factorialyS2iYaFTQ1_")
         )
 
         # Ensure we are on the last factorial call which recurses (n == 1).

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
@@ -10,6 +10,7 @@ class TestCase(lldbtest.TestBase):
 
     unwind_fail_range_cache = dict()
 
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=["windows",])
     @skipIf(archs=["arm64e"])

--- a/lldb/test/API/lang/swift/async/variables/Makefile
+++ b/lldb/test/API/lang/swift/async/variables/Makefile
@@ -1,3 +1,4 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 SWIFTFLAGS_EXTRAS := -Xfrontend -enable-upcoming-feature -Xfrontend NonisolatedNonsendingByDefault
 include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
@@ -1,4 +1,5 @@
 SWIFT_SOURCES := main.swift
-SWIFT_EMBEDDED_CONCURRENCY := 1
+SWIFT_EMBEDDED_MODE := 1
+SWIFT_CONCURRENCY := 1
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/actor/Makefile
+++ b/lldb/test/API/lang/swift/variables/actor/Makefile
@@ -1,3 +1,4 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/Makefile
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/Makefile
@@ -1,3 +1,4 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -24,7 +24,6 @@ def stderr_print(line):
     sys.stderr.write(line + "\n")
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -24,6 +24,8 @@ def stderr_print(line):
     sys.stderr.write(line + "\n")
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while


### PR DESCRIPTION
Embedded swift needs an explicit import to _Concurrency. Fix this via '-Xfrontend -import-module -Xfrontend _Concurrency', when compiling tests in the embedded variant, when they have the new SWIFT_CONCURRENCY_IF_EMBEDDED variable set.

Assisted-by: claude

rdar://183960945