### PR TITLE
[lldb][embedded] Supported mixed embedded/regular swift programs

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -29,7 +29,10 @@ namespace {
 /// as they are tied to each type system typeref's symbol file. This class's
 /// only purpose is to allow this swapping.
 struct DescriptorFinderForwarder : public swift::reflection::DescriptorFinder {
-  DescriptorFinderForwarder() = default;
+  /// \param always_consult is used in embedded swift mode since it doesn't have
+  /// reflection metadata.
+  explicit DescriptorFinderForwarder(bool always_consult)
+      : m_always_consult(always_consult) {}
   ~DescriptorFinderForwarder() override = default;
 
   std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
@@ -67,12 +70,14 @@ struct DescriptorFinderForwarder : public swift::reflection::DescriptorFinder {
     m_image_added |= image_added;
   }
 
-  /// Record that LLDB has encountered an Embedded Swift type and thus that the
-  /// external descriptor finder should be enabled.
-  void SetEmbedded() { m_embedded = true; }
-
 private:
   bool shouldConsultDescriptorFinder() {
+    // Embedded Swift never has reflection metadata for its types, so the
+    // external descriptor finder is the only source of type information, and
+    // the setting below has no say in the matter.
+    if (m_always_consult)
+      return true;
+
     switch (ModuleList::GetGlobalModuleListProperties()
                 .GetSwiftEnableFullDwarfDebugging()) {
     case lldb_private::AutoBool::True:
@@ -80,12 +85,8 @@ private:
     case lldb_private::AutoBool::False:
       return false;
     case lldb_private::AutoBool::Auto:
-      // Embedded Swift never has reflection metadata for its types, so the
-      // external descriptor finder is the only source of type information.
-      if (m_embedded)
-        return true;
-      // Otherwise, full DWARF debugging is auto-enabled if there is no
-      // reflection metadata to read from.
+      // Full DWARF debugging is auto-enabled if there is no reflection
+      // metadata to read from.
       return !m_image_added;
     }
   }
@@ -93,7 +94,7 @@ private:
   llvm::SmallVector<swift::reflection::DescriptorFinder *, 1>
       m_descriptor_finders;
   bool m_image_added = false;
-  bool m_embedded = false;
+  const bool m_always_consult;
 };
 
 /// An implementation of the generic ReflectionContextInterface that
@@ -101,152 +102,520 @@ private:
 /// 32-bit or 64-bit pointers, with and without ObjC interoperability.
 template <typename ReflectionContext, bool ObjCEnabled, unsigned PointerSize>
 class TargetReflectionContext : public ReflectionContextInterface {
-  DescriptorFinderForwarder m_forwader;
-  ReflectionContext m_reflection_ctx;
-  swift::reflection::TypeConverter &m_type_converter;
+  /// A swift::reflection::ReflectionContext bound to a single mangling flavor,
+  /// bundled with the descriptor finder forwarder that gates its DWARF
+  /// fallback.
+  struct Instance {
+    Instance(std::shared_ptr<swift::reflection::MemoryReader> reader,
+             SwiftMetadataCache *swift_metadata_cache,
+             swift::Mangle::ManglingFlavor flavor)
+        : m_forwader(flavor == swift::Mangle::ManglingFlavor::Embedded),
+          m_reflection_ctx(reader, swift_metadata_cache, &m_forwader, flavor),
+          m_type_converter(m_reflection_ctx.getBuilder().getTypeConverter()) {
+      m_type_converter.enableErrorCache();
+    }
+
+    bool IsEmbedded() {
+      return m_reflection_ctx.getBuilder().getManglingFlavor() ==
+             swift::Mangle::ManglingFlavor::Embedded;
+    }
+
+    std::optional<uint32_t> AddImage(
+        llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
+            swift::ReflectionSectionKind)>
+            find_section,
+        llvm::SmallVector<llvm::StringRef, 1> likely_module_names) {
+      assert(!IsEmbedded() && "Embedded Swift has no reflection metadata");
+      auto id = m_reflection_ctx.addImage(find_section, likely_module_names);
+      m_forwader.SetImageAdded(id.has_value());
+      return id;
+    }
+
+    std::optional<uint32_t>
+    AddImage(swift::remote::RemoteAddress image_start,
+             llvm::SmallVector<llvm::StringRef, 1> likely_module_names) {
+      assert(!IsEmbedded() && "Embedded Swift has no reflection metadata");
+      auto id = m_reflection_ctx.addImage(image_start, likely_module_names);
+      m_forwader.SetImageAdded(id.has_value());
+      return id;
+    }
+
+    /// Sets the descriptor finder, and on scope exit clears it out.
+    auto PushDescriptorFinderAndPopOnExit(
+        swift::reflection::DescriptorFinder *descriptor_finder) {
+      m_forwader.PushExternalDescriptorFinder(descriptor_finder);
+      return llvm::make_scope_exit(
+          [this]() { m_forwader.PopExternalDescriptorFinder(); });
+    }
+
+    llvm::Expected<const swift::reflection::TypeRef &>
+    GetTypeRef(swift::Demangle::Demangler &dem,
+               swift::Demangle::NodePointer node) {
+      auto type_ref_or_err = swift::Demangle::decodeMangledType(
+          m_reflection_ctx.getBuilder(), node);
+      if (type_ref_or_err.isError())
+        return llvm::createStringError(
+            type_ref_or_err.getError()->copyErrorString());
+      auto *tr = type_ref_or_err.getType();
+      if (!tr)
+        return llvm::createStringError(
+            "decoder returned nullptr typeref but no error");
+      return *tr;
+    }
+
+    llvm::Expected<const swift::reflection::RecordTypeInfo &>
+    GetClassInstanceTypeInfo(
+        const swift::reflection::TypeRef &type_ref,
+        swift::remote::TypeInfoProvider *provider,
+        swift::reflection::DescriptorFinder *descriptor_finder) {
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+      auto start = m_reflection_ctx.computeUnalignedFieldStartOffset(&type_ref,
+                                                                     provider);
+      if (!start) {
+        std::stringstream ss;
+        type_ref.dump(ss);
+        return llvm::createStringError(
+            "Could not compute start field offset for typeref: " + ss.str());
+      }
+
+      auto *rti = m_type_converter.getClassInstanceTypeInfo(&type_ref, *start,
+                                                            provider);
+      if (!rti)
+        return llvm::createStringError(m_type_converter.takeLastError());
+      return *rti;
+    }
+
+    llvm::Expected<const swift::reflection::TypeInfo &> GetTypeInfoFromInstance(
+        lldb::addr_t instance, swift::remote::TypeInfoProvider *provider,
+        swift::reflection::DescriptorFinder *descriptor_finder) {
+      assert(!IsEmbedded() &&
+             "Embedded Swift has no runtime metadata records to read");
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+      auto *ti = m_reflection_ctx.getInstanceTypeInfo(
+          swift::remote::RemoteAddress(
+              instance, swift::remote::RemoteAddress::DefaultAddressSpace),
+          provider);
+      if (!ti)
+        return llvm::createStringError("could not get instance type info");
+      return *ti;
+    }
+
+    swift::reflection::MemoryReader &GetReader() {
+      return m_reflection_ctx.getReader();
+    }
+
+    const swift::reflection::TypeRef *
+    LookupSuperclass(const swift::reflection::TypeRef &tr,
+                     swift::reflection::DescriptorFinder *descriptor_finder) {
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+      return m_reflection_ctx.getBuilder().lookupSuperclass(&tr);
+    }
+
+    bool ForEachSuperClassType(
+        swift::remote::TypeInfoProvider *tip,
+        swift::reflection::DescriptorFinder *descriptor_finder,
+        const swift::reflection::TypeRef *tr,
+        std::function<bool(SuperClassType)> fn) {
+      // Guard against faulty self-referential metadata.
+      unsigned limit = 256;
+      while (tr && --limit) {
+        if (fn({[=]() -> const swift::reflection::RecordTypeInfo * {
+                  auto ti_or_err =
+                      GetRecordTypeInfo(*tr, tip, descriptor_finder);
+                  if (!ti_or_err) {
+                    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types),
+                                    ti_or_err.takeError(),
+                                    "ForEachSuperClassType: {0}");
+                    return nullptr;
+                  }
+                  return &*ti_or_err;
+                },
+                [=]() -> const swift::reflection::TypeRef * { return tr; }}))
+          return true;
+
+        tr = LookupSuperclass(*tr, descriptor_finder);
+      }
+      return false;
+    }
+
+    bool ForEachSuperClassType(
+        swift::remote::TypeInfoProvider *tip,
+        swift::reflection::DescriptorFinder *descriptor_finder,
+        lldb::addr_t pointer, std::function<bool(SuperClassType)> fn) {
+      assert(!IsEmbedded() &&
+             "Embedded Swift has no runtime metadata records to read");
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+      // Guard against faulty self-referential metadata.
+      unsigned limit = 256;
+      auto md_ptr = m_reflection_ctx.readMetadataFromInstance(
+          swift::remote::RemoteAddress(
+              pointer, swift::remote::RemoteAddress::DefaultAddressSpace));
+      if (!md_ptr)
+        return false;
+
+      // Class object.
+      while (md_ptr && *md_ptr && --limit) {
+        // Reading metadata is potentially expensive since (in a remote
+        // debugging scenario it may even incur network traffic) so we
+        // just return closures that the caller can use to query details
+        // if they need them.'
+        auto metadata = *md_ptr;
+        if (fn({[=]() -> const swift::reflection::RecordTypeInfo * {
+                  auto *ti =
+                      m_reflection_ctx.getMetadataTypeInfo(metadata, tip);
+                  return llvm::dyn_cast_or_null<
+                      swift::reflection::RecordTypeInfo>(ti);
+                },
+                [=]() -> const swift::reflection::TypeRef * {
+                  return m_reflection_ctx.readTypeFromMetadata(metadata);
+                }}))
+          return true;
+
+        // Continue with the base class.
+        md_ptr = m_reflection_ctx.readSuperClassFromClassMetadata(metadata);
+      }
+      return false;
+    }
+
+    llvm::Expected<std::pair<const swift::reflection::TypeRef *,
+                             swift::reflection::RemoteAddress>>
+    ProjectExistentialAndUnwrapClass(
+        swift::reflection::RemoteAddress existential_address,
+        const swift::reflection::TypeRef &existential_tr,
+        swift::reflection::DescriptorFinder *descriptor_finder) {
+      assert(!IsEmbedded() &&
+             "Embedded Swift has no runtime metadata records to read");
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+      auto result = m_reflection_ctx.projectExistentialAndUnwrapClass(
+          existential_address, existential_tr);
+      if (!result)
+        return llvm::createStringError(
+            "failed to project existential and unwrap class");
+      return *result;
+    }
+
+    llvm::Expected<const swift::reflection::TypeRef &>
+    LookupTypeWitness(const std::string &MangledTypeName,
+                      const std::string &Member, StringRef Protocol) {
+      assert(!IsEmbedded() &&
+             "associated type records only exist in reflection metadata");
+      if (auto *tr = m_type_converter.getBuilder().lookupTypeWitness(
+              MangledTypeName, Member, Protocol))
+        return *tr;
+      return llvm::createStringError("could not lookup type witness");
+    }
+
+    swift::reflection::ConformanceCollectionResult GetAllConformances() {
+      assert(!IsEmbedded() &&
+             "conformance records only exist in reflection metadata");
+      swift::reflection::TypeRefBuilder &b = m_type_converter.getBuilder();
+      if (ObjCEnabled)
+        return b.collectAllConformances<swift::WithObjCInterop, PointerSize>();
+      return b.collectAllConformances<swift::NoObjCInterop, PointerSize>();
+    }
+
+    llvm::Expected<const swift::reflection::TypeRef &>
+    ReadTypeFromMetadata(lldb::addr_t metadata_address,
+                         swift::reflection::DescriptorFinder *descriptor_finder,
+                         bool skip_artificial_subclasses) {
+      assert(!IsEmbedded() &&
+             "Embedded Swift has no runtime metadata records to read");
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+      if (auto *tr = m_reflection_ctx.readTypeFromMetadata(
+              swift::remote::RemoteAddress(
+                  metadata_address,
+                  swift::remote::RemoteAddress::DefaultAddressSpace),
+              skip_artificial_subclasses))
+        return *tr;
+      return llvm::createStringError("could not read type from metadata");
+    }
+
+    llvm::Expected<const swift::reflection::TypeRef &>
+    ReadTypeFromInstance(lldb::addr_t instance_address,
+                         swift::reflection::DescriptorFinder *descriptor_finder,
+                         bool skip_artificial_subclasses) {
+      assert(!IsEmbedded() &&
+             "Embedded Swift has no runtime metadata records to read");
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+      auto metadata_address = m_reflection_ctx.readMetadataFromInstance(
+          swift::remote::RemoteAddress(
+              instance_address,
+              swift::remote::RemoteAddress::DefaultAddressSpace));
+      if (!metadata_address)
+        return llvm::createStringError(
+            llvm::formatv("could not read heap metadata for object at {0:x}",
+                          instance_address));
+
+      if (auto *tr = m_reflection_ctx.readTypeFromMetadata(
+              *metadata_address, skip_artificial_subclasses))
+        return *tr;
+      return llvm::createStringError("could not read type from metadata");
+    }
+
+    std::optional<swift::remote::RemoteAbsolutePointer>
+    ReadPointer(lldb::addr_t instance_address) {
+      return m_reflection_ctx.readPointer(swift::remote::RemoteAddress(
+          instance_address, swift::remote::RemoteAddress::DefaultAddressSpace));
+    }
+
+    std::optional<swift::remote::RemoteExistential>
+    ReadMetadataAndValueOpaqueExistential(lldb::addr_t existential_address) {
+      return m_reflection_ctx.readMetadataAndValueOpaqueExistential(
+          swift::remote::RemoteAddress(
+              existential_address,
+              swift::remote::RemoteAddress::DefaultAddressSpace));
+    }
+
+    std::optional<bool> IsValueInlinedInExistentialContainer(
+        swift::remote::RemoteAddress existential_address) {
+      return m_reflection_ctx.isValueInlinedInExistentialContainer(
+          existential_address);
+    }
+
+    llvm::Expected<const swift::reflection::TypeRef &>
+    ApplySubstitutions(const swift::reflection::TypeRef &type_ref,
+                       swift::reflection::GenericArgumentMap substitutions,
+                       swift::reflection::DescriptorFinder *descriptor_finder) {
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+      if (auto *tr =
+              type_ref.subst(m_reflection_ctx.getBuilder(), substitutions))
+        return *tr;
+      return llvm::createStringError("failed to apply substitutions");
+    }
+
+    swift::remote::RemoteAbsolutePointer
+    StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) {
+      return m_reflection_ctx.stripSignedPointer(pointer);
+    }
+
+    llvm::Expected<AsyncTaskInfo> asyncTaskInfo(lldb::addr_t AsyncTaskPtr,
+                                                unsigned ChildTaskLimit,
+                                                unsigned AsyncBacktraceLimit) {
+      auto [error, task_info] = m_reflection_ctx.asyncTaskInfo(
+          swift::remote::RemoteAddress(
+              AsyncTaskPtr, swift::remote::RemoteAddress::DefaultAddressSpace),
+          ChildTaskLimit, AsyncBacktraceLimit);
+      if (error)
+        return llvm::createStringError(*error);
+
+      AsyncTaskInfo result;
+      result.taskAddr = AsyncTaskPtr;
+      result.isChildTask = task_info.IsChildTask;
+      result.isFuture = task_info.IsFuture;
+      result.isGroupChildTask = task_info.IsGroupChildTask;
+      result.isAsyncLetTask = task_info.IsAsyncLetTask;
+      result.isCancelled = task_info.IsCancelled;
+      result.isStatusRecordLocked = task_info.IsStatusRecordLocked;
+      result.isEscalated = task_info.IsEscalated;
+      result.hasIsRunning = task_info.HasIsRunning;
+      result.isRunning = task_info.IsRunning;
+      result.isEnqueued = task_info.IsEnqueued;
+      result.isComplete = task_info.IsComplete;
+      result.isSuspended = task_info.IsSuspended;
+      result.id = task_info.Id;
+      result.kind = task_info.Kind;
+      result.enqueuePriority = task_info.EnqueuePriority;
+      result.resumeAsyncContext = task_info.ResumeAsyncContext;
+      result.runJob = task_info.RunJob;
+      result.parentTask = task_info.ParentTask;
+      for (auto child : task_info.ChildTasks)
+        result.childTasks.push_back(child);
+      for (auto waiting : task_info.WaitingTasks)
+        result.waitingTasks.push_back(waiting);
+      for (auto pc : task_info.AsyncBacktraceFrames)
+        result.asyncBacktracePcs.push_back(pc);
+      return result;
+    }
+
+    /// Return a description of the layout of the record (classes, structs and
+    /// tuples) type given its typeref.
+    llvm::Expected<const swift::reflection::RecordTypeInfo &>
+    GetRecordTypeInfo(const swift::reflection::TypeRef &type_ref,
+                      swift::remote::TypeInfoProvider *tip,
+                      swift::reflection::DescriptorFinder *descriptor_finder) {
+      auto type_info_or_err =
+          GetTypeInfoFromTypeRef(type_ref, tip, descriptor_finder);
+      if (!type_info_or_err)
+        return type_info_or_err.takeError();
+      auto *type_info = &*type_info_or_err;
+      if (auto record_type_info =
+              llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(
+                  type_info))
+        return *record_type_info;
+      if (llvm::isa_and_nonnull<swift::reflection::ReferenceTypeInfo>(
+              type_info))
+        return GetClassInstanceTypeInfo(type_ref, tip, descriptor_finder);
+      std::stringstream ss;
+      type_ref.dump(ss);
+      return llvm::createStringError(
+          "Could not get record type info for typeref: " + ss.str());
+    }
+
+    llvm::Expected<const swift::reflection::TypeInfo &> GetTypeInfoFromTypeRef(
+        const swift::reflection::TypeRef &type_ref,
+        swift::remote::TypeInfoProvider *provider,
+        swift::reflection::DescriptorFinder *descriptor_finder) {
+      auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+
+      Log *log(GetLog(LLDBLog::Types));
+      if (log && log->GetVerbose()) {
+        std::stringstream ss;
+        type_ref.dump(ss);
+        LLDB_LOG(log,
+                 "[TargetReflectionContext[{0:x}]::getTypeInfo] Getting type "
+                 "info for typeref {1}",
+                 provider ? provider->getId() : 0, ss.str());
+      }
+
+      auto type_info_or_err = m_reflection_ctx.getTypeInfo(type_ref, provider);
+      if (!type_info_or_err)
+        return llvm::joinErrors(
+            llvm::createStringError(
+                "Could not find reflection metadata for type"),
+            type_info_or_err.takeError());
+
+      if (log && log->GetVerbose()) {
+        std::stringstream ss;
+        type_info_or_err->dump(ss);
+        LLDB_LOG(log,
+                 "[TargetReflectionContext::getTypeInfo] Found type info {0}",
+                 ss.str());
+      }
+      return *type_info_or_err;
+    }
+
+  private:
+    DescriptorFinderForwarder m_forwader;
+    ReflectionContext m_reflection_ctx;
+    swift::reflection::TypeConverter &m_type_converter;
+  };
+
+  std::shared_ptr<swift::reflection::MemoryReader> m_reader;
+  SwiftMetadataCache *m_swift_metadata_cache;
+
+  /// The context for the regular (`$s`) mangling flavor. It reads either 
+  // reflection metadata or DWARF.
+  std::unique_ptr<Instance> m_regular;
+  /// The context for the Embedded Swift (`$e`) mangling flavor. Embedded Swift
+  /// has no reflection metadata for its own types, so this one always consults
+  /// DWARF.
+  std::unique_ptr<Instance> m_embedded;
+
+  Instance &Get(std::unique_ptr<Instance> &instance,
+                swift::Mangle::ManglingFlavor flavor) {
+    if (!instance) {
+      // Only the regular context gets the metadata cache.
+      auto *cache = flavor == swift::Mangle::ManglingFlavor::Embedded
+                        ? nullptr
+                        : m_swift_metadata_cache;
+      instance = std::make_unique<Instance>(m_reader, cache, flavor);
+    }
+    return *instance;
+  }
+
+  /// The context that owns the types of \p flavor. Used by the entry points
+  /// that both flavors can answer.
+  Instance &Get(swift::Mangle::ManglingFlavor flavor) {
+    if (flavor == swift::Mangle::ManglingFlavor::Embedded)
+      return GetEmbedded();
+    return GetRegular();
+  }
+
+  Instance &GetEmbedded() {
+    return Get(m_embedded, swift::Mangle::ManglingFlavor::Embedded);
+  }
+
+  /// The regular Swift context. Used by the entry points that only regular
+  /// Swift can answer -- those that need reflection metadata or runtime
+  /// metadata records -- and by those that don't depend on the flavor at all.
+  Instance &GetRegular() {
+    return Get(m_regular, swift::Mangle::ManglingFlavor::Default);
+  }
 
 public:
   TargetReflectionContext(
       std::shared_ptr<swift::reflection::MemoryReader> reader,
-      SwiftMetadataCache *swift_metadata_cache,
-      swift::Mangle::ManglingFlavor flavor)
-      : m_reflection_ctx(reader, swift_metadata_cache, &m_forwader, flavor),
-        m_type_converter(m_reflection_ctx.getBuilder().getTypeConverter()) {
-    m_type_converter.enableErrorCache();
-  }
+      SwiftMetadataCache *swift_metadata_cache)
+      : m_reader(std::move(reader)),
+        m_swift_metadata_cache(swift_metadata_cache) {}
 
