### PR TITLE
[BoundsSafety][CMake] Guard `lldb` runtimes dependency on `LLVM_INCLUDE_TESTS`

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -594,32 +594,32 @@ if(build_runtimes)
     if(WIN32)
       list(APPEND extra_deps KillTheDoctor)
     endif()
-  endif()
 
-  # TO_UPSTREAM(BoundsSafety) ON
-  # Ensure a just-built lldb (and its python bindings) are built before the
-  # runtimes configure step runs `lldb -P`, so compiler-rt's bounds-safety tests
-  # can use the in-tree lldb. lldb is already built when it is in
-  # LLVM_ENABLE_PROJECTS.
-  set(_compiler_rt_is_runtime FALSE)
-  if("compiler-rt" IN_LIST LLVM_ENABLE_RUNTIMES)
-    set(_compiler_rt_is_runtime TRUE)
-  else()
-    foreach(target ${LLVM_RUNTIME_TARGETS})
-      if("compiler-rt" IN_LIST RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES)
-        set(_compiler_rt_is_runtime TRUE)
-        break()
-      endif()
-    endforeach()
+    # TO_UPSTREAM(BoundsSafety) ON
+    # Ensure a just-built lldb (and its python bindings) are built before the
+    # runtimes configure step runs `lldb -P`, so compiler-rt's bounds-safety tests
+    # can use the in-tree lldb. lldb is already built when it is in
+    # LLVM_ENABLE_PROJECTS.
+    set(_compiler_rt_is_runtime FALSE)
+    if("compiler-rt" IN_LIST LLVM_ENABLE_RUNTIMES)
+      set(_compiler_rt_is_runtime TRUE)
+    else()
+      foreach(target ${LLVM_RUNTIME_TARGETS})
+        if("compiler-rt" IN_LIST RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES)
+          set(_compiler_rt_is_runtime TRUE)
+          break()
+        endif()
+      endforeach()
+    endif()
+    if(_compiler_rt_is_runtime)
+      foreach(dep lldb lldb-python)
+        if(TARGET ${dep})
+          list(APPEND extra_deps ${dep})
+        endif()
+      endforeach()
+    endif()
+    # TO_UPSTREAM(BoundsSafety) OFF
   endif()
-  if(_compiler_rt_is_runtime)
-    foreach(dep lldb lldb-python)
-      if(TARGET ${dep})
-        list(APPEND extra_deps ${dep})
-      endif()
-    endforeach()
-  endif()
-  # TO_UPSTREAM(BoundsSafety) OFF
 
   # Forward user-provived system configuration to runtimes for requirement introspection.
   # CMAKE_PREFIX_PATH is the search path for CMake packages.


### PR DESCRIPTION
The `TO_UPSTREAM(BoundsSafety)` block in `llvm/runtimes/CMakeLists.txt` adds `lldb` and `lldb-python` to the runtimes `extra_deps` so that a just-built `lldb` (and its Python bindings) are available for the -fbounds-safety runtime tests configure step in compiler-rt.

Previously this block lived *after* the `if(LLVM_INCLUDE_TESTS)` block that populates the other test-only dependencies (`FileCheck`, `clang`, `not`, etc.). This meant the `lldb`/`lldb-python` dependencies were added unconditionally whenever the runtimes were built, even in configurations where tests are disabled (`LLVM_INCLUDE_TESTS=OFF`).

This patch moves the block inside the `if(LLVM_INCLUDE_TESTS)` guard so the `lldb`/`lldb-python` dependencies are only added when tests are actually being built, matching the treatment of the other test-only runtimes dependencies.

Assisted-by: Claude Code

rdar://184144696