### PR TITLE
[ADT] Fix module build with missing bit.h include

### DIFF
--- a/llvm/include/llvm/ADT/Bitset.h
+++ b/llvm/include/llvm/ADT/Bitset.h
@@ -17,6 +17,7 @@
 #define LLVM_ADT_BITSET_H
 
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/bit.h>
 #include <array>
 #include <climits>
 #include <cstdint>


### PR DESCRIPTION
`Bisect::count` calls `popcount` but `Bitset.h` never includes `bit.h` only transitively. This breaks module build.