+  /// Register an image's reflection metadata.
   std::optional<uint32_t> AddImage(
       llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
           swift::ReflectionSectionKind)>
           find_section,
       llvm::SmallVector<llvm::StringRef, 1> likely_module_names) override {
-    auto id = m_reflection_ctx.addImage(find_section, likely_module_names);
-    m_forwader.SetImageAdded(id.has_value());
-    return id;
+    return GetRegular().AddImage(find_section, likely_module_names);
   }
 
   std::optional<uint32_t>
   AddImage(swift::remote::RemoteAddress image_start,
            llvm::SmallVector<llvm::StringRef, 1> likely_module_names) override {
-    auto id = m_reflection_ctx.addImage(image_start, likely_module_names);
-    m_forwader.SetImageAdded(id.has_value());
-    return id;
+    return GetRegular().AddImage(image_start, likely_module_names);
   }
 
   llvm::Expected<const swift::reflection::TypeRef &>
   GetTypeRef(StringRef mangled_type_name) override {
     swift::Demangle::Demangler dem;
     swift::Demangle::NodePointer node = dem.demangleSymbol(mangled_type_name);
-    return GetTypeRef(dem, node);
-  }
-
-  /// Sets the descriptor finder, and on scope exit clears it out.
-  auto PushDescriptorFinderAndPopOnExit(
-      swift::reflection::DescriptorFinder *descriptor_finder) {
-    m_forwader.PushExternalDescriptorFinder(descriptor_finder);
-    return llvm::make_scope_exit(
-        [&]() { m_forwader.PopExternalDescriptorFinder(); });
+    return GetTypeRef(
+        dem, node, SwiftLanguageRuntime::GetManglingFlavor(mangled_type_name));
   }
 
   llvm::Expected<const swift::reflection::TypeRef &>
