### PR TITLE
Add HiddenTypeLayoutInfo to exhaustive switch

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5487,6 +5487,7 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::Decl *decl) {
     case swift::DeclKind::Missing:
     case swift::DeclKind::MissingMember:
     case swift::DeclKind::Using:
+    case swift::DeclKind::HiddenTypeLayoutInfo:
       break;
 
     case swift::DeclKind::InfixOperator:


### PR DESCRIPTION
When a new kind of Decl is added, it needs to be added to this switch statement, or otherwise it doesn't handle all cases and won't compile.