### PR TITLE
[lldb] Add more error handling to BindGenericPackType

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -36,6 +36,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorExtras.h"
 
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-forward.h"
@@ -2327,6 +2328,17 @@ SwiftLanguageRuntime::BindGenericPackType(StackFrame &frame,
         return bound_typeref_or_err.takeError();
       swift::Demangle::NodePointer node = bound_typeref_or_err->getDemangling(dem);
       CompilerType type = ts->RemangleAsType(dem, node, flavor);
+      // RemangleAsType() rejects demangle trees that the remangler cannot
+      // handle. This happens when the type metadata that was read out of the
+      // type pack isn't actually type metadata, for example because the
+      // metadata pack variable in the frame hasn't been initialized at the
+      // current PC yet. Reporting this as an error is much better than
+      // silently building a pack type with a hole in it.
+      if (!type)
+        return llvm::createStringErrorV(
+            "cannot decode pack_expansion type: failed to remangle the "
+            "substituted type for element {0}/{1} of the pack",
+            j, *count);
 
       // Add the substituted type to the tuple.
       elements.push_back({{}, type});
@@ -2344,9 +2356,18 @@ SwiftLanguageRuntime::BindGenericPackType(StackFrame &frame,
       using Kind = Node::Kind;
       auto *dem_sil_pack_type =
           swift_demangle::ChildAtPath(global, {Kind::TypeMangling, Kind::Type});
+      if (!dem_sil_pack_type)
+        return llvm::createStringErrorV(
+            "cannot decode pack_expansion type: failed to demangle the "
+            "expanded SILPackType \"{0}\"",
+            sil_pack_type.GetMangledTypeName());
       return dem_sil_pack_type;
     }
-    return CreatePackType(dem, *ts, elements);
+    if (auto *pack = CreatePackType(dem, *ts, elements))
+      return pack;
+    return llvm::createStringErrorV(
+        "cannot decode pack_expansion type: failed to build the expanded pack "
+        "type");
   };
 
   swift::Demangle::Context dem_ctx;

--- a/lldb/test/API/lang/swift/variadic_generics_pack_shape_requirement/Makefile
+++ b/lldb/test/API/lang/swift/variadic_generics_pack_shape_requirement/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variadic_generics_pack_shape_requirement/TestSwiftVariadicGenericsPackShapeRequirement.py
+++ b/lldb/test/API/lang/swift/variadic_generics_pack_shape_requirement/TestSwiftVariadicGenericsPackShapeRequirement.py
@@ -1,0 +1,26 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    """Test variable inspection in a variadic generic method of a variadic
+    generic type, whose generic signature has a pack shape requirement."""
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+
+        self_var = self.frame().FindVariable("self")
+        # FIXME: This doesn't produce any useful output, but also should not
+        # crash. Once this actually produces a value, this test should be
+        # updated.
+        self.assertTrue(self_var.GetError())
+

--- a/lldb/test/API/lang/swift/variadic_generics_pack_shape_requirement/main.swift
+++ b/lldb/test/API/lang/swift/variadic_generics_pack_shape_requirement/main.swift
@@ -1,0 +1,21 @@
+struct Container<each T> {
+  let items: (repeat each T)
+
+  init(_ items: repeat each T) {
+    self.items = (repeat each items)
+  }
+}
+
+extension Container {
+  // A variadic generic method of a variadic generic type. Its generic
+  // signature has a pack shape requirement (τ_0_0.shape == τ_1_0.shape),
+  // and the metadata pack for the outer pack `each T` is described by a
+  // debug variable.
+  func process<each U>(transform: repeat (each T) -> each U) -> (repeat each U) {
+    let result = (repeat (each transform)(each items))
+    return result // break here
+  }
+}
+
+let many = Container(1, "hello", 3.14)
+_ = many.process(transform: { $0 + 1 }, { $0 + "!" }, { $0 * 2 })


### PR DESCRIPTION
BindGenericPackType() expands the pack expansions in a type by reading the type metadata out of the type packs that the frame's `$τ_<d>_<i>` metadata variables point at, and building a Pack node from the substituted element types.

The element types come out of `RemangleAsType()`, which returns an empty CompilerType for demangle trees that the remangler cannot handle. The expansion callback then handed those to `CreatePackType()`, which returned a nullptr, and `TryTransform()` asserted:

    Assertion failed: (transformed && "callback returned a nullptr"),
    function TryTransform, file TypeSystemSwiftTypeRef.cpp, line 1522.

For a variadic generic method of a variadic generic type with a pack shape requirement (`τ_0_0.shape == τ_1_0.shape`), the debug variable that describes the metadata pack of the outer pack `each T` is only written on the path where the pack has exactly one element. When the pack is longer, the slot holds whatever was in that stack memory before, so the "metadata" read out of it decodes into garbage nodes that the remangler rejects.

There is nothing LLDB can do to recover the type in that case, but reporting an error is both correct and much better than silently building a pack type that is missing an element.

This patch adds more error handling to this code path.