### PR TITLE
[lldb] Cherry-pick embedded Swift debugging work from stable/21.x to next

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1619,6 +1619,23 @@ class Base(unittest.TestCase):
     def getSwiftModuleImporterVariant(self):
         return self.getVariant("swift_module_importer")
 
+    def getSwiftEmbeddedVariant(self):
+        return self.getVariant("swift_embedded")
+
+    def isEmbeddedSwift(self):
+        """Return True when running the embedded Swift variant of this test."""
+        return self.getSwiftEmbeddedVariant() == "swiftembed"
+
+    def swiftMangledName(self, mangled_name):
+        """Return *mangled_name* in the mangling flavor of the current variant.
+
+        Embedded Swift prefixes every mangled symbol with `$e` where regular
+        Swift uses `$s`. A test that hardcodes a mangled name should pass it
+        through here instead of spelling both flavors out."""
+        if self.isEmbeddedSwift() and mangled_name.startswith("$s"):
+            return "$e" + mangled_name[2:]
+        return mangled_name
+
     def build(
         self,
         *,

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -164,13 +164,6 @@ ifeq "$(SWIFT_CXX_INTEROP)" "1"
 endif
 
 #----------------------------------------------------------------------
-# SWIFT_EMBEDDED_CONCURRENCY implies SWIFT_EMBEDDED_MODE
-#----------------------------------------------------------------------
-ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
-	SWIFT_EMBEDDED_MODE = 1
-endif
-
-#----------------------------------------------------------------------
 # Check if we should compile in Swift embedded mode
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
@@ -209,15 +202,27 @@ ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
 endif
 
 #----------------------------------------------------------------------
-# Check if we need embedded Swift concurrency support
+# Check if we need embedded Swift concurrency support.
+#
+# A test whose sources use async/await or actors sets SWIFT_CONCURRENCY to any
+# non-empty value.
+# Regular Swift needs nothing extra, so this only has an effect on an embedded
+# build, and it never turns embedded mode on by itself: an embedded-only test
+# sets both SWIFT_CONCURRENCY and SWIFT_EMBEDDED_MODE.
 #----------------------------------------------------------------------
-ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
+ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
+ifneq "$(SWIFT_CONCURRENCY)" ""
+  # Embedded Swift disables the implicit _Concurrency import on every target
+  # except WASI. We inject it via the swift flags so the tests that compile in
+  # both variants can stay unchanged.
+	SWIFTFLAGS += -Xfrontend -import-module -Xfrontend _Concurrency
 	SWIFT_EMBEDDED_LIB_DIR = $(shell dirname $(SWIFTC))/../lib/swift/embedded/$(SWIFT_EMBEDDED_TRIPLE)
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_Concurrency.a
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_ConcurrencyDefaultExecutor.a
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswiftEmbeddedPlatformSingleThreaded.a
 	LD_EXTRAS += -lc++
 	LD_EXTRAS += -Xlinker -dead_strip
+endif
 endif
 
 #----------------------------------------------------------------------

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -39,7 +39,7 @@ let Definition = "modulelist", Path = "symbols" in {
     Desc<"Validate all Swift typesystem queries. Used for testing an asserts-enabled LLDB only.">;
   def SwiftTypeSystemFallback
       : Property<"swift-typesystem-compiler-fallback", "Boolean">,
-        DefaultTrue,
+        DefaultFalse,
         Desc<"If a query against reflection metadata / debug info fails, retry "
              "using Swift modules.">;
   def SwiftLoadConformances: Property<"swift-load-conformances", "Boolean">,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -755,11 +755,10 @@ protected:
 
   /// Resolves the type whose metadata the pointer stored at \p
   /// metadata_ptr_addr points to. That word is a class instance's metadata
-  /// pointer, or an error box's payload metadata pointer. \p type_in_context is
-  /// only used to reach the type system the result is created in.
+  /// pointer, or an error box's payload metadata pointer.
   llvm::Expected<CompilerType>
   GetTypeFromMetadataPointerEmbedded(lldb::addr_t metadata_ptr_addr,
-                                     CompilerType type_in_context);
+                                     TypeSystemSwiftTypeRef &ts);
 
   /// Resolves the type whose metadata symbol covers \p metadata_addr.
   llvm::Expected<CompilerType>

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -757,10 +757,28 @@ protected:
   CompilerType GetDynamicTypeAndAddress_EmbeddedClass(uint64_t instance_ptr,
                                                       CompilerType class_type);
 
-  /// Resolves the dynamic type of a class-constrained embedded Swift
-  /// existential.
+  /// Resolves the type whose metadata symbol covers \p metadata_addr.
+  CompilerType GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
+                                          TypeSystemSwiftTypeRef &ts);
+
+  /// Resolves the type a "type metadata for T" symbol names, and whether the
+  /// symbol names full metadata rather than type metadata.
+  std::pair<CompilerType, bool>
+  GetTypeFromMetadataSymbol(llvm::StringRef symbol_name,
+                            TypeSystemSwiftTypeRef &ts);
+
+  /// If \p type is a class, returns the address of the instance \p addr holds a
+  /// reference to, which is what callers of dynamic type resolution expect;
+  /// any other type is already the value, so \p addr is returned unchanged.
+  /// Returns std::nullopt if the reference could not be read.
+  std::optional<lldb::addr_t> UnwrapClassReferenceIfNeeded(CompilerType type,
+                                                           lldb::addr_t addr);
+
+  /// Resolves the dynamic type of the class reference an embedded Swift
+  /// class-constrained existential holds in its first word. Returns
+  /// std::nullopt if that word does not resolve to a class.
   std::optional<std::pair<CompilerType, uint64_t>>
-  GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
+  GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type);
 
   /// Resolves the dynamic type of an embedded Swift existential container.
@@ -768,11 +786,22 @@ protected:
   GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type);
 
+  /// Resolves the dynamic type of an embedded Swift error existential, which
+  /// points to a heap box holding the payload's type metadata.
+  std::optional<std::pair<CompilerType, uint64_t>>
+  GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+      lldb::addr_t existential_address, CompilerType existential_type,
+      ExecutionContextScope *exe_scope);
+
   /// Resolves the dynamic type of an embedded Swift existential.
-  /// Tries class-constrained first, then falls back to existential container.
+  /// Dispatches on the existential's representation, which reflection derives
+  /// from the protocol's debug info. \p exe_scope is needed to reach the type
+  /// system that can read that debug info; without it the representation is
+  /// unknown and every layout is tried in turn.
   llvm::Expected<std::pair<CompilerType, uint64_t>>
-  GetDynamicTypeAndAddress_ExistentialEmbedded(lldb::addr_t existential_address,
-                                               CompilerType existential_type);
+  GetDynamicTypeAndAddress_ExistentialEmbedded(
+      lldb::addr_t existential_address, CompilerType existential_type,
+      ExecutionContextScope *exe_scope);
 
   /// Dynamic type resolution tends to want to generate scalar data -
   /// but there are caveats Per original comment here "Our address is

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -753,42 +753,46 @@ protected:
       TypeAndOrName &class_type_or_name, Address &address,
       Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer);
 
-  /// Resolves the dynamic type of an embedded Swift class type.
-  CompilerType GetDynamicTypeAndAddress_EmbeddedClass(uint64_t instance_ptr,
-                                                      CompilerType class_type);
+  /// Resolves the type whose metadata the pointer stored at \p
+  /// metadata_ptr_addr points to. That word is a class instance's metadata
+  /// pointer, or an error box's payload metadata pointer. \p type_in_context is
+  /// only used to reach the type system the result is created in.
+  llvm::Expected<CompilerType>
+  GetTypeFromMetadataPointerEmbedded(lldb::addr_t metadata_ptr_addr,
+                                     CompilerType type_in_context);
 
   /// Resolves the type whose metadata symbol covers \p metadata_addr.
-  CompilerType GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
-                                          TypeSystemSwiftTypeRef &ts);
+  llvm::Expected<CompilerType>
+  GetTypeFromMetadataAddressEmbedded(lldb::addr_t metadata_addr,
+                                     TypeSystemSwiftTypeRef &ts);
 
   /// Resolves the type a "type metadata for T" symbol names, and whether the
   /// symbol names full metadata rather than type metadata.
-  std::pair<CompilerType, bool>
-  GetTypeFromMetadataSymbol(llvm::StringRef symbol_name,
-                            TypeSystemSwiftTypeRef &ts);
+  llvm::Expected<std::pair<CompilerType, bool>>
+  GetTypeFromMetadataSymbolEmbedded(llvm::StringRef symbol_name,
+                                    TypeSystemSwiftTypeRef &ts);
 
   /// If \p type is a class, returns the address of the instance \p addr holds a
   /// reference to, which is what callers of dynamic type resolution expect;
   /// any other type is already the value, so \p addr is returned unchanged.
-  /// Returns std::nullopt if the reference could not be read.
-  std::optional<lldb::addr_t> UnwrapClassReferenceIfNeeded(CompilerType type,
-                                                           lldb::addr_t addr);
+  llvm::Expected<lldb::addr_t> UnwrapClassReferenceIfNeeded(CompilerType type,
+                                                            lldb::addr_t addr);
 
   /// Resolves the dynamic type of the class reference an embedded Swift
-  /// class-constrained existential holds in its first word. Returns
-  /// std::nullopt if that word does not resolve to a class.
-  std::optional<std::pair<CompilerType, uint64_t>>
+  /// class-constrained existential holds in its first word. Fails if that word
+  /// does not resolve to a class.
+  llvm::Expected<std::pair<CompilerType, uint64_t>>
   GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type);
 
   /// Resolves the dynamic type of an embedded Swift existential container.
-  std::optional<std::pair<CompilerType, uint64_t>>
+  llvm::Expected<std::pair<CompilerType, uint64_t>>
   GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type);
 
   /// Resolves the dynamic type of an embedded Swift error existential, which
   /// points to a heap box holding the payload's type metadata.
