### PR TITLE
[lldb] Preserve the MTE tag in context-free po's object pointer

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1180,9 +1180,10 @@ SwiftLanguageRuntime::PrintObjectViaPointer(Stream &strm, ValueObject &object,
   Flags flags(object.GetCompilerType().GetTypeInfo());
   addr_t addr = LLDB_INVALID_ADDRESS;
   if (flags.Test(eTypeInstanceIsPointer)) {
-    // Objects are pointers.
+    // Objects are pointers. The inferior dereferences this pointer, so the
+    // metadata bits that authenticate a memory access have to be preserved.
     addr = object.GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-    addr = process.FixDataAddress(addr);
+    addr = process.FixAnyAddressPreservingAuthentication(addr);
   } else {
     // Get the address of non-object values (structs, enums).
     auto addr_and_type = object.GetAddressOf(false);


### PR DESCRIPTION
PrintObjectViaPointer() passed the object pointer through FixDataAddress(), which masks the entire top byte and so discards the Memory Tagging Extension tag. The inferior then trapped with EXC_ARM_MTE_TAG_FAULT, po fell back to the legacy path, and that reported "Couldn't realize Swift AST type of self". Use
FixAnyAddressPreservingAuthentication(), which exists for this case.

Enables TestSwiftPrintObjectPrivateSubclass (4 variants).

Assisted-by: claude