-  GetTypeRef(swift::Demangle::Demangler &dem,
-             swift::Demangle::NodePointer node) override {
-    auto type_ref_or_err =
-        swift::Demangle::decodeMangledType(m_reflection_ctx.getBuilder(), node);
-    if (type_ref_or_err.isError())
-      return llvm::createStringError(
-          type_ref_or_err.getError()->copyErrorString());
-    auto *tr = type_ref_or_err.getType();
-    if (!tr)
-      return llvm::createStringError(
-          "decoder returned nullptr typeref but no error");
-    return *tr;
+  GetTypeRef(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+             swift::Mangle::ManglingFlavor flavor) override {
+    return Get(flavor).GetTypeRef(dem, node);
   }
 
   llvm::Expected<const swift::reflection::RecordTypeInfo &>
   GetClassInstanceTypeInfo(
       const swift::reflection::TypeRef &type_ref,
       swift::remote::TypeInfoProvider *provider,
+      swift::Mangle::ManglingFlavor flavor,
       swift::reflection::DescriptorFinder *descriptor_finder) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    auto start =
-        m_reflection_ctx.computeUnalignedFieldStartOffset(&type_ref, provider);
-    if (!start) {
-      std::stringstream ss;
-      type_ref.dump(ss);
-      return llvm::createStringError(
-          "Could not compute start field offset for typeref: " + ss.str());
-    }
-
-    auto *rti =
-        m_type_converter.getClassInstanceTypeInfo(&type_ref, *start, provider);
-    if (!rti)
-      return llvm::createStringError(m_type_converter.takeLastError());
-    return *rti;
+    return Get(flavor).GetClassInstanceTypeInfo(type_ref, provider,
+                                                descriptor_finder);
   }
 
   llvm::Expected<const swift::reflection::TypeInfo &>
   GetTypeInfo(CompilerType type, swift::remote::TypeInfoProvider *provider,
               swift::reflection::DescriptorFinder *descriptor_finder) override {
-    if (SwiftLanguageRuntime::GetManglingFlavor(
-            type.GetMangledTypeName().GetStringRef()) ==
-        swift::Mangle::ManglingFlavor::Embedded)
-      m_forwader.SetEmbedded();
-
+    auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+        type.GetMangledTypeName().GetStringRef());
     auto type_ref_or_err = GetCanonicalTypeRef(type);
     if (!type_ref_or_err)
       return type_ref_or_err.takeError();
