### PR TITLE
[lldb] Don't evaluate as generic when inner generic params are in scope

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -22,6 +22,7 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/Demangler.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 
@@ -148,23 +149,30 @@ static llvm::Expected<llvm::SmallVector<MetadataInfo>> CollectMetadataInfos(
             metadata_variables[i]->GetMetadata())
             ->m_variable_sp;
     auto archetype_name = variable_sp->GetType()->GetName();
-    if (generic_sig)
-      metadata_info.emplace_back(generic_sig->generic_params[i].is_pack,
-                                 generic_sig->generic_params[i].depth,
-                                 generic_sig->generic_params[i].index,
-                                 archetype_name);
-    else {
-      auto maybe_depth_and_index =
-          ParseSwiftGenericParameter(metadata_variables[i]->GetName().str());
-      if (!maybe_depth_and_index)
-        return llvm::createStringError(llvm::errc::not_supported,
-                                       "unexpected metadata variable");
-      metadata_info.emplace_back(false, maybe_depth_and_index->first,
-                                 maybe_depth_and_index->second, archetype_name);
+    auto maybe_depth_and_index =
+        ParseSwiftGenericParameter(metadata_variables[i]->GetName().str());
+    if (!maybe_depth_and_index)
+      return llvm::createStringError(llvm::errc::not_supported,
+                                     "unexpected metadata variable");
+    unsigned depth = maybe_depth_and_index->first;
+    unsigned index = maybe_depth_and_index->second;
+
+    // Whether this is a pack is only known from the generic signature.
+    bool is_pack = false;
+    if (generic_sig) {
+      const auto &params = generic_sig->generic_params;
+      const auto *it = llvm::find_if(params, [&](const auto &param) {
+        return param.depth == depth && param.index == index;
+      });
+      if (it != params.end())
+        is_pack = it->is_pack;
     }
+
+    metadata_info.emplace_back(is_pack, depth, index, archetype_name);
   }
   return metadata_info;
 }
+
 /// Constructs the signatures for the expression evaluation functions based on
 /// the metadata variables in scope and any variadic functiontion parameters.
 /// For every outermost metadata pointer in scope ($τ_0_0, $τ_0_1, etc), we want
