### PR TITLE
[lldb] Don't double-wrap the children of sugared types in Type nodes

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1578,6 +1578,11 @@ Desugar(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
   assert(node->getNumChildren() >= 1 && node->getNumChildren() <= 2 &&
          "Sugared types should only have 1 or 2 children");
   for (NodePointer child : *node) {
+    // Don't wrap types in another type node.
+    if (child->getKind() == Node::Kind::Type) {
+      type_list->addChild(child, dem);
+      continue;
+    }
     NodePointer type = dem.createNode(Node::Kind::Type);
     type->addChild(child, dem);
     type_list->addChild(type, dem);

--- a/lldb/test/API/lang/swift/sugared_type_substitution/Makefile
+++ b/lldb/test/API/lang/swift/sugared_type_substitution/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/sugared_type_substitution/TestSwiftSugaredTypeSubstitution.py
+++ b/lldb/test/API/lang/swift/sugared_type_substitution/TestSwiftSugaredTypeSubstitution.py
@@ -1,0 +1,36 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import ValueCheck
+
+class TestCase(lldbtest.TestBase):
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        """Canonicalizing a sugared type must yield a canonical mangled name"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        # Desugaring the [[Int]] in the key path's value type used to produce
+        # a Type(Type(...)) demangle tree, which defeated the remangler's
+        # structural substitution matching. The resulting mangled name was not
+        # canonical, which tripped an assertion in CompilerType.
+        self.expect_var_path("kp", type="WritableKeyPath<S, [[Int]]>")
+        self.expect_var_path(
+            "s",
+            children=[
+                ValueCheck(
+                    children=[
+                        ValueCheck(
+                            summary="2 values",
+                            children=[
+                                ValueCheck(name="[0]", value="1"),
+                                ValueCheck(name="[1]", value="2"),
+                            ],
+                        ),
+                    ],
+                )
+            ],
+        )

--- a/lldb/test/API/lang/swift/sugared_type_substitution/main.swift
+++ b/lldb/test/API/lang/swift/sugared_type_substitution/main.swift
@@ -1,0 +1,15 @@
+// The debug info type of `kp` is
+// WritableKeyPath<f() -> [Int].(S), [[Int]]>, where the [[Int]] is
+// spelled with the debugger-only "sugared array" mangling, while the [Int]
+// in the enclosing function's return value is spelled out as Array<Int>.
+func f() -> [Int] {
+  struct S {
+    var values: [[Int]] = [[1, 2]]
+  }
+  let kp = \S.values
+  let s = S()
+  print(s[keyPath: kp]) // break here
+  return [0]
+}
+
+_ = f()


### PR DESCRIPTION
The Swift demangler creates the children of the debugger-only sugared type nodes (SugaredArray, SugaredOptional, SugaredDictionary) as Type nodes already, but TypeSystemSwiftTypeRef's Desugar() wrapped each child in yet another Type node. The resulting Type(Type(...)) tree mangles to the same string, so this went mostly unnoticed, but it is not structurally identical to the tree the demangler produces for that string.

The remangler matches substitutions structurally (SubstitutionEntry uses a deep hash / deep equality over the node tree), so the spurious Type node makes a desugared type fail to match an otherwise identical type that was demangled from a non-sugared mangling. The remangler then emits the type in full instead of as a substitution, and the mangled name that GetCanonicalType() hands to GetTypeFromMangledTypename() is not canonical, tripping the Verify() assertion in CompilerType's constructor.

This was reachable from `frame variable` on a key path whose root is a type local to a function:

  func f() -> [Double] {
    struct S { var values: [[Double]] = [[1.5, 2.5]] }
    let kp = \S.values
    ...
  }

The debug info type of `kp` is
$ss15WritableKeyPathCy4main1fSaySdGyF1SL_VSdXSaXSaGD, which contains Array<Double> spelled out in f()'s signature and, later, the sugared [[Double]]. After desugaring, the two Array<Double> subtrees differed only by the extra Type node, so the second one was not substituted and canonicalization produced ...SaySaySdGGGD instead of ...SayAEGGD.