### PR TITLE
[lldb][test] Fix embedded Swift macOS deployment target for API tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -176,16 +176,30 @@ endif
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
 	SWIFTFLAGS += -gdwarf-types -enable-experimental-feature Embedded -enable-experimental-feature ValueGenerics -Xfrontend -disable-objc-interop -runtime-compatibility-version none
 	ifeq "$(OS)" "Darwin"
-		# If TARGET_SWIFTFLAGS already specifies a -target (e.g. for remote-ios),
-		# honour it; the embedded triple is the target triple with the version
-		# number stripped (e.g. arm64-apple-ios26.0 → arm64-apple-ios).
-		# Otherwise default to a macOS host build.
+		# If TARGET_SWIFTFLAGS already specifies a -target for a different
+		# platform (e.g. for remote-ios), honour it; the embedded triple is
+		# the target triple with the version number stripped (e.g.
+		# arm64-apple-ios26.0 → arm64-apple-ios).
+		#
+		# For a macOS build (the default, or an explicit macOS -target),
+		# always use at least macos14: the embedded macOS standard library
+		# has a minimum deployment target of macOS 14, but the API test
+		# suite's default -target (TARGET_SWIFTFLAGS, e.g.
+		# arm64-apple-macosx13.0) is derived from the toolchain's configured
+		# minimum deployment target, which can be lower. Appending another
+		# -target here overrides the earlier one, since swiftc/clang honour
+		# the last -target flag on the command line.
+		TARGET_SWIFTFLAGS_TRIPLE = $(shell echo $(TARGET_SWIFTFLAGS) | sed -E 's/.*-target ([^ ]+).*/\1/')
 		ifneq "$(findstring -target,$(TARGET_SWIFTFLAGS))" ""
-			# Extract the triple from TARGET_SWIFTFLAGS (e.g. "-target arm64-apple-ios26.0"
-			# becomes "arm64-apple-ios26.0"), then strip the version number so the result
-			# matches the directory names under lib/swift/embedded/ (e.g. "arm64-apple-ios").
-			SWIFT_EMBEDDED_TRIPLE_VERSIONED = $(shell echo $(TARGET_SWIFTFLAGS) | sed -E 's/.*-target ([^ ]+).*/\1/')
-			SWIFT_EMBEDDED_TRIPLE = $(shell echo $(SWIFT_EMBEDDED_TRIPLE_VERSIONED) | sed -E 's/([^-]+-[^-]+-[^.0-9]+).*/\1/')
+			ifeq "$(findstring apple-macos,$(TARGET_SWIFTFLAGS_TRIPLE))" ""
+				# Extract the triple from TARGET_SWIFTFLAGS (e.g. "-target arm64-apple-ios26.0"
+				# becomes "arm64-apple-ios26.0"), then strip the version number so the result
+				# matches the directory names under lib/swift/embedded/ (e.g. "arm64-apple-ios").
+				SWIFT_EMBEDDED_TRIPLE = $(shell echo $(TARGET_SWIFTFLAGS_TRIPLE) | sed -E 's/([^-]+-[^-]+-[^.0-9]+).*/\1/')
+			else
+				SWIFTFLAGS += -target $(ARCH)-apple-macos14
+				SWIFT_EMBEDDED_TRIPLE = $(ARCH)-apple-macos
+			endif
 		else
 			SWIFTFLAGS += -target $(ARCH)-apple-macos14
 			SWIFT_EMBEDDED_TRIPLE = $(ARCH)-apple-macos


### PR DESCRIPTION
The embedded macOS Swift standard library has a minimum deployment target of macOS 14 (swift/stdlib/public/CMakeLists.txt), but the lldb API test suite's default -target for Swift test builds (TARGET_SWIFTFLAGS) is derived from the toolchain's configured minimum deployment target, which is typically much lower (e.g. arm64-apple-macosx13.0).

Assisted-by: claude