-  std::optional<std::pair<CompilerType, uint64_t>>
+  llvm::Expected<std::pair<CompilerType, uint64_t>>
   GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
       lldb::addr_t existential_address, CompilerType existential_type,
       ExecutionContextScope *exe_scope);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2375,32 +2375,41 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Pack(
   return true;
 }
 
-std::pair<CompilerType, bool>
-SwiftLanguageRuntime::GetTypeFromMetadataSymbol(llvm::StringRef symbol_name,
-                                                TypeSystemSwiftTypeRef &ts) {
+llvm::Expected<std::pair<CompilerType, bool>>
+SwiftLanguageRuntime::GetTypeFromMetadataSymbolEmbedded(
+    llvm::StringRef symbol_name, TypeSystemSwiftTypeRef &ts) {
   // The symbol name will be something like "type metadata for Class", extract
   // "Class" from that name.
-  return ts.GetTypeFromTypeMetadataNode(symbol_name);
+  auto [type, is_full_metadata] = ts.GetTypeFromTypeMetadataNode(symbol_name);
+  if (!type)
+    return llvm::createStringError("no type for metadata symbol " +
+                                   symbol_name);
+  return std::make_pair(type, is_full_metadata);
 }
 
-CompilerType
-SwiftLanguageRuntime::GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
-                                                 TypeSystemSwiftTypeRef &ts) {
+llvm::Expected<CompilerType>
+SwiftLanguageRuntime::GetTypeFromMetadataAddressEmbedded(
+    lldb::addr_t metadata_addr, TypeSystemSwiftTypeRef &ts) {
   // Embedded Swift emits no metadata records, but it does emit a symbol for
   // every type's metadata, so the type can be recovered from the symbol name.
   Address address;
   address.SetLoadAddress(metadata_addr, &GetProcess().GetTarget());
   Symbol *symbol = address.CalculateSymbolContextSymbol();
   if (!symbol)
-    return {};
+    return llvm::createStringError(
+        llvm::formatv("no symbol for metadata at {0:x}", metadata_addr).str());
   Mangled mangled = symbol->GetMangled();
   if (!mangled)
-    return {};
+    return llvm::createStringError(
+        llvm::formatv("symbol for metadata at {0:x} is not mangled",
+                      metadata_addr)
+            .str());
 
-  auto [type, is_full_metadata] =
-      GetTypeFromMetadataSymbol(mangled.GetMangledName().GetStringRef(), ts);
-  if (!type)
-    return {};
+  auto type_or_err = GetTypeFromMetadataSymbolEmbedded(
+      mangled.GetMangledName().GetStringRef(), ts);
+  if (!type_or_err)
+    return type_or_err.takeError();
+  auto [type, is_full_metadata] = *type_or_err;
 
   // Sanity check that the symbol's start address matches what we expect. This
   // depends on whether the symbol is full type metadata (one pointer sized
@@ -2409,18 +2418,17 @@ SwiftLanguageRuntime::GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
   uint64_t expected_offset =
       is_full_metadata ? GetProcess().GetAddressByteSize() : 0;
   if (symbol_addr == LLDB_INVALID_ADDRESS ||
-      metadata_addr - symbol_addr != expected_offset) {
-    LLDB_LOG(GetLog(LLDBLog::Types),
-             "[GetTypeFromMetadataAddress] metadata at {0:x} is {1} bytes into "
-             "{2}, not its address point",
-             metadata_addr, metadata_addr - symbol_addr,
-             mangled.GetMangledName());
-    return {};
-  }
+      metadata_addr - symbol_addr != expected_offset)
+    return llvm::createStringError(
+        llvm::formatv("metadata at {0:x} is {1} bytes into {2}, not its "
+                      "address point",
+                      metadata_addr, metadata_addr - symbol_addr,
+                      mangled.GetMangledName())
+            .str());
   return type;
 }
 
-std::optional<lldb::addr_t>
+llvm::Expected<lldb::addr_t>
 SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
                                                    lldb::addr_t addr) {
   // Only a class is stored as a reference; any other type is already the value.
@@ -2428,53 +2436,66 @@ SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
     return addr;
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return std::nullopt;
+    return llvm::createStringError("no reflection context");
   std::optional<swift::remote::RemoteAbsolutePointer> instance =
       reflection_ctx->ReadPointer(addr);
   if (!instance)
-    return std::nullopt;
+    return llvm::createStringError(
+        llvm::formatv("could not read the class reference stored at {0:x}",
+                      addr)
+            .str());
   return instance->getResolvedAddress().getRawAddress();
 }
 
-CompilerType SwiftLanguageRuntime::GetDynamicTypeAndAddress_EmbeddedClass(
-    uint64_t instance_ptr, CompilerType class_type) {
+llvm::Expected<CompilerType>
+SwiftLanguageRuntime::GetTypeFromMetadataPointerEmbedded(
+    lldb::addr_t metadata_ptr_addr, CompilerType type_in_context) {
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return {};
-  auto tss = class_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+    return llvm::createStringError("no reflection context");
+  auto tss =
+      type_in_context.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!tss)
-    return {};
+    return llvm::createStringError("not a Swift type system");
   TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
   if (!ts)
-    return {};
+    return llvm::createStringError("no Swift typeref typesystem");
 
-  /// If this is an embedded Swift type, there is no metadata, and the
-  /// pointer points to the type's vtable. We can still resolve the type by
-  /// reading the vtable's symbol name.
   std::optional<swift::remote::RemoteAbsolutePointer> pointer =
-      reflection_ctx->ReadPointer(instance_ptr);
+      reflection_ctx->ReadPointer(metadata_ptr_addr);
   if (!pointer)
-    return {};
+    return llvm::createStringError(
+        llvm::formatv("could not read the metadata pointer at {0:x}",
+                      metadata_ptr_addr)
+            .str());
 
   // A RemoteAbsolutePointer can contain a symbol or an address. If we have the
   // symbol, we can extract the dynamic type from the symbol's mangled name.
-  if (!pointer->getSymbol().empty() && !pointer->getOffset())
-    return GetTypeFromMetadataSymbol(pointer->getSymbol(), *ts).first;
+  if (!pointer->getSymbol().empty() && !pointer->getOffset()) {
+    auto type_or_err =
+        GetTypeFromMetadataSymbolEmbedded(pointer->getSymbol(), *ts);
+    if (!type_or_err)
+      return type_or_err.takeError();
+    return type_or_err->first;
+  }
   // Otherwise, we need to look up which symbol matches the address.
-  return GetTypeFromMetadataAddress(
+  return GetTypeFromMetadataAddressEmbedded(
       pointer->getResolvedAddress().getRawAddress(), *ts);
 }
 
-std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
+llvm::Expected<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
     GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
         lldb::addr_t existential_address, CompilerType existential_type) {
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return std::nullopt;
+    return llvm::createStringError("no reflection context");
 
   auto maybe_addr_or_symbol = reflection_ctx->ReadPointer(existential_address);
   if (!maybe_addr_or_symbol)
-    return std::nullopt;
+    return llvm::createStringError(
+        llvm::formatv("could not read the class reference stored at {0:x}",
+                      existential_address)
+            .str());
 
   uint64_t address = 0;
   if (maybe_addr_or_symbol->getSymbol().empty() &&
@@ -2487,101 +2508,103 @@ std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
         ConstString(maybe_addr_or_symbol->getSymbol()), eSymbolTypeAny,
         sc_list);
     if (sc_list.GetSize() != 1)
-      return std::nullopt;
+      return llvm::createStringError("no unique symbol named " +
+                                     maybe_addr_or_symbol->getSymbol());
 
     SymbolContext sc = sc_list[0];
     Symbol *symbol = sc.symbol;
     address = symbol->GetLoadAddress(&GetProcess().GetTarget());
   }
 
-  CompilerType dynamic_type =
-      GetDynamicTypeAndAddress_EmbeddedClass(address, existential_type);
-  if (!dynamic_type)
-    return std::nullopt;
+  auto dynamic_type_or_err =
+      GetTypeFromMetadataPointerEmbedded(address, existential_type);
+  if (!dynamic_type_or_err)
+    return dynamic_type_or_err.takeError();
+  CompilerType dynamic_type = *dynamic_type_or_err;
 
   // For a class-constrained existential this word is the instance reference, so
   // resolving it to anything else means there's something wrong.
-  if (!Flags(dynamic_type.GetTypeInfo()).AllSet(eTypeIsClass)) {
-    LLDB_LOG(GetLog(LLDBLog::Types),
-             "[GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded] {0} "
-             "is not a class",
-             dynamic_type.GetMangledTypeName());
-    return std::nullopt;
-  }
+  if (!Flags(dynamic_type.GetTypeInfo()).AllSet(eTypeIsClass))
+    return llvm::createStringError(
+        "class-constrained existential resolved to non-class type " +
+        dynamic_type.GetMangledTypeName().GetStringRef());
 
   return std::make_pair(
       dynamic_type, maybe_addr_or_symbol->getResolvedAddress().getRawAddress());
 }
 
-std::optional<std::pair<CompilerType, uint64_t>>
+llvm::Expected<std::pair<CompilerType, uint64_t>>
 SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
     lldb::addr_t existential_address, CompilerType existential_type) {
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return std::nullopt;
+    return llvm::createStringError("no reflection context");
   auto tss =
       existential_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!tss)
-    return std::nullopt;
+    return llvm::createStringError("not a Swift type system");
   TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
   if (!ts)
-    return std::nullopt;
+    return llvm::createStringError("no Swift typeref typesystem");
 
   auto existential_container =
       reflection_ctx->ReadMetadataAndValueOpaqueExistential(
           existential_address);
   if (!existential_container)
