### PR TITLE
[lldb] Port swift tests to use the require decorators

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1246,9 +1246,32 @@ def requireDarwin(func):
     return requirePlatform(lldbplatform.translate(lldbplatform.darwin_all))(func)
 
 
+def requireMacOS(func):
+    """Mark the item as inherently macOS-only, as opposed to other Darwin
+    platforms (iOS, tvOS, watchOS, ...). Non-macOS targets report
+    UNSUPPORTED."""
+    return requirePlatform(["macosx"])(func)
+
+
 def requireNotDarwin(func):
     """Mark the item as inherently inapplicable to Darwin targets."""
     return requireNotPlatform(lldbplatform.translate(lldbplatform.darwin_all))(func)
+
+
+def requireObjCFoundation(func):
+    """Mark the item as inherently Foundation-only.
+
+    Platforms which only have FoundationEssentials (Linux and Windows) cannot run these tests.
+
+    This is an alias for requireDarwin.
+    """
+    return requireDarwin(func)
+
+
+def requireSwiftObjCInterop(func):
+    """Mark the item as inherently ObjC-only. This is an alias for
+    requireDarwin."""
+    return requireDarwin(func)
 
 
 def requireLinux(func):
@@ -1292,6 +1315,11 @@ def requireMacOS(func):
     platforms (iOS, tvOS, watchOS, ...).
     """
     return requirePlatform(["macosx"])(func)
+
+
+def requireTSAN(func):
+    """Mark the item as requiring a platform which has TSAN."""
+    return requirePOSIX(func)
 
 
 def requireSignals(func):

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1287,6 +1287,13 @@ def requirePOSIX(func):
     return requireNotPlatform(["windows"])(func)
 
 
+def requireMacOS(func):
+    """Mark the item as inherently macOS-only, as opposed to other Darwin
+    platforms (iOS, tvOS, watchOS, ...).
+    """
+    return requirePlatform(["macosx"])(func)
+
+
 def requireSignals(func):
     """Mark the item as requiring POSIX signal support on the target."""
     return requireNotPlatform(["windows", "wasip1", "wasi"])(func)

--- a/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
+++ b/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
@@ -34,7 +34,7 @@ class AsanSwiftTestCase(lldbtest.TestBase):
         self.build(make_targets=["asan"])
         self.do_test_asan()
 
-    @skipIf(oslist=no_match(["macosx"]))
+    @requireMacOS
     @skipIf(macos_version=["<", "15.0"])
     @skipIfDarwin #  rdar://142836595
     def test_libsanitizers_swift(self):

--- a/lldb/test/API/functionalities/data-formatter/swift/bridged-string/TestSwiftBridgedStringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/bridged-string/TestSwiftBridgedStringFormatters.py
@@ -8,7 +8,7 @@ class TestCase(TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessFoundation
+    @requireObjCFoundation
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
@@ -78,7 +78,7 @@ class TestCase(TestBase):
         )
 
     @requireNotEmbeddedSwift
-    @skipUnlessFoundation
+    @requireObjCFoundation
     @swiftTest
     def test_swift_string_index_formatters_bridged(self):
         """Test String.Index summary strings for a bridged String."""

--- a/lldb/test/API/functionalities/mtc/swift-property/TestSwiftMTCProperty.py
+++ b/lldb/test/API/functionalities/mtc/swift-property/TestSwiftMTCProperty.py
@@ -14,7 +14,7 @@ import json
 
 class MTCSwiftPropertyTestCase(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test(self):
         self.mtc_dylib_path = findMainThreadCheckerDylib()

--- a/lldb/test/API/functionalities/mtc/swift/TestSwiftMTC.py
+++ b/lldb/test/API/functionalities/mtc/swift/TestSwiftMTC.py
@@ -14,7 +14,7 @@ import json
 
 class MTCSwiftTestCase(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test(self):
         self.mtc_dylib_path = findMainThreadCheckerDylib()

--- a/lldb/test/API/functionalities/tsan/swift-access-race/TestSwiftTsanAccessRace.py
+++ b/lldb/test/API/functionalities/tsan/swift-access-race/TestSwiftTsanAccessRace.py
@@ -27,7 +27,7 @@ class TsanSwiftAccessRaceTestCase(lldbtest.TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipIfWindows
+    @requireTSAN
     @skipIfLinux
     @skipUnlessSwiftThreadSanitizer
     @skipIfAsan # This test does not behave reliable with an ASANified LLDB.

--- a/lldb/test/API/functionalities/tsan/swift/TestSwiftTsan.py
+++ b/lldb/test/API/functionalities/tsan/swift/TestSwiftTsan.py
@@ -26,7 +26,7 @@ class TsanSwiftTestCase(lldbtest.TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipIfWindows
+    @requireTSAN
     @skipIfLinux
     @skipUnlessSwiftThreadSanitizer
     @skipIfAsan # This test does not behave reliable with an ASANified LLDB.

--- a/lldb/test/API/lang/swift/array_bridged_enum/TestArrayBridgedEnum.py
+++ b/lldb/test/API/lang/swift/array_bridged_enum/TestArrayBridgedEnum.py
@@ -2,4 +2,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift,
-        swiftTest, skipUnlessFoundation])
+        swiftTest, requireObjCFoundation])

--- a/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
+++ b/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftArtificialSubclass(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessObjCInterop
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         """ Test that displaying an artificial type works correctly"""

--- a/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
@@ -36,7 +36,7 @@ class TestAvailability(TestBase):
 
     @requireNotEmbeddedSwift # embedded Swift strips functions the program never calls, so f() is not in the binary to call
     @swiftTest
-    @skipIf(oslist=['linux', 'windows'])
+    @requireDarwin
     def testAvailability(self):
         platform_name = lldbplatformutil.getPlatform()
         arch = lldbplatformutil.getArchitecture()

--- a/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
+++ b/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
@@ -11,7 +11,7 @@ import os
 class TestSwiftBridgedMetatype(TestBase):
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessFoundation
+    @requireObjCFoundation
     def test_swift_bridged_metatype(self):
         """Test the formatting of bridged Swift metatypes"""
         self.build()

--- a/lldb/test/API/lang/swift/cf/uuid/TestCFUUID.py
+++ b/lldb/test/API/lang/swift/cf/uuid/TestCFUUID.py
@@ -11,7 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessFoundation
+    @requireObjCFoundation
     def test(self):
         """Test CFUUID object description prints the UUID string."""
         self.build()

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
@@ -8,7 +8,7 @@ class TestSwiftNSClassBaseClass(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here",

--- a/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/TestSwiftClangImporterExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/TestSwiftClangImporterExtraInhabitants.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftClangImporterExtraInhabitants(TestBase):
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -21,7 +21,7 @@ class TestSwiftMacroConflict(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(bugnumber="rdar://121539666")
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.
@@ -57,7 +57,7 @@ class TestSwiftMacroConflict(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(bugnumber="rdar://121539666")
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test_with_dwarfimporter(self):
         """

