### PR TITLE
[lldb] Stop clobbering the type name in getTypeAndDie's diagnostic

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -187,12 +187,13 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
     }
   }
   if (!lldb_type) {
-    std::tie(lldb_type, type) = DWARFASTParserSwift::ResolveTypeAlias(type);
-    if (lldb_type) {
+    auto [alias_lldb_type, alias_type] =
+        DWARFASTParserSwift::ResolveTypeAlias(type);
+    if (alias_lldb_type) {
       auto *dwarf =
-          llvm::cast<SymbolFileDWARF>(lldb_type->GetSymbolFile());
-      auto die = dwarf->GetDIE(lldb_type->GetID());
-      return {{type, die}};
+          llvm::cast<SymbolFileDWARF>(alias_lldb_type->GetSymbolFile());
+      auto die = dwarf->GetDIE(alias_lldb_type->GetID());
+      return {{alias_type, die}};
     }
   }
   if (!lldb_type) {


### PR DESCRIPTION
`ResolveTypeAlias()` returns a default-constructed pair on each of its failure paths, and its result was assigned straight back into the type being looked up:

    std::tie(lldb_type, type) = DWARFASTParserSwift::ResolveTypeAlias(type);

So a failed alias resolution replaced `type` with an invalid CompilerType, and the diagnostic a few lines below reported

    Could not find type <invalid> in module

Assisted-by: Claude