### PR TITLE
[lldb] Rework dynamic type resolution for embedded Swift

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -739,11 +739,10 @@ protected:
 
   /// Resolves the type whose metadata the pointer stored at \p
   /// metadata_ptr_addr points to. That word is a class instance's metadata
-  /// pointer, or an error box's payload metadata pointer. \p type_in_context is
-  /// only used to reach the type system the result is created in.
+  /// pointer, or an error box's payload metadata pointer.
   llvm::Expected<CompilerType>
   GetTypeFromMetadataPointerEmbedded(lldb::addr_t metadata_ptr_addr,
-                                     CompilerType type_in_context);
+                                     TypeSystemSwiftTypeRef &ts);
 
   /// Resolves the type whose metadata symbol covers \p metadata_addr.
   llvm::Expected<CompilerType>

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -737,42 +737,46 @@ protected:
       TypeAndOrName &class_type_or_name, Address &address,
       Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer);
 
-  /// Resolves the dynamic type of an embedded Swift class type.
-  CompilerType GetDynamicTypeAndAddress_EmbeddedClass(uint64_t instance_ptr,
-                                                      CompilerType class_type);
+  /// Resolves the type whose metadata the pointer stored at \p
+  /// metadata_ptr_addr points to. That word is a class instance's metadata
+  /// pointer, or an error box's payload metadata pointer. \p type_in_context is
+  /// only used to reach the type system the result is created in.
+  llvm::Expected<CompilerType>
+  GetTypeFromMetadataPointerEmbedded(lldb::addr_t metadata_ptr_addr,
+                                     CompilerType type_in_context);
 
   /// Resolves the type whose metadata symbol covers \p metadata_addr.
-  CompilerType GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
-                                          TypeSystemSwiftTypeRef &ts);
+  llvm::Expected<CompilerType>
+  GetTypeFromMetadataAddressEmbedded(lldb::addr_t metadata_addr,
+                                     TypeSystemSwiftTypeRef &ts);
 
   /// Resolves the type a "type metadata for T" symbol names, and whether the
   /// symbol names full metadata rather than type metadata.
-  std::pair<CompilerType, bool>
-  GetTypeFromMetadataSymbol(llvm::StringRef symbol_name,
-                            TypeSystemSwiftTypeRef &ts);
+  llvm::Expected<std::pair<CompilerType, bool>>
+  GetTypeFromMetadataSymbolEmbedded(llvm::StringRef symbol_name,
+                                    TypeSystemSwiftTypeRef &ts);
 
   /// If \p type is a class, returns the address of the instance \p addr holds a
   /// reference to, which is what callers of dynamic type resolution expect;
   /// any other type is already the value, so \p addr is returned unchanged.
-  /// Returns std::nullopt if the reference could not be read.
-  std::optional<lldb::addr_t> UnwrapClassReferenceIfNeeded(CompilerType type,
-                                                           lldb::addr_t addr);
+  llvm::Expected<lldb::addr_t> UnwrapClassReferenceIfNeeded(CompilerType type,
+                                                            lldb::addr_t addr);
 
   /// Resolves the dynamic type of the class reference an embedded Swift
-  /// class-constrained existential holds in its first word. Returns
-  /// std::nullopt if that word does not resolve to a class.
-  std::optional<std::pair<CompilerType, uint64_t>>
+  /// class-constrained existential holds in its first word. Fails if that word
+  /// does not resolve to a class.
+  llvm::Expected<std::pair<CompilerType, uint64_t>>
   GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type);
 
   /// Resolves the dynamic type of an embedded Swift existential container.
-  std::optional<std::pair<CompilerType, uint64_t>>
+  llvm::Expected<std::pair<CompilerType, uint64_t>>
   GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type);
 
   /// Resolves the dynamic type of an embedded Swift error existential, which
   /// points to a heap box holding the payload's type metadata.
-  std::optional<std::pair<CompilerType, uint64_t>>
+  llvm::Expected<std::pair<CompilerType, uint64_t>>
   GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type,
       ExecutionContextScope *exe_scope);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -741,10 +741,28 @@ protected:
   CompilerType GetDynamicTypeAndAddress_EmbeddedClass(uint64_t instance_ptr,
                                                       CompilerType class_type);
 
-  /// Resolves the dynamic type of a class-constrained embedded Swift
-  /// existential.
+  /// Resolves the type whose metadata symbol covers \p metadata_addr.
+  CompilerType GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
+                                          TypeSystemSwiftTypeRef &ts);
+
+  /// Resolves the type a "type metadata for T" symbol names, and whether the
+  /// symbol names full metadata rather than type metadata.
+  std::pair<CompilerType, bool>
+  GetTypeFromMetadataSymbol(llvm::StringRef symbol_name,
+                            TypeSystemSwiftTypeRef &ts);
+
+  /// If \p type is a class, returns the address of the instance \p addr holds a
+  /// reference to, which is what callers of dynamic type resolution expect;
+  /// any other type is already the value, so \p addr is returned unchanged.
+  /// Returns std::nullopt if the reference could not be read.
+  std::optional<lldb::addr_t> UnwrapClassReferenceIfNeeded(CompilerType type,
+                                                           lldb::addr_t addr);
+
+  /// Resolves the dynamic type of the class reference an embedded Swift
+  /// class-constrained existential holds in its first word. Returns
+  /// std::nullopt if that word does not resolve to a class.
   std::optional<std::pair<CompilerType, uint64_t>>
-  GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
+  GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type);
 
   /// Resolves the dynamic type of an embedded Swift existential container.
@@ -752,11 +770,22 @@ protected:
   GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type);
 
+  /// Resolves the dynamic type of an embedded Swift error existential, which
+  /// points to a heap box holding the payload's type metadata.
+  std::optional<std::pair<CompilerType, uint64_t>>
+  GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+      lldb::addr_t existential_address, CompilerType existential_type,
+      ExecutionContextScope *exe_scope);
+
   /// Resolves the dynamic type of an embedded Swift existential.
-  /// Tries class-constrained first, then falls back to existential container.
+  /// Dispatches on the existential's representation, which reflection derives
+  /// from the protocol's debug info. \p exe_scope is needed to reach the type
+  /// system that can read that debug info; without it the representation is
+  /// unknown and every layout is tried in turn.
   llvm::Expected<std::pair<CompilerType, uint64_t>>
-  GetDynamicTypeAndAddress_ExistentialEmbedded(lldb::addr_t existential_address,
-                                               CompilerType existential_type);
+  GetDynamicTypeAndAddress_ExistentialEmbedded(
+      lldb::addr_t existential_address, CompilerType existential_type,
+      ExecutionContextScope *exe_scope);
 
   /// Dynamic type resolution tends to want to generate scalar data -
   /// but there are caveats Per original comment here "Our address is

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2436,6 +2436,18 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Pack(
   return true;
 }
 
