### PR TITLE
[Cherry-pick into next] [LLDB] Bump deployment target of tests that depend on newer APIs

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -51,6 +51,16 @@ ifeq "$(findstring -target,$(SWIFTFLAGS))" ""
   SWIFTFLAGS += $(TARGET_SWIFTFLAGS)
 endif
 
+# A test whose sources use an API that was introduced in a specific OS
+# version sets SWIFT_DEPLOYMENT_TARGET to that version. Note that this
+# only works with versions >= 26 when the versioning scheme was unified.
+ifneq "$(SWIFT_DEPLOYMENT_TARGET)" ""
+ifneq "$(findstring -apple-,$(TARGET_SWIFTFLAGS))" ""
+  SWIFT_DEPLOYMENT_TRIPLE := $(shell echo '$(TARGET_SWIFTFLAGS)' | sed -E 's/.*-target ([^ ]+).*/\1/; s/^([^-]*-[^-]*-[a-zA-Z]+)[0-9.]*/\1$(SWIFT_DEPLOYMENT_TARGET)/')
+  SWIFTFLAGS += -target $(SWIFT_DEPLOYMENT_TRIPLE)
+endif
+endif
+
 ifeq "$(OS)" "Windows_NT"
   SWIFTFLAGS += -resource-dir "$(SWIFTSDKROOT)/usr/lib/swift"
 endif

--- a/lldb/test/API/lang/swift/observation/Makefile
+++ b/lldb/test/API/lang/swift/observation/Makefile
@@ -1,2 +1,4 @@
 SWIFT_SOURCES := main.swift
+SWIFT_DEPLOYMENT_TARGET := 26
+
 include Makefile.rules

--- a/lldb/test/API/lang/swift/other_arch_dylib/Makefile
+++ b/lldb/test/API/lang/swift/other_arch_dylib/Makefile
@@ -2,6 +2,10 @@ export SWIFT_ENABLE_EXPLICIT_MODULES := NO
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS = -F$(BUILDDIR) -Xlinker -rpath -Xlinker $(BUILDDIR)
 
+# OtherArch.framework below is built for macOS 15, and a module cannot be
+# imported by code with a lower deployment target.
+SWIFT_DEPLOYMENT_TARGET := 26
+
 all: OtherArch.framework/Versions/A/OtherArch $(EXE)
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/swiftui_formatters/Makefile
+++ b/lldb/test/API/lang/swift/swiftui_formatters/Makefile
@@ -6,5 +6,6 @@ SWIFT_SOURCES := main.swift
 # the plugin server can't start ("malformed response") and the macro fails to
 # resolve. Disable the macro-plugin sandbox so the test subject builds.
 SWIFTFLAGS_EXTRAS := -Xfrontend -disable-sandbox
+SWIFT_DEPLOYMENT_TARGET := 26
 
 include Makefile.rules


### PR DESCRIPTION
```
commit 0452590402eeb9dd290347d8d7d3f5a69e2f25af
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Aug 11 14:47:01 2026 -0700

    [LLDB] Bump deployment target of tests that depend on newer APIs
```
