### PR TITLE
🍒 [clang][tmo][nfc] Remove packed attribute from TypedMemorySummary

### DIFF
--- a/clang/include/clang/AST/TypedMemoryDescriptorBits.h
+++ b/clang/include/clang/AST/TypedMemoryDescriptorBits.h
@@ -97,7 +97,7 @@ struct TypedMemorySummary {
            (TypeFlags << kTypeFlagsShift) | (TypeKind << kTypeKindShift) |
            (CallsiteFlags << kCallsiteFlagsShift) | (Version << kVersionShift);
   }
-} __attribute__((packed));
+};
 
 struct TypedMemoryDescriptorBits {
   TypedMemoryDescriptorBits() : Hash(0) {}
@@ -116,11 +116,6 @@ struct TypedMemoryDescriptorBits {
     return (Summary << kSummaryShift) | (Hash << kHashShift);
   }
 };
-
-static_assert(sizeof(TypedMemorySummary) == sizeof(uint32_t),
-              "Summary must be 32 bits");
-static_assert(sizeof(TypedMemoryDescriptorBits) == sizeof(uint64_t),
-              "Descriptor must be 64 bits");
 
 } // namespace clang
 


### PR DESCRIPTION
MSVC doesn't support the `__attribute__` syntax but we also don't actually need to pack the struct at all anymore. The original implementation serialized via memcpy, but we decided that was not sufficiently explicit and moved to manually constructing the the descriptor. Because of that change we no longer need to pack the struct at all.

(cherry picked from commit 07b3631776ccad375f0c71cb78d0a1f2d0d1b5e7)