### PR TITLE
[lldb] Forward GetCompileOption() to the OSOs in SymbolFileDWARFDebugMap

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1734,6 +1734,32 @@ Status SymbolFileDWARFDebugMap::CalculateFrameVariableError(StackFrame &frame) {
   return Status();
 }
 
+bool SymbolFileDWARFDebugMap::GetCompileOption(const char *option,
+                                               std::string &value,
+                                               CompileUnit *cu) {
+  value.clear();
+
+  // The compile options are recorded in the DW_AT_APPLE_flags of the compile
+  // units in the .o files, so the query has to be forwarded to the
+  // SymbolFileDWARF of the corresponding object file.
+  if (cu) {
+    if (SymbolFileDWARF *oso_dwarf = GetSymbolFile(*cu))
+      return oso_dwarf->GetCompileOption(option, value, cu);
+    return false;
+  }
+
+  bool found = false;
+  ForEachSymbolFile("Parsing compile option",
+                    [&](SymbolFileDWARF &oso_dwarf) {
+                      if (oso_dwarf.GetCompileOption(option, value)) {
+                        found = true;
+                        return IterationAction::Stop;
+                      }
+                      return IterationAction::Continue;
+                    });
+  return found;
+}
+
 void SymbolFileDWARFDebugMap::GetCompileOptions(
     std::unordered_map<lldb::CompUnitSP, Args> &args) {
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
@@ -151,6 +151,9 @@ public:
   // Statistics overrides.
   ModuleList GetDebugInfoModules() override;
 
+  bool GetCompileOption(const char *option, std::string &value,
+                        CompileUnit *cu = nullptr) override;
+
   void
   GetCompileOptions(std::unordered_map<lldb::CompUnitSP, Args> &args) override;
 


### PR DESCRIPTION
SymbolFileDWARFDebugMap overrides only the plural GetCompileOptions(), so the singular GetCompileOption() fell through to the base class and reported every DW_AT_APPLE_flags option as absent for unlinked DWARF. CheckFlagInCU() therefore saw neither -enable-embedded-swift nor -enable-experimental-cxx-interop, the scratch SwiftASTContext never enabled swift::Feature::Embedded, and importing the embedded stdlib failed with "module 'Swift' cannot be imported because it was built with embedded Swift". Forward the query to the OSO's SymbolFileDWARF.

Assisted-by: claude