### PR TITLE
[lldb][embedded] Adapt functions in tests so they're aren't optimized out

### DIFF
--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestExpressionsInSwiftMethodsPureSwift(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_expressions_in_methods(self):
         """Tests that we can run simple Swift expressions correctly"""

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/main.swift
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/main.swift
@@ -9,7 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-class PureSwift
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class PureSwift
 {
     init (int_value: Int)
     {
@@ -30,4 +32,6 @@ class PureSwift
 }
 
 var my_swift_object = PureSwift(int_value: 10)
+// Keep the getter alive for embedded Swift.
+print(my_swift_object.m_computed_ivar)
 my_swift_object.stop_here()

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -29,7 +29,7 @@ def execute_command(command):
     return exit_status
 
 class TestExclusivitySuppression(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     # Test that we can evaluate w.s.i at Breakpoint 1 without triggering
     # a failure due to exclusivity
     @swiftTest
@@ -45,7 +45,7 @@ class TestExclusivitySuppression(TestBase):
 
         lldbutil.check_expression(self, frame, "w.s.i", "8", use_summary=False)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     # Test that we properly handle nested expression evaluations by:
     # (1) Breaking at breakpoint 1
     # (2) Running 'expr get()' (which will hit breakpoint 2)

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/main.swift
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/main.swift
@@ -30,7 +30,9 @@ struct S {
 // global. LLDB accesses globals via unsafe pointers, which aren't subject to
 // dynamic exclusivity checks, and we need to actually hit these checks to
 // verify that enforcement is suppressed.
-class Wrapper {
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class Wrapper {
   var s = S()
 }
 

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -35,7 +35,6 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.build()
         self.do_test()
 
-    @skipEmbeddedSwift
     @swiftTest
     @skipEmbeddedSwiftOnWindows
     def test_ivars_in_generic_expressions(self):

--- a/lldb/test/API/lang/swift/expression/generic/main.swift
+++ b/lldb/test/API/lang/swift/expression/generic/main.swift
@@ -42,7 +42,9 @@ func a (_ i : Int)
 
 // Class, function
 
-class B
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class B
 {
   var m_t : Int
   var m_s : S<Int>
@@ -62,7 +64,7 @@ class B
 
 // Generic class, function
 
-class C<T>
+final class C<T>
 {
   var m_t : T
   var m_s : S<T>
@@ -89,7 +91,7 @@ func d<U> (_ i : U)
 
 // Class, generic function
 
-class E
+final class E
 {
   var m_t : Int
   var m_s : S<Int>
@@ -109,7 +111,7 @@ class E
 
 // Generic class, generic function
 
-class F<T>
+final class F<T>
 {
   var m_t : T
   var m_s : S<T>

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -19,6 +19,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftFixIts(TestBase):
+    # Embedded Swift: `Optional: Equatable` asserts in IRGen, and
+    # `_swift_beginAccess` is missing from the runtime.
     @skipEmbeddedSwift
     @swiftTest
     def test_swift_fixits(self):

--- a/lldb/test/API/lang/swift/inlined_self_scope/TestSwiftInlinedSelfScope.py
+++ b/lldb/test/API/lang/swift/inlined_self_scope/TestSwiftInlinedSelfScope.py
@@ -18,7 +18,7 @@ class TestSwiftInlinedSelfScope(TestBase):
         )
         return frame
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_self_scope_in_inlined_frames(self):
         self.build()

--- a/lldb/test/API/lang/swift/inlined_self_scope/main.swift
+++ b/lldb/test/API/lang/swift/inlined_self_scope/main.swift
@@ -11,7 +11,9 @@ func freeFunction() {
   blackhole(42) // break here in free function
 }
 
-class Tester {
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class Tester {
   var count = 41
 
   // An inlined *method* with its own `self`.

--- a/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
+++ b/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftProtocolCompositionExpr(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test that expression evaluation can call functions in protocol composition existentials"""

--- a/lldb/test/API/lang/swift/protocol_composition_expr/main.swift
+++ b/lldb/test/API/lang/swift/protocol_composition_expr/main.swift
@@ -33,6 +33,11 @@ struct S: P1, P2 {
 func f() {
     let c: any P1 & P2 = C()
     let s: any P1 & P2 = S()
+    // Use func so they aren't optimized out in embedded swift
+    print(c.foo())
+    print(c.bar())
+    print(s.foo())
+    print(s.bar())
     print("break here")
 }
 

--- a/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
+++ b/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest]
+)

--- a/lldb/test/API/lang/swift/protocol_extension_two/main.swift
+++ b/lldb/test/API/lang/swift/protocol_extension_two/main.swift
@@ -20,4 +20,5 @@ struct Patatino<T> where T : Tinky {
 }
 
 let pat = Patatino<Winky>(x: Winky(x: 23))
+print(pat.baciotto) // Use it so it isn't optimized out in embedded swift.
 pat.f()

--- a/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -23,7 +23,7 @@ class TestSwiftSplitDebug(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_split_debug_info(self):
         """Test split debug info"""

--- a/lldb/test/API/lang/swift/split_debug/main.swift
+++ b/lldb/test/API/lang/swift/split_debug/main.swift
@@ -9,14 +9,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-class Class {
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class Class {
     var c_x : UInt32 = 12345
     var c_y : UInt32 = 6789
 }
 
 func main() {
     var c = Class()
-
     print("hello world") // Break here in main
 }
 


### PR DESCRIPTION
    Our tests sometimes calls functions that aren't used in the test
    programs. In embedded swift, these functions are optimized out. Make sure
    to use them so they aren't. Some of these tests were solved by this, but
    others are still failing.

    Furthermore, embedded swift devirtualizes virtual functions and removes
    them as well, making them not callable from lldb. Mark them as final so
    devirtualization doesn't happen.

    Assisted-by: claude