### PR TITLE
[LLDB] Evaluate expressions as freestanding functions if self is unav… 

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -698,6 +698,26 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
           func_name.GetStringRef(), *ts);
     }
 
+    // Try to evaluate the expression without self if it is not available.
+    if (m_needs_object_ptr || m_in_static_method) {
+      bool has_self = llvm::any_of(
+          local_variables,
+          [](const SwiftASTManipulator::VariableInfo &variable) {
+            return variable.IsSelf();
+          });
+      if (!has_self) {
+        LLDB_LOG(log, "`self` is not avilable, "
+                      "downgrading to freestanding function");
+        diagnostic_manager.PutString(lldb::eSeverityWarning,
+                                     "'self' is not available in this frame; "
+                                     "evaluating the expression without it");
+        m_needs_object_ptr = false;
+        m_in_static_method = false;
+        m_is_class = false;
+        m_is_weak_self = false;
+      }
+    }
+
     if (!SwiftASTManipulator::ShouldBindGenericTypes(
             m_options.GetSwiftBindGenericTypes()) &&
         !CanEvaluateExpressionWithoutBindingGenericParams(

--- a/lldb/test/API/lang/swift/cross_module_extension_self/Lib.swift
+++ b/lldb/test/API/lang/swift/cross_module_extension_self/Lib.swift
@@ -1,0 +1,5 @@
+// Module Lib: defines the type that gets extended from another module.
+public struct Root {
+  public var value: Int
+  public init(value: Int) { self.value = value }
+}

--- a/lldb/test/API/lang/swift/cross_module_extension_self/Makefile
+++ b/lldb/test/API/lang/swift/cross_module_extension_self/Makefile
@@ -1,0 +1,19 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -I.
+LD_EXTRAS = -L. -Xlinker -rpath -Xlinker $(BUILDDIR) -lLib
+
+all: clean dylib a.out
+
+include Makefile.rules
+
+# DYLIB_HIDE_SWIFTMODULE together with no reflection metadata makes it
+# impossible to lay out `self`.
+.PHONY: dylib
+dylib: Lib.swift
+	"$(MAKE)" -f $(MAKEFILE_RULES) -C $(BUILDDIR) VPATH=$(SRCDIR) \
+		CC=$(CC) SWIFTC=$(SWIFTC) ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		DYLIB_HIDE_SWIFTMODULE=YES \
+		DYLIB_ONLY=YES \
+		DYLIB_NAME=Lib \
+		DYLIB_SWIFT_SOURCES=Lib.swift \
+		SWIFTFLAGS_EXTRAS="-Xfrontend -disable-reflection-metadata -enable-library-evolution"

--- a/lldb/test/API/lang/swift/cross_module_extension_self/TestSwiftCrossModuleExtensionSelf.py
+++ b/lldb/test/API/lang/swift/cross_module_extension_self/TestSwiftCrossModuleExtensionSelf.py
@@ -1,0 +1,42 @@
+"""
+Test expression evaluation in a frame whose `self` type cannot be realized.
+
+`Lib.Root` is defined in one module and extended from another.  Reflection
+metadata for `Lib.Root` is unavailable and Lib's AST is not reachable either, so
+LLDB has a valid *location* for `self` but no usable value for it.
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftCrossModuleExtensionSelf(TestBase):
+    @requireNotEmbeddedSwift
+    @swiftTest
+    def test_unusable_self_does_not_break_frame(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        # Verify that `self` is indeed not available.
+        self_var = self.frame().FindVariable("self")
+        self.assertTrue(self_var.IsValid(), "expected a 'self' variable")
+        self.assertEqual(self_var.GetType().GetName(), "Lib.Root")
+        self.assertTrue(
+            self_var.GetError().Fail(),
+            "expected 'self' to have no usable value, got %s"
+            % self_var.GetValue(),
+        )
+
+        # A local variable is not a member of `self`, so it must still resolve --
+        # and materialize -- even though `self` was dropped from the wrapper.
+        factor = self.frame().EvaluateExpression("factor")
+        self.assertSuccess(factor.GetError())
+        self.assertEqual(factor.GetValue(), "7")
+
+        # Expressions that need `self` must fail with a diagnostic about `self`.
+        error = self.frame().EvaluateExpression("self").GetError().GetCString() or ""
+        self.assertIn("cannot find 'self' in scope", error)
+        self.assertNotIn("$__lldb_injected_self", error)

--- a/lldb/test/API/lang/swift/cross_module_extension_self/TestSwiftCrossModuleExtensionSelf.py
+++ b/lldb/test/API/lang/swift/cross_module_extension_self/TestSwiftCrossModuleExtensionSelf.py
@@ -12,7 +12,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftCrossModuleExtensionSelf(TestBase):
-    @requireNotEmbeddedSwift
+    @skipEmbeddedSwift # 6.4.x only
     @swiftTest
     def test_unusable_self_does_not_break_frame(self):
         self.build()

--- a/lldb/test/API/lang/swift/cross_module_extension_self/main.swift
+++ b/lldb/test/API/lang/swift/cross_module_extension_self/main.swift
@@ -1,0 +1,12 @@
+import Lib
+
+// A cross-module extension of Lib.Root: in the DWARF for this compile unit the
+// getter's decl context is Lib (module) -> Root (struct) -> doubled.get.
+extension Root {
+  var doubled: Int {
+    let factor = 7
+    return value * factor // break here
+  }
+}
+
+print(Root(value: 21).doubled)


### PR DESCRIPTION
…ailable

Today it is a fatal error for all expressions if `self` is not available. By downgrading to a non-method we can at least support some expressions. This patch also dramtically improves the error messages produced in this case.

rdar://183769766

Assisted-by: claude