### PR TITLE
[lldb][test] Opt Swift tests that mutate build artifacts out of SHARE D_BUILD_TESTCASE

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -22,6 +22,8 @@ import re
 import shutil
 
 class TestObjCIVarDiscovery(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 @skipIfWindows
 class TestCase(lldbtest.TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
     @requireNotEmbeddedSwift
     @swiftTest

--- a/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExpressionErrorMissingType(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipEmbeddedSwift

--- a/lldb/test/API/lang/swift/late_symbols/TestSwiftLateSymbols.py
+++ b/lldb/test/API/lang/swift/late_symbols/TestSwiftLateSymbols.py
@@ -6,6 +6,8 @@ import shutil
 import os
 
 class TestSwiftLateSymbols(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @swiftTest
     @skipUnlessDarwin
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part01.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part01.py
@@ -26,6 +26,8 @@ import os.path
 
 
 class TestSwiftInterfaceNoDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def get_toolchain(self):
         sdkroot = self.get_sdkroot()
         # The SDK root is expected to be wihin the Xcode.app/Contents

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part02.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo_part02.py
@@ -26,6 +26,8 @@ import os.path
 
 
 class TestSwiftInterfaceNoDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def get_toolchain(self):
         sdkroot = self.get_sdkroot()
         # The SDK root is expected to be wihin the Xcode.app/Contents

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo_part01.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo_part01.py
@@ -26,6 +26,8 @@ import os.path
 
 
 class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         # The custom swift module cache location
         swift_mod_cache = self.getBuildArtifact("MCP")

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo_part02.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo_part02.py
@@ -26,6 +26,8 @@ import os.path
 
 
 class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         # The custom swift module cache location
         swift_mod_cache = self.getBuildArtifact("MCP")

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -21,6 +21,8 @@ import shutil
 
 
 class TestSwiftStructChangeRerun(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @expectedFailureWindows  # https://github.com/swiftlang/llvm-project/issues/13444
     @swiftTest
     @skipIf(


### PR DESCRIPTION
These tests delete a module cache, remove a .swiftmodule, move a dSYM aside, or rebuild main.swift from different sources. With one build directory shared across a class's variants, each variant ran against the previous one's mutations and failed with FileNotFoundError, FileExistsError, or stale FileCheck input.

Enables TestObjCIvarDiscovery, TestSwiftExplicitModulesImplicitFallback, TestSwiftExpressionErrorMissingType, TestSwiftLateSymbols, TestSwiftInterfaceNoDebugInfo part01 and part02,
TestSwiftInterfaceStaticNoDebugInfo part01 and part02, and TestSwiftStructChangeRerun.

Assisted-by: claude