+/// Returns the TypeSystemSwiftTypeRef \p type belongs to.
+static llvm::Expected<TypeSystemSwiftTypeRefSP>
+GetTypeSystemSwiftTypeRef(CompilerType type) {
+  auto tss = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!tss)
+    return llvm::createStringError("not a Swift type");
+  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
+  if (!ts)
+    return llvm::createStringError("no Swift typeref typesystem");
+  return ts;
+}
+
 llvm::Expected<std::pair<CompilerType, bool>>
 SwiftLanguageRuntime::GetTypeFromMetadataSymbolEmbedded(
     llvm::StringRef symbol_name, TypeSystemSwiftTypeRef &ts) {
@@ -2510,17 +2522,10 @@ SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
 
 llvm::Expected<CompilerType>
 SwiftLanguageRuntime::GetTypeFromMetadataPointerEmbedded(
-    lldb::addr_t metadata_ptr_addr, CompilerType type_in_context) {
+    lldb::addr_t metadata_ptr_addr, TypeSystemSwiftTypeRef &ts) {
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
-  auto tss =
-      type_in_context.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
-  if (!tss)
-    return llvm::createStringError("not a Swift type system");
-  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
-  if (!ts)
-    return llvm::createStringError("no Swift typeref typesystem");
 
   std::optional<swift::remote::RemoteAbsolutePointer> pointer =
       reflection_ctx->ReadPointer(metadata_ptr_addr);
@@ -2534,14 +2539,14 @@ SwiftLanguageRuntime::GetTypeFromMetadataPointerEmbedded(
   // symbol, we can extract the dynamic type from the symbol's mangled name.
   if (!pointer->getSymbol().empty() && !pointer->getOffset()) {
     auto type_or_err =
-        GetTypeFromMetadataSymbolEmbedded(pointer->getSymbol(), *ts);
+        GetTypeFromMetadataSymbolEmbedded(pointer->getSymbol(), ts);
     if (!type_or_err)
       return type_or_err.takeError();
     return type_or_err->first;
   }
   // Otherwise, we need to look up which symbol matches the address.
   return GetTypeFromMetadataAddressEmbedded(
-      pointer->getResolvedAddress().getRawAddress(), *ts);
+      pointer->getResolvedAddress().getRawAddress(), ts);
 }
 
 llvm::Expected<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
@@ -2550,6 +2555,9 @@ llvm::Expected<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
+  auto ts_or_err = GetTypeSystemSwiftTypeRef(existential_type);
+  if (!ts_or_err)
+    return ts_or_err.takeError();
 
   auto maybe_addr_or_symbol = reflection_ctx->ReadPointer(existential_address);
   if (!maybe_addr_or_symbol)
@@ -2578,7 +2586,7 @@ llvm::Expected<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
   }
 
   auto dynamic_type_or_err =
-      GetTypeFromMetadataPointerEmbedded(address, existential_type);
+      GetTypeFromMetadataPointerEmbedded(address, **ts_or_err);
   if (!dynamic_type_or_err)
     return dynamic_type_or_err.takeError();
   CompilerType dynamic_type = *dynamic_type_or_err;
