### PR TITLE
[lldb] Fix misconstructed log/formatv calls (#196129)

### DIFF
--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -320,7 +320,7 @@ lldb::ChildCacheState BytecodeSyntheticChildren::FrontEnd::Update() {
   } else {
     LLDB_LOG(GetLog(LLDBLog::DataFormatters),
              "Bytecode formatter did not return a valid reuse response from "
-             "@update (type: `{1}`, name: `{2}`)",
+             "@update (type: `{}`, name: `{}`)",
              m_backend.GetDisplayTypeName(), m_backend.GetName());
   }
 

--- a/lldb/source/Expression/Expression.cpp
+++ b/lldb/source/Expression/Expression.cpp
@@ -75,9 +75,8 @@ std::string lldb_private::FunctionCallLabel::toString() const {
 
 void llvm::format_provider<FunctionCallLabel>::format(
     const FunctionCallLabel &label, raw_ostream &OS, StringRef Style) {
-  OS << llvm::formatv("FunctionCallLabel{ discriminator: {0}, module_id: "
-                      "{1:x}, symbol_id: {2:x}, "
-                      "lookup_name: {3} }",
+  OS << llvm::formatv("FunctionCallLabel{{ discriminator: {}, module_id: "
+                      "{:x}, symbol_id: {:x}, lookup_name: {} }}",
                       label.discriminator, label.module_id, label.symbol_id,
                       label.lookup_name);
 }

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -1239,8 +1239,8 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
                        eErrorTypePOSIX);
         if (error.Fail())
           LLDB_LOG(log,
-                   "error: {0}, ::posix_spawnattr_setarchpref_np ( &attr, 1, "
-                   "cpu_type = {1:x}, cpu_subtype = {1:x}, count => {2} )",
+                   "error: {}, ::posix_spawnattr_setarchpref_np ( &attr, 1, "
+                   "cpu_type = {:x}, cpu_subtype = {:x}, count => {} )",
                    error, cpu_type, cpu_subtype, ocount);
 
         if (error.Fail() || ocount != 1)

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -908,7 +908,7 @@ void DynamicLoaderDarwin::ImageInfo::PutToLog(Log *log) const {
   if (!log)
     return;
   if (address == LLDB_INVALID_ADDRESS) {
-    LLDB_LOG(log, "uuid={1} path='{2}' (UNLOADED)", uuid.GetAsString(),
+    LLDB_LOG(log, "uuid={} path='{}' (UNLOADED)", uuid.GetAsString(),
              file_spec.GetPath());
   } else {
     LLDB_LOG(log, "address={0:x+16} uuid={1} path='{2}'", address,

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -457,8 +457,7 @@ bool ClassDescriptorV2::relative_list_list_t::Read(Process *process,
   // FIXME: Propagate this error up
   process->ReadMemory(addr, buffer.GetBytes(), size, error);
   if (error.Fail()) {
-    LLDB_LOG(log, "Failed to read relative_list_list_t at address 0x" PRIx64,
-             addr);
+    LLDB_LOG(log, "Failed to read relative_list_list_t at address {:x+}", addr);
     return false;
   }
 
@@ -482,8 +481,8 @@ ClassDescriptorV2::GetMethodList(Process *process,
   const size_t method_size = method_t::GetSize(process, method_list.m_is_small);
   if (method_list.m_entsize != method_size) {
     LLDB_LOG(log,
-             "method_list_t at address 0x" PRIx64 " has an entsize of " PRIu16
-             " but method size should be " PRIu64,
+             "method_list_t at address {:x+} has an entsize of {:x+} but "
+             "method size should be {:x+}",
              method_list_ptr, method_list.m_entsize, method_size);
     return std::nullopt;
   }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
@@ -186,8 +186,7 @@ bool AppleThreadPlanStepThroughObjCTrampoline::ShouldStop(Event *event_ptr) {
         LLDB_LOG(log, "Failed to deallocate the sel str at {0} - error: {1}",
                  m_sel_str_addr, dealloc_error);
       objc_runtime->AddToMethodCache(m_isa_addr, m_sel_str, target_addr);
-      LLDB_LOG(log,
-               "Adding \\{isa-addr={0}, sel-addr={1}\\} = addr={2} to cache.",
+      LLDB_LOG(log, "Adding {{isa-addr={}, sel-addr={}}} = addr={} to cache.",
                m_isa_addr, m_sel_str, target_addr);
     } else {
       objc_runtime->AddToMethodCache(m_isa_addr, m_sel_addr, target_addr);

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -733,13 +733,16 @@ void ObjectFileWasm::CreateSections(SectionList &unified_section_list) {
     if (segment.type == WasmSegment::Active) {
       // FIXME: Support segments with a memory index.
       if (segment.memory_index != 0) {
-        LLDB_LOG(log, "Skipping segment {0}: non-zero memory index is "
-                      "currently unsupported");
+        LLDB_LOG(log,
+                 "Skipping segment {}: non-zero memory index is "
+                 "currently unsupported",
+                 segment.name);
         continue;
       }
 
       if (segment.init_expr_offset == LLDB_INVALID_OFFSET) {
-        LLDB_LOG(log, "Skipping segment {0}: unsupported init expression");
+        LLDB_LOG(log, "Skipping segment {}: unsupported init expression",
+                 segment.name);
         continue;
       }
     }

--- a/lldb/source/Plugins/Process/MacOSX-Kernel/CommunicationKDP.cpp
+++ b/lldb/source/Plugins/Process/MacOSX-Kernel/CommunicationKDP.cpp
@@ -194,8 +194,8 @@ size_t CommunicationKDP::WaitForPacketWithTimeoutMicroSecondsNoLock(
                              status, &error);
 
     LLDB_LOGV(log,
-              "Read (buffer, sizeof(buffer), timeout_usec = 0x{0:x}, "
-              "status = {1}, error = {2}) => bytes_read = {4}",
+              "Read (buffer, sizeof(buffer), timeout_usec = {:x+}, "
+              "status = {}, error = {}) => bytes_read = {}",
               timeout_usec, Communication::ConnectionStatusAsString(status),
               error, bytes_read);
 

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4700,9 +4700,8 @@ static std::vector<RegisterFlags::Field> ParseFlagsFields(
       else {
         if (RegisterFlags::Field::GetSizeInBits(*start, *end) > 64)
           LLDB_LOG(log,
-                   "ProcessGDBRemote::ParseFlagsFields Ignoring field \"{2}\" "
-                   "that has "
-                   "size > 64 bits, this is not supported",
+                   "ProcessGDBRemote::ParseFlagsFields Ignoring field \"{}\" "
+                   "that has size > 64 bits, this is not supported",
                    name->data());
         else {
           // A field's type may be set to the name of an enum type.

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.cpp
@@ -78,7 +78,7 @@ bool ScriptedBreakpointPythonInterface::ResolverCallback(
   if (!ScriptedInterface::CheckStructuredDataObject(LLVM_PRETTY_FUNCTION, obj,
                                                     error)) {
     Log *log = GetLog(LLDBLog::Script);
-    LLDB_LOG(log, "Error calling __callback__ method: {1}", error);
+    LLDB_LOG(log, "Error calling __callback__ method: {}", error);
     return true;
   }
   return obj->GetBooleanValue();

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -175,8 +175,8 @@ bool SymbolFileCTF::ParseHeader() {
 
     if (zstr.total_out != decompressed_size) {
       LLDB_LOG(log,
-               "CTF parsing failed: decompressed size ({0}) doesn't match "
-               "expected size ([1})",
+               "CTF parsing failed: decompressed size ({}) doesn't match "
+               "expected size ({})",
                zstr.total_out, decompressed_size);
       return false;
     }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -7547,9 +7547,8 @@ clang::FieldDecl *TypeSystemClang::AddFieldToRecordType(
   clang::Expr *bit_width = nullptr;
   if (bitfield_bit_size != 0) {
     if (clang_ast.IntTy.isNull()) {
-      LLDB_LOG(
-          GetLog(LLDBLog::Expressions),
-          "{0} failed: builtin ASTContext types have not been initialized");
+      LLDB_LOG(GetLog(LLDBLog::Expressions),
+               "builtin ASTContext types have not been initialized");
       return nullptr;
     }
 

--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -152,7 +152,7 @@ AssertFrameRecognizer::RecognizeFrame(lldb::StackFrameSP frame_sp) {
 
     if (!prev_frame_sp) {
       Log *log = GetLog(LLDBLog::Unwind);
-      LLDB_LOG(log, "Abort Recognizer: Hit unwinding bound ({1} frames)!",
+      LLDB_LOG(log, "Abort Recognizer: Hit unwinding bound ({} frames)!",
                frames_to_fetch);
       break;
     }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2826,7 +2826,7 @@ Target::GetPersistentExpressionStateForLanguage(lldb::LanguageType language) {
     return ts->GetPersistentExpressionState();
 
   LLDB_LOG(GetLog(LLDBLog::Target),
-           "Unable to get persistent expression state for language {1}: {0}",
+           "Unable to get persistent expression state for language {}:",
            Language::GetNameForLanguageType(language));
   return nullptr;
 }


### PR DESCRIPTION
Fixes `LLDB_LOG` and `formatv` source errors found using https://github.com/llvm/llvm-project/pull/195974

(cherry picked from commit 9f968a8e579d9eb9942fb04ed1e068f6209f9601)