### PR TITLE
🍒 [Modules] Don't merge attributes for namespace redeclarations. (#214361)

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3912,7 +3912,7 @@ void ASTDeclReader::attachPreviousDecl(ASTReader &Reader, Decl *D,
 
   if (PreviousNonLocal) {
     if (Sema *S = Reader.getSema()) {
-      if (auto *ND = dyn_cast<NamedDecl>(D))
+      if (auto *ND = dyn_cast<NamedDecl>(D); ND && !isa<NamespaceDecl>(ND))
         S->mergeDeclAttributes(ND, PreviousNonLocal);
     }
   }

--- a/clang/test/Modules/decl-attr-merge2.c
+++ b/clang/test/Modules/decl-attr-merge2.c
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps \
 // RUN:   -fmodules-cache-path=%t/mcache -triple arm64-apple-macosx10.7.0 \
-// RUN:   -I%t/headers -fsyntax-only %t/test.c -verify
+// RUN:   -I%t/headers -fsyntax-only %t/test.cpp -verify
 
 // Check more cases of attribute merging across multiple modules.
 
@@ -17,11 +17,25 @@ module Second {
 void additiveAttr(void) __attribute__((availability(macos,unavailable)));
 void exclusiveAttr(void) __attribute__((hot));
 
+namespace N {
+inline namespace with_tag __attribute__((__abi_tag__("a"))) {
+  struct First {};
+}
+inline namespace with_tag {
+}
+}
+
 //--- headers/second.h
 void additiveAttr(void) __attribute__((availability(ios,introduced=4.0)));
 void exclusiveAttr(void) __attribute__((cold));
 
-//--- test.c
+namespace N {
+inline namespace with_tag {
+  struct Second {};
+}
+}
+
+//--- test.cpp
 #include <first.h>
 #include <second.h>
 
@@ -35,4 +49,6 @@ void test(void) {
   exclusiveAttr();
   // expected-error@second.h:* {{'cold' and 'hot' attributes are not compatible}}
   // expected-note@first.h:* {{conflicting attribute is here}}
+
+  N::Second second;
 }


### PR DESCRIPTION
Follow-up to #208348 which aimed to handle decl attributes on deserialization the same way as during parsing. Turned out during parsing we don't merge attributes for namespace redeclarations.

(cherry picked from commit c3a0eb4b8f4f4b5c4b705c04bc3f16e4985ddbdf)