### PR TITLE
[Cherry-pick into stable/23.x] [lldb] Distinguish tests that can never run from tests that are broken

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -1275,6 +1275,12 @@ def run_suite():
 
     configuration.failed = not result.wasSuccessful()
 
+    if getattr(result, "skipped", None):
+        sys.stderr.write(
+            "Skip breakdown (unsupported=%d, skipped=%d)\n"
+            % (result.countUnsupported(), result.countSkipped())
+        )
+
     if configuration.sdir_has_content and configuration.verbose:
         sys.stderr.write(
             "Session logs for test failures/errors/unexpected successes"

--- a/lldb/packages/Python/lldbsuite/test/skip_reason.py
+++ b/lldb/packages/Python/lldbsuite/test/skip_reason.py
@@ -1,0 +1,17 @@
+"""
+Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+See https://llvm.org/LICENSE.txt for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+Distinguishes the two reasons a test can end up not running.
+"""
+
+
+class UnsupportedReason(str):
+    """A skip reason meaning "this test can never run here", not "this test is
+    broken here". Reported as UNSUPPORTED rather than SKIPPED."""
+
+
+def is_unsupported(reason):
+    """Return True if *reason* marks a test as unsupported rather than skipped."""
+    return isinstance(reason, UnsupportedReason)

--- a/lldb/packages/Python/lldbsuite/test/test_result.py
+++ b/lldb/packages/Python/lldbsuite/test/test_result.py
@@ -16,6 +16,7 @@ import unittest
 
 # LLDB Modules
 from . import configuration
+from .skip_reason import UnsupportedReason, is_unsupported
 from lldbsuite.test_event import build_exception
 
 
@@ -162,9 +163,17 @@ class LLDBTestResult(unittest.TextTestResult):
         getattr(test, test._testMethodName).__func__.__unittest_skip__ = True
         getattr(
             test, test._testMethodName
-        ).__func__.__unittest_skip_why__ = (
+        ).__func__.__unittest_skip_why__ = UnsupportedReason(
             "test case does not fall in any category of interest for this run"
         )
+
+    def countUnsupported(self):
+        """Number of skipped tests that can never run in this configuration."""
+        return sum(1 for _, reason in self.skipped if is_unsupported(reason))
+
+    def countSkipped(self):
+        """Number of skipped tests that ought to run here but don't work yet."""
+        return len(self.skipped) - self.countUnsupported()
 
     def checkExclusion(self, exclusion_list, name):
         if exclusion_list:
@@ -282,9 +291,13 @@ class LLDBTestResult(unittest.TextTestResult):
         method = getattr(test, "markSkippedTest", None)
         if method:
             method()
+        # A test turned off by a `require*` decorator can never run in this
+        # configuration, so report it as UNSUPPORTED. Anything else is a test
+        # that ought to run here but doesn't work yet: report it as SKIPPED.
+        status = "UNSUPPORTED" if is_unsupported(reason) else "SKIPPED"
         self.stream.write(
-            "UNSUPPORTED: LLDB (%s) :: %s (%s) \n"
-            % (self._config_string(test), str(test), reason)
+            "%s: LLDB (%s) :: %s (%s) \n"
+            % (status, self._config_string(test), str(test), reason)
         )
 
     def addUnexpectedSuccess(self, test):


### PR DESCRIPTION
```
commit eb5a87e152730e7934f9bc3f834a8f429e1c8db8
Author: Augusto Noronha <anoronha@apple.com>
Date:   Mon Aug 3 14:39:54 2026 -0700

    [lldb] Distinguish tests that can never run from tests that are broken
    
    This is the subset of https://github.com/swiftlang/llvm-project/pull/13615
    (cherry-picking llvm/llvm-project#212753 by Charles Zablit) that the embedded
    Swift decorator split in the next commit needs.
```
