### PR TITLE
[llvm] Keep CASPluginTest in SHLIBDIR for the CAS lit tests

### DIFF
--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -74,12 +74,13 @@ add_llvm_unittest(CASTests
 target_link_libraries(CASTests PRIVATE LLVMTestingSupport)
 
 if (TARGET CASPluginTest)
-  # Place the plugin library next to the test executable so getCASPluginPath()
-  # can locate it with a single parent_path regardless of the generator type.
-  set(CAS_UNITTEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR})
-  set_output_directory(CASPluginTest
-      BINARY_DIR ${CAS_UNITTEST_DIR}
-      LIBRARY_DIR ${CAS_UNITTEST_DIR}
-  )
   add_dependencies(CASTests CASPluginTest)
+  # Symlink the plugin library next to the test executable so getCASPluginPath()
+  # can locate it with a single parent_path regardless of the generator type.
+  add_custom_command(TARGET CASTests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+            $<TARGET_FILE:CASPluginTest>
+            $<TARGET_FILE_DIR:CASTests>/$<TARGET_FILE_PREFIX:CASPluginTest>CASPluginTest$<TARGET_FILE_SUFFIX:CASPluginTest>
+    VERBATIM
+  )
 endif()


### PR DESCRIPTION
And symlink into unittests directory. Upstream 1f105fbdccf3 introduced a regression that breaks downstream tests where our lit tests expecting plugin dylib in the SHLIBDIR.

rdar://184580571