--- a/lldb/test/API/lang/swift/clangimporter/nserror/TestNSError.py
+++ b/lldb/test/API/lang/swift/clangimporter/nserror/TestNSError.py
@@ -20,14 +20,14 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftNSErrorTest(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireObjCFoundation
     @swiftTest
     def test_swift_nserror(self):
         """Tests that Swift displays NSError correctly"""
         self.build()
         self.nserror_commands(check_userInfo=False)
 
-    @skipUnlessDarwin
+    @requireObjCFoundation
     @swiftTest
     @skipIf(bugnumber="rdar://71549869")
     def test_swift_nserror_fails(self):

--- a/lldb/test/API/lang/swift/clangimporter/nsinteger_nsenum/TestSwiftNSIntegerNSEnum.py
+++ b/lldb/test/API/lang/swift/clangimporter/nsinteger_nsenum/TestSwiftNSIntegerNSEnum.py
@@ -22,7 +22,7 @@ class TestSwiftNSIntegerNSEnum(lldbtest.TestBase):
         check(frame.FindVariable('e2'), 'eCase2')
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test_reflection(self):
         self.expect("setting set symbols.swift-enable-ast-context false")
@@ -31,7 +31,7 @@ class TestSwiftNSIntegerNSEnum(lldbtest.TestBase):
     @requireNotEmbeddedSwift
     # Don't run a clangimporter test without ClangImporter.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test_swift_ast(self):
         self.expect("setting set symbols.swift-enable-ast-context true")

--- a/lldb/test/API/lang/swift/clangimporter/objc-interop/TestSwiftObjCInterop.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc-interop/TestSwiftObjCInterop.py
@@ -13,4 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(), decorators=[
-        swiftTest,skipUnlessObjCInterop])
+        swiftTest,requireSwiftObjCInterop])

