### PR TITLE
[LLDB] Adapt the Swift REPL for upstream changes to SymbolFile

### DIFF
--- a/lldb/include/lldb/Core/SwiftForward.h
+++ b/lldb/include/lldb/Core/SwiftForward.h
@@ -1,4 +1,4 @@
-//===-- SwiftForward.h ------------------------------------------*- C++ -*-===//
+//===-- SwiftForward.h ----------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -102,6 +102,8 @@ public:
 
   ArchSpec GetArchitecture() override;
 
+  lldb::TargetSP GetTargetSP() override { return GetTarget(); }
+
   lldb::ModuleSP GetJITModule();
 
   lldb::ModuleSP CreateJITModule(const char *name);

--- a/lldb/include/lldb/Expression/ObjectFileJIT.h
+++ b/lldb/include/lldb/Expression/ObjectFileJIT.h
@@ -28,6 +28,8 @@ public:
   virtual void PopulateSectionList(lldb_private::ObjectFile *obj_file,
                                    lldb_private::SectionList &section_list) = 0;
   virtual ArchSpec GetArchitecture() = 0;
+  /// Returns the Target this JIT-compiled code was produced for.
+  virtual lldb::TargetSP GetTargetSP() = 0;
 };
 
 class ObjectFileJIT : public ObjectFile {
@@ -93,6 +95,10 @@ public:
   lldb_private::ArchSpec GetArchitecture() override;
 
   lldb_private::UUID GetUUID() override;
+
+  /// Returns the Target this JIT-compiled code was produced for, or null
+  /// if the delegate that created this ObjectFile no longer exists.
+  lldb::TargetSP GetTargetSP();
 
   uint32_t GetDependentModules(lldb_private::FileSpecList &files) override;
 

--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -1381,6 +1381,7 @@ lldb::ModuleSP IRExecutionUnit::GetJITModule() {
   return m_jit_module_wp.lock();
 }
 
+// BEGIN SWIFT
 lldb::ModuleSP IRExecutionUnit::CreateJITModule(const char *name) {
   lldb::ModuleSP jit_module_sp(m_jit_module_wp.lock());
   if (jit_module_sp)
@@ -1405,8 +1406,6 @@ lldb::ModuleSP IRExecutionUnit::CreateJITModule(const char *name) {
       bool changed = false;
       jit_module_sp->SetLoadAddress(*target, 0, true, changed);
 
-      jit_module_sp->SetTypeSystemMap(target->GetTypeSystemMap());
-
       FileSpec jit_file;
       jit_file.SetFilename(name);
       jit_module_sp->SetFileSpecAndObjectName(jit_file, ConstString());
@@ -1417,6 +1416,7 @@ lldb::ModuleSP IRExecutionUnit::CreateJITModule(const char *name) {
   }
   return lldb::ModuleSP();
 }
+// END SWIFT
 
 std::recursive_mutex &IRExecutionUnit::GetLLVMGlobalContextMutex() {
   static std::recursive_mutex s_llvm_context_mutex;

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -167,6 +167,12 @@ ArchSpec ObjectFileJIT::GetArchitecture() {
   return ArchSpec();
 }
 
+TargetSP ObjectFileJIT::GetTargetSP() {
+  if (ObjectFileJITDelegateSP delegate_sp = m_delegate_wp.lock())
+    return delegate_sp->GetTargetSP();
+  return nullptr;
+}
+
 bool ObjectFileJIT::SetLoadAddress(Target &target, lldb::addr_t value,
                                    bool value_is_offset) {
   size_t num_loaded_sections = 0;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -1,4 +1,4 @@
-//===-- SwiftASTManipulator.h -----------------------------------*- C++ -*-===//
+//===-- SwiftASTManipulator.h ---------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftDiagnostic.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftDiagnostic.h
@@ -1,4 +1,4 @@
-//===-- SwiftDiagnostic.h -------------------------------------*- C++ -*-===//
+//===-- SwiftDiagnostic.h -----------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -1,4 +1,4 @@
-//===-- SwiftExpressionParser.h ---------------------------------*- C++ -*-===//
+//===-- SwiftExpressionParser.h -------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
@@ -1,4 +1,4 @@
-//===-- SwiftExpressionSourceCode.h ----------------------------------*- C++ -*-===//
+//===-- SwiftExpressionSourceCode.h --------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionVariable.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionVariable.h
@@ -1,4 +1,4 @@
-//===-- SwiftExpressionVariable.h -------------------------------*- C++ -*-===//
+//===-- SwiftExpressionVariable.h -----------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -1,4 +1,4 @@
-//===-- SwiftPersistentExpressionState.h ------------------------*- C++ -*-===//
+//===-- SwiftPersistentExpressionState.h ----------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
@@ -1,4 +1,4 @@
-//===-- SwiftREPL.h ---------------------------------------------*- C++ -*-===//
+//===-- SwiftREPL.h -------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.h
@@ -1,4 +1,4 @@
-//===-- SwiftREPLMaterializer.h ---------------------------------*- C++ -*-===//
+//===-- SwiftREPLMaterializer.h -------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftSILManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftSILManipulator.h
@@ -1,4 +1,4 @@
-//===-- SwiftSILManipulator.h -----------------------------------*- C++ -*-===//
+//===-- SwiftSILManipulator.h ---------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -1,4 +1,4 @@
-//===-- SwiftUserExpression.h -----------------------------------*- C++ -*-===//
+//===-- SwiftUserExpression.h ---------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.h
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.h
@@ -1,4 +1,4 @@
-//===-- FoundationValueTypes.h ----------------------------------*- C++ -*-===//
+//===-- FoundationValueTypes.h --------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/LogChannelSwift.h
+++ b/lldb/source/Plugins/Language/Swift/LogChannelSwift.h
@@ -1,4 +1,4 @@
-//===-- LogChannelSwift.h ---------------------------------------*- C++ -*-===//
+//===-- LogChannelSwift.h -------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.h
+++ b/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.h
@@ -1,4 +1,4 @@
-//===-- ObjCRuntimeSyntheticProvider.h --------------------------*- C++ -*-===//
+//===-- ObjCRuntimeSyntheticProvider.h ------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.h
@@ -1,4 +1,4 @@
-//===-- SwiftArray.h --------------------------------------------*- C++ -*-===//
+//===-- SwiftArray.h ------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftBasicTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftBasicTypes.h
@@ -1,4 +1,4 @@
-//===-- SwiftBasicTypes.h ---------------------------------------*- C++ -*-===//
+//===-- SwiftBasicTypes.h -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftDictionary.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftDictionary.h
@@ -1,4 +1,4 @@
-//===-- SwiftDictionary.h ---------------------------------------*- C++ -*-===//
+//===-- SwiftDictionary.h -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -1,4 +1,4 @@
-//===-- SwiftFormatters.h ---------------------------------------*- C++ -*-===//
+//===-- SwiftFormatters.h -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.h
@@ -1,4 +1,4 @@
-//===-- SwiftFrameRecognizers.h ---------------------------------*- C++ -*-===//
+//===-- SwiftFrameRecognizers.h -------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -1,4 +1,4 @@
-//===-- SwiftHashedContainer.h ----------------------------------*- C++ -*-===//
+//===-- SwiftHashedContainer.h --------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -1,4 +1,4 @@
-//===-- SwiftLanguage.h -----------------------------------------*- C++ -*-===//
+//===-- SwiftLanguage.h ---------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftMangled.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftMangled.h
@@ -1,4 +1,4 @@
-//===-- SwiftMangled.h ------------------------------------------*- C++ -*-===//
+//===-- SwiftMangled.h ----------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftMetatype.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftMetatype.h
@@ -1,4 +1,4 @@
-//===-- SwiftMetatype.h -----------------------------------------*- C++ -*-===//
+//===-- SwiftMetatype.h ---------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.h
@@ -1,4 +1,4 @@
-//===-- SwiftOptionSet.h ----------------------------------------*- C++ -*-===//
+//===-- SwiftOptionSet.h --------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.h
@@ -1,4 +1,4 @@
-//===-- SwiftOptional.h -----------------------------------------*- C++ -*-===//
+//===-- SwiftOptional.h ---------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftSet.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftSet.h
@@ -1,4 +1,4 @@
-//===-- SwiftSet.h ----------------------------------------------*- C++ -*-===//
+//===-- SwiftSet.h --------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftStringIndex.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftStringIndex.h
@@ -1,4 +1,4 @@
-//===-- SwiftStringIndex.h --------------------------------------*- C++ -*-===//
+//===-- SwiftStringIndex.h ------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftUIFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftUIFormatters.h
@@ -1,4 +1,4 @@
-//===-- SwiftUIFormatters.h -------------------------------------*- C++ -*-===//
+//===-- SwiftUIFormatters.h -----------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.h
@@ -1,4 +1,4 @@
-//===-- SwiftUnsafeTypes.h --------------------------------------*- C++ -*-===//
+//===-- SwiftUnsafeTypes.h ------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -1,4 +1,4 @@
-//===-- LLDBMemoryReader.h --------------------------------------*- C++ -*-===//
+//===-- LLDBMemoryReader.h ------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LockGuarded.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LockGuarded.h
@@ -1,4 +1,4 @@
-//===----------------- LockGuarded.h ----------------------------*- C++ -*-===//
+//===----------------- LockGuarded.h --------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -1,4 +1,4 @@
-//===-- ReflectionContextInterface.h ----------------------------*- C++ -*-===//
+//===-- ReflectionContextInterface.h --------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -1,4 +1,4 @@
-//===-- SwiftLanguageRuntime.h ----------------------------------*- C++ -*-===//
+//===-- SwiftLanguageRuntime.h --------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h
@@ -1,4 +1,4 @@
-//===-- SwiftMetadataCache.h ------------------------------------*- C++ -*-===//
+//===-- SwiftMetadataCache.h ----------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h
@@ -1,4 +1,4 @@
-//===--LLDBExplicitModuleLoader.h -------------------------------*- C++-*-===//
+//===--LLDBExplicitModuleLoader.h -----------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -1,4 +1,4 @@
-//===-- StoringDiagnosticConsumer.h -----------------------------*- C++ -*-===//
+//===-- StoringDiagnosticConsumer.h ---------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -1,4 +1,4 @@
-//===-- SwiftASTContext.h ---------------------------------------*- C++ -*-===//
+//===-- SwiftASTContext.h -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.h
@@ -1,4 +1,4 @@
-//===-- SwiftDWARFImporterForClangTypes.h -------------------*- C++ -*-----===//
+//===-- SwiftDWARFImporterForClangTypes.h ---------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -1,4 +1,4 @@
-//===-- SwiftDemangle.h ---------------------------------------*- C++ -*-===//
+//===-- SwiftDemangle.h -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -14,10 +14,13 @@
 
 #include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRefForExpressionsProxy.h"
+#include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Expression/ObjectFileJIT.h"
 #include "lldb/Symbol/CompileUnit.h"
-#include "llvm/Support/Error.h"
 #include "lldb/Utility/LLDBLog.h"
+#include "llvm/Support/Error.h"
 #include <lldb/lldb-enumerations.h>
 #include <llvm/ADT/StringRef.h>
 
@@ -31,6 +34,61 @@ TypeSystemSwift::TypeSystemSwift() : TypeSystem() {}
 
 /// TypeSystem Plugin functionality.
 /// \{
+
+/// Returns a fresh proxy for \p module's Target-scoped Swift expression
+/// TypeSystem if \p module is a JIT expression module, or null otherwise.
+///
+/// Expression lldb_private::Modules all share the same TypeSystem for
+/// the lifetime of a Target, so declarations from one expression
+/// remain visible to later ones. Handing that shared object out
+/// directly would let two expression modules' SymbolFiles compete for
+/// its single TypeSystem::SetSymbolFile() binding; the proxy gives
+/// each Module its own binding while still deferring everything else
+/// to the shared TypeSystem.
+///
+/// \verbatim
+///
+///            ┌───────────────┐  ┌─────────┐
+/// 1> 2+2   ─→│Module #1 (JIT)│─→│Proxy #1 │──┐
+///            └───────────────┘  └─────────┘  │
+///                                    ↑       │
+///                                    │       │            Target
+///                             ┌─────────────┐│               │
+///                             │SymbolFile 1 ││               ↓
+///                             └─────────────┘│ ┌───────────────────────────┐
+///                                            │ │          (real)           │
+///            ┌───────────────┐  ┌─────────┐  │ │                           │
+/// 2> foo() ─→│Module #2 (JIT)│─→│Proxy #2 │──┼→│      SwiftASTContext      │
+///            └───────────────┘  └─────────┘  │ │ PersistentExpressionState │
+///                                    ↑       │ └───────────────────────────┘
+///                                    │       │
+///                             ┌─────────────┐│
+///                             │SymbolFile 2 ││
+///                             └─────────────┘│
+///                                            │
+///            ┌───────────────┐  ┌─────────┐  │
+/// 3> bar() ─→│Module #3 (JIT)│─→│Proxy #3 │──┘
+///            └───────────────┘  └─────────┘
+///                                    ↑
+///                                    │
+///                             ┌─────────────┐
+///                             │SymbolFile 3 │
+///                             └─────────────┘
+static TypeSystemSP CreateExpressionModuleProxyIfApplicable(Module &module) {
+  LockedPtr<ObjectFile> objfile = module.GetObjectFileLocked();
+  auto *jit_objfile = llvm::dyn_cast_or_null<ObjectFileJIT>(objfile.get());
+  if (!jit_objfile)
+    return {};
+  TargetSP target_sp = jit_objfile->GetTargetSP();
+  if (!target_sp)
+    return {};
+  TypeSystemSwiftTypeRefForExpressionsSP real =
+      TypeSystemSwiftTypeRefForExpressions::GetForTarget(*target_sp);
+  if (!real)
+    return {};
+  return std::make_shared<TypeSystemSwiftTypeRefForExpressionsProxy>(real);
+}
+
 static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
                                                    Module *module,
                                                    Target *target) {
@@ -40,6 +98,8 @@ static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
   // This should be called with either a target or a module.
   if (module) {
     assert(!target);
+    if (TypeSystemSP proxy = CreateExpressionModuleProxyIfApplicable(*module))
+      return proxy;
     return std::shared_ptr<TypeSystemSwiftTypeRef>(
         new TypeSystemSwiftTypeRef(*module));
   } else if (target) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -1,4 +1,4 @@
-//===-- TypeSystemSwift.h ---------------------------------------*- C++ -*-===//
+//===-- TypeSystemSwift.h -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -1,4 +1,4 @@
-//===-- TypeSystemSwiftTypeRef.h --------------------------------*- C++ -*-===//
+//===-- TypeSystemSwiftTypeRef.h ------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRefForExpressionsProxy.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRefForExpressionsProxy.h
@@ -1,4 +1,4 @@
-//===-- TypeSystemSwiftTypeRefForExpressionsProxy.h ------------*- C++ -*-===//
+//===-- TypeSystemSwiftTypeRefForExpressionsProxy.h ----------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRefForExpressionsProxy.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRefForExpressionsProxy.h
@@ -1,0 +1,389 @@
+//===-- TypeSystemSwiftTypeRefForExpressionsProxy.h ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_TypeSystemSwiftTypeRefForExpressionsProxy_h_
+#define liblldb_TypeSystemSwiftTypeRefForExpressionsProxy_h_
+
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+
+namespace lldb_private {
+
+/// A variant of TypeSystemSwiftTypeRefForExpressions that forwards
+/// all calls to another TypeSystemSwiftTypeRefForExpressions.
+class TypeSystemSwiftTypeRefForExpressionsProxy
+    : public TypeSystemSwiftTypeRefForExpressions {
+public:
+  /// Constructing the base class with repl and playground both false skips
+  /// eagerly creating a SwiftASTContext that would never be used: this
+  /// object never accesses its own base-class state, only forwards to
+  /// \p real.
+  TypeSystemSwiftTypeRefForExpressionsProxy(
+      std::shared_ptr<TypeSystemSwiftTypeRefForExpressions> real)
+      : TypeSystemSwiftTypeRefForExpressions(lldb::eLanguageTypeSwift,
+                                             *real->GetTargetWP().lock(),
+                                             /*repl=*/false,
+                                             /*playground=*/false),
+        m_real(std::move(real)) {}
+
+  SwiftASTContextSP GetSwiftASTContext(const SymbolContext &sc) const override {
+    return m_real->GetSwiftASTContext(sc);
+  }
+  SwiftASTContextSP
+  GetSwiftASTContextOrNull(const SymbolContext &sc) const override {
+    return m_real->GetSwiftASTContextOrNull(sc);
+  }
+  void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override {
+    m_real->SetTriple(sc, triple);
+  }
+  void ClearModuleDependentCaches() override {
+    m_real->ClearModuleDependentCaches();
+  }
+  lldb::TargetWP GetTargetWP() const override { return m_real->GetTargetWP(); }
+  CompilerType
+  GetTypeFromMangledTypename(ConstString mangled_typename) override {
+    return m_real->GetTypeFromMangledTypename(mangled_typename);
+  }
+  CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,
+                                      size_t idx) override {
+    return m_real->GetGenericArgumentType(type, idx);
+  }
+  llvm::StringRef GetPluginName() override { return m_real->GetPluginName(); }
+  bool SupportsLanguage(lldb::LanguageType language) override {
+    return m_real->SupportsLanguage(language);
+  }
+  Status IsCompatible() override { return m_real->IsCompatible(); }
+  plugin::dwarf::DWARFASTParser *GetDWARFParser() override {
+    return m_real->GetDWARFParser();
+  }
+  npdb::PdbAstBuilder *GetNativePDBParser() override {
+    return m_real->GetNativePDBParser();
+  }
+  ConstString DeclGetName(void *opaque_decl) override {
+    return m_real->DeclGetName(opaque_decl);
+  }
+  std::vector<CompilerDecl>
+  DeclContextFindDeclByName(void *opaque_decl_ctx, ConstString name,
+                            const bool ignore_imported_decls) override {
+    return m_real->DeclContextFindDeclByName(opaque_decl_ctx, name,
+                                             ignore_imported_decls);
+  }
+  bool DeclContextIsContainedInLookup(void *opaque_decl_ctx,
+                                      void *other_opaque_decl_ctx) override {
+    return m_real->DeclContextIsContainedInLookup(opaque_decl_ctx,
+                                                  other_opaque_decl_ctx);
+  }
+  bool IsAggregateType(lldb::opaque_compiler_type_t type) override {
+    return m_real->IsAggregateType(type);
+  }
+  bool IsDefined(lldb::opaque_compiler_type_t type) override {
+    return m_real->IsDefined(type);
+  }
+  bool IsFunctionType(lldb::opaque_compiler_type_t type) override {
+    return m_real->IsFunctionType(type);
+  }
+  size_t
+  GetNumberOfFunctionArguments(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetNumberOfFunctionArguments(type);
+  }
+  CompilerType GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
+                                          const size_t index) override {
+    return m_real->GetFunctionArgumentAtIndex(type, index);
+  }
+  bool IsFunctionPointerType(lldb::opaque_compiler_type_t type) override {
+    return m_real->IsFunctionPointerType(type);
+  }
+  bool IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
+                             CompilerType *target_type, bool check_cplusplus,
+                             bool check_objc) override {
+    return m_real->IsPossibleDynamicType(type, target_type, check_cplusplus,
+                                         check_objc);
+  }
+  bool IsPointerType(lldb::opaque_compiler_type_t type,
+                     CompilerType *pointee_type) override {
+    return m_real->IsPointerType(type, pointee_type);
+  }
+  bool IsVoidType(lldb::opaque_compiler_type_t type) override {
+    return m_real->IsVoidType(type);
+  }
+  uint32_t GetPointerByteSize() override {
+    return m_real->GetPointerByteSize();
+  }
+  ConstString GetTypeName(lldb::opaque_compiler_type_t type,
+                          bool BaseOnly) override {
+    return m_real->GetTypeName(type, BaseOnly);
+  }
+  ConstString GetDisplayTypeName(lldb::opaque_compiler_type_t type,
+                                 const SymbolContext *sc) override {
+    return m_real->GetDisplayTypeName(type, sc);
+  }
+  ConstString GetMangledTypeName(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetMangledTypeName(type);
+  }
+  uint32_t GetTypeInfo(lldb::opaque_compiler_type_t type,
+                       CompilerType *pointee_or_element_clang_type) override {
+    return m_real->GetTypeInfo(type, pointee_or_element_clang_type);
+  }
+  lldb::TypeClass GetTypeClass(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetTypeClass(type);
+  }
+  CompilerType GetArrayElementType(lldb::opaque_compiler_type_t type,
+                                   ExecutionContextScope *exe_scope) override {
+    return m_real->GetArrayElementType(type, exe_scope);
+  }
+  CompilerType GetCanonicalType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetCanonicalType(type);
+  }
+  int GetFunctionArgumentCount(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetFunctionArgumentCount(type);
+  }
+  CompilerType GetFunctionArgumentTypeAtIndex(lldb::opaque_compiler_type_t type,
+                                              size_t idx) override {
+    return m_real->GetFunctionArgumentTypeAtIndex(type, idx);
+  }
+  CompilerType
+  GetFunctionReturnType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetFunctionReturnType(type);
+  }
+  size_t GetNumMemberFunctions(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetNumMemberFunctions(type);
+  }
+  TypeMemberFunctionImpl
+  GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
+                           size_t idx) override {
+    return m_real->GetMemberFunctionAtIndex(type, idx);
+  }
+  CompilerType GetPointeeType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetPointeeType(type);
+  }
+  CompilerType GetPointerType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetPointerType(type);
+  }
+  CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) override {
+    return m_real->GetBasicTypeFromAST(basic_type);
+  }
+  llvm::Expected<uint64_t>
+  GetBitSize(lldb::opaque_compiler_type_t type,
+             ExecutionContextScope *exe_scope) override {
+    return m_real->GetBitSize(type, exe_scope);
+  }
+  std::optional<uint64_t>
+  GetByteStride(lldb::opaque_compiler_type_t type,
+                ExecutionContextScope *exe_scope) override {
+    return m_real->GetByteStride(type, exe_scope);
+  }
+  lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetEncoding(type);
+  }
+  llvm::Expected<uint32_t>
+  GetNumChildren(lldb::opaque_compiler_type_t type,
+                 bool omit_empty_base_classes,
+                 const ExecutionContext *exe_ctx) override {
+    return m_real->GetNumChildren(type, omit_empty_base_classes, exe_ctx);
+  }
+  uint32_t GetNumFields(lldb::opaque_compiler_type_t type,
+                        ExecutionContext *exe_ctx = nullptr) override {
+    return m_real->GetNumFields(type, exe_ctx);
+  }
+  CompilerType GetFieldAtIndex(lldb::opaque_compiler_type_t type, size_t idx,
+                               std::string &name, uint64_t *bit_offset_ptr,
+                               uint32_t *bitfield_bit_size_ptr,
+                               bool *is_bitfield_ptr) override {
+    return m_real->GetFieldAtIndex(type, idx, name, bit_offset_ptr,
+                                   bitfield_bit_size_ptr, is_bitfield_ptr);
+  }
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
+      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
+      bool transparent_pointers, bool omit_empty_base_classes,
+      bool ignore_array_bounds, std::string &child_name,
+      uint32_t &child_byte_size, int32_t &child_byte_offset,
+      uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
+      bool &child_is_base_class, bool &child_is_deref_of_parent,
+      ValueObject *valobj, uint64_t &language_flags) override {
+    return m_real->GetChildCompilerTypeAtIndex(
+        type, exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
+        ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
+        child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
+        child_is_deref_of_parent, valobj, language_flags);
+  }
+  size_t
+  GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
+                                llvm::StringRef name, ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                std::vector<uint32_t> &child_indexes) override {
+    return m_real->GetIndexOfChildMemberWithName(
+        type, name, exe_ctx, omit_empty_base_classes, child_indexes);
+  }
+  size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
+                                 bool expand_pack) override {
+    return m_real->GetNumTemplateArguments(type, expand_pack);
+  }
+  lldb::TemplateArgumentKind
+  GetTemplateArgumentKind(lldb::opaque_compiler_type_t type, size_t idx,
+                          bool expand_pack) override {
+    return m_real->GetTemplateArgumentKind(type, idx, expand_pack);
+  }
+  CompilerType GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
+                                       size_t idx, bool expand_pack) override {
+    return m_real->GetTypeTemplateArgument(type, idx, expand_pack);
+  }
+  CompilerType
+  GetTypeForFormatters(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetTypeForFormatters(type);
+  }
+  LazyBool ShouldPrintAsOneLiner(lldb::opaque_compiler_type_t type,
+                                 ValueObject *valobj) override {
+    return m_real->ShouldPrintAsOneLiner(type, valobj);
+  }
+  bool IsMeaninglessWithoutDynamicResolution(
+      lldb::opaque_compiler_type_t type) override {
+    return m_real->IsMeaninglessWithoutDynamicResolution(type);
+  }
+  void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull,
+      ExecutionContextScope *exe_scope = nullptr) override {
+    m_real->DumpTypeDescription(type, level, exe_scope);
+  }
+  void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type, Stream &s,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull,
+      ExecutionContextScope *exe_scope = nullptr) override {
+    m_real->DumpTypeDescription(type, s, level, exe_scope);
+  }
+  void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull,
+      ExecutionContextScope *exe_scope = nullptr) override {
+    m_real->DumpTypeDescription(type, print_help_if_available,
+                                print_extensions_if_available, level,
+                                exe_scope);
+  }
+  void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type, Stream *s,
+      bool print_help_if_available, bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull,
+      ExecutionContextScope *exe_scope = nullptr) override {
+    m_real->DumpTypeDescription(type, s, print_help_if_available,
+                                print_extensions_if_available, level,
+                                exe_scope);
+  }
+  bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
+                                CompilerType *pointee_type) override {
+    return m_real->IsPointerOrReferenceType(type, pointee_type);
+  }
+  std::optional<size_t>
+  GetTypeBitAlign(lldb::opaque_compiler_type_t type,
+                  ExecutionContextScope *exe_scope) override {
+    return m_real->GetTypeBitAlign(type, exe_scope);
+  }
+  CompilerType GetBuiltinTypeForEncodingAndBitSize(lldb::Encoding encoding,
+                                                   size_t bit_size) override {
+    return m_real->GetBuiltinTypeForEncodingAndBitSize(encoding, bit_size);
+  }
+  bool IsTypedefType(lldb::opaque_compiler_type_t type) override {
+    return m_real->IsTypedefType(type);
+  }
+  CompilerType GetTypedefedType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetTypedefedType(type);
+  }
+  CompilerType
+  GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetFullyUnqualifiedType(type);
+  }
+  uint32_t GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetNumDirectBaseClasses(type);
+  }
+  CompilerType GetDirectBaseClassAtIndex(lldb::opaque_compiler_type_t type,
+                                         size_t idx,
+                                         uint32_t *bit_offset_ptr) override {
+    return m_real->GetDirectBaseClassAtIndex(type, idx, bit_offset_ptr);
+  }
+  bool IsReferenceType(lldb::opaque_compiler_type_t type,
+                       CompilerType *pointee_type, bool *is_rvalue) override {
+    return m_real->IsReferenceType(type, pointee_type, is_rvalue);
+  }
+  bool IsImportedType(lldb::opaque_compiler_type_t type,
+                      CompilerType *original_type) override {
+    return m_real->IsImportedType(type, original_type);
+  }
+  bool IsErrorType(lldb::opaque_compiler_type_t type,
+                   const ExecutionContext *exe_ctx) override {
+    return m_real->IsErrorType(type, exe_ctx);
+  }
+  CompilerType GetErrorType(swift::Mangle::ManglingFlavor flavor) override {
+    return m_real->GetErrorType(flavor);
+  }
+  CompilerType GetWeakReferent(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetWeakReferent(type);
+  }
+  CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetReferentType(type);
+  }
+  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type,
+                               ExecutionContextScope *exe_scope) override {
+    return m_real->GetInstanceType(type, exe_scope);
+  }
+  CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetStaticSelfType(type);
+  }
+  CompilerType CreateTupleType(const std::vector<TupleElement> &elements,
+                               swift::Mangle::ManglingFlavor flavor) override {
+    return m_real->CreateTupleType(elements, flavor);
+  }
+  bool IsTupleType(lldb::opaque_compiler_type_t type) override {
+    return m_real->IsTupleType(type);
+  }
+  std::optional<NonTriviallyManagedReferenceKind>
+  GetNonTriviallyManagedReferenceKind(
+      lldb::opaque_compiler_type_t type) override {
+    return m_real->GetNonTriviallyManagedReferenceKind(type);
+  }
+  CompilerType
+  CreateGenericTypeParamType(unsigned int depth, unsigned int index,
+                             swift::Mangle::ManglingFlavor flavor) override {
+    return m_real->CreateGenericTypeParamType(depth, index, flavor);
+  }
+  std::string GetSwiftName(const clang::Decl *clang_decl,
+                           TypeSystemClang &clang_typesystem) override {
+    return m_real->GetSwiftName(clang_decl, clang_typesystem);
+  }
+  CompilerType
+  ConvertClangTypeToSwiftType(CompilerType clang_type,
+                              swift::Mangle::ManglingFlavor flavor) override {
+    return m_real->ConvertClangTypeToSwiftType(clang_type, flavor);
+  }
+  UserExpression *GetUserExpression(llvm::StringRef expr,
+                                    llvm::StringRef prefix,
+                                    SourceLanguage language,
+                                    Expression::ResultType desired_type,
+                                    const EvaluateExpressionOptions &options,
+                                    ValueObject *ctx_obj) override {
+    return m_real->GetUserExpression(expr, prefix, language, desired_type,
+                                     options, ctx_obj);
+  }
+  PersistentExpressionState *GetPersistentExpressionState() override {
+    return m_real->GetPersistentExpressionState();
+  }
+  ExecutionContextRef
+  GetExecutionContextForType(lldb::opaque_compiler_type_t type) override {
+    return m_real->GetExecutionContextForType(type);
+  }
+
+private:
+  std::shared_ptr<TypeSystemSwiftTypeRefForExpressions> m_real;
+};
+
+} // namespace lldb_private
+
+#endif // liblldb_TypeSystemSwiftTypeRefForExpressionsProxy_h_


### PR DESCRIPTION
On stable/21.x all JIT-compiled modules from REPL expressions would register their SymbolFile as the one SymbolFile belonging to the persitent expression type system. This interface was removed upstream because it allowed for race conditions.

This patch creates a proxy TypeSystem that forwards to the persistent expression TypeSystem for each JIT module, so each SymbolFile can be tied to its own TypeSystem.

Assisted-by: claude