-    return GetTypeInfoFromTypeRef(*type_ref_or_err, provider,
-                                  descriptor_finder);
+    return Get(flavor).GetTypeInfoFromTypeRef(*type_ref_or_err, provider,
+                                              descriptor_finder);
   }
 
   llvm::Expected<const swift::reflection::TypeInfo &> GetTypeInfoFromInstance(
       lldb::addr_t instance, swift::remote::TypeInfoProvider *provider,
       swift::reflection::DescriptorFinder *descriptor_finder) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    auto *ti = m_reflection_ctx.getInstanceTypeInfo(
-        swift::remote::RemoteAddress(
-            instance, swift::remote::RemoteAddress::DefaultAddressSpace),
-        provider);
-    if (!ti)
-      return llvm::createStringError("could not get instance type info");
-    return *ti;
+    return GetRegular().GetTypeInfoFromInstance(instance, provider,
+                                                descriptor_finder);
   }
 
   swift::reflection::MemoryReader &GetReader() override {
-    return m_reflection_ctx.getReader();
+    // Both contexts share the same memory reader.
+    return GetRegular().GetReader();
   }
 
   const swift::reflection::TypeRef *LookupSuperclass(
       const swift::reflection::TypeRef &tr,
+      swift::Mangle::ManglingFlavor flavor,
       swift::reflection::DescriptorFinder *descriptor_finder) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    return m_reflection_ctx.getBuilder().lookupSuperclass(&tr);
+    return Get(flavor).LookupSuperclass(tr, descriptor_finder);
   }
 
   bool
   ForEachSuperClassType(swift::remote::TypeInfoProvider *tip,
+                        swift::Mangle::ManglingFlavor flavor,
                         swift::reflection::DescriptorFinder *descriptor_finder,
                         const swift::reflection::TypeRef *tr,
                         std::function<bool(SuperClassType)> fn) override {
-    // Guard against faulty self-referential metadata.
-    unsigned limit = 256;
-    while (tr && --limit) {
-      if (fn({[=]() -> const swift::reflection::RecordTypeInfo * {
-                auto ti_or_err = GetRecordTypeInfo(*tr, tip, descriptor_finder);
-                if (!ti_or_err) {
-                  LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), ti_or_err.takeError(),
-                                  "ForEachSuperClassType: {0}");
-                  return nullptr;
-                }
-                return &*ti_or_err;
-              },
-              [=]() -> const swift::reflection::TypeRef * { return tr; }}))
-        return true;
-
-      tr = LookupSuperclass(*tr, descriptor_finder);
-    }
-    return false;
+    return Get(flavor).ForEachSuperClassType(tip, descriptor_finder, tr, fn);
   }
 
   bool
@@ -254,49 +623,8 @@ public:
                         swift::reflection::DescriptorFinder *descriptor_finder,
                         lldb::addr_t pointer,
                         std::function<bool(SuperClassType)> fn) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    // Guard against faulty self-referential metadata.
-    unsigned limit = 256;
-    auto md_ptr =
-        m_reflection_ctx.readMetadataFromInstance(swift::remote::RemoteAddress(
-            pointer, swift::remote::RemoteAddress::DefaultAddressSpace));
-    if (!md_ptr)
-      return false;
-
-    // Class object.
-    while (md_ptr && *md_ptr && --limit) {
-      // Reading metadata is potentially expensive since (in a remote
-      // debugging scenario it may even incur network traffic) so we
-      // just return closures that the caller can use to query details
-      // if they need them.'
-      auto metadata = *md_ptr;
-      if (fn({[=]() -> const swift::reflection::RecordTypeInfo * {
-                auto *ti = m_reflection_ctx.getMetadataTypeInfo(metadata, tip);
-                return llvm::dyn_cast_or_null<
-                    swift::reflection::RecordTypeInfo>(ti);
-              },
-              [=]() -> const swift::reflection::TypeRef * {
-                return m_reflection_ctx.readTypeFromMetadata(metadata);
-              }}))
-        return true;
-
-      // Continue with the base class.
-      md_ptr = m_reflection_ctx.readSuperClassFromClassMetadata(metadata);
-    }
-    return false;
-  }
-
-  std::optional<int32_t> ProjectEnumValue(
-      swift::remote::RemoteAddress enum_addr,
-      const swift::reflection::TypeRef *enum_type_ref,
-      swift::remote::TypeInfoProvider *provider,
-      swift::reflection::DescriptorFinder *descriptor_finder) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    int32_t case_idx;
-    if (m_reflection_ctx.projectEnumValue(enum_addr, enum_type_ref, &case_idx,
-                                          provider))
-      return case_idx;
-    return {};
+    return GetRegular().ForEachSuperClassType(tip, descriptor_finder, pointer,
+                                              fn);
   }
 
   llvm::Expected<std::pair<const swift::reflection::TypeRef *,