-    return std::nullopt;
+    return llvm::createStringError(
+        llvm::formatv("could not read the existential container at {0:x}",
+                      existential_address)
+            .str());
 
   lldb::addr_t metadata_addr =
       existential_container->MetadataAddress.getRawAddress();
   auto dynamic_address = existential_container->PayloadAddress.getRawAddress();
   if (dynamic_address == 0)
-    return std::nullopt;
+    return llvm::createStringError("existential container has no payload");
 
-  CompilerType dynamic_type = GetTypeFromMetadataAddress(metadata_addr, *ts);
-  if (!dynamic_type) {
-    LLDB_LOG(GetLog(LLDBLog::Types),
-             "[GetDynamicTypeAndAddress_ExistentialContainerEmbedded] no type "
-             "for metadata at {0:x}",
-             metadata_addr);
-    return std::nullopt;
-  }
+  auto dynamic_type_or_err =
+      GetTypeFromMetadataAddressEmbedded(metadata_addr, *ts);
+  if (!dynamic_type_or_err)
+    return dynamic_type_or_err.takeError();
+  CompilerType dynamic_type = *dynamic_type_or_err;
 
-  auto instance_addr =
+  auto instance_addr_or_err =
       UnwrapClassReferenceIfNeeded(dynamic_type, dynamic_address);
-  if (!instance_addr)
-    return std::nullopt;
+  if (!instance_addr_or_err)
+    return instance_addr_or_err.takeError();
 
-  return std::make_pair(dynamic_type, *instance_addr);
+  return std::make_pair(dynamic_type, *instance_addr_or_err);
 }
 
-std::optional<std::pair<CompilerType, uint64_t>>
+llvm::Expected<std::pair<CompilerType, uint64_t>>
 SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
     lldb::addr_t existential_address, CompilerType existential_type,
     ExecutionContextScope *exe_scope) {
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return std::nullopt;
+    return llvm::createStringError("no reflection context");
 
   // An error existential is a pointer to a heap box laid out as [HeapObject,
-  // payload metadata, Error witness table, payload].
+  // payload metadata, Error witness table, payload]. This matches
+  // swift_allocError in the embedded runtime (EmbeddedRuntime.swift).
   auto box = reflection_ctx->ReadPointer(existential_address);
   if (!box)
-    return std::nullopt;
+    return llvm::createStringError(
+        llvm::formatv("could not read the error box pointer at {0:x}",
+                      existential_address)
+            .str());
   lldb::addr_t box_addr = box->getResolvedAddress().getRawAddress();
   if (box_addr == 0 || box_addr == LLDB_INVALID_ADDRESS)
-    return std::nullopt;
+    return llvm::createStringError("error existential has no box");
 
   uint32_t ptr_size = GetProcess().GetAddressByteSize();
 
-  // The payload's metadata follows the object header. Reading the metadata
-  // pointer at an address and resolving its symbol is what resolving an
-  // embedded class does, so reuse that.
-  CompilerType dynamic_type = GetDynamicTypeAndAddress_EmbeddedClass(
+  // The payload's metadata follows the object header.
+  auto dynamic_type_or_err = GetTypeFromMetadataPointerEmbedded(
       box_addr + 2 * ptr_size, existential_type);
-  if (!dynamic_type)
-    return std::nullopt;
+  if (!dynamic_type_or_err)
+    return dynamic_type_or_err.takeError();
+  CompilerType dynamic_type = *dynamic_type_or_err;
 
   // The payload follows the metadata and the witness table, rounded up to its
   // own alignment.
@@ -2595,10 +2618,11 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
   }
   lldb::addr_t payload_addr = llvm::alignTo(box_addr + 4 * ptr_size, alignment);
 
-  if (auto instance_addr =
-          UnwrapClassReferenceIfNeeded(dynamic_type, payload_addr))
-    return std::make_pair(dynamic_type, *instance_addr);
-  return std::nullopt;
+  auto instance_addr_or_err =
+      UnwrapClassReferenceIfNeeded(dynamic_type, payload_addr);
+  if (!instance_addr_or_err)
+    return instance_addr_or_err.takeError();
+  return std::make_pair(dynamic_type, *instance_addr_or_err);
 }
 
 llvm::Expected<std::pair<CompilerType, uint64_t>>
@@ -2618,26 +2642,16 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialEmbedded(
 
   switch (kind) {
   case swift::reflection::RecordKind::ErrorExistential:
-    if (auto result = GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
-            existential_address, existential_type, exe_scope))
-      return *result;
-    return llvm::createStringError(
-        "failed to resolve dynamic type of embedded error existential");
+    return GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+        existential_address, existential_type, exe_scope);
 
   case swift::reflection::RecordKind::ClassExistential:
-    if (auto result =
-            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
-                existential_address, existential_type))
-      return *result;
-    return llvm::createStringError("failed to resolve dynamic type of "
-                                   "class-constrained embedded existential");
+    return GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
+        existential_address, existential_type);
 
   case swift::reflection::RecordKind::OpaqueExistential:
-    if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
-            existential_address, existential_type))
-      return *result;
-    return llvm::createStringError(
-        "failed to resolve dynamic type of opaque embedded existential");
+    return GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+        existential_address, existential_type);
 
   default:
     // No record layout for the existential, as a fallback try each one in turn.
@@ -2645,17 +2659,30 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialEmbedded(
              "[GetDynamicTypeAndAddress_ExistentialEmbedded] unknown "
              "representation of {0}, trying every layout",
              existential_type.GetMangledTypeName());
-    if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
-            existential_address, existential_type))
+
+    auto try_layout =
+        [&](llvm::Expected<std::pair<CompilerType, uint64_t>> result)
+        -> std::optional<std::pair<CompilerType, uint64_t>> {
+      if (result)
+        return *result;
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types), result.takeError(),
+                     "[GetDynamicTypeAndAddress_ExistentialEmbedded] {0}");
+      return std::nullopt;
+    };
+
+    if (auto result =
+            try_layout(GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+                existential_address, existential_type)))
+      return *result;
+
+    if (auto result = try_layout(
+            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
+                existential_address, existential_type)))
       return *result;
 
     if (auto result =
-            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
-                existential_address, existential_type))
-      return *result;
-
-    if (auto result = GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
-            existential_address, existential_type, exe_scope))
+            try_layout(GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+                existential_address, existential_type, exe_scope)))
       return *result;
 
     return llvm::createStringError(
@@ -2755,14 +2782,16 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
           dynamic_type = class_type;
       }
     } else {
-      dynamic_type =
-          GetDynamicTypeAndAddress_EmbeddedClass(instance_ptr, class_type);
-      if (!dynamic_type) {
+      auto dynamic_type_or_err =
+          GetTypeFromMetadataPointerEmbedded(instance_ptr, class_type);
+      if (!dynamic_type_or_err) {
         HEALTH_LOG("could not resolve dynamic type of embedded swift class: "
-                   "{0} (instance_ptr = {1:x})",
-                   class_type.GetMangledTypeName(), instance_ptr);
+                   "{0} (instance_ptr = {1:x}): {2}",
+                   class_type.GetMangledTypeName(), instance_ptr,
+                   llvm::toString(dynamic_type_or_err.takeError()));
         return false;
       }
+      dynamic_type = *dynamic_type_or_err;
     }
     class_type_or_name.SetCompilerType(dynamic_type);
     LLDB_LOG(GetLog(LLDBLog::Types),

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2375,44 +2375,98 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Pack(
   return true;
 }
 
+std::pair<CompilerType, bool>
+SwiftLanguageRuntime::GetTypeFromMetadataSymbol(llvm::StringRef symbol_name,
+                                                TypeSystemSwiftTypeRef &ts) {
+  // The symbol name will be something like "type metadata for Class", extract
+  // "Class" from that name.
+  return ts.GetTypeFromTypeMetadataNode(symbol_name);
+}
+
+CompilerType
+SwiftLanguageRuntime::GetTypeFromMetadataAddress(lldb::addr_t metadata_addr,
+                                                 TypeSystemSwiftTypeRef &ts) {
+  // Embedded Swift emits no metadata records, but it does emit a symbol for
+  // every type's metadata, so the type can be recovered from the symbol name.
+  Address address;
+  address.SetLoadAddress(metadata_addr, &GetProcess().GetTarget());
+  Symbol *symbol = address.CalculateSymbolContextSymbol();
+  if (!symbol)
+    return {};
+  Mangled mangled = symbol->GetMangled();
+  if (!mangled)
+    return {};
+
+  auto [type, is_full_metadata] =
+      GetTypeFromMetadataSymbol(mangled.GetMangledName().GetStringRef(), ts);
+  if (!type)
+    return {};
+
+  // Sanity check that the symbol's start address matches what we expect. This
+  // depends on whether the symbol is full type metadata (one pointer sized
+  // offset) or regular type metadata.
+  lldb::addr_t symbol_addr = symbol->GetLoadAddress(&GetProcess().GetTarget());
+  uint64_t expected_offset =
+      is_full_metadata ? GetProcess().GetAddressByteSize() : 0;
+  if (symbol_addr == LLDB_INVALID_ADDRESS ||
+      metadata_addr - symbol_addr != expected_offset) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[GetTypeFromMetadataAddress] metadata at {0:x} is {1} bytes into "
+             "{2}, not its address point",
+             metadata_addr, metadata_addr - symbol_addr,
+             mangled.GetMangledName());
+    return {};
+  }
+  return type;
+}
+
+std::optional<lldb::addr_t>
+SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
+                                                   lldb::addr_t addr) {
+  // Only a class is stored as a reference; any other type is already the value.
+  if (!Flags(type.GetTypeInfo()).AllSet(eTypeIsClass))
+    return addr;
+  auto reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return std::nullopt;
+  std::optional<swift::remote::RemoteAbsolutePointer> instance =
+      reflection_ctx->ReadPointer(addr);
+  if (!instance)
+    return std::nullopt;
+  return instance->getResolvedAddress().getRawAddress();
+}
+
 CompilerType SwiftLanguageRuntime::GetDynamicTypeAndAddress_EmbeddedClass(
     uint64_t instance_ptr, CompilerType class_type) {
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return {};
+  auto tss = class_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!tss)
+    return {};
+  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
+  if (!ts)
+    return {};
+
   /// If this is an embedded Swift type, there is no metadata, and the
   /// pointer points to the type's vtable. We can still resolve the type by
   /// reading the vtable's symbol name.