@@ -2600,13 +2608,9 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
-  auto tss =
-      existential_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
-  if (!tss)
-    return llvm::createStringError("not a Swift type system");
-  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
-  if (!ts)
-    return llvm::createStringError("no Swift typeref typesystem");
+  auto ts_or_err = GetTypeSystemSwiftTypeRef(existential_type);
+  if (!ts_or_err)
+    return ts_or_err.takeError();
 
   auto existential_container =
       reflection_ctx->ReadMetadataAndValueOpaqueExistential(
@@ -2624,7 +2628,7 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
     return llvm::createStringError("existential container has no payload");
 
   auto dynamic_type_or_err =
-      GetTypeFromMetadataAddressEmbedded(metadata_addr, *ts);
+      GetTypeFromMetadataAddressEmbedded(metadata_addr, **ts_or_err);
   if (!dynamic_type_or_err)
     return dynamic_type_or_err.takeError();
   CompilerType dynamic_type = *dynamic_type_or_err;
@@ -2644,6 +2648,9 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
+  auto ts_or_err = GetTypeSystemSwiftTypeRef(existential_type);
+  if (!ts_or_err)
+    return ts_or_err.takeError();
 
   // An error existential is a pointer to a heap box laid out as [HeapObject,
   // payload metadata, Error witness table, payload]. This matches
@@ -2661,8 +2668,8 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
   uint32_t ptr_size = GetProcess().GetAddressByteSize();
 
   // The payload's metadata follows the object header.
-  auto dynamic_type_or_err = GetTypeFromMetadataPointerEmbedded(
-      box_addr + 2 * ptr_size, existential_type);
+  auto dynamic_type_or_err =
+      GetTypeFromMetadataPointerEmbedded(box_addr + 2 * ptr_size, **ts_or_err);
   if (!dynamic_type_or_err)
     return dynamic_type_or_err.takeError();
   CompilerType dynamic_type = *dynamic_type_or_err;
@@ -2844,7 +2851,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
       }
     } else {
       auto dynamic_type_or_err =
-          GetTypeFromMetadataPointerEmbedded(instance_ptr, class_type);
+          GetTypeFromMetadataPointerEmbedded(instance_ptr, *ts);
       if (!dynamic_type_or_err) {
         HEALTH_LOG("could not resolve dynamic type of embedded swift class: "
                    "{0} (instance_ptr = {1:x}): {2}",

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2436,32 +2436,41 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Pack(
   return true;
 }
 
-std::pair<CompilerType, bool>
-SwiftLanguageRuntime::GetTypeFromMetadataSymbol(llvm::StringRef symbol_name,
-                                                TypeSystemSwiftTypeRef &ts) {
+llvm::Expected<std::pair<CompilerType, bool>>
+SwiftLanguageRuntime::GetTypeFromMetadataSymbolEmbedded(
+    llvm::StringRef symbol_name, TypeSystemSwiftTypeRef &ts) {
   // The symbol name will be something like "type metadata for Class", extract
   // "Class" from that name.
-  return ts.GetTypeFromTypeMetadataNode(symbol_name);
+  auto [type, is_full_metadata] = ts.GetTypeFromTypeMetadataNode(symbol_name);
+  if (!type)
+    return llvm::createStringError("no type for metadata symbol " +
+                                   symbol_name);
+  return std::make_pair(type, is_full_metadata);
 }
 
-CompilerType
-SwiftLanguageRuntime::GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
-                                                 TypeSystemSwiftTypeRef &ts) {
+llvm::Expected<CompilerType>
+SwiftLanguageRuntime::GetTypeFromMetadataAddressEmbedded(
+    lldb::addr_t metadata_addr, TypeSystemSwiftTypeRef &ts) {
   // Embedded Swift emits no metadata records, but it does emit a symbol for
   // every type's metadata, so the type can be recovered from the symbol name.
   Address address;
   address.SetLoadAddress(metadata_addr, &GetProcess().GetTarget());
   Symbol *symbol = address.CalculateSymbolContextSymbol();
   if (!symbol)
-    return {};
+    return llvm::createStringError(
+        llvm::formatv("no symbol for metadata at {0:x}", metadata_addr).str());
   Mangled mangled = symbol->GetMangled();
   if (!mangled)
-    return {};
+    return llvm::createStringError(
+        llvm::formatv("symbol for metadata at {0:x} is not mangled",
+                      metadata_addr)
+            .str());
 
-  auto [type, is_full_metadata] =
-      GetTypeFromMetadataSymbol(mangled.GetMangledName().GetStringRef(), ts);
-  if (!type)
-    return {};
+  auto type_or_err = GetTypeFromMetadataSymbolEmbedded(
+      mangled.GetMangledName().GetStringRef(), ts);
+  if (!type_or_err)
+    return type_or_err.takeError();
+  auto [type, is_full_metadata] = *type_or_err;
 
   // Sanity check that the symbol's start address matches what we expect. This
   // depends on whether the symbol is full type metadata (one pointer sized
@@ -2470,18 +2479,17 @@ SwiftLanguageRuntime::GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
   uint64_t expected_offset =
       is_full_metadata ? GetProcess().GetAddressByteSize() : 0;
   if (symbol_addr == LLDB_INVALID_ADDRESS ||
-      metadata_addr - symbol_addr != expected_offset) {
-    LLDB_LOG(GetLog(LLDBLog::Types),
-             "[GetTypeFromMetadataAddress] metadata at {0:x} is {1} bytes into "
-             "{2}, not its address point",
-             metadata_addr, metadata_addr - symbol_addr,
-             mangled.GetMangledName());
-    return {};
-  }
+      metadata_addr - symbol_addr != expected_offset)
+    return llvm::createStringError(
+        llvm::formatv("metadata at {0:x} is {1} bytes into {2}, not its "
+                      "address point",
+                      metadata_addr, metadata_addr - symbol_addr,
+                      mangled.GetMangledName())
+            .str());
   return type;
 }
 
-std::optional<lldb::addr_t>
+llvm::Expected<lldb::addr_t>
 SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
                                                    lldb::addr_t addr) {
   // Only a class is stored as a reference; any other type is already the value.
@@ -2489,53 +2497,66 @@ SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
     return addr;
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return std::nullopt;
+    return llvm::createStringError("no reflection context");
   std::optional<swift::remote::RemoteAbsolutePointer> instance =
       reflection_ctx->ReadPointer(addr);
   if (!instance)
-    return std::nullopt;
+    return llvm::createStringError(
+        llvm::formatv("could not read the class reference stored at {0:x}",
+                      addr)
+            .str());
   return instance->getResolvedAddress().getRawAddress();
 }
 
-CompilerType SwiftLanguageRuntime::GetDynamicTypeAndAddress_EmbeddedClass(
-    uint64_t instance_ptr, CompilerType class_type) {
+llvm::Expected<CompilerType>
+SwiftLanguageRuntime::GetTypeFromMetadataPointerEmbedded(
+    lldb::addr_t metadata_ptr_addr, CompilerType type_in_context) {
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return {};
-  auto tss = class_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+    return llvm::createStringError("no reflection context");
+  auto tss =
+      type_in_context.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!tss)
-    return {};
+    return llvm::createStringError("not a Swift type system");
   TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
   if (!ts)
-    return {};
+    return llvm::createStringError("no Swift typeref typesystem");
 
-  /// If this is an embedded Swift type, there is no metadata, and the
-  /// pointer points to the type's vtable. We can still resolve the type by
-  /// reading the vtable's symbol name.
   std::optional<swift::remote::RemoteAbsolutePointer> pointer =
-      reflection_ctx->ReadPointer(instance_ptr);
+      reflection_ctx->ReadPointer(metadata_ptr_addr);
   if (!pointer)
-    return {};
+    return llvm::createStringError(
+        llvm::formatv("could not read the metadata pointer at {0:x}",
+                      metadata_ptr_addr)
+            .str());
 
   // A RemoteAbsolutePointer can contain a symbol or an address. If we have the
   // symbol, we can extract the dynamic type from the symbol's mangled name.
-  if (!pointer->getSymbol().empty() && !pointer->getOffset())
-    return GetTypeFromMetadataSymbol(pointer->getSymbol(), *ts).first;
+  if (!pointer->getSymbol().empty() && !pointer->getOffset()) {
+    auto type_or_err =
+        GetTypeFromMetadataSymbolEmbedded(pointer->getSymbol(), *ts);
+    if (!type_or_err)
+      return type_or_err.takeError();
+    return type_or_err->first;
+  }
   // Otherwise, we need to look up which symbol matches the address.
-  return GetTypeFromMetadataAddress(
+  return GetTypeFromMetadataAddressEmbedded(
       pointer->getResolvedAddress().getRawAddress(), *ts);
 }
 
-std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
+llvm::Expected<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
     GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
         lldb::addr_t existential_address, CompilerType existential_type) {
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return std::nullopt;
+    return llvm::createStringError("no reflection context");
 
   auto maybe_addr_or_symbol = reflection_ctx->ReadPointer(existential_address);
   if (!maybe_addr_or_symbol)
-    return std::nullopt;
+    return llvm::createStringError(
+        llvm::formatv("could not read the class reference stored at {0:x}",
+                      existential_address)
+            .str());
 
   uint64_t address = 0;
   if (maybe_addr_or_symbol->getSymbol().empty() &&
@@ -2548,101 +2569,103 @@ std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
         ConstString(maybe_addr_or_symbol->getSymbol()), eSymbolTypeAny,
         sc_list);
     if (sc_list.GetSize() != 1)
-      return std::nullopt;
+      return llvm::createStringError("no unique symbol named " +
+                                     maybe_addr_or_symbol->getSymbol());
 
     SymbolContext sc = sc_list[0];
     Symbol *symbol = sc.symbol;
     address = symbol->GetLoadAddress(&GetProcess().GetTarget());
   }
 
-  CompilerType dynamic_type =
-      GetDynamicTypeAndAddress_EmbeddedClass(address, existential_type);
-  if (!dynamic_type)
-    return std::nullopt;
+  auto dynamic_type_or_err =
+      GetTypeFromMetadataPointerEmbedded(address, existential_type);
+  if (!dynamic_type_or_err)
+    return dynamic_type_or_err.takeError();
+  CompilerType dynamic_type = *dynamic_type_or_err;
 
   // For a class-constrained existential this word is the instance reference, so
   // resolving it to anything else means there's something wrong.
-  if (!Flags(dynamic_type.GetTypeInfo()).AllSet(eTypeIsClass)) {
-    LLDB_LOG(GetLog(LLDBLog::Types),
-             "[GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded] {0} "
-             "is not a class",
-             dynamic_type.GetMangledTypeName());
-    return std::nullopt;
-  }
+  if (!Flags(dynamic_type.GetTypeInfo()).AllSet(eTypeIsClass))
+    return llvm::createStringError(
+        "class-constrained existential resolved to non-class type " +
+        dynamic_type.GetMangledTypeName().GetStringRef());
 
   return std::make_pair(
       dynamic_type, maybe_addr_or_symbol->getResolvedAddress().getRawAddress());
 }
 
-std::optional<std::pair<CompilerType, uint64_t>>
+llvm::Expected<std::pair<CompilerType, uint64_t>>
 SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
     lldb::addr_t existential_address, CompilerType existential_type) {
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return std::nullopt;
+    return llvm::createStringError("no reflection context");
   auto tss =
       existential_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!tss)
