### PR TITLE
[BoundsSafety] fix assertion when count expr refs anonymous union field

### DIFF
--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.h
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.h
@@ -15,6 +15,7 @@
 
 #include "TreeTransform.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/Sema/Sema.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -113,7 +114,7 @@ public:
     // p2, which would trigger an assert "building reference to field in C?' in
     // TreeTransform::RebuildDeclRefExpr. To avoid this, we build the
     // DeclRefExprs here manually.
-    if (isa<FieldDecl>(VD)) {
+    if (isa<FieldDecl, IndirectFieldDecl>(VD)) {
       // Copy-paste from Sema::BuildDeclarationNameExpr, but without assert.
       QualType Ty = VD->getType().getNonReferenceType();
       ExprValueKind VK = VK_LValue;

--- a/clang/test/BoundsSafety/Sema/counted-by-union-count.c
+++ b/clang/test/BoundsSafety/Sema/counted-by-union-count.c
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+// Regression test to make sure we don't crash in the presence of IndirectFieldDecls in count expressionns.
+
+#include <ptrcheck.h>
+
+struct A {
+    union {
+        unsigned len;
+        unsigned other;
+    };
+    // expected-error@+1{{count expression on struct field may only reference other fields of the same struct}}
+    int *__counted_by(len) p;
+};
+
+int f(struct A *a) {
+    int *q = a->p;
+    return *q;
+}
+
+struct B {
+    struct {
+        unsigned len;
+        unsigned other;
+    };
+    // expected-error@+1{{count expression on struct field may only reference other fields of the same struct}}
+    int *__counted_by(len) p;
+};
+
+int g(struct B *b) {
+    int *q = b->p;
+    return *q;
+}


### PR DESCRIPTION
Referring to an anonymous union or struct field in a count expression is an error, but the compilation keeps going. Since these field decls are not `FieldDecls` but `IndirectFieldDecls`, which have no subtype relationship, it avoids a check for `isa<FieldDecl>` and enters a path it shouldn't, eventually triggering an assert due to our abuse of `DeclRefExpr`s for fields.

rdar://182748814