### PR TITLE
[lldb] Fix TestRegisters.py

### DIFF
--- a/lldb/source/Utility/Args.cpp
+++ b/lldb/source/Utility/Args.cpp
@@ -441,7 +441,7 @@ lldb::Encoding Args::StringToEncoding(llvm::StringRef s,
 uint32_t Args::StringToGenericRegister(llvm::StringRef s) {
   if (s.empty())
     return LLDB_INVALID_REGNUM;
-  uint32_t result = llvm::StringSwitch<uint32_t>(s)
+  uint32_t result = llvm::StringSwitch<uint32_t>(s.lower())
                         .Case("pc", LLDB_REGNUM_GENERIC_PC)
                         .Case("sp", LLDB_REGNUM_GENERIC_SP)
                         .Case("fp", LLDB_REGNUM_GENERIC_FP)


### PR DESCRIPTION
Root cause: a8a6ddc26b51710495b67e074b554b98f2ce3479 We took the test but not the LLDB change.