@@ -175,8 +183,18 @@ static llvm::Expected<llvm::SmallVector<MetadataInfo>> CollectMetadataInfos(
 /// func $__lldb_user_expr<T0, T1, ..., Tn>
 ///     (_ $__lldb_arg: UnsafeMutablePointer<(T0, T1, ..., Tn)>)
 ///
-/// - An optional $__lldb_trampoline signature like the above, but
-///   that also takes in a pointer to self:
+///   With \p inherit_context_generic_params -- an instance method in an
+///   extension of the generic context -- those parameters are already in
+///   scope under the same archetype names, and are the only ones that get
+///   this far. Declaring them again would shadow them and drop their
+///   requirements, so the list is omitted and $__lldb_arg's tuple refers to
+///   the context's parameters:
+///
+/// func $__lldb_user_expr
+///     (_ $__lldb_arg: UnsafeMutablePointer<(T0, T1, ..., Tn)>)
+///
+/// - An optional $__lldb_trampoline signature, which always declares the
+///   parameters and also takes in a pointer to self:
 ///
 /// func $__lldb_trampoline<T0, T1, ..., Tn>
 ///      (_ $__lldb_arg: UnsafeMutablePointer<(T0, T1, ..., Tn)>,
@@ -199,7 +217,7 @@ static llvm::Expected<llvm::SmallVector<MetadataInfo>> CollectMetadataInfos(
 static llvm::Expected<CallsAndArgs> MakeGenericSignaturesAndCalls(
     llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables,
     const std::optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
-    bool needs_object_ptr) {
+    bool needs_object_ptr, bool inherit_context_generic_params) {
   auto metadata_variables = CollectMetadataVariables(local_variables);
   // The number of metadata variables could be > if the function is in
   // a generic context.
@@ -236,10 +254,12 @@ static llvm::Expected<CallsAndArgs> MakeGenericSignaturesAndCalls(
   if (!generic_params_no_packs.empty())
     generic_params_no_packs.pop_back();
 
-  std::string user_expr; 
+  std::string user_expr;
   llvm::raw_string_ostream user_expr_stream(user_expr);
-  user_expr_stream << "func $__lldb_user_expr<" << generic_params
-                   << ">(_ $__lldb_arg: UnsafeMutablePointer<("
+  user_expr_stream << "func $__lldb_user_expr";
+  if (!inherit_context_generic_params)
+    user_expr_stream << "<" << generic_params << ">";
+  user_expr_stream << "(_ $__lldb_arg: UnsafeMutablePointer<("
                    << generic_params_no_packs << ")>";
   for (auto &var : local_variables)
     if (var.GetType().GetTypeInfo() & lldb::eTypeIsPack) {
@@ -482,8 +502,16 @@ do {
       // FIXME: the current approach names the generic parameter "T", use the
       // user's name for the generic parameter, so they can refer to it in
       // their expression.
+      //
+      // $__lldb_user_expr can only inherit the context's generic parameters
+      // when the extension it lands in is an extension of the generic context
+      // itself. With a weak self it is an extension of Swift.Optional, where
+      // only `Wrapped` is in scope, so there the parameters have to be
+      // redeclared.
+      bool inherit_context_generic_params = needs_object_ptr && !weak_self;
       auto c = MakeGenericSignaturesAndCalls(local_variables, generic_sig,
-                                             needs_object_ptr);
+                                             needs_object_ptr,
+                                             inherit_context_generic_params);
       if (!c) {
         status = Status::FromError(c.takeError());
         return status;
@@ -547,8 +575,12 @@ func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
     }
   } else if (!SwiftASTManipulator::ShouldBindGenericTypes(
                  options.GetSwiftBindGenericTypes())) {
-    auto c = MakeGenericSignaturesAndCalls(local_variables, generic_sig,
-                                           needs_object_ptr);
+    // Without a self there is no extension to inherit generic parameters
+    // from: $__lldb_user_expr is emitted at the top level and has to declare
+    // them itself.
+    auto c = MakeGenericSignaturesAndCalls(
+        local_variables, generic_sig, needs_object_ptr,
+        /*inherit_context_generic_params=*/false);
     if (!c) {
       status = Status::FromError(c.takeError());
       return status;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -566,13 +566,24 @@ static llvm::Error RegisterAllVariables(
 /// Check if we can evaluate the expression as generic.
 /// Currently, evaluating expression as a generic has several limitations:
 /// - Only self will be evaluated with unbound generics.
-/// - The Self type can only have one generic parameter. 
+/// - The Self type can only have one generic parameter.
 /// - The Self type has to be the outermost type with unbound generics.
+/// - Every generic parameter in scope has to belong to the outermost type.
 static bool CanEvaluateExpressionWithoutBindingGenericParams(
     const llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &variables,
     const std::optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
     SwiftASTContextForExpressions &scratch_ctx, Block *block,
     StackFrame &stack_frame) {
+  // Only the generic parameters of the outermost type are passed to the
+  // expression, so a context that has generic parameters of its own -- a
+  // generic method of a generic type, for example, whose parameters are at
+  // depth 1 -- cannot be evaluated this way.
+  if (llvm::any_of(variables, [](const auto &variable) {
+        return variable.IsMetadataPointer() &&
+               !variable.IsOutermostMetadataPointer();
+      }))
+    return false;
+
   // First, find the compiler type of self with the generic parameters not
   // bound.
   auto self_var = SwiftExpressionParser::FindSelfVariable(block);

--- a/lldb/test/API/lang/swift/inner_generic_params/Makefile
+++ b/lldb/test/API/lang/swift/inner_generic_params/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/inner_generic_params/TestSwiftInnerGenericParams.py
+++ b/lldb/test/API/lang/swift/inner_generic_params/TestSwiftInnerGenericParams.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftInnerGenericParams(TestBase):
-    @requireNotEmbeddedSwift
+    @skipEmbeddedSwift # 6.4.x. only
     @swiftTest
     def test_outermost_params(self):
         """Sanity check: a non-generic method works."""
@@ -15,7 +15,7 @@ class TestSwiftInnerGenericParams(TestBase):
         )
         self.expect("expression --bind-generic-types false -- value", substrs=["42"])
 
-    @requireNotEmbeddedSwift
+    @skipEmbeddedSwift # 6.4.x. only
     @swiftTest
     def test_inner_params_are_declined(self):
         """A generic method in a generic context is not supported."""

--- a/lldb/test/API/lang/swift/inner_generic_params/TestSwiftInnerGenericParams.py
+++ b/lldb/test/API/lang/swift/inner_generic_params/TestSwiftInnerGenericParams.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftInnerGenericParams(TestBase):
+    @requireNotEmbeddedSwift
+    @swiftTest
+    def test_outermost_params(self):
+        """Sanity check: a non-generic method works."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break in method", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("expression --bind-generic-types false -- value", substrs=["42"])
+
+    @requireNotEmbeddedSwift
+    @swiftTest
+    def test_inner_params_are_declined(self):
+        """A generic method in a generic context is not supported."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break in generic method", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "expression --bind-generic-types false -- value",
+            error=True,
+            substrs=[
+                "Could not evaluate the expression without binding generic types."
+            ],
+        )
+        # The default retries with the generic parameters bound, which works.
+        self.expect("expression value", substrs=["42"])
+        self.expect("expression --bind-generic-types true -- value", substrs=["42"])

--- a/lldb/test/API/lang/swift/inner_generic_params/main.swift
+++ b/lldb/test/API/lang/swift/inner_generic_params/main.swift
@@ -1,0 +1,18 @@
+class Container<A, B> {
+  var value = 42
+
+  // No generic parameters of its own, so every parameter in scope belongs to
+  // the outermost type and the unbound path applies.
+  func method() {
+    print(value) // break in method
+  }
+
+  // Generic parameters of its own, which live at depth 1.
+  func genericMethod<X>(_ x: X) {
+    print(value) // break in generic method
+  }
+}
+
+let container = Container<Int, String>()
+container.method()
+container.genericMethod(0)


### PR DESCRIPTION
Evaluating an expression without binding the generic parameters only works when every generic parameter in scope belongs to the outermost type: those are the only ones whose metadata is passed to the expression, as the $τ_0_* variables.

This commit detects the support case and refuses the unsupported case with a clear error message.