@@ -305,199 +633,88 @@ public:
       swift::reflection::RemoteAddress existential_address,
       CompilerType existential_type,
       swift::reflection::DescriptorFinder *descriptor_finder) override {
+    assert(SwiftLanguageRuntime::GetManglingFlavor(
+               existential_type.GetMangledTypeName().GetStringRef()) !=
+               swift::Mangle::ManglingFlavor::Embedded &&
+           "embedded existentials are resolved from metadata symbols instead");
     auto type_ref_or_err = GetCanonicalTypeRef(existential_type);
     if (!type_ref_or_err)
       return type_ref_or_err.takeError();
-    auto &existential_tr = *type_ref_or_err;
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    auto result = m_reflection_ctx.projectExistentialAndUnwrapClass(
-        existential_address, existential_tr);
-    if (!result)
-      return llvm::createStringError(
-          "failed to project existential and unwrap class");
-    return *result;
+    return GetRegular().ProjectExistentialAndUnwrapClass(
+        existential_address, *type_ref_or_err, descriptor_finder);
   }
 
   llvm::Expected<const swift::reflection::TypeRef &>
   LookupTypeWitness(const std::string &MangledTypeName,
                     const std::string &Member, StringRef Protocol) override {
-    if (auto *tr = m_type_converter.getBuilder().lookupTypeWitness(
-            MangledTypeName, Member, Protocol))
-      return *tr;
-    return llvm::createStringError("could not lookup type witness");
+    return GetRegular().LookupTypeWitness(MangledTypeName, Member, Protocol);
   }
+
   swift::reflection::ConformanceCollectionResult GetAllConformances() override {
-    swift::reflection::TypeRefBuilder &b = m_type_converter.getBuilder();
-    if (ObjCEnabled)
-      return b.collectAllConformances<swift::WithObjCInterop, PointerSize>();
-    return b.collectAllConformances<swift::NoObjCInterop, PointerSize>();
+    // Conformance records live in reflection metadata; DWARF has none.
+    return GetRegular().GetAllConformances();
   }
 
   llvm::Expected<const swift::reflection::TypeRef &>
   ReadTypeFromMetadata(lldb::addr_t metadata_address,
                        swift::reflection::DescriptorFinder *descriptor_finder,
                        bool skip_artificial_subclasses) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    if (auto *tr = m_reflection_ctx.readTypeFromMetadata(
-            swift::remote::RemoteAddress(
-                metadata_address,
-                swift::remote::RemoteAddress::DefaultAddressSpace),
-            skip_artificial_subclasses))
-      return *tr;
-    return llvm::createStringError("could not read type from metadata");
+    return GetRegular().ReadTypeFromMetadata(
+        metadata_address, descriptor_finder, skip_artificial_subclasses);
   }
 
   llvm::Expected<const swift::reflection::TypeRef &>
   ReadTypeFromInstance(lldb::addr_t instance_address,
                        swift::reflection::DescriptorFinder *descriptor_finder,
                        bool skip_artificial_subclasses) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    auto metadata_address =
-        m_reflection_ctx.readMetadataFromInstance(swift::remote::RemoteAddress(
-            instance_address,
-            swift::remote::RemoteAddress::DefaultAddressSpace));
-    if (!metadata_address)
-      return llvm::createStringError(
-          llvm::formatv("could not read heap metadata for object at {0:x}",
-                        instance_address));
-
-    if (auto *tr = m_reflection_ctx.readTypeFromMetadata(
-            *metadata_address, skip_artificial_subclasses))
-      return *tr;
-    return llvm::createStringError("could not read type from metadata");
+    return GetRegular().ReadTypeFromInstance(
+        instance_address, descriptor_finder, skip_artificial_subclasses);
   }
 
   std::optional<swift::remote::RemoteAbsolutePointer>
   ReadPointer(lldb::addr_t instance_address) override {
-    auto ptr = m_reflection_ctx.readPointer(swift::remote::RemoteAddress(
-        instance_address, swift::remote::RemoteAddress::DefaultAddressSpace));
-    return ptr;
+    // A plain pointer read: it goes through the shared MemoryReader and
+    // touches neither metadata nor a TypeRefBuilder.
+    return GetRegular().ReadPointer(instance_address);
   }
 
   std::optional<swift::remote::RemoteExistential>
   ReadMetadataAndValueOpaqueExistential(
-      lldb::addr_t existential_address) override {
-    return m_reflection_ctx.readMetadataAndValueOpaqueExistential(
-        swift::remote::RemoteAddress(
-            existential_address,
-            swift::remote::RemoteAddress::DefaultAddressSpace));
+      lldb::addr_t existential_address,
+      swift::Mangle::ManglingFlavor flavor) override {
+    return Get(flavor).ReadMetadataAndValueOpaqueExistential(
+        existential_address);
   }
 
   std::optional<bool> IsValueInlinedInExistentialContainer(
-      swift::remote::RemoteAddress existential_address) override {
-    return m_reflection_ctx.isValueInlinedInExistentialContainer(
+      swift::remote::RemoteAddress existential_address,
+      swift::Mangle::ManglingFlavor flavor) override {
+    return Get(flavor).IsValueInlinedInExistentialContainer(
         existential_address);
   }
 
   llvm::Expected<const swift::reflection::TypeRef &> ApplySubstitutions(
       const swift::reflection::TypeRef &type_ref,
       swift::reflection::GenericArgumentMap substitutions,
+      swift::Mangle::ManglingFlavor flavor,
       swift::reflection::DescriptorFinder *descriptor_finder) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    if (auto *tr = type_ref.subst(m_reflection_ctx.getBuilder(), substitutions))
-      return *tr;
-    return llvm::createStringError("failed to apply substitutions");
+    return Get(flavor).ApplySubstitutions(type_ref, substitutions,
+                                          descriptor_finder);
   }
 
   swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) override {
-    return m_reflection_ctx.stripSignedPointer(pointer);
+    // Stripping a pointer's signature touches no per-flavor state.
+    return GetRegular().StripSignedPointer(pointer);
   }
 
   llvm::Expected<AsyncTaskInfo>
   asyncTaskInfo(lldb::addr_t AsyncTaskPtr, unsigned ChildTaskLimit,
                 unsigned AsyncBacktraceLimit) override {
-    auto [error, task_info] = m_reflection_ctx.asyncTaskInfo(
-        swift::remote::RemoteAddress(
-            AsyncTaskPtr, swift::remote::RemoteAddress::DefaultAddressSpace),
-        ChildTaskLimit, AsyncBacktraceLimit);
-    if (error)
-      return llvm::createStringError(*error);
-
-    AsyncTaskInfo result;
-    result.taskAddr = AsyncTaskPtr;
-    result.isChildTask = task_info.IsChildTask;
-    result.isFuture = task_info.IsFuture;
-    result.isGroupChildTask = task_info.IsGroupChildTask;
-    result.isAsyncLetTask = task_info.IsAsyncLetTask;
-    result.isCancelled = task_info.IsCancelled;
-    result.isStatusRecordLocked = task_info.IsStatusRecordLocked;
-    result.isEscalated = task_info.IsEscalated;
-    result.hasIsRunning = task_info.HasIsRunning;
-    result.isRunning = task_info.IsRunning;
-    result.isEnqueued = task_info.IsEnqueued;
-    result.isComplete = task_info.IsComplete;
-    result.isSuspended = task_info.IsSuspended;
-    result.id = task_info.Id;
-    result.kind = task_info.Kind;
-    result.enqueuePriority = task_info.EnqueuePriority;
-    result.resumeAsyncContext = task_info.ResumeAsyncContext;
-    result.runJob = task_info.RunJob;
-    result.parentTask = task_info.ParentTask;
-    for (auto child : task_info.ChildTasks)
-      result.childTasks.push_back(child);
-    for (auto waiting : task_info.WaitingTasks)
-      result.waitingTasks.push_back(waiting);
-    for (auto pc : task_info.AsyncBacktraceFrames)
-      result.asyncBacktracePcs.push_back(pc);
-    return result;
-  }
-
-private:
-  /// Return a description of the layout of the record (classes, structs and
-  /// tuples) type given its typeref.
-  llvm::Expected<const swift::reflection::RecordTypeInfo &>
-  GetRecordTypeInfo(const swift::reflection::TypeRef &type_ref,
-                    swift::remote::TypeInfoProvider *tip,
-                    swift::reflection::DescriptorFinder *descriptor_finder) {
-    auto type_info_or_err =
-        GetTypeInfoFromTypeRef(type_ref, tip, descriptor_finder);
-    if (!type_info_or_err)
-      return type_info_or_err.takeError();
-    auto *type_info = &*type_info_or_err;
-    if (auto record_type_info =
-            llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(
-                type_info))
-      return *record_type_info;
-    if (llvm::isa_and_nonnull<swift::reflection::ReferenceTypeInfo>(type_info))
-      return GetClassInstanceTypeInfo(type_ref, tip, descriptor_finder);
-    std::stringstream ss;
-    type_ref.dump(ss);
-    return llvm::createStringError(
-        "Could not get record type info for typeref: " + ss.str());
-  }
-
-  llvm::Expected<const swift::reflection::TypeInfo &> GetTypeInfoFromTypeRef(
-      const swift::reflection::TypeRef &type_ref,
-      swift::remote::TypeInfoProvider *provider,
-      swift::reflection::DescriptorFinder *descriptor_finder) {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-
-    Log *log(GetLog(LLDBLog::Types));
-    if (log && log->GetVerbose()) {
-      std::stringstream ss;
-      type_ref.dump(ss);
-      LLDB_LOG(log,
-               "[TargetReflectionContext[{0:x}]::getTypeInfo] Getting type "
-               "info for typeref {1}",
-               provider ? provider->getId() : 0, ss.str());
-    }
-
-    auto type_info_or_err = m_reflection_ctx.getTypeInfo(type_ref, provider);
-    if (!type_info_or_err)
-      return llvm::joinErrors(
-          llvm::createStringError(
-              "Could not find reflection metadata for type"),
-          type_info_or_err.takeError());
-
-    if (log && log->GetVerbose()) {
-      std::stringstream ss;
-      type_info_or_err->dump(ss);
-      LLDB_LOG(log,
-               "[TargetReflectionContext::getTypeInfo] Found type info {0}",
-               ss.str());
-    }
-    return *type_info_or_err;
+    // Only reads the concurrency runtime's task structs; no metadata records
+    // and no TypeRefBuilder are involved.
+    return GetRegular().asyncTaskInfo(AsyncTaskPtr, ChildTaskLimit,
+                                      AsyncBacktraceLimit);
   }
 };
 } // namespace