-    return std::nullopt;
+    return llvm::createStringError("not a Swift type system");
   TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
   if (!ts)
-    return std::nullopt;
+    return llvm::createStringError("no Swift typeref typesystem");
 
   auto existential_container =
       reflection_ctx->ReadMetadataAndValueOpaqueExistential(
           existential_address);
   if (!existential_container)
-    return std::nullopt;
+    return llvm::createStringError(
+        llvm::formatv("could not read the existential container at {0:x}",
+                      existential_address)
+            .str());
 
   lldb::addr_t metadata_addr =
       existential_container->MetadataAddress.getRawAddress();
   auto dynamic_address = existential_container->PayloadAddress.getRawAddress();
   if (dynamic_address == 0)
-    return std::nullopt;
+    return llvm::createStringError("existential container has no payload");
 
-  CompilerType dynamic_type = GetTypeFromMetadataAddress(metadata_addr, *ts);
-  if (!dynamic_type) {
-    LLDB_LOG(GetLog(LLDBLog::Types),
-             "[GetDynamicTypeAndAddress_ExistentialContainerEmbedded] no type "
-             "for metadata at {0:x}",
-             metadata_addr);
-    return std::nullopt;
-  }
+  auto dynamic_type_or_err =
+      GetTypeFromMetadataAddressEmbedded(metadata_addr, *ts);
+  if (!dynamic_type_or_err)
+    return dynamic_type_or_err.takeError();
+  CompilerType dynamic_type = *dynamic_type_or_err;
 
-  auto instance_addr =
+  auto instance_addr_or_err =
       UnwrapClassReferenceIfNeeded(dynamic_type, dynamic_address);
-  if (!instance_addr)
-    return std::nullopt;
+  if (!instance_addr_or_err)
+    return instance_addr_or_err.takeError();
 
-  return std::make_pair(dynamic_type, *instance_addr);
+  return std::make_pair(dynamic_type, *instance_addr_or_err);
 }
 
-std::optional<std::pair<CompilerType, uint64_t>>
+llvm::Expected<std::pair<CompilerType, uint64_t>>
 SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
     lldb::addr_t existential_address, CompilerType existential_type,
     ExecutionContextScope *exe_scope) {
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return std::nullopt;
+    return llvm::createStringError("no reflection context");
 
   // An error existential is a pointer to a heap box laid out as [HeapObject,
-  // payload metadata, Error witness table, payload].
+  // payload metadata, Error witness table, payload]. This matches
+  // swift_allocError in the embedded runtime (EmbeddedRuntime.swift).
   auto box = reflection_ctx->ReadPointer(existential_address);
   if (!box)
-    return std::nullopt;
+    return llvm::createStringError(
+        llvm::formatv("could not read the error box pointer at {0:x}",
+                      existential_address)
+            .str());
   lldb::addr_t box_addr = box->getResolvedAddress().getRawAddress();
   if (box_addr == 0 || box_addr == LLDB_INVALID_ADDRESS)
-    return std::nullopt;
+    return llvm::createStringError("error existential has no box");
 
   uint32_t ptr_size = GetProcess().GetAddressByteSize();
 
-  // The payload's metadata follows the object header. Reading the metadata
-  // pointer at an address and resolving its symbol is what resolving an
-  // embedded class does, so reuse that.
-  CompilerType dynamic_type = GetDynamicTypeAndAddress_EmbeddedClass(
+  // The payload's metadata follows the object header.
+  auto dynamic_type_or_err = GetTypeFromMetadataPointerEmbedded(
       box_addr + 2 * ptr_size, existential_type);
-  if (!dynamic_type)
-    return std::nullopt;
+  if (!dynamic_type_or_err)
+    return dynamic_type_or_err.takeError();
+  CompilerType dynamic_type = *dynamic_type_or_err;
 
   // The payload follows the metadata and the witness table, rounded up to its
   // own alignment.
@@ -2656,10 +2679,11 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
   }
   lldb::addr_t payload_addr = llvm::alignTo(box_addr + 4 * ptr_size, alignment);
 
-  if (auto instance_addr =
-          UnwrapClassReferenceIfNeeded(dynamic_type, payload_addr))
-    return std::make_pair(dynamic_type, *instance_addr);
-  return std::nullopt;
+  auto instance_addr_or_err =
+      UnwrapClassReferenceIfNeeded(dynamic_type, payload_addr);
+  if (!instance_addr_or_err)
+    return instance_addr_or_err.takeError();
+  return std::make_pair(dynamic_type, *instance_addr_or_err);
 }
 
 llvm::Expected<std::pair<CompilerType, uint64_t>>
@@ -2679,26 +2703,16 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialEmbedded(
 
   switch (kind) {
   case swift::reflection::RecordKind::ErrorExistential:
-    if (auto result = GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
-            existential_address, existential_type, exe_scope))
-      return *result;
-    return llvm::createStringError(
-        "failed to resolve dynamic type of embedded error existential");
+    return GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+        existential_address, existential_type, exe_scope);
 
   case swift::reflection::RecordKind::ClassExistential:
-    if (auto result =
-            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
-                existential_address, existential_type))
-      return *result;
-    return llvm::createStringError("failed to resolve dynamic type of "
-                                   "class-constrained embedded existential");
+    return GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
+        existential_address, existential_type);
 
   case swift::reflection::RecordKind::OpaqueExistential:
-    if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
-            existential_address, existential_type))
-      return *result;
-    return llvm::createStringError(
-        "failed to resolve dynamic type of opaque embedded existential");
+    return GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+        existential_address, existential_type);
 
   default:
     // No record layout for the existential, as a fallback try each one in turn.
@@ -2706,17 +2720,30 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialEmbedded(
              "[GetDynamicTypeAndAddress_ExistentialEmbedded] unknown "
              "representation of {0}, trying every layout",
              existential_type.GetMangledTypeName());
