### PR TITLE
[lldb][rebranch] Fix a number of rebranch issues

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1180,9 +1180,13 @@ SwiftLanguageRuntime::PrintObjectViaPointer(Stream &strm, ValueObject &object,
   Flags flags(object.GetCompilerType().GetTypeInfo());
   addr_t addr = LLDB_INVALID_ADDRESS;
   if (flags.Test(eTypeInstanceIsPointer)) {
-    // Objects are pointers.
+    // Objects are pointers. This address is passed back into the inferior as
+    // the argument of stringForPrintObject(_:mangledTypeName:), which loads
+    // from it, so its authentication metadata has to survive: strip the PAC
+    // and TBI bits but preserve the MTE tag, or the load faults under memory
+    // tagging.
     addr = object.GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-    addr = process.FixDataAddress(addr);
+    addr = process.FixAnyAddressPreservingAuthentication(addr);
   } else {
     // Get the address of non-object values (structs, enums).
     auto addr_and_type = object.GetAddressOf(false);

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1734,6 +1734,35 @@ Status SymbolFileDWARFDebugMap::CalculateFrameVariableError(StackFrame &frame) {
   return Status();
 }
 
+bool SymbolFileDWARFDebugMap::GetCompileOption(const char *option,
+                                               std::string &value,
+                                               CompileUnit *cu) {
+  value.clear();
+
+  // The compile options are recorded in the .o files, so the query has to be
+  // forwarded to the SymbolFileDWARF of the corresponding object file. Without
+  // this override the default implementation would report every option as
+  // absent, and callers that use a flag in DW_AT_APPLE_flags to detect how a
+  // compile unit was built (Embedded Swift, C++ interop) would silently take
+  // the "not enabled" path for unlinked DWARF.
+  if (cu) {
+    if (SymbolFileDWARF *oso_dwarf = GetSymbolFile(*cu))
+      return oso_dwarf->GetCompileOption(option, value, cu);
+    return false;
+  }
+
+  bool found = false;
+  ForEachSymbolFile("Parsing compile option",
+                    [&](SymbolFileDWARF &oso_dwarf) {
+                      if (oso_dwarf.GetCompileOption(option, value)) {
+                        found = true;
+                        return IterationAction::Stop;
+                      }
+                      return IterationAction::Continue;
+                    });
+  return found;
+}
+
 void SymbolFileDWARFDebugMap::GetCompileOptions(
     std::unordered_map<lldb::CompUnitSP, Args> &args) {
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
@@ -151,6 +151,9 @@ public:
   // Statistics overrides.
   ModuleList GetDebugInfoModules() override;
 
+  bool GetCompileOption(const char *option, std::string &value,
+                        CompileUnit *cu = nullptr) override;
+
   void
   GetCompileOptions(std::unordered_map<lldb::CompUnitSP, Args> &args) override;
 

--- a/lldb/test/Shell/SwiftREPL/InitFile.test
+++ b/lldb/test/Shell/SwiftREPL/InitFile.test
@@ -4,8 +4,8 @@
 
 // RUN: export HOME=%t
 // RUN: mkdir -p %t
-// RUN: echo 'br set -f main.c -l 123' > ~/.lldbinit
-// RUN: echo 'br set -f swift-repl.c -l 456' > ~/.lldbinit-swift-repl
+// RUN: echo 'br set -f main.c -l 123' > %t/.lldbinit
+// RUN: echo 'br set -f swift-repl.c -l 456' > %t/.lldbinit-swift-repl
 // RUN: %lldb-init --repl < %s 2>&1 | FileCheck %s
 
 :br list


### PR DESCRIPTION
This should fix:

    021ba9f3945e — InitFile.test redirects to %t
    - lldb-shell :: SwiftREPL/InitFile.test

    5213c1b15296 — GetCompileOption() forwarded to the OSOs (the swiftembed variants of these 15)
    - lang/swift/clangimporter/objc-interop/TestSwiftObjCInterop.py
    - lang/swift/class_empty/TestSwiftClassEmpty.py
    - lang/swift/class_static/TestSwiftClassStatic.py
    - lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
    - lang/swift/enum_tagged/TestEnumTagged.py
    - lang/swift/expression/empty_self/TestEmptySelf.py
    - lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
    - lang/swift/expression/mutating_struct_extension/TestMutatingStructExtension.py
    - lang/swift/expression/self/TestSwiftSelf.py
    - lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
    - lang/swift/generic_self/TestSwiftGenericSelf.py
    - lang/swift/generic_tuple/TestSwiftGenericTuple.py
    - lang/swift/local_types/TestSwiftLocalTypes.py
    - lang/swift/private_var/TestSwiftPrivateVar.py
    - lang/swift/swift_callback/TestSwiftCallback.py
    - lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
    - lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py

    f7ca642a371c — MTE tag preserved in po
    - lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py (4 variants)