### PR TITLE
[lldb][test] Keep po/uninitialized test running under embedded Swift

### DIFF
--- a/lldb/test/API/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
+++ b/lldb/test/API/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
@@ -9,9 +9,41 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ------------------------------------------------------------------------------
-import lldbsuite.test.lldbinline as lldbinline
+"""
+Test that po detects a class reference that has not been assigned yet.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[skipEmbeddedSwift,
-        swiftTest])
+
+class TestCase(TestBase):
+    @skipEmbeddedSwiftOnWindows
+    @swiftTest
+    def test_uninitialized(self):
+        """po on a not-yet-assigned class reference reports <uninitialized>."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break before assignment", lldb.SBFileSpec("main.swift")
+        )
+
+        self.assertIsNone(
+            self.frame().FindVariable("object").GetObjectDescription(),
+            "po correctly detects uninitialized instances",
+        )
+        self.expect("po object", substrs=["<uninitialized>"])
+
+    @swiftTest
+    @requireNotEmbeddedSwift
+    def test_initialized(self):
+        """Once assigned, po prints the instance's description."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break after assignment", lldb.SBFileSpec("main.swift")
+        )
+
+        description = self.frame().FindVariable("object").GetObjectDescription()
+        self.assertIsNotNone(description)
+        self.assertIn("POClass:", description)

--- a/lldb/test/API/lang/swift/po/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/po/uninitialized/main.swift
@@ -15,8 +15,8 @@ class POClass {
 
 func main() {
   var object: POClass
-  object = POClass() //% self.assertEqual(self.frame().FindVariable('object').GetObjectDescription(), None, 'po correctly detects uninitialized instances'); self.expect("po object", substrs=["<uninitialized>"])
-  print("yay I am done") //% self.assertTrue('POClass:' in self.frame().FindVariable('object').GetObjectDescription())
+  object = POClass() // break before assignment
+  print("yay I am done") // break after assignment
 }
 
 print("Some code here")


### PR DESCRIPTION
The test has two halves, and only the second is impossible in embedded Swift.

The first -- that `po` on a not-yet-assigned class reference reports
`<uninitialized>` -- is the actual point of the test and works fine in
embedded.

Assisted-by: claude
