### PR TITLE
[lldb][test] Use the correct 'symbol' log category name

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -18,7 +18,7 @@ class TestSwiftClangImporterCaching(TestBase):
         log = self.getBuildArtifact("types.log")
         self.runCmd("settings set target.swift-clang-override-options +-DADDED=1")
         self.runCmd("settings set target.swift-extra-clang-flags -- -DEXTRA=1")
-        self.expect('log enable lldb types symbols -f "%s"' % log)
+        self.expect('log enable lldb types symbol -f "%s"' % log)
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["b ="])
 

--- a/lldb/test/API/lang/swift/explicit_modules/caching/TestSwiftExplicitModuleCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/caching/TestSwiftExplicitModuleCaching.py
@@ -16,7 +16,7 @@ class TestSwiftExplicitModuleCaching(TestBase):
             self, "break here", lldb.SBFileSpec('main.swift')
         )
         log = self.getBuildArtifact("types.log")
-        self.expect('log enable lldb types symbols -f "%s"' % log)
+        self.expect('log enable lldb types symbol -f "%s"' % log)
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["b ="])
 

--- a/lldb/test/API/lang/swift/explicit_modules/no-caching/TestSwiftExplicitModuleNoCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/no-caching/TestSwiftExplicitModuleNoCaching.py
@@ -17,7 +17,7 @@ class TestSwiftExplicitModuleNoCaching(TestBase):
             self, "break here", lldb.SBFileSpec('main.swift')
         )
         log = self.getBuildArtifact("types.log")
-        self.expect('log enable lldb types symbols -f "%s"' % log)
+        self.expect('log enable lldb types symbol -f "%s"' % log)
         self.expect("expression 1+1")
         self.filecheck_log(log, __file__)
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ConfigureDefaultCASStorage() -- Bound default CAS at path


### PR DESCRIPTION
Three Swift tests enabled logging with `log enable lldb types symbols`, but the log category is named `symbol`, not `symbols`. This went unnoticed because Log::EnableChannel printed an error for unrecognized categories yet still returned success, so `log enable` was not marked as a failed command.

Upstream 85bce2e5fc93 ("[lldb] Fix surprising return values from Log::Enable/DisableChannel") made these return false when a channel or category is not recognized, so the stale category name now fails the `self.expect()` that runs the command.

This fixes TestSwiftExplicitModuleNoCaching. TestSwiftClangImporterCaching and TestSwiftExplicitModuleCaching.

Assisted-by: claude