### PR TITLE
[lldb][test] Drop the duplicate variant-exclusion definition that disabled it

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1998,32 +1998,6 @@ def _is_excluded_variant_combination(method, variant_name, value_name):
         if combo.get(variant_name) != value_name:
             continue
         if all(
-            getattr(method, k, None) == v
-            for k, v in combo.items()
-            if k != variant_name
-        ):
-            return True
-    return False
-
-
-# Variant value combinations that should never be generated. Each entry maps
-# `variant_name -> value`; a method copy is dropped when its already-set
-# variant attributes plus the new value being added match every key in the
-# entry. Add entries here for crosses that don't exercise anything new and
-# would only inflate the matrix on remote test runs.
-_excluded_variant_combinations = [
-    # Example (uncomment + adapt when registering a real cross to drop):
-    # {"swift_module_importer": "noclang", "swift_embedded": "swiftembed"},
-]
-
-
-def _is_excluded_variant_combination(method, variant_name, value_name):
-    """Return True if assigning *variant_name=value_name* to *method* would
-    produce a combination listed in `_excluded_variant_combinations`."""
-    for combo in _excluded_variant_combinations:
-        if combo.get(variant_name) != value_name:
-            continue
-        if all(
             getattr(method, k, None) == v for k, v in combo.items() if k != variant_name
         ):
             return True


### PR DESCRIPTION
_excluded_variant_combinations and _is_excluded_variant_combination are each defined twice, about thirty lines apart. The first copy carries the one real entry.

Assisted-by: claude