### PR TITLE
[BoundsSafety] Fix attribute from COnly to CountedBySupported

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2754,7 +2754,7 @@ def CountedByOrNull : DeclOrTypeAttr {
   let LateParsed = LateAttrParseExperimentalExt;
   let ParseArgumentsAsUnevaluated = 1;
   let Documentation = [CountedByOrNullDocs];
-  let LangOpts = [COnly];
+  let LangOpts = [CountedBySupported];
   // TO_UPSTREAM(BoundsSafety) OFF
 }
 
@@ -2783,7 +2783,7 @@ def SizedBy : DeclOrTypeAttr {
   let LateParsed = LateAttrParseExperimentalExt;
   let ParseArgumentsAsUnevaluated = 1;
   let Documentation = [SizedByDocs];
-  let LangOpts = [COnly];
+  let LangOpts = [CountedBySupported];
   // TO_UPSTREAM(BoundsSafety) OFF
 }
 
@@ -2799,7 +2799,7 @@ def SizedByOrNull : DeclOrTypeAttr {
   let LateParsed = LateAttrParseExperimentalExt;
   let ParseArgumentsAsUnevaluated = 1;
   let Documentation = [SizedByOrNullDocs];
-  let LangOpts = [COnly];
+  let LangOpts = [CountedBySupported];
   // TO_UPSTREAM(BoundsSafety) OFF
 }
 


### PR DESCRIPTION
Under `-fexperimental-bounds-safety-attributes` `sided_by`, `sized_by_or_null`, and `counted_by_or_null` were wrongly gated on `COnly`, when they should be `CountedBySupported`. This came from f435f18dd0ad.

rdar://184168423