### PR TITLE
🍒 Guard against non-linux/FreeBSD systems for copy_file_range

### DIFF
--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -41,7 +41,7 @@
 #include <time.h>
 
 // since Linux 4.5 and FreeBSD 13, but the Linux libc wrapper is only provided by glibc >= 2.27 and musl
-#if _LIBCPP_GLIBC_PREREQ(2, 27) || _LIBCPP_HAS_MUSL_LIBC || defined(__FreeBSD__)
+#if (defined(__linux__) && (_LIBCPP_GLIBC_PREREQ(2, 27) || _LIBCPP_HAS_MUSL_LIBC)) || defined(__FreeBSD__)
 #  define _LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE
 #endif
 


### PR DESCRIPTION
(cherry picked from commit 1cb53dbd1ceff0db89093567f2c859114b5a748b)


Cherry-picking to unblock Swift CI. The upstream PR, https://github.com/llvm/llvm-project/pull/184373, is getting pushback due to wasi not being an officially supported platform for libcxx.