@@ -506,8 +723,7 @@ namespace lldb_private {
 std::unique_ptr<ReflectionContextInterface>
 ReflectionContextInterface::CreateReflectionContext(
     uint8_t ptr_size, std::shared_ptr<swift::remote::MemoryReader> reader,
-    bool ObjCInterop, SwiftMetadataCache *swift_metadata_cache,
-    swift::Mangle::ManglingFlavor flavor) {
+    bool ObjCInterop, SwiftMetadataCache *swift_metadata_cache) {
   using ReflectionContext32ObjCInterop = TargetReflectionContext<
       swift::reflection::ReflectionContext<
           swift::External<swift::WithObjCInterop<swift::RuntimeTarget<4>>>>,
@@ -527,16 +743,16 @@ ReflectionContextInterface::CreateReflectionContext(
   if (ptr_size == 4) {
     if (ObjCInterop)
       return std::make_unique<ReflectionContext32ObjCInterop>(
-          reader, swift_metadata_cache, flavor);
+          reader, swift_metadata_cache);
     return std::make_unique<ReflectionContext32NoObjCInterop>(
-        reader, swift_metadata_cache, flavor);
+        reader, swift_metadata_cache);
   }
   if (ptr_size == 8) {
     if (ObjCInterop)
       return std::make_unique<ReflectionContext64ObjCInterop>(
-          reader, swift_metadata_cache, flavor);
+          reader, swift_metadata_cache);
     return std::make_unique<ReflectionContext64NoObjCInterop>(
-        reader, swift_metadata_cache, flavor);
+        reader, swift_metadata_cache);
   }
   return {};
 }
@@ -567,7 +783,7 @@ ReflectionContextInterface::GetCanonicalTypeRef(CompilerType type) {
   auto node_or_err = tr_ts->RemoveMarkerProtocols(dem, node, flavor, exe_ctx);
   if (!node_or_err)
     return node_or_err.takeError();
-  return GetTypeRef(dem, *node_or_err);
+  return GetTypeRef(dem, *node_or_err, flavor);
 }
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -68,8 +68,7 @@ public:
   /// Return a reflection context.
   static std::unique_ptr<ReflectionContextInterface> CreateReflectionContext(
       uint8_t pointer_size, std::shared_ptr<swift::remote::MemoryReader> reader,
-      bool objc_interop, SwiftMetadataCache *swift_metadata_cache,
-      swift::Mangle::ManglingFlavor flavor);
+      bool objc_interop, SwiftMetadataCache *swift_metadata_cache);
 
   virtual ~ReflectionContextInterface() = default;
 
@@ -84,8 +83,8 @@ public:
   virtual llvm::Expected<const swift::reflection::TypeRef &>
   GetTypeRef(llvm::StringRef mangled_type_name) = 0;
   virtual llvm::Expected<const swift::reflection::TypeRef &>
-  GetTypeRef(swift::Demangle::Demangler &dem,
-             swift::Demangle::NodePointer node) = 0;
+  GetTypeRef(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+             swift::Mangle::ManglingFlavor flavor) = 0;
 
   /// Build a TypeRef suitable for use in reflection context queries. This
   /// performs canonical demangling (type alias resolution and