-    if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
-            existential_address, existential_type))
+
+    auto try_layout =
+        [&](llvm::Expected<std::pair<CompilerType, uint64_t>> result)
+        -> std::optional<std::pair<CompilerType, uint64_t>> {
+      if (result)
+        return *result;
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types), result.takeError(),
+                     "[GetDynamicTypeAndAddress_ExistentialEmbedded] {0}");
+      return std::nullopt;
+    };
+
+    if (auto result =
+            try_layout(GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+                existential_address, existential_type)))
+      return *result;
+
+    if (auto result = try_layout(
+            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
+                existential_address, existential_type)))
       return *result;
 
     if (auto result =
-            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
-                existential_address, existential_type))
-      return *result;
-
-    if (auto result = GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
-            existential_address, existential_type, exe_scope))
+            try_layout(GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+                existential_address, existential_type, exe_scope)))
       return *result;
 
     return llvm::createStringError(
@@ -2816,14 +2843,16 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
           dynamic_type = class_type;
       }
     } else {
-      dynamic_type =
-          GetDynamicTypeAndAddress_EmbeddedClass(instance_ptr, class_type);
-      if (!dynamic_type) {
+      auto dynamic_type_or_err =
+          GetTypeFromMetadataPointerEmbedded(instance_ptr, class_type);
+      if (!dynamic_type_or_err) {
         HEALTH_LOG("could not resolve dynamic type of embedded swift class: "
-                   "{0} (instance_ptr = {1:x})",
-                   class_type.GetMangledTypeName(), instance_ptr);
+                   "{0} (instance_ptr = {1:x}): {2}",
+                   class_type.GetMangledTypeName(), instance_ptr,
+                   llvm::toString(dynamic_type_or_err.takeError()));
         return false;
       }
+      dynamic_type = *dynamic_type_or_err;
     }
     class_type_or_name.SetCompilerType(dynamic_type);
     LLDB_LOG(GetLog(LLDBLog::Types),

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2436,44 +2436,98 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Pack(
   return true;
 }
 
+std::pair<CompilerType, bool>
+SwiftLanguageRuntime::GetTypeFromMetadataSymbol(llvm::StringRef symbol_name,
+                                                TypeSystemSwiftTypeRef &ts) {
+  // The symbol name will be something like "type metadata for Class", extract
+  // "Class" from that name.
+  return ts.GetTypeFromTypeMetadataNode(symbol_name);
+}
+
+CompilerType
+SwiftLanguageRuntime::GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
+                                                 TypeSystemSwiftTypeRef &ts) {
+  // Embedded Swift emits no metadata records, but it does emit a symbol for
+  // every type's metadata, so the type can be recovered from the symbol name.
+  Address address;
+  address.SetLoadAddress(metadata_addr, &GetProcess().GetTarget());
+  Symbol *symbol = address.CalculateSymbolContextSymbol();
+  if (!symbol)
+    return {};
+  Mangled mangled = symbol->GetMangled();
+  if (!mangled)
+    return {};
+
+  auto [type, is_full_metadata] =
+      GetTypeFromMetadataSymbol(mangled.GetMangledName().GetStringRef(), ts);
+  if (!type)
+    return {};
+
+  // Sanity check that the symbol's start address matches what we expect. This
+  // depends on whether the symbol is full type metadata (one pointer sized
+  // offset) or regular type metadata.
+  lldb::addr_t symbol_addr = symbol->GetLoadAddress(&GetProcess().GetTarget());
+  uint64_t expected_offset =
+      is_full_metadata ? GetProcess().GetAddressByteSize() : 0;
+  if (symbol_addr == LLDB_INVALID_ADDRESS ||
+      metadata_addr - symbol_addr != expected_offset) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[GetTypeFromMetadataAddress] metadata at {0:x} is {1} bytes into "
+             "{2}, not its address point",
+             metadata_addr, metadata_addr - symbol_addr,
+             mangled.GetMangledName());
+    return {};
+  }
+  return type;
+}
+
+std::optional<lldb::addr_t>
+SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
+                                                   lldb::addr_t addr) {
+  // Only a class is stored as a reference; any other type is already the value.
+  if (!Flags(type.GetTypeInfo()).AllSet(eTypeIsClass))
+    return addr;
+  auto reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return std::nullopt;
+  std::optional<swift::remote::RemoteAbsolutePointer> instance =
+      reflection_ctx->ReadPointer(addr);
+  if (!instance)
+    return std::nullopt;
+  return instance->getResolvedAddress().getRawAddress();
+}
+
 CompilerType SwiftLanguageRuntime::GetDynamicTypeAndAddress_EmbeddedClass(
     uint64_t instance_ptr, CompilerType class_type) {
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return {};
+  auto tss = class_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!tss)
+    return {};
+  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
+  if (!ts)
+    return {};
+
   /// If this is an embedded Swift type, there is no metadata, and the
   /// pointer points to the type's vtable. We can still resolve the type by
   /// reading the vtable's symbol name.
-  auto pointer = reflection_ctx->ReadPointer(instance_ptr);
+  std::optional<swift::remote::RemoteAbsolutePointer> pointer =
+      reflection_ctx->ReadPointer(instance_ptr);
   if (!pointer)
     return {};
-  llvm::StringRef symbol_name;
-  if (pointer->getSymbol().empty() || pointer->getOffset()) {
-    // Find the symbol name at this address.
-    Address address;
-    address.SetLoadAddress(pointer->getResolvedAddress().getRawAddress(),
-                           &GetProcess().GetTarget());
-    Symbol *symbol = address.CalculateSymbolContextSymbol();
-    if (!symbol)
-      return {};
-    Mangled mangled = symbol->GetMangled();
-    if (!mangled)
-      return {};
-    symbol_name = symbol->GetMangled().GetMangledName().GetStringRef();
-  } else {
-    symbol_name = pointer->getSymbol();
-  }
-  TypeSystemSwiftTypeRefSP ts = class_type.GetTypeSystem()
-                                    .dyn_cast_or_null<TypeSystemSwift>()
-                                    ->GetTypeSystemSwiftTypeRef();
-  // The symbol name will be something like "type metadata for Class", extract
-  // "Class" from that name.
-  auto dynamic_type = ts->GetTypeFromTypeMetadataNode(symbol_name);
-  return dynamic_type;
+
+  // A RemoteAbsolutePointer can contain a symbol or an address. If we have the
+  // symbol, we can extract the dynamic type from the symbol's mangled name.
+  if (!pointer->getSymbol().empty() && !pointer->getOffset())
+    return GetTypeFromMetadataSymbol(pointer->getSymbol(), *ts).first;
+  // Otherwise, we need to look up which symbol matches the address.
+  return GetTypeFromMetadataAddress(
+      pointer->getResolvedAddress().getRawAddress(), *ts);
 }
 
 std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
-    GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
+    GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
         lldb::addr_t existential_address, CompilerType existential_type) {
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
@@ -2506,6 +2560,16 @@ std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
   if (!dynamic_type)
     return std::nullopt;
 
+  // For a class-constrained existential this word is the instance reference, so
+  // resolving it to anything else means there's something wrong.
+  if (!Flags(dynamic_type.GetTypeInfo()).AllSet(eTypeIsClass)) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded] {0} "
+             "is not a class",
+             dynamic_type.GetMangledTypeName());
+    return std::nullopt;
+  }
+
   return std::make_pair(
       dynamic_type, maybe_addr_or_symbol->getResolvedAddress().getRawAddress());
 }