-  auto pointer = reflection_ctx->ReadPointer(instance_ptr);
+  std::optional<swift::remote::RemoteAbsolutePointer> pointer =
+      reflection_ctx->ReadPointer(instance_ptr);
   if (!pointer)
     return {};
-  llvm::StringRef symbol_name;
-  if (pointer->getSymbol().empty() || pointer->getOffset()) {
-    // Find the symbol name at this address.
-    Address address;
-    address.SetLoadAddress(pointer->getResolvedAddress().getRawAddress(),
-                           &GetProcess().GetTarget());
-    Symbol *symbol = address.CalculateSymbolContextSymbol();
-    if (!symbol)
-      return {};
-    Mangled mangled = symbol->GetMangled();
-    if (!mangled)
-      return {};
-    symbol_name = symbol->GetMangled().GetMangledName().GetStringRef();
-  } else {
-    symbol_name = pointer->getSymbol();
-  }
-  TypeSystemSwiftTypeRefSP ts = class_type.GetTypeSystem()
-                                    .dyn_cast_or_null<TypeSystemSwift>()
-                                    ->GetTypeSystemSwiftTypeRef();
-  // The symbol name will be something like "type metadata for Class", extract
-  // "Class" from that name.
-  auto dynamic_type = ts->GetTypeFromTypeMetadataNode(symbol_name);
-  return dynamic_type;
+
+  // A RemoteAbsolutePointer can contain a symbol or an address. If we have the
+  // symbol, we can extract the dynamic type from the symbol's mangled name.
+  if (!pointer->getSymbol().empty() && !pointer->getOffset())
+    return GetTypeFromMetadataSymbol(pointer->getSymbol(), *ts).first;
+  // Otherwise, we need to look up which symbol matches the address.
+  return GetTypeFromMetadataAddress(
+      pointer->getResolvedAddress().getRawAddress(), *ts);
 }
 
 std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
-    GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
+    GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
         lldb::addr_t existential_address, CompilerType existential_type) {
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
@@ -2445,6 +2499,16 @@ std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
   if (!dynamic_type)
     return std::nullopt;
 
+  // For a class-constrained existential this word is the instance reference, so
+  // resolving it to anything else means there's something wrong.
+  if (!Flags(dynamic_type.GetTypeInfo()).AllSet(eTypeIsClass)) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded] {0} "
+             "is not a class",
+             dynamic_type.GetMangledTypeName());
+    return std::nullopt;
+  }
+
   return std::make_pair(
       dynamic_type, maybe_addr_or_symbol->getResolvedAddress().getRawAddress());
 }
@@ -2455,6 +2519,13 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return std::nullopt;
+  auto tss =
+      existential_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!tss)
+    return std::nullopt;
+  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
+  if (!ts)
+    return std::nullopt;
 
   auto existential_container =
       reflection_ctx->ReadMetadataAndValueOpaqueExistential(
@@ -2464,69 +2535,132 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
 
   lldb::addr_t metadata_addr =
       existential_container->MetadataAddress.getRawAddress();
-  if (metadata_addr == 0)
-    return std::nullopt;
-
   auto dynamic_address = existential_container->PayloadAddress.getRawAddress();
   if (dynamic_address == 0)
     return std::nullopt;
 
-  // The value witness table pointer is stored at MetadataAddress - PointerSize.
-  size_t ptr_size = GetProcess().GetAddressByteSize();
-  lldb::addr_t vwt_ptr_addr = metadata_addr - ptr_size;
+  CompilerType dynamic_type = GetTypeFromMetadataAddress(metadata_addr, *ts);
+  if (!dynamic_type) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[GetDynamicTypeAndAddress_ExistentialContainerEmbedded] no type "
+             "for metadata at {0:x}",
+             metadata_addr);
+    return std::nullopt;
+  }
 
-  Status error;
-  lldb::addr_t vwt_addr =
-      GetProcess().ReadPointerFromMemory(vwt_ptr_addr, error);
-  if (error.Fail() || vwt_addr == 0 || vwt_addr == LLDB_INVALID_ADDRESS)
+  auto instance_addr =
+      UnwrapClassReferenceIfNeeded(dynamic_type, dynamic_address);
+  if (!instance_addr)
     return std::nullopt;
 
-  Address vwt_address;
-  vwt_address.SetLoadAddress(vwt_addr, &GetProcess().GetTarget());
-  Symbol *symbol = vwt_address.CalculateSymbolContextSymbol();
-  if (!symbol)
+  return std::make_pair(dynamic_type, *instance_addr);
+}
+
+std::optional<std::pair<CompilerType, uint64_t>>
+SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+    lldb::addr_t existential_address, CompilerType existential_type,
+    ExecutionContextScope *exe_scope) {
+  auto reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
     return std::nullopt;
 
-  Mangled mangled = symbol->GetMangled();
-  if (!mangled)
+  // An error existential is a pointer to a heap box laid out as [HeapObject,
+  // payload metadata, Error witness table, payload].
+  auto box = reflection_ctx->ReadPointer(existential_address);
+  if (!box)
+    return std::nullopt;
+  lldb::addr_t box_addr = box->getResolvedAddress().getRawAddress();
+  if (box_addr == 0 || box_addr == LLDB_INVALID_ADDRESS)
     return std::nullopt;
 
-  llvm::StringRef symbol_name = mangled.GetMangledName().GetStringRef();
-  TypeSystemSwiftTypeRefSP ts = existential_type.GetTypeSystem()
-                                    .dyn_cast_or_null<TypeSystemSwift>()
-                                    ->GetTypeSystemSwiftTypeRef();
-  if (!ts)
-    return std::nullopt;
+  uint32_t ptr_size = GetProcess().GetAddressByteSize();
 
-  CompilerType dynamic_type = ts->GetTypeFromValueWitnessTable(symbol_name);
+  // The payload's metadata follows the object header. Reading the metadata
+  // pointer at an address and resolving its symbol is what resolving an
+  // embedded class does, so reuse that.
+  CompilerType dynamic_type = GetDynamicTypeAndAddress_EmbeddedClass(
+      box_addr + 2 * ptr_size, existential_type);
   if (!dynamic_type)
     return std::nullopt;
 
-  return std::make_pair(dynamic_type,
-                        existential_container->PayloadAddress.getRawAddress());
+  // The payload follows the metadata and the witness table, rounded up to its
+  // own alignment.
+  unsigned alignment = 1;
+  if (auto ti_or_err = GetSwiftRuntimeTypeInfo(dynamic_type, exe_scope)) {
+    if (unsigned payload_alignment = ti_or_err->getAlignment())
+      alignment = payload_alignment;
+  } else {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), ti_or_err.takeError(),
+                   "no type info for error existential payload: {0}");
+  }
+  lldb::addr_t payload_addr = llvm::alignTo(box_addr + 4 * ptr_size, alignment);
+
+  if (auto instance_addr =
+          UnwrapClassReferenceIfNeeded(dynamic_type, payload_addr))
+    return std::make_pair(dynamic_type, *instance_addr);
+  return std::nullopt;
 }
 
 llvm::Expected<std::pair<CompilerType, uint64_t>>
 SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialEmbedded(
-    lldb::addr_t existential_address, CompilerType existential_type) {
-  // In the embedded Swift case, if the existential is class constrained, it
-  // will simply point to the instance. If it's not class constrained, it will
-  // have an existential container. Since there is no metadata to distinguish
-  // between the cases, we need to try both cases.
+    lldb::addr_t existential_address, CompilerType existential_type,
+    ExecutionContextScope *exe_scope) {
+  auto kind = swift::reflection::RecordKind::Invalid;
+  auto ti_or_err = GetSwiftRuntimeTypeInfo(existential_type, exe_scope);
+  if (ti_or_err) {
+    if (auto *rti =
+            llvm::dyn_cast<swift::reflection::RecordTypeInfo>(&*ti_or_err))
+      kind = rti->getRecordKind();
+  } else {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), ti_or_err.takeError(),
+                   "no type info for embedded existential: {0}");
+  }
 
-  // First, try class-constrained existential.
-  if (auto result =
-          GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
-              existential_address, existential_type))
-    return *result;
+  switch (kind) {
+  case swift::reflection::RecordKind::ErrorExistential:
+    if (auto result = GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+            existential_address, existential_type, exe_scope))
+      return *result;
+    return llvm::createStringError(
+        "failed to resolve dynamic type of embedded error existential");
 
-  // If that fails, try existential container.
-  if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
-          existential_address, existential_type))
-    return *result;
+  case swift::reflection::RecordKind::ClassExistential:
+    if (auto result =
+            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
+                existential_address, existential_type))
+      return *result;
+    return llvm::createStringError("failed to resolve dynamic type of "
+                                   "class-constrained embedded existential");
 
