### PR TITLE
[BoundsSafety] Fix `counted_by_or_null`, `sized_by`, and `sized_by_or_null` being ignored

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2754,7 +2754,7 @@ def CountedByOrNull : DeclOrTypeAttr {
   let LateParsed = LateAttrParseExperimentalExt;
   let ParseArgumentsAsUnevaluated = 1;
   let Documentation = [CountedByOrNullDocs];
-  let LangOpts = [COnly];
+  let LangOpts = [CountedBySupported];
   // TO_UPSTREAM(BoundsSafety) OFF
 }
 
@@ -2783,7 +2783,7 @@ def SizedBy : DeclOrTypeAttr {
   let LateParsed = LateAttrParseExperimentalExt;
   let ParseArgumentsAsUnevaluated = 1;
   let Documentation = [SizedByDocs];
-  let LangOpts = [COnly];
+  let LangOpts = [CountedBySupported];
   // TO_UPSTREAM(BoundsSafety) OFF
 }
 
@@ -2799,7 +2799,7 @@ def SizedByOrNull : DeclOrTypeAttr {
   let LateParsed = LateAttrParseExperimentalExt;
   let ParseArgumentsAsUnevaluated = 1;
   let Documentation = [SizedByOrNullDocs];
-  let LangOpts = [COnly];
+  let LangOpts = [CountedBySupported];
   // TO_UPSTREAM(BoundsSafety) OFF
 }
 


### PR DESCRIPTION
In `f435f18dd0ad` ("Merge commit '745271fc23fd' from llvm.org/main into next") a conflict in `clang/include/clang/Basic/Attr.td` was resolved in a way that regressed the availability of the `counted_by_or_null`, `sized_by` and `sized_by_or_null` attributes in C++/Obj-C++.

The merged upstream change (llvm.org PR #212877, "[NFC][BoundsSafety] Give `counted_by_or_null`, `sized_by`, and `sized_by_or_null` their own documentation") only intended to update the `Documentation` of these attributes and was genuinely NFC upstream, where all three are gated on `COnly` (i.e. `!LangOpts.CPlusPlus`). Downstream, however, these attributes had been customized to use `CountedBySupported`:

```
!LangOpts.CPlusPlus || LangOpts.BoundsSafetyAttributes
```

so that they remain available in experimental C++/Obj-C++ under `-fexperimental-bounds-safety-attributes`. When resolving the conflict the upstream hunk was taken wholesale: the new (correct) `Documentation` was picked up, but `LangOpts` was also reverted from `CountedBySupported` back to `COnly`, dropping the downstream customization.

As a result, under `-fexperimental-bounds-safety-attributes` in C++ and Obj-C++ these three attributes were no longer recognized and were silently ignored:

```
warning: '__sized_by__' attribute ignored [-Wignored-attributes]
warning: '__counted_by_or_null__' attribute ignored [-Wignored-attributes]
warning: '__sized_by_or_null__' attribute ignored [-Wignored-attributes]
```

`counted_by` was unaffected because its `CountedBySupported` gate was not part of the conflicted hunk, which is why only the three sibling attributes regressed. This broke a number of tests, e.g. `BoundsSafety/Sema/count-attrs.c`,
`BoundsSafety/Sema/counted-by-nullability-attrs.c` and the various `*-attribute-only-mode` tests, whose C++/Obj-C++ `RUN` lines expect the attributes to be honored.

The fix restores `LangOpts = [CountedBySupported]` on all three attributes so they once again match `counted_by`, while keeping the corrected `Documentation` from the upstream change.

Assisted-by: Claude Code
rdar://184187478