@@ -2516,6 +2580,13 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return std::nullopt;
+  auto tss =
+      existential_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!tss)
+    return std::nullopt;
+  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
+  if (!ts)
+    return std::nullopt;
 
   auto existential_container =
       reflection_ctx->ReadMetadataAndValueOpaqueExistential(
@@ -2525,69 +2596,132 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
 
   lldb::addr_t metadata_addr =
       existential_container->MetadataAddress.getRawAddress();
-  if (metadata_addr == 0)
-    return std::nullopt;
-
   auto dynamic_address = existential_container->PayloadAddress.getRawAddress();
   if (dynamic_address == 0)
     return std::nullopt;
 
-  // The value witness table pointer is stored at MetadataAddress - PointerSize.
-  size_t ptr_size = GetProcess().GetAddressByteSize();
-  lldb::addr_t vwt_ptr_addr = metadata_addr - ptr_size;
+  CompilerType dynamic_type = GetTypeFromMetadataAddress(metadata_addr, *ts);
+  if (!dynamic_type) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[GetDynamicTypeAndAddress_ExistentialContainerEmbedded] no type "
+             "for metadata at {0:x}",
+             metadata_addr);
+    return std::nullopt;
+  }
 
-  Status error;
-  lldb::addr_t vwt_addr =
-      GetProcess().ReadPointerFromMemory(vwt_ptr_addr, error);
-  if (error.Fail() || vwt_addr == 0 || vwt_addr == LLDB_INVALID_ADDRESS)
+  auto instance_addr =
+      UnwrapClassReferenceIfNeeded(dynamic_type, dynamic_address);
+  if (!instance_addr)
     return std::nullopt;
 
-  Address vwt_address;
-  vwt_address.SetLoadAddress(vwt_addr, &GetProcess().GetTarget());
-  Symbol *symbol = vwt_address.CalculateSymbolContextSymbol();
-  if (!symbol)
+  return std::make_pair(dynamic_type, *instance_addr);
+}
+
+std::optional<std::pair<CompilerType, uint64_t>>
+SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+    lldb::addr_t existential_address, CompilerType existential_type,
+    ExecutionContextScope *exe_scope) {
+  auto reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
     return std::nullopt;
 
-  Mangled mangled = symbol->GetMangled();
-  if (!mangled)
+  // An error existential is a pointer to a heap box laid out as [HeapObject,
+  // payload metadata, Error witness table, payload].
+  auto box = reflection_ctx->ReadPointer(existential_address);
+  if (!box)
+    return std::nullopt;
+  lldb::addr_t box_addr = box->getResolvedAddress().getRawAddress();
+  if (box_addr == 0 || box_addr == LLDB_INVALID_ADDRESS)
     return std::nullopt;
 
-  llvm::StringRef symbol_name = mangled.GetMangledName().GetStringRef();
-  TypeSystemSwiftTypeRefSP ts = existential_type.GetTypeSystem()
-                                    .dyn_cast_or_null<TypeSystemSwift>()
-                                    ->GetTypeSystemSwiftTypeRef();
-  if (!ts)
-    return std::nullopt;
+  uint32_t ptr_size = GetProcess().GetAddressByteSize();
 
-  CompilerType dynamic_type = ts->GetTypeFromValueWitnessTable(symbol_name);
+  // The payload's metadata follows the object header. Reading the metadata
+  // pointer at an address and resolving its symbol is what resolving an
+  // embedded class does, so reuse that.
+  CompilerType dynamic_type = GetDynamicTypeAndAddress_EmbeddedClass(
+      box_addr + 2 * ptr_size, existential_type);
   if (!dynamic_type)
     return std::nullopt;
 
-  return std::make_pair(dynamic_type,
-                        existential_container->PayloadAddress.getRawAddress());
+  // The payload follows the metadata and the witness table, rounded up to its
+  // own alignment.
+  unsigned alignment = 1;
+  if (auto ti_or_err = GetSwiftRuntimeTypeInfo(dynamic_type, exe_scope)) {
+    if (unsigned payload_alignment = ti_or_err->getAlignment())
+      alignment = payload_alignment;
+  } else {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), ti_or_err.takeError(),
+                   "no type info for error existential payload: {0}");
+  }
+  lldb::addr_t payload_addr = llvm::alignTo(box_addr + 4 * ptr_size, alignment);
+
+  if (auto instance_addr =
+          UnwrapClassReferenceIfNeeded(dynamic_type, payload_addr))
+    return std::make_pair(dynamic_type, *instance_addr);
+  return std::nullopt;
 }
 
 llvm::Expected<std::pair<CompilerType, uint64_t>>
 SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialEmbedded(
-    lldb::addr_t existential_address, CompilerType existential_type) {
-  // In the embedded Swift case, if the existential is class constrained, it
-  // will simply point to the instance. If it's not class constrained, it will
-  // have an existential container. Since there is no metadata to distinguish
-  // between the cases, we need to try both cases.
+    lldb::addr_t existential_address, CompilerType existential_type,
+    ExecutionContextScope *exe_scope) {
+  auto kind = swift::reflection::RecordKind::Invalid;
+  auto ti_or_err = GetSwiftRuntimeTypeInfo(existential_type, exe_scope);
+  if (ti_or_err) {
+    if (auto *rti =
+            llvm::dyn_cast<swift::reflection::RecordTypeInfo>(&*ti_or_err))
+      kind = rti->getRecordKind();
+  } else {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), ti_or_err.takeError(),
+                   "no type info for embedded existential: {0}");
+  }
 
-  // First, try class-constrained existential.
-  if (auto result =
-          GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
-              existential_address, existential_type))
-    return *result;
+  switch (kind) {
+  case swift::reflection::RecordKind::ErrorExistential:
+    if (auto result = GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+            existential_address, existential_type, exe_scope))
+      return *result;
+    return llvm::createStringError(
+        "failed to resolve dynamic type of embedded error existential");
 
-  // If that fails, try existential container.
-  if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
-          existential_address, existential_type))
-    return *result;
+  case swift::reflection::RecordKind::ClassExistential:
+    if (auto result =
+            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
+                existential_address, existential_type))
+      return *result;
+    return llvm::createStringError("failed to resolve dynamic type of "
+                                   "class-constrained embedded existential");
 