@@ -96,6 +95,7 @@ public:
   GetClassInstanceTypeInfo(
       const swift::reflection::TypeRef &type_ref,
       swift::remote::TypeInfoProvider *provider,
+      swift::Mangle::ManglingFlavor flavor,
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual llvm::Expected<const swift::reflection::TypeInfo &>
   GetTypeInfo(CompilerType type, swift::remote::TypeInfoProvider *provider,
@@ -107,6 +107,7 @@ public:
   virtual swift::remote::MemoryReader &GetReader() = 0;
   virtual const swift::reflection::TypeRef *
   LookupSuperclass(const swift::reflection::TypeRef &tr,
+                   swift::Mangle::ManglingFlavor flavor,
                    swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual bool
   ForEachSuperClassType(swift::remote::TypeInfoProvider *tip,
@@ -120,6 +121,7 @@ public:
   /// binary (for example, when debugging embedded Swift programs).
   virtual bool
   ForEachSuperClassType(swift::remote::TypeInfoProvider *tip,
+                        swift::Mangle::ManglingFlavor flavor,
                         swift::reflection::DescriptorFinder *descriptor_finder,
                         const swift::reflection::TypeRef *tr,
                         std::function<bool(SuperClassType)> fn) = 0;
@@ -129,11 +131,6 @@ public:
   ProjectExistentialAndUnwrapClass(
       swift::remote::RemoteAddress existential_addess,
       CompilerType existential_type,
-      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
-  virtual std::optional<int32_t> ProjectEnumValue(
-      swift::remote::RemoteAddress enum_addr,
-      const swift::reflection::TypeRef *enum_type_ref,
-      swift::remote::TypeInfoProvider *provider,
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual llvm::Expected<const swift::reflection::TypeRef &>
   LookupTypeWitness(const std::string &MangledTypeName,
@@ -151,15 +148,19 @@ public:
   virtual std::optional<swift::remote::RemoteAbsolutePointer>
   ReadPointer(lldb::addr_t instance_address) = 0;
   virtual std::optional<bool> IsValueInlinedInExistentialContainer(
-      swift::remote::RemoteAddress existential_address) = 0;
+      swift::remote::RemoteAddress existential_address,
+      swift::Mangle::ManglingFlavor flavor) = 0;
   virtual llvm::Expected<const swift::reflection::TypeRef &> ApplySubstitutions(
       const swift::reflection::TypeRef &type_ref,
       swift::reflection::GenericArgumentMap substitutions,
+      swift::Mangle::ManglingFlavor flavor,
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
   virtual std::optional<swift::remote::RemoteExistential>
-  ReadMetadataAndValueOpaqueExistential(lldb::addr_t existential_address) = 0;
+  ReadMetadataAndValueOpaqueExistential(
+      lldb::addr_t existential_address,
+      swift::Mangle::ManglingFlavor flavor) = 0;
   struct AsyncTaskInfo {
     lldb::addr_t taskAddr = 0;
     bool isChildTask = false;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -513,17 +513,12 @@ void SwiftLanguageRuntime::SetupReflection() {
 
   auto &triple = exe_module->GetArchitecture().GetTriple();
   uint32_t ptr_size = m_process->GetAddressByteSize();
-  // FIXME: We should have a way to support a mixed embedded/regular swift
-  // program, as embedded swift is a per CU property. rdar://183664838
-  auto flavor = target.IsEmbeddedSwift()
-                    ? swift::Mangle::ManglingFlavor::Embedded
-                    : swift::Mangle::ManglingFlavor::Default;
   LLDB_LOG(log, "Initializing a {0}-bit reflection context ({1}) for \"{2}\"",
            ptr_size * 8, triple.str(), objc_interop_msg);
   if (ptr_size == 4 || ptr_size == 8)
     m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext(
         ptr_size, this->GetMemoryReader(), objc_interop,
-        GetSwiftMetadataCache(), flavor);
+        GetSwiftMetadataCache());
   if (!m_reflection_ctx)
     LLDB_LOG(log, "Could not initialize reflection context for \"{0}\"",
              triple.str());

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1324,7 +1324,7 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
 
       LLDBTypeInfoProvider tip(m_runtime, ts);
       auto cti_or_err = reflection_ctx->GetClassInstanceTypeInfo(
-          *tr, &tip,
+          *tr, &tip, m_flavor,
           ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope()));
       if (!cti_or_err)
         return AugmentReflectionError(cti_or_err.takeError());
@@ -1338,15 +1338,16 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
           // The superclass, if any, is an extra child.
           if (!m_hide_superclass &&
               reflection_ctx->LookupSuperclass(
-                  *tr, ts.GetDescriptorFinder(
-                           m_exe_ctx.GetBestExecutionContextScope())))
+                  *tr, m_flavor,
+                  ts.GetDescriptorFinder(
+                      m_exe_ctx.GetBestExecutionContextScope())))
             return rti->getNumFields() + 1;
           return rti->getNumFields();
         }
         if (m_visit_superclass) {
           unsigned depth = 0;
           reflection_ctx->ForEachSuperClassType(
-              &tip,
+              &tip, m_flavor,
               ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope()),
               tr, [&](SuperClassType sc) {
                 auto *tr = sc.get_typeref();
@@ -1357,8 +1358,9 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
                   return true;
 
                 if (auto *super_tr = reflection_ctx->LookupSuperclass(
-                        *tr, ts.GetDescriptorFinder(
-                                 m_exe_ctx.GetBestExecutionContextScope())))
+                        *tr, m_flavor,
+                        ts.GetDescriptorFinder(
+                            m_exe_ctx.GetBestExecutionContextScope())))
                   if (auto error = visit_callback(
                           GetTypeFromTypeRef(ts, super_tr, m_flavor), depth,
                           []() -> std::string { return "<base class>"; },
@@ -1388,8 +1390,9 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
           return success;
         }
         if (auto *super_tr = reflection_ctx->LookupSuperclass(
-                *tr, ts.GetDescriptorFinder(
-                         m_exe_ctx.GetBestExecutionContextScope()))) {
+                *tr, m_flavor,
+                ts.GetDescriptorFinder(
+                    m_exe_ctx.GetBestExecutionContextScope()))) {
           auto get_name = []() -> std::string { return "<base class>"; };
           auto get_info = []() -> llvm::Expected<ChildInfo> {
             return ChildInfo();
@@ -1461,7 +1464,7 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
       // If the pointer based super class traversal failed (this may happen
       // when metadata is not present in the binary, for example: embedded
       // Swift), try the typeref based one next.
-      reflection_ctx->ForEachSuperClassType(&tip, desc_finder, tr,
+      reflection_ctx->ForEachSuperClassType(&tip, m_flavor, desc_finder, tr,
                                             superclass_finder);
 
     if (supers.empty() && tr) {
@@ -1469,8 +1472,8 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
                "Couldn't find the type metadata for {0} in instance",
                m_type.GetTypeName());
 
-      auto cti_or_err =
-          reflection_ctx->GetClassInstanceTypeInfo(*tr, &tip, desc_finder);
+      auto cti_or_err = reflection_ctx->GetClassInstanceTypeInfo(
+          *tr, &tip, m_flavor, desc_finder);
       if (!cti_or_err)
         return AugmentReflectionError(cti_or_err.takeError());
       const swift::reflection::TypeInfo *cti = &*cti_or_err;
@@ -2019,6 +2022,8 @@ CompilerType SwiftLanguageRuntime::GetBaseClass(CompilerType class_ty) {
   auto tr_ts = ts_sp->GetTypeSystemSwiftTypeRef();
   if (!tr_ts)
     return {};
+  auto flavor =
+      SwiftLanguageRuntime::GetManglingFlavor(class_ty.GetMangledTypeName());
   auto type_ref_or_err =
       reflection_ctx->GetTypeRef(class_ty.GetMangledTypeName().GetStringRef());
   if (!type_ref_or_err) {
@@ -2027,9 +2032,7 @@ CompilerType SwiftLanguageRuntime::GetBaseClass(CompilerType class_ty) {
     return {};
   }
   auto *super_tr = reflection_ctx->LookupSuperclass(
-      *type_ref_or_err, tr_ts->GetDescriptorFinder());
-  auto flavor =
-      SwiftLanguageRuntime::GetManglingFlavor(class_ty.GetMangledTypeName());
+      *type_ref_or_err, flavor, tr_ts->GetDescriptorFinder());
   return GetTypeFromTypeRef(*tr_ts, super_tr, flavor);
 }
 
@@ -2315,14 +2318,15 @@ SwiftLanguageRuntime::BindGenericPackType(StackFrame &frame,
           });
 
       // Build a TypeRef from the demangle tree.
-      auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, pack_element);
+      auto type_ref_or_err =
+          reflection_ctx->GetTypeRef(dem, pack_element, flavor);
       if (!type_ref_or_err)
         return type_ref_or_err.takeError();
       auto &type_ref = *type_ref_or_err;
 
       // Apply the substitutions.
       auto bound_typeref_or_err = reflection_ctx->ApplySubstitutions(
-          type_ref, substitutions, ts->GetDescriptorFinder());
+          type_ref, substitutions, flavor, ts->GetDescriptorFinder());
       if (!bound_typeref_or_err)
         return bound_typeref_or_err.takeError();
       swift::Demangle::NodePointer node = bound_typeref_or_err->getDemangling(dem);
@@ -2614,7 +2618,7 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
 
   auto existential_container =
       reflection_ctx->ReadMetadataAndValueOpaqueExistential(
-          existential_address);
+          existential_address, swift::Mangle::ManglingFlavor::Embedded);
   if (!existential_container)
     return llvm::createStringError(
         llvm::formatv("could not read the existential container at {0:x}",
@@ -3099,6 +3103,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialMetatype(
   if (!tr_ts)
     return false;
 
+  auto flavor =
+      SwiftLanguageRuntime::GetManglingFlavor(meta_type.GetMangledTypeName());
   auto type_ref_or_err =
       reflection_ctx->ReadTypeFromMetadata(ptr, tr_ts->GetDescriptorFinder());
   if (!type_ref_or_err) {
@@ -3120,8 +3126,6 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialMetatype(
   meta->addChild(node, dem);
   wrapped->addChild(meta,dem);
 
-  auto flavor =
-      SwiftLanguageRuntime::GetManglingFlavor(meta_type.GetMangledTypeName());
   meta_type =
       tss->GetTypeSystemSwiftTypeRef()->RemangleAsType(dem, wrapped, flavor);
   class_type_or_name.SetCompilerType(meta_type);
@@ -3248,7 +3252,9 @@ CompilerType SwiftLanguageRuntime::BindGenericTypeParameters(
   if (!tr_ts)
     return unbound_type;
 
-  auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, unbound_node);
+  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+      unbound_type.GetMangledTypeName().GetStringRef());
+  auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, unbound_node, flavor);
   if (!type_ref_or_err) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions | LLDBLog::Types),
                    type_ref_or_err.takeError(),
@@ -3293,7 +3299,7 @@ CompilerType SwiftLanguageRuntime::BindGenericTypeParameters(
 
   // Apply the substitutions.
   auto bound_type_ref_or_err = reflection_ctx->ApplySubstitutions(
-      type_ref, substitutions, tr_ts->GetDescriptorFinder());
+      type_ref, substitutions, flavor, tr_ts->GetDescriptorFinder());
   if (!bound_type_ref_or_err) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions | LLDBLog::Types),
                    bound_type_ref_or_err.takeError(),
@@ -3302,10 +3308,7 @@ CompilerType SwiftLanguageRuntime::BindGenericTypeParameters(
   }
 
   NodePointer node = bound_type_ref_or_err->getDemangling(dem);
-  return ts->GetTypeSystemSwiftTypeRef()->RemangleAsType(
-      dem, node,
-      SwiftLanguageRuntime::GetManglingFlavor(
-          unbound_type.GetMangledTypeName()));
+  return ts->GetTypeSystemSwiftTypeRef()->RemangleAsType(dem, node, flavor);
 }
 
 llvm::Expected<CompilerType>
@@ -3328,6 +3331,9 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
   NodePointer canonical = TypeSystemSwiftTypeRef::GetStaticSelfType(
       dem, dem.demangleSymbol(mangled_name.GetStringRef()));
   canonical = ts.DesugarNode(dem, canonical);
+
+  auto flavor =
+      SwiftLanguageRuntime::GetManglingFlavor(mangled_name.GetStringRef());
 
   // Build the list of type substitutions.
   swift::reflection::GenericArgumentMap substitutions;
@@ -3356,8 +3362,6 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
 
     substitutions.insert({{depth, index}, &*type_ref_or_err});
   });
-  auto flavor =
-      SwiftLanguageRuntime::GetManglingFlavor(mangled_name.GetStringRef());
 
   // Nothing to do if there are no type parameters.
   auto get_canonical = [&]() {
@@ -3371,7 +3375,7 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
     return get_canonical();
 
   // Build a TypeRef from the demangle tree.
-  auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, canonical);
+  auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, canonical, flavor);
   if (!type_ref_or_err)
     return llvm::joinErrors(
         llvm::createStringError("cannot bind generic parameters"),
@@ -3380,7 +3384,7 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
 
   // Apply the substitutions.
   auto bound_type_ref_or_err = reflection_ctx->ApplySubstitutions(
-      type_ref, substitutions, ts.GetDescriptorFinder());
+      type_ref, substitutions, flavor, ts.GetDescriptorFinder());
   if (!bound_type_ref_or_err)
     return bound_type_ref_or_err.takeError();
   auto &bound_type_ref = *bound_type_ref_or_err;
