### PR TITLE
[lldb][test] Un-skip cxx_interop forward-interop step-into-extension in embedded

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping_part02.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping_part02.py
@@ -47,7 +47,6 @@ class TestSwiftForwardInteropStepping(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn('testContructor', name)
 
-    @skipEmbeddedSwift
     @swiftTest
     @skipEmbeddedSwiftOnWindows
     def test_step_into_extension(self):

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly_part02.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly_part02.py
@@ -47,7 +47,6 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertIn('testContructor', name)
 
-    @skipEmbeddedSwift
     @swiftTest
     @skipEmbeddedSwiftOnWindows
     def test_step_into_extension(self):


### PR DESCRIPTION
Both `test_step_into_extension` methods failed in embedded Swift because a
specialized `witness_method` lost its lexical debug scope, which is
fixed on the compiler side.

Assisted-by: claude