--- a/lldb/test/API/lang/swift/clangimporter/objc/dynamic-swift-type/TestSwiftObjCDynamicType.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc/dynamic-swift-type/TestSwiftObjCDynamicType.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessFoundation
+    @requireObjCFoundation
     @swiftTest
     def test(self):
         """Verify printing of Swift implemented ObjC objects."""

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestObjCInternalPropertyRedecl.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/TestObjCInternalPropertyRedecl.py
@@ -9,7 +9,7 @@ class TestObjCInternalPropertyRedecl(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/TestSwiftObjCOptionalDict.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/TestSwiftObjCOptionalDict.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCOptionalDict(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireObjCFoundation
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCProtocol(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         """Test printing an Objective-C protocol existential member."""

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol_fields/TestSwiftObjCProtocolFields.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol_fields/TestSwiftObjCProtocolFields.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftObjCBaseClassMemberLookup(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         """Test accessing a static member from a member function"""

--- a/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -23,7 +23,7 @@ import shutil
 
 class TestObjCIVarDiscovery(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @skipIf(debug_info=no_match("dsym"))
     @swiftTest
     def test_nodbg(self):
@@ -32,7 +32,7 @@ class TestObjCIVarDiscovery(TestBase):
         self.do_test(False)
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @skipIf(debug_info=no_match("dsym"))
     @swiftTest
     def test_dbg(self):

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -21,7 +21,7 @@ class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
     @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -24,7 +24,7 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
     @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClangImporterProtocolComposition(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         """Test that protocol composition types can be resolved

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -21,7 +21,7 @@ class TestSwiftRewriteClangPaths(TestBase):
     @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
     def testWithRemap(self):
@@ -30,7 +30,7 @@ class TestSwiftRewriteClangPaths(TestBase):
     @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
     def testWithoutRemap(self):

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -20,7 +20,7 @@ class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
     @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -23,7 +23,7 @@ class TestSwiftDeploymentTarget(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
     @swiftTest
@@ -35,7 +35,7 @@ class TestSwiftDeploymentTarget(TestBase):
         self.expect("expression f", substrs=['i = 23'])
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
     @swiftTest
@@ -49,7 +49,7 @@ class TestSwiftDeploymentTarget(TestBase):
         self.expect("expression self", substrs=['i = 23'])
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
     @skipIf(macos_version=["<", "11.1"])
     # FIXME: This config started failing in CI only after switching to
@@ -70,7 +70,7 @@ class TestSwiftDeploymentTarget(TestBase):
 #       CHECK-NOT: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RegisterSectionModules("a.out"){{.*}} AST Data blobs
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin  # This test uses macOS triples explicitly.
+    @requireDarwin
     @skipIfDarwinEmbedded
     @skipIf(macos_version=["<", "11.1"])
     @swiftTest

--- a/lldb/test/API/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -35,7 +35,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
         shutil.rmtree(include)
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
@@ -62,7 +62,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
         #self.expect("target var -O proto", substrs=["<ProtoImpl"])
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test_expr(self):
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
@@ -84,7 +84,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
 
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test_eager_member_completion(self):
         """

--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -24,7 +24,7 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
         shutil.rmtree(include)
 
     @requireNotEmbeddedSwift # embedded Swift disables ObjC interop, so this test's Foundation import does not compile
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/embedded/dwarflinker_raw_value_enum/TestSwiftEmbeddedDWARFLinkerRawValueEnum.py
+++ b/lldb/test/API/lang/swift/embedded/dwarflinker_raw_value_enum/TestSwiftEmbeddedDWARFLinkerRawValueEnum.py
@@ -10,7 +10,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftEmbeddedDWARFLinkerRawValueEnum(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipUnlessEmbeddedSwift
     def test(self):

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -18,7 +18,7 @@ import os
 
 class TestSwiftExpressionObjCContext(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
@@ -23,7 +23,7 @@ class TestSwiftSubmoduleImport(TestBase):
     # Have to find some submodule that is present on both Darwin & Linux for this
     # test to run on both systems...
 
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test_swift_submodule_import(self):
         """Tests that swift expressions can import sub-modules correctly"""

--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestExternalProviderExtraInhabitants(TestBase):
 
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/foundation_value_types/cfstringref/TestSwiftFoundationTypeCFStringRef.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/cfstringref/TestSwiftFoundationTypeCFStringRef.py
@@ -7,7 +7,7 @@ class TestSwiftFoundationTypeCFStringRef(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessFoundation
+    @requireObjCFoundation
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, 'break here',

--- a/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/TestSwiftSharedStringStorage.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/shared_string_storage/TestSwiftSharedStringStorage.py
@@ -8,7 +8,7 @@ class TestSwiftSharedStringStorage(TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessFoundation
+    @requireObjCFoundation
     def test(self):
         """Non-ASCII strings bridged to NSString/CFString are backed by
         __SharedStringStorage. Check that the data formatter decodes them,

--- a/lldb/test/API/lang/swift/foundation_value_types/urlcomponents/TestSwiftFoundationTypeURLComponents.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/urlcomponents/TestSwiftFoundationTypeURLComponents.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin,
+                          decorators=[swiftTest,requireObjCFoundation,
                                       expectedFailureAll(bugnumber='rdar://32800121')])

--- a/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
+++ b/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
@@ -10,7 +10,7 @@ class TestSwiftFrameworkPaths(lldbtest.TestBase):
     @swiftTest
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=no_match(["macosx"]))
+    @requireMacOS
     def test_system_framework(self):
         """Test the discovery of framework search paths from framework dependencies."""
         self.build()

--- a/lldb/test/API/lang/swift/generic_objcclasswrapper/TestGenericObjcClassWrapper.py
+++ b/lldb/test/API/lang/swift/generic_objcclasswrapper/TestGenericObjcClassWrapper.py
@@ -2,4 +2,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(), decorators=[requireNotEmbeddedSwift,
-        swiftTest, skipUnlessDarwin])
+        swiftTest, requireObjCFoundation])

--- a/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -21,7 +21,7 @@ import os
 
 class TestSwiftCGImportedTypes(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test_swift_cg_imported_types(self):
         """Test that we are able to deal with C-imported types from CoreGraphics"""

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateDylib(TestBase):
     @requireNotEmbeddedSwift # the embedded test harness appends its own -target, overriding the deployment targets under test
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIfDarwinEmbedded
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))

--- a/lldb/test/API/lang/swift/late_symbols/TestSwiftLateSymbols.py
+++ b/lldb/test/API/lang/swift/late_symbols/TestSwiftLateSymbols.py
@@ -7,7 +7,7 @@ import os
 
 class TestSwiftLateSymbols(TestBase):
     @swiftTest
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIf(debug_info=no_match(["dsym"]))
     def test_any_object_type(self):
         """Test the AnyObject type"""

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -12,7 +12,7 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
 
     @skipEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=no_match(["macosx"]))
+    @requireMacOS
     # FIXME: Without the ClangImporter, transitive module dependencies can't be
     # fully resolved, so collectLinkLibraries() misses autolinked frameworks.
     # This causes DoLoadImage() to allocate memory while the process is still
@@ -42,7 +42,7 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
         self.expect("image list", substrs=["Lazy.framework/Versions/A/Lazy"])
 
     @swiftTest
-    @skipIf(oslist=no_match(["macosx"]))
+    @requireMacOS
     def test_precise_compiler_invocation(self):
         """In modern LLDB, with precise compiler invocations the expression
            is evaluated in the local context by default."""

--- a/lldb/test/API/lang/swift/macCatalyst/TestSwiftMacCatalyst.py
+++ b/lldb/test/API/lang/swift/macCatalyst/TestSwiftMacCatalyst.py
@@ -8,7 +8,7 @@ import os
 class TestSwiftMacCatalyst(TestBase):
     @swiftTest
     @skipIf(macos_version=["<", "10.15"])
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded
     def test_macCatalyst(self):
         """Test the ${arch}-apple-ios-macabi target.

--- a/lldb/test/API/lang/swift/macCatalystFramework/TestSwiftMacCatalystFramework.py
+++ b/lldb/test/API/lang/swift/macCatalystFramework/TestSwiftMacCatalystFramework.py
@@ -10,7 +10,7 @@ class TestSwiftMacCatalystFramework(TestBase):
 
     @swiftTest
     @skipIf(macos_version=["<", "26"])
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded
     def test(self):
         """A macCatalyst (arm64-apple-ios-macabi) executable that loads a plain

--- a/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
+++ b/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
@@ -11,7 +11,7 @@ import os
 class TestMultilangFormatterCategories(TestBase):
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
+    @requireObjCFoundation
     def test_multilang_formatter_categories(self):
         """Test that formatter categories can work for multiple languages"""
         self.build()

--- a/lldb/test/API/lang/swift/noncopyable_field_reflection/TestSwiftNoncopyableFieldReflection.py
+++ b/lldb/test/API/lang/swift/noncopyable_field_reflection/TestSwiftNoncopyableFieldReflection.py
@@ -9,7 +9,7 @@ class TestSwiftNoncopyableFieldReflection(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipUnlessDarwin
+    @requireDarwin
     @skipEmbeddedSwift
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
+++ b/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
@@ -16,5 +16,5 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     decorators=[requireNotEmbeddedSwift,
-        swiftTest, skipUnlessDarwin, skipIf(macos_version=["=", "15.0"])],
+        swiftTest, requireObjCFoundation, skipIf(macos_version=["=", "15.0"])],
 )

--- a/lldb/test/API/lang/swift/objc_block/TestSwiftObjCBlock.py
+++ b/lldb/test/API/lang/swift/objc_block/TestSwiftObjCBlock.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftObjCBlock(TestBase):
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
+++ b/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
@@ -8,7 +8,7 @@ class TestCase(TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessFoundation
+    @requireObjCFoundation
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/objc_obj_field/TestSwiftObjCObjField.py
+++ b/lldb/test/API/lang/swift/objc_obj_field/TestSwiftObjCObjField.py
@@ -9,7 +9,7 @@ class TestCase(TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
+++ b/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjcProtocol(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         """Tests that dynamic type resolution works for an Objective-C protocol existential"""

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/TestSwiftObjCSuperClassNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/TestSwiftObjCSuperClassNoDebugInfo.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjCSuperClassNoDebugInfo(TestBase):
     @swiftTest
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @requireNotEmbeddedSwift
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
+++ b/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
@@ -14,4 +14,4 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
                           decorators=[requireNotEmbeddedSwift,
-        swiftTest,skipUnlessDarwin])
+        swiftTest,requireObjCFoundation])

--- a/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
+++ b/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
@@ -11,7 +11,7 @@ class TestSwiftOtherArchDylib(TestBase):
 
     @requireNotEmbeddedSwift # the embedded test harness appends its own -target, so the other-arch dylib is never built
     @swiftTest
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded
     @skipIf(archs=no_match(["arm64"]))
     @skipIf(archs=["arm64e"], bugnumber="the swift.org toolchain cannot produce arm64e binaries")

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part03.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part03.py
@@ -135,7 +135,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessPlatform(["macosx"])
+    @requireMacOS
     def test_prebuilt_cache_location(self):
         """Verify the prebuilt cache path is correct"""
         self.build()

--- a/lldb/test/API/lang/swift/path_with_colons/TestSwiftPathWithColons.py
+++ b/lldb/test/API/lang/swift/path_with_colons/TestSwiftPathWithColons.py
@@ -24,7 +24,7 @@ import shutil
 # this should be a perfectly general feature but I could not
 # cause the failure to reproduce against clang, so put it here
 class TestSwiftPathWithColon(TestBase):
-    @skipIf(oslist=['windows'])
+    @requirePOSIX
     @skipIfiOSSimulator
     @swiftTest
     def test_path_with_colon(self):

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -64,7 +64,7 @@ class TestSwiftPlaygrounds(TestBase):
         return triple
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(debug_info=decorators.no_match("dsym"))
@@ -74,7 +74,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.do_basic_test(True)
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(debug_info=decorators.no_match("dsym"))
@@ -84,7 +84,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.do_basic_test(False)
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(debug_info=decorators.no_match("dsym"))
@@ -95,7 +95,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.do_concurrency_test()
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(debug_info=decorators.no_match("dsym"))

--- a/lldb/test/API/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
+++ b/lldb/test/API/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
@@ -14,4 +14,4 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
                           decorators=[requireNotEmbeddedSwift,
-        swiftTest,skipUnlessFoundation,skipIf(oslist=['windows'])])
+        swiftTest,requireObjCFoundation])

--- a/lldb/test/API/lang/swift/po/objc/TestSwiftPOObjC.py
+++ b/lldb/test/API/lang/swift/po/objc/TestSwiftPOObjC.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftPOObjC(TestBase):
     @requireNotEmbeddedSwift
     #NO_DEBUG_INFO_TESTCASE = True
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         """Test running po on a Swift object from Objective-C. This

--- a/lldb/test/API/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
+++ b/lldb/test/API/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
@@ -12,11 +12,12 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__,
-                          globals(),
-                          decorators=[requireNotEmbeddedSwift,
+lldbinline.MakeInlineTest(
+    __file__,
+    globals(),
+    decorators=[
+        requireNotEmbeddedSwift,
         swiftTest,
-                              skipIf(oslist=['windows']),
-                              expectedFailureAll(oslist=["linux"],
-                                                 bugnumber="rdar://83444822")
-                          ])
+        requireSwiftObjCInterop,
+    ],
+)

--- a/lldb/test/API/lang/swift/protocols/class_protocol/TestSwiftClassConstrainedProtocolArgument.py
+++ b/lldb/test/API/lang/swift/protocols/class_protocol/TestSwiftClassConstrainedProtocolArgument.py
@@ -8,4 +8,4 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__, globals(),
             decorators=[requireNotEmbeddedSwift,
-        swiftTest,skipUnlessDarwin])
+        swiftTest,requireSwiftObjCInterop])

--- a/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
@@ -23,7 +23,7 @@ def execute_command(command):
 
 class TestSwiftResilience(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     # Because we rename the .swiftmodule files after building the
     # N_AST symbol table entry is out of sync, whereas dsymutil
@@ -35,7 +35,7 @@ class TestSwiftResilience(TestBase):
         self.doTestWithFlavor("a", "a")
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
     def test_cross_module_extension_a_b(self):
@@ -44,7 +44,7 @@ class TestSwiftResilience(TestBase):
         self.doTestWithFlavor("a", "b")
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
     def test_cross_module_extension_b_a(self):
@@ -53,7 +53,7 @@ class TestSwiftResilience(TestBase):
         self.doTestWithFlavor("b", "a")
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
     def test_cross_module_extension_b_b(self):

--- a/lldb/test/API/lang/swift/resilience_private_method/TestSwiftResiliencePrivateMethod.py
+++ b/lldb/test/API/lang/swift/resilience_private_method/TestSwiftResiliencePrivateMethod.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftResiliencePrivateMethod(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftResilienceSwiftInterface(TestBase):
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test(self):
         """Test the odd scenario where a user registers a binary

--- a/lldb/test/API/lang/swift/static_framework/TestSwiftStaticFramework.py
+++ b/lldb/test/API/lang/swift/static_framework/TestSwiftStaticFramework.py
@@ -11,7 +11,7 @@ class TestSwiftStaticFramework(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @skipIf(oslist=no_match(["macosx"]))
+    @requireMacOS
     def test_static_framework(self):
         """Make sure LLDB doesn't attempt to import static frameworks"""
         n = 10

--- a/lldb/test/API/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
+++ b/lldb/test/API/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
@@ -33,7 +33,7 @@ class SwiftStaticLinkingMacOSTestCase(TestBase):
                     substrs=substrs)
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test_variables_print_from_both_swift_modules(self):
         """Test that variables from two modules can be accessed."""

--- a/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
+++ b/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjcProtocol(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/step_into_swift_override/TestStepFromObjCToSwiftOverride.py
+++ b/lldb/test/API/lang/swift/step_into_swift_override/TestStepFromObjCToSwiftOverride.py
@@ -7,7 +7,7 @@ class TestStepFromObjCToSwiftOverride(TestBase):
     """Test that you can step from an ObjC method of a class into the swift
        override of one of the methods."""
 
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     @swiftTest
     @requireNotEmbeddedSwift
     def test(self):

--- a/lldb/test/API/lang/swift/swift_array_of_objc_items/TestSwiftArrayOfObjCItems.py
+++ b/lldb/test/API/lang/swift/swift_array_of_objc_items/TestSwiftArrayOfObjCItems.py
@@ -8,7 +8,7 @@ class TestCase(TestBase):
 
     @swiftTest
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     def test(self):
         """Test that a Swift array of ObjC items prints correctly."""
 

--- a/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
+++ b/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
@@ -21,7 +21,7 @@ import os
 
 class TestSwiftieFormatting(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireObjCFoundation
     @swiftTest
     def test_swiftie_formatting(self):
         """Test that data formatters honor Swift conventions"""

--- a/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
+++ b/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test_body(self):
         self.build()
@@ -19,7 +19,7 @@ class TestCase(TestBase):
         self._do_test("self._count", 41, is_graph_update=True)
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test_appear(self):
         self.build()
@@ -31,7 +31,7 @@ class TestCase(TestBase):
         self._do_test("self._count", 41, is_graph_update=False)
 
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireDarwin
     @swiftTest
     def test_change(self):
         self.build()

--- a/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -10,7 +10,7 @@ class TestSwiftSystemFramework(lldbtest.TestBase):
 
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipIf(oslist=no_match(["macosx"]))
+    @requireMacOS
     def test_system_framework(self):
         """Make sure no framework paths into /System/Library are added"""
         self.build()

--- a/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
+++ b/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
@@ -11,7 +11,7 @@ class TestSwiftTaggedPointer(lldbtest.TestBase):
     @swiftTest
     # This test depends on NSObject, so it is not available on non-Darwin
     # platforms.
-    @skipUnlessDarwin
+    @requireObjCFoundation
     # This test exposes a bug in DWARFImporterForClangTypes, which
     # doesn't do type completion correctly. (rdar://118337109)
     def test(self):

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -9,7 +9,7 @@ class TestSwiftTripleDetection(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded
     def test(self):
         """Test that an underspecified triple is upgraded with a version number.

--- a/lldb/test/API/lang/swift/variables/bridged_array/TestSwiftBridgedArray.py
+++ b/lldb/test/API/lang/swift/variables/bridged_array/TestSwiftBridgedArray.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftBridgedArray(TestBase):
-    @skipUnlessDarwin
+    @requireObjCFoundation
     @swiftTest
     @expectedFailureAll(bugnumber="<rdar://problem/32024572>")
     def test_swift_bridged_array(self):

--- a/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -24,7 +24,7 @@ import os
 
 class TestSwiftBridgedStringVariables(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireObjCFoundation
     @swiftTest
     def test_swift_bridged_string_variables(self):
         """Test that Swift.String formats properly"""

--- a/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
+++ b/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
@@ -22,7 +22,7 @@ import os
 class TestSwiftCoreGraphicsTypes(TestBase):
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
+    @requireDarwin
     def test_swift_coregraphics_types(self):
         """Test that we are able to properly format basic CG types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -21,7 +21,7 @@ import os
 
 class TestDictionaryNSObjectAnyObject(TestBase):
     @requireNotEmbeddedSwift
-    @skipUnlessDarwin
+    @requireObjCFoundation
     @swiftTest
     def test_dictionary_nsobject_any_object(self):
         """Tests that we properly vend synthetic children for Swift.Dictionary<NSObject,AnyObject>"""

--- a/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
+++ b/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
@@ -22,7 +22,7 @@ import os
 class TestSwiftObjCImportedTypes(TestBase):
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
+    @requireObjCFoundation
     def test_swift_objc_imported_types(self):
         """Test that we are able to deal with ObjC-imported types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -22,7 +22,7 @@ import os
 class TestSwiftObjCOptionalType(TestBase):
     @requireNotEmbeddedSwift
     @swiftTest
-    @skipUnlessDarwin
+    @requireSwiftObjCInterop
     def test_swift_objc_optional_type(self):
         """Check formatting for T? and T! when T is an ObjC type"""
         self.build()

--- a/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
+++ b/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
@@ -32,7 +32,7 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
         self.assertEqual(precise, expect_precise)
 
     @swiftTest
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded
     def test_decode(self):
         """Test that we can detect an Xcode SDK from the DW_AT_LLVM_sdk attribute."""
@@ -46,7 +46,7 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
         self.check_log(log, "MacOSX", True)
 
     @swiftTest
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test('iphone')
     # FIXME: This test depends on https://reviews.llvm.org/D81980.
@@ -65,7 +65,7 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
         self.check_log(log, "iPhoneSimulator", True)
 
     @swiftTest
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfDarwinEmbedded
     def test_override(self):
         """Test that we can override the Xcode SDK using the target setting."""


### PR DESCRIPTION
This introduces 4 new require decorators:
- `requireFoundation`
- `requireObjCInterop`
- `requireTSAN`
- `requireMacOS`

This also converts the LLDB Swift tests to use those decorators.