@@ -3546,8 +3550,8 @@ Value::ValueType SwiftLanguageRuntime::GetValueType(
       if (ThreadSafeReflectionContext reflection_ctx = GetReflectionContext()) {
         std::optional<bool> is_inlined =
             reflection_ctx->IsValueInlinedInExistentialContainer(
-                remote_existential);
-
+                remote_existential,
+                GetManglingFlavor(static_type.GetMangledTypeName()));
 
         // An error has occurred when trying to read value witness table,
         // default to treating it as pointer.
@@ -4373,7 +4377,7 @@ SwiftLanguageRuntime::ResolveTypeAlias(CompilerType alias) {
         substitutions.insert({{0, idx++}, &type_ref});
       }
       auto type_ref_or_err = reflection_ctx->ApplySubstitutions(
-          *type_ref, substitutions, tr_ts->GetDescriptorFinder());
+          *type_ref, substitutions, flavor, tr_ts->GetDescriptorFinder());
       if (!type_ref_or_err) {
         LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), type_ref_or_err.takeError(),
                         "{0}");

--- a/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
+++ b/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
@@ -28,7 +28,7 @@ class TestCase(TestBase):
         task_info_output = self.res.GetOutput()
         self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))
 
-    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @skipUnlessPlatform(["macosx", "linux"])
     @swiftTest
     def test_compare_printed_task_variable_to_task_info_with_address(self):

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
@@ -8,8 +8,11 @@ class TestSwiftFModuleFlags(TestBase):
     @skipIf(macos_version=["<", "14.0"])
     @skipIfDarwinEmbedded
     @swiftTest
-    @skipEmbeddedSwiftOnLinux # Failed to load SwiftCore.so
-    @skipEmbeddedSwiftOnWindows # module 'Swift' cannot be imported in embedded mode
+    # main.swift is empty and built with -parse-stdlib, so the program contains
+    # no Swift types at all and its debug info describes none. "expression 1"
+    # then asks for the size of Swift.Int, which an embedded program can only
+    # answer out of its own debug info.
+    @requireNotEmbeddedSwift
     def test(self):
         """Test that -fmodule flags get stripped out"""
         self.build()

--- a/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
+++ b/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftClassBaseClass(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         self.build()


### PR DESCRIPTION
So far, ReflectionContext was initialized with either regular or embedded mangling flavor. This has caused issues because we used indirect information, like whether we registered reflection metadata, or the mangling flavor or the first type we looked up to decide on the overall flavor. Besides, this doesn't support a mixed embedded/regular swift program.

To fix this, we now (lazily) initialize two contexts, one for each flavor, and dispatch any queries to the correct one, depending on the mangling flavor.

Assisted-by: claude

rdar://183664838