-  return llvm::createStringError(
-      "failed to resolve dynamic type of embedded existential");
+  case swift::reflection::RecordKind::OpaqueExistential:
+    if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+            existential_address, existential_type))
+      return *result;
+    return llvm::createStringError(
+        "failed to resolve dynamic type of opaque embedded existential");
+
+  default:
+    // No record layout for the existential, as a fallback try each one in turn.
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[GetDynamicTypeAndAddress_ExistentialEmbedded] unknown "
+             "representation of {0}, trying every layout",
+             existential_type.GetMangledTypeName());
+    if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+            existential_address, existential_type))
+      return *result;
+
+    if (auto result =
+            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
+                existential_address, existential_type))
+      return *result;
+
+    if (auto result = GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+            existential_address, existential_type, exe_scope))
+      return *result;
+
+    return llvm::createStringError(
+        "failed to resolve dynamic type of embedded existential");
+  }
 }
 
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
@@ -2873,8 +3007,10 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
       dynamic_type = ts->RemangleAsType(dem, node, flavor);
       dynamic_address = out_address.getRawAddress();
     } else {
+      ExecutionContext exe_ctx = in_value.GetExecutionContextRef().Lock(true);
       auto result_or_err = GetDynamicTypeAndAddress_ExistentialEmbedded(
-          existential_address, existential_type);
+          existential_address, existential_type,
+          exe_ctx.GetBestExecutionContextScope());
       if (!result_or_err) {
         LLDB_LOG_ERROR(GetLog(LLDBLog::Types), result_or_err.takeError(),
                        "{0}");

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -47,20 +47,26 @@ DWARFASTParserSwift::DWARFASTParserSwift(
 
 DWARFASTParserSwift::~DWARFASTParserSwift() {}
 
-/// Returns true if the DIE represents a protocol annotated with @_marker.
-static bool IsMarkerProtocol(const DWARFDIE &die) {
-  if (die.Tag() != llvm::dwarf::DW_TAG_structure_type)
-    return false;
+bool DWARFASTParserSwift::HasSwiftFlagAnnotation(
+    const DWARFDIE &die, llvm::StringRef annotation_name) {
   for (DWARFDIE child : die.children()) {
     if (child.Tag() != llvm::dwarf::DW_TAG_LLVM_annotation)
       continue;
     const char *name =
         child.GetAttributeValueAsString(llvm::dwarf::DW_AT_name, nullptr);
-    if (llvm::StringRef(name) == "swift.MarkerProtocol")
+    if (llvm::StringRef(name) == annotation_name)
       return child.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_const_value,
                                                0) != 0;
   }
   return false;
+}
+
+/// Returns true if the DIE represents a protocol annotated with @_marker.
+static bool IsMarkerProtocol(const DWARFDIE &die) {
+  if (die.Tag() != llvm::dwarf::DW_TAG_structure_type)
+    return false;
+  return DWARFASTParserSwift::HasSwiftFlagAnnotation(die,
+                                                     "swift.MarkerProtocol");
 }
 
 static llvm::StringRef GetTypedefName(const DWARFDIE &die) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -17,6 +17,7 @@
 #include "DWARFDIE.h"
 #include "swift/RemoteInspection/DescriptorFinder.h"
 #include "swift/RemoteInspection/TypeRef.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
 namespace reflection {
@@ -81,6 +82,12 @@ public:
   static bool classof(const DWARFASTParser *Parser) {
     return Parser->GetKind() == Kind::DWARFASTParserSwift;
   }
+
+  /// Returns the value of the boolean `swift.*` DW_TAG_LLVM_annotation named
+  /// \p annotation_name on \p die, or false if the DIE carries no such
+  /// annotation.
+  static bool HasSwiftFlagAnnotation(const DWARFDIE &die,
+                                     llvm::StringRef annotation_name);
 
   /// Returns a field descriptor constructed from DWARF info.
   std::unique_ptr<swift::reflection::FieldDescriptorBase>

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -210,8 +210,19 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
   return {{type, die}};
 }
 
+/// Determine the field descriptor kind of \p die, the DIE of a protocol.
+static swift::reflection::FieldDescriptorKind
+getProtocolFieldDescriptorKind(const DWARFDIE &die) {
+  if (DWARFASTParserSwift::HasSwiftFlagAnnotation(die, "swift.ObjCProtocol"))
+    return swift::reflection::FieldDescriptorKind::ObjCProtocol;
+  if (DWARFASTParserSwift::HasSwiftFlagAnnotation(
+          die, "swift.ClassConstrainedProtocol"))
+    return swift::reflection::FieldDescriptorKind::ClassProtocol;
+  return swift::reflection::FieldDescriptorKind::Protocol;
+}
+
 static std::optional<swift::reflection::FieldDescriptorKind>
-getFieldDescriptorKindForDie(CompilerType type) {
+getFieldDescriptorKindForDie(CompilerType type, const DWARFDIE &die) {
   auto type_class = type.GetTypeClass();
   switch (type_class) {
   case lldb::eTypeClassClass:
@@ -222,7 +233,7 @@ getFieldDescriptorKindForDie(CompilerType type) {
     return swift::reflection::FieldDescriptorKind::Enum;
   default:
     if (Flags(type.GetTypeInfo()).AnySet(lldb::eTypeIsProtocol))
-      return swift::reflection::FieldDescriptorKind::Protocol;
+      return getProtocolFieldDescriptorKind(die);
     LLDB_LOG(GetLog(LLDBLog::Types),
              "Could not determine file descriptor kind for type: {0}",
              type.GetMangledTypeName());
@@ -592,7 +603,7 @@ DWARFASTParserSwift::getFieldDescriptor(const swift::reflection::TypeRef *TR) {
   auto [type, die] = *pair;
   if (!die)
     return nullptr;
-  auto kind = getFieldDescriptorKindForDie(type);
+  auto kind = getFieldDescriptorKindForDie(type, die);
   if (!kind)
     return nullptr;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -398,33 +398,24 @@ TypeSystemSwiftTypeRef::GetBaseName(lldb::opaque_compiler_type_t type) {
   return GetBaseName(node).str();
 }
 
-CompilerType TypeSystemSwiftTypeRef::GetTypeFromTypeMetadataNode(
+std::pair<CompilerType, bool>
+TypeSystemSwiftTypeRef::GetTypeFromTypeMetadataNode(
     llvm::StringRef mangled_name) {
   Demangler dem;
   NodePointer node = dem.demangleSymbol(mangled_name);
+  bool is_full_metadata = false;
   NodePointer type = swift_demangle::NodeAtPath(
       node, {Node::Kind::Global, Node::Kind::TypeMetadata, Node::Kind::Type});
-  if (!type)
+  if (!type) {
     type = swift_demangle::NodeAtPath(
         node,
         {Node::Kind::Global, Node::Kind::FullTypeMetadata, Node::Kind::Type});
+    is_full_metadata = type != nullptr;
+  }
   if (!type)
     return {};
   auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
-  return RemangleAsType(dem, type, flavor);
-}
-
-CompilerType TypeSystemSwiftTypeRef::GetTypeFromValueWitnessTable(
-    llvm::StringRef mangled_name) {
-  Demangler dem;
-  NodePointer node = dem.demangleSymbol(mangled_name);
-  NodePointer type = swift_demangle::NodeAtPath(
-      node,
-      {Node::Kind::Global, Node::Kind::ValueWitnessTable, Node::Kind::Type});
-  if (!type)
-    return {};
-  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
-  return RemangleAsType(dem, type, flavor);
+  return {RemangleAsType(dem, type, flavor), is_full_metadata};
 }
 
 TypeSP TypeSystemSwiftTypeRef::LookupClangType(StringRef name_ref,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -483,13 +483,10 @@ public:
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
   std::string GetBaseName(lldb::opaque_compiler_type_t type);
 
-  /// Given a mangled name that mangles a "type metadata for Type", return a
-  /// CompilerType with that Type.
-  CompilerType GetTypeFromTypeMetadataNode(llvm::StringRef mangled_name);
-
-  /// Given a mangled name that mangles a "value witness table for Type",
-  /// return a CompilerType with that Type.
-  CompilerType GetTypeFromValueWitnessTable(llvm::StringRef mangled_name);
+  /// Given a mangled name that mangles a "type metadata for Type", return that
+  /// Type, and whether the name mangles full metadata.
+  std::pair<CompilerType, bool>
+  GetTypeFromTypeMetadataNode(llvm::StringRef mangled_name);
 
   /// Use API notes to determine the swiftified name of \p clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
@@ -8,7 +8,6 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftForwardInteropCxxClassAsExistential(TestBase):
 
-    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropCxxClassAsExistential(TestBase):
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/embedded/boxed_existential/Makefile
+++ b/lldb/test/API/lang/swift/embedded/boxed_existential/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/boxed_existential/TestSwiftEmbeddedBoxedExistential.py
+++ b/lldb/test/API/lang/swift/embedded/boxed_existential/TestSwiftEmbeddedBoxedExistential.py
@@ -1,0 +1,70 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedBoxedExistential(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    @skipUnlessEmbeddedSwift
+    def test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        # A payload that does not fit inline is boxed on the heap. Its fields
+        # start past the box's HeapObject header, not at the box address.
+        self.expect(
+            "frame variable pBoxed",
+            substrs=["a.Boxed", "a = 111", "b = 222", "c = 333", "d = 444"],
+        )
+        self.expect(
+            "frame variable pEnumLarge", substrs=["a.E", "large", "1", "2", "3", "4"]
+        )
+
+        # Payloads that do fit inline, and a class reference, which is one word
+        # and is therefore never boxed.
+        self.expect("frame variable pInline", substrs=["a.Inline", "a = 555", "b = 666"])
+        self.expect("frame variable pEnumSmall", substrs=["a.E", "small", "888"])
+        self.expect("frame variable pClass", substrs=["a.C", "classField = 777"])
+        self.expect("frame variable classBound", substrs=["a.C", "classField = 777"])
+
+        # A class-constrained existential is a reference plus a witness table,
+        # not a five-word opaque container.
+        self.expect(
+            "frame variable -d no-dynamic-values classBound",
+            substrs=["a.ClassBound", "object", "wtable"],
+        )
+        self.expect(
+            "frame variable -d no-dynamic-values classBound",
+            substrs=["payload_data_"],
+            matching=False,
+        )
+
+        # A tuple payload is described only by DWARF, since it is not nominal
+        # and embedded Swift emits stub metadata for it.
+        self.expect(
+            "frame variable boxedTuple",
+            substrs=["(Int, Int, Int, Int)", "0 = 1", "1 = 2", "2 = 3", "3 = 4"],
+        )
+        self.expect(
+            "frame variable inlineTuple", substrs=["(Int, Int)", "0 = 5", "1 = 6"]
+        )
+
+        # An error existential points to a heap box that names the payload's
+        # type. The payload follows the box's header, metadata and witness
+        # table, so a wrong offset here would print garbage rather than fail.
+        self.expect(
+            "frame variable anyError",
+            substrs=["a.MyError", "code = 999", "extra = 111"],
+        )
+
+        # A class payload is a reference stored in that slot, so resolving it
+        # has to step through to the instance.
+        self.expect(
+            "frame variable classError",
+            substrs=["a.MyClassError", "classCode = 4242"],
+        )

--- a/lldb/test/API/lang/swift/embedded/boxed_existential/main.swift
+++ b/lldb/test/API/lang/swift/embedded/boxed_existential/main.swift
@@ -1,0 +1,86 @@
+// A class-constrained existential stores the instance pointer directly; an
+// opaque one has an existential container, whose payload is stored inline only
+// if it fits in three words.
+protocol ClassBound: AnyObject {
+}
+
+protocol P {
+}
+
+// Four words, so this does not fit in the existential's inline buffer and is
+// boxed on the heap.
+struct Boxed: P {
+    let a = 111
+    let b = 222
+    let c = 333
+    let d = 444
+}
+
+// Two words, so this is stored inline.
+struct Inline: P {
+    let a = 555
+    let b = 666
+}
+
+// A class reference is one word, and is therefore never boxed.
+class C: P, ClassBound {
+    let classField = 777
+}
+
+enum E: P {
+    case small(Int)
+    case large(Int, Int, Int, Int)
+}
+
+// An error existential is a pointer to a heap box that holds the payload's type
+// metadata, rather than an existential container.
+struct MyError: Error {
+    let code = 999
+    let extra = 111
+}
+
+// A class payload is stored in the box as a reference, not inline.
+class MyClassError: Error {
+    let classCode = 4242
+}
+
+func mayThrow() throws {
+    throw MyError()
+}
+
+func mayThrowClass() throws {
+    throw MyClassError()
+}
+
+func f() {
+    let pBoxed: any P = Boxed()
+    let pInline: any P = Inline()
+    let pClass: any P = C()
+    let classBound: any ClassBound = C()
+    // Tuples are not nominal, so the metadata the existential points at carries
+    // no layout for them; DWARF is the only description of these.
+    let boxedTuple: Any = (1, 2, 3, 4)
+    let inlineTuple: Any = (5, 6)
+    // FIXME: rdar://168697959 (Debug info for enums is not generated, if there
+    // are no variables/parameter with the enum type in embedded swift)
+    let bug = E.small(0)
+    let pEnumSmall: any P = E.small(888)
+    let pEnumLarge: any P = E.large(1, 2, 3, 4)
+    do {
+        try mayThrow()
+    } catch {
+        // Binding the error to a variable of its own gives that variable a
+        // slot holding the box pointer. A direct `any Error = MyError()`
+        // would instead be described as living inside the box.
+        let anyError: any Error = error
+        do {
+            try mayThrowClass()
+        } catch {
+            let classError: any Error = error
+            print("break here")
+            _ = (anyError, classError)
+        }
+    }
+}
+
+f()

--- a/lldb/test/API/lang/swift/generic_error/TestGenericError.py
+++ b/lldb/test/API/lang/swift/generic_error/TestGenericError.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_error/TestGenericError.py
+++ b/lldb/test/API/lang/swift/generic_error/TestGenericError.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipEmbeddedSwiftOnLinux, skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipEmbeddedSwiftOnLinux, skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftTuple(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftTuple(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()


### PR DESCRIPTION
Resolving an embedded Swift existential used to be guesswork. LLDB tried each possible layout in turn, and recovered the payload's type from its value witness table symbol, which cannot name a class payload because every class shares one table. Error existentials had no support at all.

Both facts are actually knowable. The compiler now records a protocol's class constraint in DWARF, so reflection can say which representation an existential has and LLDB dispatches on that instead of trying layouts.

Assisted-by: claude