-  return llvm::createStringError(
-      "failed to resolve dynamic type of embedded existential");
+  case swift::reflection::RecordKind::OpaqueExistential:
+    if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+            existential_address, existential_type))
+      return *result;
+    return llvm::createStringError(
+        "failed to resolve dynamic type of opaque embedded existential");
+
+  default:
+    // No record layout for the existential, as a fallback try each one in turn.
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[GetDynamicTypeAndAddress_ExistentialEmbedded] unknown "
+             "representation of {0}, trying every layout",
+             existential_type.GetMangledTypeName());
+    if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+            existential_address, existential_type))
+      return *result;
+
+    if (auto result =
+            GetDynamicTypeAndAddress_ExistentialClassReferenceEmbedded(
+                existential_address, existential_type))
+      return *result;
+
+    if (auto result = GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
+            existential_address, existential_type, exe_scope))
+      return *result;
+
+    return llvm::createStringError(
+        "failed to resolve dynamic type of embedded existential");
+  }
 }
 
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
@@ -2812,8 +2946,10 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
       dynamic_type = ts->RemangleAsType(dem, node, flavor);
       dynamic_address = out_address.getRawAddress();
     } else {
+      ExecutionContext exe_ctx = in_value.GetExecutionContextRef().Lock(true);
       auto result_or_err = GetDynamicTypeAndAddress_ExistentialEmbedded(
-          existential_address, existential_type);
+          existential_address, existential_type,
+          exe_ctx.GetBestExecutionContextScope());
       if (!result_or_err) {
         LLDB_LOG_ERROR(GetLog(LLDBLog::Types), result_or_err.takeError(),
                        "{0}");

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2375,6 +2375,18 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Pack(
   return true;
 }
 
+/// Returns the TypeSystemSwiftTypeRef \p type belongs to.
+static llvm::Expected<TypeSystemSwiftTypeRefSP>
+GetTypeSystemSwiftTypeRef(CompilerType type) {
+  auto tss = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!tss)
+    return llvm::createStringError("not a Swift type");
+  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
+  if (!ts)
+    return llvm::createStringError("no Swift typeref typesystem");
+  return ts;
+}
+
 llvm::Expected<std::pair<CompilerType, bool>>
 SwiftLanguageRuntime::GetTypeFromMetadataSymbolEmbedded(
     llvm::StringRef symbol_name, TypeSystemSwiftTypeRef &ts) {
@@ -2449,17 +2461,10 @@ SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
 
 llvm::Expected<CompilerType>
 SwiftLanguageRuntime::GetTypeFromMetadataPointerEmbedded(
-    lldb::addr_t metadata_ptr_addr, CompilerType type_in_context) {
+    lldb::addr_t metadata_ptr_addr, TypeSystemSwiftTypeRef &ts) {
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
-  auto tss =
-      type_in_context.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
-  if (!tss)
-    return llvm::createStringError("not a Swift type system");
-  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
-  if (!ts)
-    return llvm::createStringError("no Swift typeref typesystem");
 
   std::optional<swift::remote::RemoteAbsolutePointer> pointer =
       reflection_ctx->ReadPointer(metadata_ptr_addr);
@@ -2473,14 +2478,14 @@ SwiftLanguageRuntime::GetTypeFromMetadataPointerEmbedded(
   // symbol, we can extract the dynamic type from the symbol's mangled name.
   if (!pointer->getSymbol().empty() && !pointer->getOffset()) {
     auto type_or_err =
-        GetTypeFromMetadataSymbolEmbedded(pointer->getSymbol(), *ts);
+        GetTypeFromMetadataSymbolEmbedded(pointer->getSymbol(), ts);
     if (!type_or_err)
       return type_or_err.takeError();
     return type_or_err->first;
   }
   // Otherwise, we need to look up which symbol matches the address.
   return GetTypeFromMetadataAddressEmbedded(
-      pointer->getResolvedAddress().getRawAddress(), *ts);
+      pointer->getResolvedAddress().getRawAddress(), ts);
 }
 
 llvm::Expected<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
@@ -2489,6 +2494,9 @@ llvm::Expected<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
+  auto ts_or_err = GetTypeSystemSwiftTypeRef(existential_type);
+  if (!ts_or_err)
+    return ts_or_err.takeError();
 
   auto maybe_addr_or_symbol = reflection_ctx->ReadPointer(existential_address);
   if (!maybe_addr_or_symbol)
@@ -2517,7 +2525,7 @@ llvm::Expected<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
   }
 
   auto dynamic_type_or_err =
-      GetTypeFromMetadataPointerEmbedded(address, existential_type);
+      GetTypeFromMetadataPointerEmbedded(address, **ts_or_err);
   if (!dynamic_type_or_err)
     return dynamic_type_or_err.takeError();
   CompilerType dynamic_type = *dynamic_type_or_err;
@@ -2539,13 +2547,9 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
-  auto tss =
-      existential_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
-  if (!tss)
-    return llvm::createStringError("not a Swift type system");
-  TypeSystemSwiftTypeRefSP ts = tss->GetTypeSystemSwiftTypeRef();
-  if (!ts)
-    return llvm::createStringError("no Swift typeref typesystem");
+  auto ts_or_err = GetTypeSystemSwiftTypeRef(existential_type);
+  if (!ts_or_err)
+    return ts_or_err.takeError();
 
   auto existential_container =
       reflection_ctx->ReadMetadataAndValueOpaqueExistential(
@@ -2563,7 +2567,7 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
     return llvm::createStringError("existential container has no payload");
 
   auto dynamic_type_or_err =
-      GetTypeFromMetadataAddressEmbedded(metadata_addr, *ts);
+      GetTypeFromMetadataAddressEmbedded(metadata_addr, **ts_or_err);
   if (!dynamic_type_or_err)
     return dynamic_type_or_err.takeError();
   CompilerType dynamic_type = *dynamic_type_or_err;
@@ -2583,6 +2587,9 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
   auto reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
+  auto ts_or_err = GetTypeSystemSwiftTypeRef(existential_type);
+  if (!ts_or_err)
+    return ts_or_err.takeError();
 
   // An error existential is a pointer to a heap box laid out as [HeapObject,
   // payload metadata, Error witness table, payload]. This matches
@@ -2600,8 +2607,8 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorExistentialEmbedded(
   uint32_t ptr_size = GetProcess().GetAddressByteSize();
 
   // The payload's metadata follows the object header.
-  auto dynamic_type_or_err = GetTypeFromMetadataPointerEmbedded(
-      box_addr + 2 * ptr_size, existential_type);
+  auto dynamic_type_or_err =
+      GetTypeFromMetadataPointerEmbedded(box_addr + 2 * ptr_size, **ts_or_err);
   if (!dynamic_type_or_err)
     return dynamic_type_or_err.takeError();
   CompilerType dynamic_type = *dynamic_type_or_err;
@@ -2783,7 +2790,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
       }
     } else {
       auto dynamic_type_or_err =
-          GetTypeFromMetadataPointerEmbedded(instance_ptr, class_type);
+          GetTypeFromMetadataPointerEmbedded(instance_ptr, *ts);
       if (!dynamic_type_or_err) {
         HEALTH_LOG("could not resolve dynamic type of embedded swift class: "
                    "{0} (instance_ptr = {1:x}): {2}",

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -47,20 +47,26 @@ DWARFASTParserSwift::DWARFASTParserSwift(
 
 DWARFASTParserSwift::~DWARFASTParserSwift() {}
 
-/// Returns true if the DIE represents a protocol annotated with @_marker.
-static bool IsMarkerProtocol(const DWARFDIE &die) {
-  if (die.Tag() != llvm::dwarf::DW_TAG_structure_type)
-    return false;
+bool DWARFASTParserSwift::HasSwiftFlagAnnotation(
+    const DWARFDIE &die, llvm::StringRef annotation_name) {
   for (DWARFDIE child : die.children()) {
     if (child.Tag() != llvm::dwarf::DW_TAG_LLVM_annotation)
       continue;
     const char *name =
         child.GetAttributeValueAsString(llvm::dwarf::DW_AT_name, nullptr);
-    if (llvm::StringRef(name) == "swift.MarkerProtocol")
+    if (llvm::StringRef(name) == annotation_name)
       return child.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_const_value,
                                                0) != 0;
   }
   return false;
+}
+
+/// Returns true if the DIE represents a protocol annotated with @_marker.
+static bool IsMarkerProtocol(const DWARFDIE &die) {
+  if (die.Tag() != llvm::dwarf::DW_TAG_structure_type)
+    return false;
+  return DWARFASTParserSwift::HasSwiftFlagAnnotation(die,
+                                                     "swift.MarkerProtocol");
 }
 
 static llvm::StringRef GetTypedefName(const DWARFDIE &die) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -17,6 +17,7 @@
 #include "DWARFDIE.h"
 #include "swift/RemoteInspection/DescriptorFinder.h"
 #include "swift/RemoteInspection/TypeRef.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
 namespace reflection {
@@ -81,6 +82,12 @@ public:
   static bool classof(const DWARFASTParser *Parser) {
     return Parser->GetKind() == Kind::DWARFASTParserSwift;
   }
+
+  /// Returns the value of the boolean `swift.*` DW_TAG_LLVM_annotation named
+  /// \p annotation_name on \p die, or false if the DIE carries no such
+  /// annotation.
+  static bool HasSwiftFlagAnnotation(const DWARFDIE &die,
+                                     llvm::StringRef annotation_name);
 
   /// Returns a field descriptor constructed from DWARF info.
   std::unique_ptr<swift::reflection::FieldDescriptorBase>

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -212,8 +212,19 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
   return {{type, die}};
 }
 
+/// Determine the field descriptor kind of \p die, the DIE of a protocol.
+static swift::reflection::FieldDescriptorKind
+getProtocolFieldDescriptorKind(const DWARFDIE &die) {
+  if (DWARFASTParserSwift::HasSwiftFlagAnnotation(die, "swift.ObjCProtocol"))
+    return swift::reflection::FieldDescriptorKind::ObjCProtocol;
+  if (DWARFASTParserSwift::HasSwiftFlagAnnotation(
+          die, "swift.ClassConstrainedProtocol"))
+    return swift::reflection::FieldDescriptorKind::ClassProtocol;
+  return swift::reflection::FieldDescriptorKind::Protocol;
+}
+
 static std::optional<swift::reflection::FieldDescriptorKind>
-getFieldDescriptorKindForDie(CompilerType type) {
+getFieldDescriptorKindForDie(CompilerType type, const DWARFDIE &die) {
   auto type_class = type.GetTypeClass();
   switch (type_class) {
   case lldb::eTypeClassClass:
@@ -224,7 +235,7 @@ getFieldDescriptorKindForDie(CompilerType type) {
     return swift::reflection::FieldDescriptorKind::Enum;
   default:
     if (Flags(type.GetTypeInfo()).AnySet(lldb::eTypeIsProtocol))
-      return swift::reflection::FieldDescriptorKind::Protocol;
+      return getProtocolFieldDescriptorKind(die);
     LLDB_LOG(GetLog(LLDBLog::Types),
              "Could not determine file descriptor kind for type: {0}",
              type.GetMangledTypeName());
@@ -611,7 +622,7 @@ DWARFASTParserSwift::getFieldDescriptor(const swift::reflection::TypeRef *TR) {
   auto [type, die] = *pair;
   if (!die)
     return nullptr;
-  auto kind = getFieldDescriptorKindForDie(type);
+  auto kind = getFieldDescriptorKindForDie(type, die);
   if (!kind)
     return nullptr;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2591,14 +2591,11 @@ ProcessModule(Module &module, std::string m_description,
   }
 }
 
-/// Matches a subset of the SILOptions that the compiler turns on by default
-/// when embedded swift enabled.
+/// Set up \p swift_ast_ctx the same way the compiler sets up an embedded Swift
+/// compilation.
 static void EnableEmbeddedSwift(SwiftASTContext &swift_ast_ctx) {
-  swift_ast_ctx.GetLanguageOptions().enableFeature(swift::Feature::Embedded);
-
-  swift::SILOptions &sil_opts = swift_ast_ctx.GetSILOptions();
-  sil_opts.EnforceExclusivityStatic = true;
-  sil_opts.EnforceExclusivityDynamic = false;
+  swift_ast_ctx.GetCompilerInvocation().setCommonEmbeddedSwiftOptions(
+      swift::CompilerInvocation::EmbeddedSwiftContext::DebuggerExpression);
 }
 
 lldb::TypeSystemSP

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2591,6 +2591,16 @@ ProcessModule(Module &module, std::string m_description,
   }
 }
 
+/// Matches a subset of the SILOptions that the compiler turns on by default
+/// when embedded swift enabled.
+static void EnableEmbeddedSwift(SwiftASTContext &swift_ast_ctx) {
+  swift_ast_ctx.GetLanguageOptions().enableFeature(swift::Feature::Embedded);
+
+  swift::SILOptions &sil_opts = swift_ast_ctx.GetSILOptions();
+  sil_opts.EnforceExclusivityStatic = true;
+  sil_opts.EnforceExclusivityDynamic = false;
+}
+
 lldb::TypeSystemSP
 SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
                                 TypeSystemSwiftTypeRef &typeref_typesystem) {
@@ -2686,7 +2696,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
       module.IsSwiftCxxInteropEnabled();
 
   if (module.IsEmbeddedSwift())
-    swift_ast_sp->GetLanguageOptions().enableFeature(swift::Feature::Embedded);
+    EnableEmbeddedSwift(*swift_ast_sp);
 
   bool found_swift_modules = false;
   SymbolFile *sym_file = module.GetSymbolFile();
@@ -3215,7 +3225,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     auto &lang_opts = swift_ast_sp->GetLanguageOptions();
     lang_opts.EnableCXXInterop = ShouldEnableCXXInterop(cu);
     if (ShouldEnableEmbeddedSwift(cu))
-      lang_opts.enableFeature(swift::Feature::Embedded);
+      EnableEmbeddedSwift(*swift_ast_sp);
   } else {
     // Typesystem fallback context.
     if (!module_sp) {
@@ -3232,7 +3242,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     lang_opts.EnableAccessControl = false;
     lang_opts.EnableCXXInterop = ShouldEnableCXXInterop(cu);
     if (ShouldEnableEmbeddedSwift(cu))
-      lang_opts.enableFeature(swift::Feature::Embedded);
+      EnableEmbeddedSwift(*swift_ast_sp);
   }
   auto defer_log = llvm::scope_exit([swift_ast_sp, repl, playground] {
     swift_ast_sp->LogConfiguration(repl, playground);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2815,27 +2815,6 @@ llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
   return {};
 }
 
-bool TypeSystemSwiftTypeRef::IsEmbeddedSwift() {
-  llvm::call_once(m_is_embedded_swift_once_flag, [&]() {
-    Module *module = GetModule();
-    if (!module)
-      return;
-    // A Swift module is compiled either entirely as Embedded Swift or not at
-    // all, so the first Swift compile unit has the answer for all of them.
-    const size_t num_compile_units = module->GetNumCompileUnits();
-    for (size_t i = 0; i < num_compile_units; ++i) {
-      lldb::CompUnitSP cu_sp = module->GetCompileUnitAtIndex(i);
-      if (!cu_sp || cu_sp->GetLanguage() != lldb::eLanguageTypeSwift)
-        continue;
-      m_is_embedded_swift = ShouldEnableEmbeddedSwift(cu_sp.get());
-      LLDB_LOGF(GetLog(LLDBLog::Types), "%s::IsEmbeddedSwift() = %d",
-                m_description.c_str(), m_is_embedded_swift);
-      return;
-    }
-  });
-  return m_is_embedded_swift;
-}
-
 void TypeSystemSwiftTypeRef::SetTriple(const SymbolContext &sc,
                                        const llvm::Triple triple) {
   // This function appears to be only called via

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -398,33 +398,24 @@ TypeSystemSwiftTypeRef::GetBaseName(lldb::opaque_compiler_type_t type) {
   return GetBaseName(node).str();
 }
 
-CompilerType TypeSystemSwiftTypeRef::GetTypeFromTypeMetadataNode(
+std::pair<CompilerType, bool>
+TypeSystemSwiftTypeRef::GetTypeFromTypeMetadataNode(
     llvm::StringRef mangled_name) {
   Demangler dem;
   NodePointer node = dem.demangleSymbol(mangled_name);
+  bool is_full_metadata = false;
   NodePointer type = swift_demangle::NodeAtPath(
       node, {Node::Kind::Global, Node::Kind::TypeMetadata, Node::Kind::Type});
-  if (!type)
+  if (!type) {
     type = swift_demangle::NodeAtPath(
         node,
         {Node::Kind::Global, Node::Kind::FullTypeMetadata, Node::Kind::Type});
+    is_full_metadata = type != nullptr;
+  }
   if (!type)
     return {};
   auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
-  return RemangleAsType(dem, type, flavor);
-}
-
-CompilerType TypeSystemSwiftTypeRef::GetTypeFromValueWitnessTable(
-    llvm::StringRef mangled_name) {
-  Demangler dem;
-  NodePointer node = dem.demangleSymbol(mangled_name);
-  NodePointer type = swift_demangle::NodeAtPath(
-      node,
-      {Node::Kind::Global, Node::Kind::ValueWitnessTable, Node::Kind::Type});
-  if (!type)
-    return {};
-  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
-  return RemangleAsType(dem, type, flavor);
+  return {RemangleAsType(dem, type, flavor), is_full_metadata};
 }
 
 TypeSP TypeSystemSwiftTypeRef::LookupClangType(StringRef name_ref,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -27,7 +27,6 @@
 #include "clang/Basic/Module.h"
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Threading.h"
 
 namespace swift {
 class DWARFImporterDelegate;
@@ -115,12 +114,6 @@ public:
   SwiftDWARFImporterForClangTypes &GetSwiftDWARFImporterForClangTypes();
   ClangNameImporter *GetNameImporter() const;
   llvm::Triple GetTriple() const;
-  /// Returns true if the module this type system was created for was compiled
-  /// as Embedded Swift. This is deliberately a *per-module* property: one
-  /// target can mix embedded and non-embedded modules, so the answer cannot
-  /// come from the target or from a global setting. The result is cached,
-  /// because computing it walks the module's compile units.
-  bool IsEmbeddedSwift();
   void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override;
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
@@ -708,10 +701,6 @@ protected:
   /// mangled type name.
   mutable llvm::DenseSet<std::pair<const char *, const char *>>
       m_dangerous_types;
-
-  /// Lazily computed cache behind IsEmbeddedSwift().
-  llvm::once_flag m_is_embedded_swift_once_flag;
-  bool m_is_embedded_swift = false;
 
   mutable std::unique_ptr<SwiftDWARFImporterForClangTypes>
       m_dwarf_importer_for_clang_types_up;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -483,13 +483,10 @@ public:
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
   std::string GetBaseName(lldb::opaque_compiler_type_t type);
 
-  /// Given a mangled name that mangles a "type metadata for Type", return a
-  /// CompilerType with that Type.
-  CompilerType GetTypeFromTypeMetadataNode(llvm::StringRef mangled_name);
-
-  /// Given a mangled name that mangles a "value witness table for Type",
-  /// return a CompilerType with that Type.
-  CompilerType GetTypeFromValueWitnessTable(llvm::StringRef mangled_name);
+  /// Given a mangled name that mangles a "type metadata for Type", return that
+  /// Type, and whether the name mangles full metadata.
+  std::pair<CompilerType, bool>
+  GetTypeFromTypeMetadataNode(llvm::StringRef mangled_name);
 
   /// Use API notes to determine the swiftified name of \p clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,

--- a/lldb/test/API/functionalities/data-formatter/poarray/TestPrintObjectArray.py
+++ b/lldb/test/API/functionalities/data-formatter/poarray/TestPrintObjectArray.py
@@ -12,14 +12,12 @@ from lldbsuite.test import lldbutil
 class PrintObjectArrayTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
 
-    @skipEmbeddedSwift
     @skipUnlessDarwin
     def test_print_array(self):
         """Test that expr -O -Z works"""
         self.build()
         self.printarray_data_formatter_commands()
 
-    @skipEmbeddedSwift
     @skipUnlessDarwin
     def test_print_array_no_const(self):
         """Test that expr -O -Z works"""

--- a/lldb/test/API/lang/swift/async/continuations/Makefile
+++ b/lldb/test/API/lang/swift/async/continuations/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/expr/Makefile
+++ b/lldb/test/API/lang/swift/async/expr/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
+++ b/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
@@ -8,7 +8,8 @@ class TestSwiftAsyncExpressions(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     @skipIf(archs=no_match(["aarch", "arm64", "arm64e", "arm64_32", "x86_64"]))
     def test_actor(self):

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -7,7 +7,8 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/parent/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/parent/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -6,7 +6,8 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test summary formatter for TaskPriority."""

--- a/lldb/test/API/lang/swift/async/frame/variable/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/variable/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/queues/Makefile
+++ b/lldb/test/API/lang/swift/async/queues/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -14,9 +14,14 @@ class TestCase(lldbtest.TestBase):
 
         src = lldb.SBFileSpec("main.swift")
         target, _, thread, _ = lldbutil.run_to_source_breakpoint(self, "await f()", src)
-        self.assertEqual(thread.frame[0].function.mangled, "$s1a5entryO4mainyyYaFZ")
+        self.assertEqual(
+            thread.frame[0].function.mangled,
+            self.swiftMangledName("$s1a5entryO4mainyyYaFZ"),
+        )
 
-        sym_ctx_list = target.FindFunctions("$s1a5entryO4mainyyYaFZTQ0_")
+        sym_ctx_list = target.FindFunctions(
+            self.swiftMangledName("$s1a5entryO4mainyyYaFZTQ0_")
+        )
         self.assertEqual(sym_ctx_list.GetSize(), 1)
         function = sym_ctx_list[0].function
         self.assertIsNotNone(function)

--- a/lldb/test/API/lang/swift/async/stepping/step_out/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
@@ -28,7 +28,7 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.assertEqual(thread.frames[0].GetFunctionName(), expected_func_name)
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step_over/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -17,7 +17,7 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwift
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):
@@ -40,7 +40,7 @@ class TestCase(lldbtest.TestBase):
             self.check_is_in_line(thread, expected_line_num)
             self.check_x_is_available(thread.frames[0])
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwift
     @skipIfOutOfTreeDebugserver
     @swiftTest
     @skipIf(oslist=["windows", "linux"])

--- a/lldb/test/API/lang/swift/async/tasks/info/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/info/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
+++ b/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
@@ -28,7 +28,7 @@ class TestCase(TestBase):
         task_info_output = self.res.GetOutput()
         self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
     @skipUnlessPlatform(["macosx", "linux"])
     @swiftTest
     def test_compare_printed_task_variable_to_task_info_with_address(self):

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestDisableLanguageUnwinder(lldbtest.TestBase):
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=['windows',])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/hidden_frames/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/hidden_frames/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -32,14 +32,17 @@ class TestCase(lldbtest.TestBase):
 
     def set_breakpoints_all_funclets(self, target):
         funclet_names = [
-            "$s1a12ASYNC___1___4condS2i_tYaF",
-            "$s1a12ASYNC___1___4condS2i_tYaFTY0_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTQ1_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTY2_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTQ3_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTY4_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTQ5_",
-            "$s1a12ASYNC___1___4condS2i_tYaFTY6_",
+            self.swiftMangledName(name)
+            for name in [
+                "$s1a12ASYNC___1___4condS2i_tYaF",
+                "$s1a12ASYNC___1___4condS2i_tYaFTY0_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTQ1_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTY2_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTQ3_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTY4_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTQ5_",
+                "$s1a12ASYNC___1___4condS2i_tYaFTY6_",
+            ]
         ]
 
         breakpoints = set()

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
@@ -10,7 +10,7 @@ class TestCase(lldbtest.TestBase):
 
     unwind_fail_range_cache = dict()
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=["windows",])
     @skipIf(archs=["arm64e"])
@@ -20,7 +20,7 @@ class TestCase(lldbtest.TestBase):
 
         source_file = lldb.SBFileSpec("main.swift")
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
-            self, "$s1a9factorialyS2iYaFTQ1_"
+            self, self.swiftMangledName("$s1a9factorialyS2iYaFTQ1_")
         )
 
         # Ensure we are on the last factorial call which recurses (n == 1).

--- a/lldb/test/API/lang/swift/async/variables/Makefile
+++ b/lldb/test/API/lang/swift/async/variables/Makefile
@@ -1,3 +1,4 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 SWIFTFLAGS_EXTRAS := -Xfrontend -enable-upcoming-feature -Xfrontend NonisolatedNonsendingByDefault
 include Makefile.rules

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
@@ -8,7 +8,6 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftForwardInteropCxxClassAsExistential(TestBase):
 
-    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropCxxClassAsExistential(TestBase):
 
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
@@ -1,4 +1,5 @@
 SWIFT_SOURCES := main.swift
-SWIFT_EMBEDDED_CONCURRENCY := 1
+SWIFT_EMBEDDED_MODE := 1
+SWIFT_CONCURRENCY := 1
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/boxed_existential/Makefile
+++ b/lldb/test/API/lang/swift/embedded/boxed_existential/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/boxed_existential/TestSwiftEmbeddedBoxedExistential.py
+++ b/lldb/test/API/lang/swift/embedded/boxed_existential/TestSwiftEmbeddedBoxedExistential.py
@@ -1,0 +1,70 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedBoxedExistential(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    @skipUnlessEmbeddedSwift
+    def test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        # A payload that does not fit inline is boxed on the heap. Its fields
+        # start past the box's HeapObject header, not at the box address.
+        self.expect(
+            "frame variable pBoxed",
+            substrs=["a.Boxed", "a = 111", "b = 222", "c = 333", "d = 444"],
+        )
+        self.expect(
+            "frame variable pEnumLarge", substrs=["a.E", "large", "1", "2", "3", "4"]
+        )
+
+        # Payloads that do fit inline, and a class reference, which is one word
+        # and is therefore never boxed.
+        self.expect("frame variable pInline", substrs=["a.Inline", "a = 555", "b = 666"])
+        self.expect("frame variable pEnumSmall", substrs=["a.E", "small", "888"])
+        self.expect("frame variable pClass", substrs=["a.C", "classField = 777"])
+        self.expect("frame variable classBound", substrs=["a.C", "classField = 777"])
+
+        # A class-constrained existential is a reference plus a witness table,
+        # not a five-word opaque container.
+        self.expect(
+            "frame variable -d no-dynamic-values classBound",
+            substrs=["a.ClassBound", "object", "wtable"],
+        )
+        self.expect(
+            "frame variable -d no-dynamic-values classBound",
+            substrs=["payload_data_"],
+            matching=False,
+        )
+
+        # A tuple payload is described only by DWARF, since it is not nominal
+        # and embedded Swift emits stub metadata for it.
+        self.expect(
+            "frame variable boxedTuple",
+            substrs=["(Int, Int, Int, Int)", "0 = 1", "1 = 2", "2 = 3", "3 = 4"],
+        )
+        self.expect(
+            "frame variable inlineTuple", substrs=["(Int, Int)", "0 = 5", "1 = 6"]
+        )
+
+        # An error existential points to a heap box that names the payload's
+        # type. The payload follows the box's header, metadata and witness
+        # table, so a wrong offset here would print garbage rather than fail.
+        self.expect(
+            "frame variable anyError",
+            substrs=["a.MyError", "code = 999", "extra = 111"],
+        )
+
+        # A class payload is a reference stored in that slot, so resolving it
+        # has to step through to the instance.
+        self.expect(
+            "frame variable classError",
+            substrs=["a.MyClassError", "classCode = 4242"],
+        )

--- a/lldb/test/API/lang/swift/embedded/boxed_existential/main.swift
+++ b/lldb/test/API/lang/swift/embedded/boxed_existential/main.swift
@@ -1,0 +1,86 @@
+// A class-constrained existential stores the instance pointer directly; an
+// opaque one has an existential container, whose payload is stored inline only
+// if it fits in three words.
+protocol ClassBound: AnyObject {
+}
+
+protocol P {
+}
+
+// Four words, so this does not fit in the existential's inline buffer and is
+// boxed on the heap.
+struct Boxed: P {
+    let a = 111
+    let b = 222
+    let c = 333
+    let d = 444
+}
+
+// Two words, so this is stored inline.
+struct Inline: P {
+    let a = 555
+    let b = 666
+}
+
+// A class reference is one word, and is therefore never boxed.
+class C: P, ClassBound {
+    let classField = 777
+}
+
+enum E: P {
+    case small(Int)
+    case large(Int, Int, Int, Int)
+}
+
+// An error existential is a pointer to a heap box that holds the payload's type
+// metadata, rather than an existential container.
+struct MyError: Error {
+    let code = 999
+    let extra = 111
+}
+
+// A class payload is stored in the box as a reference, not inline.
+class MyClassError: Error {
+    let classCode = 4242
+}
+
+func mayThrow() throws {
+    throw MyError()
+}
+
+func mayThrowClass() throws {
+    throw MyClassError()
+}
+
+func f() {
+    let pBoxed: any P = Boxed()
+    let pInline: any P = Inline()
+    let pClass: any P = C()
+    let classBound: any ClassBound = C()
+    // Tuples are not nominal, so the metadata the existential points at carries
+    // no layout for them; DWARF is the only description of these.
+    let boxedTuple: Any = (1, 2, 3, 4)
+    let inlineTuple: Any = (5, 6)
+    // FIXME: rdar://168697959 (Debug info for enums is not generated, if there
+    // are no variables/parameter with the enum type in embedded swift)
+    let bug = E.small(0)
+    let pEnumSmall: any P = E.small(888)
+    let pEnumLarge: any P = E.large(1, 2, 3, 4)
+    do {
+        try mayThrow()
+    } catch {
+        // Binding the error to a variable of its own gives that variable a
+        // slot holding the box pointer. A direct `any Error = MyError()`
+        // would instead be described as living inside the box.
+        let anyError: any Error = error
+        do {
+            try mayThrowClass()
+        } catch {
+            let classError: any Error = error
+            print("break here")
+            _ = (anyError, classError)
+        }
+    }
+}
+
+f()

--- a/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
+++ b/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest])

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestExpressionsInSwiftMethodsPureSwift(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_expressions_in_methods(self):
         """Tests that we can run simple Swift expressions correctly"""

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/main.swift
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/main.swift
@@ -9,7 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-class PureSwift
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class PureSwift
 {
     init (int_value: Int)
     {
@@ -30,4 +32,6 @@ class PureSwift
 }
 
 var my_swift_object = PureSwift(int_value: 10)
+// Keep the getter alive for embedded Swift.
+print(my_swift_object.m_computed_ivar)
 my_swift_object.stop_here()

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -29,7 +29,7 @@ def execute_command(command):
     return exit_status
 
 class TestExclusivitySuppression(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     # Test that we can evaluate w.s.i at Breakpoint 1 without triggering
     # a failure due to exclusivity
     @swiftTest
@@ -45,7 +45,7 @@ class TestExclusivitySuppression(TestBase):
 
         lldbutil.check_expression(self, frame, "w.s.i", "8", use_summary=False)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     # Test that we properly handle nested expression evaluations by:
     # (1) Breaking at breakpoint 1
     # (2) Running 'expr get()' (which will hit breakpoint 2)

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/main.swift
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/main.swift
@@ -30,7 +30,9 @@ struct S {
 // global. LLDB accesses globals via unsafe pointers, which aren't subject to
 // dynamic exclusivity checks, and we need to actually hit these checks to
 // verify that enforcement is suppressed.
-class Wrapper {
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class Wrapper {
   var s = S()
 }
 

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -35,7 +35,6 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.build()
         self.do_test()
 
-    @skipEmbeddedSwift
     @swiftTest
     @skipEmbeddedSwiftOnWindows
     def test_ivars_in_generic_expressions(self):

--- a/lldb/test/API/lang/swift/expression/generic/main.swift
+++ b/lldb/test/API/lang/swift/expression/generic/main.swift
@@ -42,7 +42,9 @@ func a (_ i : Int)
 
 // Class, function
 
-class B
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class B
 {
   var m_t : Int
   var m_s : S<Int>
@@ -62,7 +64,7 @@ class B
 
 // Generic class, function
 
-class C<T>
+final class C<T>
 {
   var m_t : T
   var m_s : S<T>
@@ -89,7 +91,7 @@ func d<U> (_ i : U)
 
 // Class, generic function
 
-class E
+final class E
 {
   var m_t : Int
   var m_s : S<Int>
@@ -109,7 +111,7 @@ class E
 
 // Generic class, generic function
 
-class F<T>
+final class F<T>
 {
   var m_t : T
   var m_s : S<T>

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -19,6 +19,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftFixIts(TestBase):
+    # Embedded Swift: `Optional: Equatable` asserts in IRGen, and
+    # `_swift_beginAccess` is missing from the runtime.
     @skipEmbeddedSwift
     @swiftTest
     def test_swift_fixits(self):

--- a/lldb/test/API/lang/swift/generic_error/TestGenericError.py
+++ b/lldb/test/API/lang/swift/generic_error/TestGenericError.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_error/TestGenericError.py
+++ b/lldb/test/API/lang/swift/generic_error/TestGenericError.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipEmbeddedSwiftOnLinux, skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipEmbeddedSwiftOnLinux, skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/inlined_self_scope/TestSwiftInlinedSelfScope.py
+++ b/lldb/test/API/lang/swift/inlined_self_scope/TestSwiftInlinedSelfScope.py
@@ -18,7 +18,7 @@ class TestSwiftInlinedSelfScope(TestBase):
         )
         return frame
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_self_scope_in_inlined_frames(self):
         self.build()

--- a/lldb/test/API/lang/swift/inlined_self_scope/main.swift
+++ b/lldb/test/API/lang/swift/inlined_self_scope/main.swift
@@ -11,7 +11,9 @@ func freeFunction() {
   blackhole(42) // break here in free function
 }
 
-class Tester {
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class Tester {
   var count = 41
 
   // An inlined *method* with its own `self`.

--- a/lldb/test/API/lang/swift/noncopyable/TestSwiftNonCopyableTypeError.py
+++ b/lldb/test/API/lang/swift/noncopyable/TestSwiftNonCopyableTypeError.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftNonCopyableTypeError(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/objc_block/TestSwiftObjCBlock.py
+++ b/lldb/test/API/lang/swift/objc_block/TestSwiftObjCBlock.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCBlock(TestBase):
     @skipUnlessDarwin
-    @skipEmbeddedSwift
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
+++ b/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftProtocolCompositionExpr(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test that expression evaluation can call functions in protocol composition existentials"""

--- a/lldb/test/API/lang/swift/protocol_composition_expr/main.swift
+++ b/lldb/test/API/lang/swift/protocol_composition_expr/main.swift
@@ -33,6 +33,11 @@ struct S: P1, P2 {
 func f() {
     let c: any P1 & P2 = C()
     let s: any P1 & P2 = S()
+    // Use func so they aren't optimized out in embedded swift
+    print(c.foo())
+    print(c.bar())
+    print(s.foo())
+    print(s.bar())
     print("break here")
 }
 

--- a/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
+++ b/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[skipEmbeddedSwiftOnWindows, swiftTest]
+)

--- a/lldb/test/API/lang/swift/protocol_extension_two/main.swift
+++ b/lldb/test/API/lang/swift/protocol_extension_two/main.swift
@@ -20,4 +20,5 @@ struct Patatino<T> where T : Tinky {
 }
 
 let pat = Patatino<Winky>(x: Winky(x: 23))
+print(pat.baciotto) // Use it so it isn't optimized out in embedded swift.
 pat.f()

--- a/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -23,7 +23,7 @@ class TestSwiftSplitDebug(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_split_debug_info(self):
         """Test split debug info"""

--- a/lldb/test/API/lang/swift/split_debug/main.swift
+++ b/lldb/test/API/lang/swift/split_debug/main.swift
@@ -9,14 +9,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-class Class {
+// "final" matters for embedded Swift because the compiler devirtualizes
+// virtual functions and removes them.
+final class Class {
     var c_x : UInt32 = 12345
     var c_y : UInt32 = 6789
 }
 
 func main() {
     var c = Class()
-
     print("hello world") // Break here in main
 }
 

--- a/lldb/test/API/lang/swift/stdlib_marker_protocols/TestStdlibMarkerProtocols.py
+++ b/lldb/test/API/lang/swift/stdlib_marker_protocols/TestStdlibMarkerProtocols.py
@@ -5,8 +5,9 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestStdlibMarkerProtocols(TestBase):
+    @skipEmbeddedSwiftOnLinux # Linker failure with arc4random_buf
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
-    @skipEmbeddedSwift
     def test(self):
         self.build()
         self.runCmd("settings set symbols.swift-enable-ast-context false")

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftTuple(TestBase):
     @swiftTest
-    @skipEmbeddedSwift
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftTuple(TestBase):
     @swiftTest
+    @skipEmbeddedSwiftOnWindows
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()

--- a/lldb/test/API/lang/swift/value_generics/TestSwiftValueGenerics.py
+++ b/lldb/test/API/lang/swift/value_generics/TestSwiftValueGenerics.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftVariadicGenerics(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/variables/actor/Makefile
+++ b/lldb/test/API/lang/swift/variables/actor/Makefile
@@ -1,3 +1,4 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/Makefile
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/Makefile
@@ -1,3 +1,4 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -24,7 +24,8 @@ def stderr_print(line):
     sys.stderr.write(line + "\n")
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while

--- a/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
+++ b/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
@@ -11,8 +11,8 @@ class TestSBValueUpdates(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @decorators.skipEmbeddedSwiftOnWindows
     @decorators.swiftTest
-    @decorators.skipEmbeddedSwift
     def test_update_and_format_with_type_change(self):
         """Test that an SBValue can update and format itself as its type
         changes"""


### PR DESCRIPTION
Cherry-picks the embedded-Swift LLDB work from `stable/21.x` onto `next`.

These correspond to the 24 open `🍒 [origin/next]` cherry-pick radars assigned to
me that were in the Analyze state. Of those 24, 13 turned out to already be on
`next` under different SHAs (patch-identical, or a superset), so this PR carries
the 11 that were genuinely missing.

### Commits

| `stable/21.x` | Subject |
| --- | --- |
| `4b015c6f101b` | fixup! [lldb] Read builtin extra inhabitant counts from DWARF instead of hardcoding them |
| `ba019a580560` | Merge pull request #13654 from augusto2112/enable-async-embedded-tests |
| `c6a4c3fc7ff6` | [lldb] Rework dynamic type resolution for embedded Swift |
| `d7b91b568686` | fixup! [lldb] Rework dynamic type resolution for embedded Swift |
| `0eae115ff6ba` | fixup! [lldb] Rework dynamic type resolution for embedded Swift |
| `84144ce471c2` | fixup! [lldb] Rework dynamic type resolution for embedded Swift |
| `ada495a636dd` | [lldb] Match embedded Swift's exclusivity SILOptions in the scratch context |
| `b29ad4ac6e05` | [lldb] Ask the compiler to set up the embedded Swift scratch context |
| `e708b4519f73` | [lldb] Disable ast-context type system fallback by default |
| `5fcd01c4bd80` | [lldb] Enable already fixed embedded swift tests |
| `3f13522e5554` | [lldb][embedded] Adapt functions in tests so they're aren't optimized out |


