### PR TITLE
[lldb] Don't substitute Clang mapped types with missing overlays in embedded Swift

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -284,11 +284,14 @@ MemoryReaderLocalBufferHolder SwiftLanguageRuntime::PushLocalBuffer(uint64_t loc
 class LLDBTypeInfoProvider : public swift::remote::TypeInfoProvider {
   SwiftLanguageRuntime &m_runtime;
   TypeSystemSwiftTypeRef &m_ts;
+  /// The mangling flavor of the program the type info is being read for.
+  swift::Mangle::ManglingFlavor m_flavor;
 
 public:
   LLDBTypeInfoProvider(SwiftLanguageRuntime &runtime,
-                       TypeSystemSwiftTypeRef &ts)
-      : m_runtime(runtime), m_ts(ts) {}
+                       TypeSystemSwiftTypeRef &ts,
+                       swift::Mangle::ManglingFlavor flavor)
+      : m_runtime(runtime), m_ts(ts), m_flavor(flavor) {}
 
   swift::remote::TypeInfoProvider::IdType getId() override {
     return (void *)((char *)&m_ts + m_runtime.GetGeneration());
@@ -431,9 +434,8 @@ public:
           auto *key = swift_type.GetMangledTypeName().AsCString(nullptr);
           m_runtime.RegisterAnonymousClangType(key, field_type);
         } else {
-          // TODO: The mangling flavor should be threaded through getTypeInfo.
-          swift_type = typesystem.ConvertClangTypeToSwiftType(
-              field_type, swift::Mangle::ManglingFlavor::Default);
+          swift_type =
+              typesystem.ConvertClangTypeToSwiftType(field_type, m_flavor);
         }
         const swift::reflection::TypeRef *typeref = nullptr;
         auto typeref_or_err = m_runtime.GetTypeRef(swift_type, &typesystem);
@@ -1064,7 +1066,7 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
       if (instance != LLDB_INVALID_ADDRESS) {
         auto *desc_finder =
             ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope());
-        LLDBTypeInfoProvider tip(m_runtime, ts);
+        LLDBTypeInfoProvider tip(m_runtime, ts, m_flavor);
         ThreadSafeReflectionContext reflection_ctx =
             m_runtime.GetReflectionContext();
         if (reflection_ctx) {
@@ -1322,7 +1324,7 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
               llvm::dyn_cast_or_null<swift::reflection::ObjCClassTypeRef>(tr))
         return visit_objcclass(*obj_tr);
 
-      LLDBTypeInfoProvider tip(m_runtime, ts);
+      LLDBTypeInfoProvider tip(m_runtime, ts, m_flavor);
       auto cti_or_err = reflection_ctx->GetClassInstanceTypeInfo(
           *tr, &tip,
           ts.GetDescriptorFinder(m_exe_ctx.GetBestExecutionContextScope()));
@@ -1445,7 +1447,7 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
       return supers.size() >= 2;
     };
 
-    LLDBTypeInfoProvider tip(m_runtime, ts);
+    LLDBTypeInfoProvider tip(m_runtime, ts, m_flavor);
     lldb::addr_t instance = ::MaskMaybeBridgedPointer(
         m_runtime.GetProcess(), m_valobj->GetPointerValue().address);
 
@@ -1832,7 +1834,7 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
 
     ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
     // The indirect enum field should point to a closure context.
-    LLDBTypeInfoProvider tip(*this, ts);
+    LLDBTypeInfoProvider tip(*this, ts, flavor);
     auto ti_or_err = reflection_ctx->GetTypeInfoFromInstance(
         pointer, &tip, ts.GetDescriptorFinder());
     if (!ti_or_err)
@@ -2048,7 +2050,8 @@ bool SwiftLanguageRuntime::ForEachSuperClassType(
   auto &ts = *tr_ts;
 
   ExecutionContext exe_ctx(instance.GetExecutionContextRef());
-  LLDBTypeInfoProvider tip(*this, ts);
+  auto flavor = GetManglingFlavor(instance_type.GetMangledTypeName());
+  LLDBTypeInfoProvider tip(*this, ts, flavor);
   lldb::addr_t pointer = instance.GetPointerValue().address;
   return reflection_ctx->ForEachSuperClassType(&tip, ts.GetDescriptorFinder(),
                                                pointer, fn);
@@ -4244,7 +4247,7 @@ SwiftLanguageRuntime::GetSwiftRuntimeTypeInfo(
       flavor == swift::Mangle::ManglingFlavor::Embedded ? g_debuginfo
                                                         : g_reflection,
       &GetProcess().GetTarget().GetDebugger(), *GetMemoryReader());
-  LLDBTypeInfoProvider provider(*this, ts);
+  LLDBTypeInfoProvider provider(*this, ts, flavor);
   return reflection_ctx->GetTypeInfo(type, &provider,
                                      ts.GetDescriptorFinder(exe_scope));
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -578,10 +578,52 @@ TypeSystemSwiftTypeRef::CreateClangStructType(llvm::StringRef name) {
   return RemangleAsType(dem, type, flavor);
 }
 
+namespace {
+/// A row of the ClangImporter's MappedTypes.def substitution table: the Swift
+/// module and type name a C type is substituted with.
+struct MappedTypeName {
+  /// Empty if no row matched.
+  llvm::StringRef module_name;
+  llvm::StringRef type_name;
+
+  /// Whether a program compiled with \p flavor can reach this substitution.
+  ///
+  /// The stdlib is present in every program, but the other modules named by the
+  /// table are Darwin overlays, and embedded Swift has none of them.
+  bool isReachableIn(swift::Mangle::ManglingFlavor flavor) const {
+    return module_name == swift::STDLIB_NAME ||
+           flavor != swift::Mangle::ManglingFlavor::Embedded;
+  }
+};
+} // namespace
+
+/// Look \p clang_name up in the ClangImporter's mapped-type table. A match is
+/// not necessarily usable; see MappedTypeName::isReachableIn().
+static MappedTypeName GetMappedTypeName(llvm::StringRef clang_name) {
+  // This X-macro expands to something like:
+  // if (clang_name == "UInt8")   return {"Swift", "UInt8"};          else
+  // if (clang_name == "UInt16")  return {"Swift", "UInt16"};         else
+  // ...
+  // if (clang_name == "CGFloat") return {"CoreGraphics", "CGFloat"}; else
+  // if (clang_name == "NSStringEncoding") return {"Swift", "UInt"};  else
+  // return {};
+  using namespace swift;
+#define MAP_TYPE(C_TYPE_NAME, C_TYPE_KIND, C_TYPE_BITWIDTH, SWIFT_MODULE_NAME, \
+                 SWIFT_TYPE_NAME, CAN_BE_MISSING, C_NAME_MAPPING)              \
+  if (clang_name == C_TYPE_NAME)                                               \
+    return {SWIFT_MODULE_NAME, SWIFT_TYPE_NAME};                               \
+  else
+#include "swift/../../lib/ClangImporter/MappedTypes.def"
+#undef MAP_TYPE
+  // The last dangling else in the macro is for this return.
+  return {};
+}
+
 /// Return a demangle tree leaf node representing \p clang_type.
 swift::Demangle::NodePointer
 TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
-                                         swift::Demangle::Demangler &dem) {
+                                         swift::Demangle::Demangler &dem,
+                                         swift::Mangle::ManglingFlavor flavor) {
   using namespace swift;
   using namespace swift::Demangle;
   Node::Kind kind = Node::Kind::Structure;
@@ -611,98 +653,113 @@ TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
   if (clang_type.IsAnonymousType())
     return nullptr;
   llvm::StringRef clang_name = clang_type.GetTypeName().GetStringRef();
-#define MAP_TYPE(C_TYPE_NAME, C_TYPE_KIND, C_TYPE_BITWIDTH, SWIFT_MODULE_NAME, \
-                 SWIFT_TYPE_NAME, CAN_BE_MISSING, C_NAME_MAPPING)              \
-  if (clang_name == C_TYPE_NAME) {                                             \
-    module_name = (SWIFT_MODULE_NAME);                                         \
-    swift_name = (SWIFT_TYPE_NAME);                                            \
-  } else
-#include "swift/../../lib/ClangImporter/MappedTypes.def"
-#undef MAP_TYPE
-  // The last dangling else in the macro is for this switch.
-  switch (clang_type.GetTypeClass()) {
-  case eTypeClassClass:
-  case eTypeClassObjCObjectPointer:
-  case eTypeClassObjCInterface:
-    // Special cases for CF-bridged classes. (Better way to do this by
-    // inspecting the clang:Type?)
-    if (clang_name != "NSNumber" && clang_name != "NSValue")
-      kind = Node::Kind::Class;
-    // Objective-C objects are first-class entities, not pointers.
-    pointee = {};
-    break;
-  case eTypeClassBuiltin:
-    kind = Node::Kind::Structure;
-    // Ask ClangImporter about the builtin type's Swift name.
-    if (auto ts =
-            clang_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>()) {
-      if (clang_type == ts->GetPointerSizedIntType(true))
-        swift_name = "Int";
-      else if (clang_type == ts->GetPointerSizedIntType(false))
-        swift_name = "UInt";
-      else
-        swift_name =
-            swift::importer::getClangTypeNameForOmission(
-                ts->getASTContext(), ClangUtil::GetQualType(clang_type))
-                .Name;
-      module_name = swift::STDLIB_NAME;
-    }
-    break;
-  case eTypeClassArray: {
-    // Ideally we would refactor ClangImporter::ImportType to use an
-    // abstract TypeBuilder and reuse it here.
-    auto *array_type = llvm::dyn_cast<clang::ConstantArrayType>(
-        ClangUtil::GetQualType(clang_type).getTypePtr());
-    if (!array_type)
-      break;
-    auto elem_type = array_type->getElementType();
-    auto size = array_type->getSize().getZExtValue();
-    if (size > 4096)
-      break;
-    auto *tuple = dem.createNode(Node::Kind::Tuple);
-    NodePointer element_type = GetClangTypeNode(
-        {clang_type.GetTypeSystem(), elem_type.getAsOpaquePtr()}, dem);
-    if (!element_type)
-      return nullptr;
-    for (unsigned i = 0; i < size; ++i) {
-      NodePointer tuple_element = dem.createNode(Node::Kind::TupleElement);
-      NodePointer type = dem.createNode(Node::Kind::Type);
-      type->addChild(element_type, dem);
-      tuple_element->addChild(type, dem);
-      tuple->addChild(tuple_element, dem);
-    }
-    return tuple;
+  MappedTypeName mapped = GetMappedTypeName(clang_name);
+  bool should_substitute = !mapped.module_name.empty();
+  if (should_substitute && !mapped.isReachableIn(flavor)) {
+    // Mirror what the compiler does with a substitution it cannot resolve:
+    // VisitTypedefType() in ClangImporter/ImportType.cpp falls back to
+    // Visit(type->desugar()), i.e. it imports the typedef's underlying type.
+    LLDB_LOGV(GetLog(LLDBLog::Types),
+              "[GetClangTypeNode] mapped clang type {0} substitutes into {1}, "
+              "which this mangling flavor has no overlay for; importing the "
+              "underlying type",
+              clang_name, mapped.module_name);
+    should_substitute = false;
+    if (CompilerType desugared = clang_type.GetTypedefedType())
+      if (NodePointer node = GetClangTypeNode(desugared, dem, flavor))
+        // Reapply the pointer peeled off before the table lookup, if any.
+        return pointee ? GetPointerTo(dem, node) : node;
   }
-  case eTypeClassTypedef:
-    kind = Node::Kind::TypeAlias;
-    pointee = {};
-    break;
-  case eTypeClassVector: {
-    CompilerType element_type;
-    uint64_t size;
-    bool is_vector = clang_type.IsVectorType(&element_type, &size);
-    if (!is_vector)
+  if (should_substitute) {
+    module_name = mapped.module_name;
+    swift_name = mapped.type_name;
+  } else {
+    switch (clang_type.GetTypeClass()) {
+    case eTypeClassClass:
+    case eTypeClassObjCObjectPointer:
+    case eTypeClassObjCInterface:
+      // Special cases for CF-bridged classes. (Better way to do this by
+      // inspecting the clang:Type?)
+      if (clang_name != "NSNumber" && clang_name != "NSValue")
+        kind = Node::Kind::Class;
+      // Objective-C objects are first-class entities, not pointers.
+      pointee = {};
       break;
-
-    auto qual_type = ClangUtil::GetQualType(clang_type);
-    const auto *ptr = qual_type.getTypePtrOrNull();
-    if (!ptr)
+    case eTypeClassBuiltin:
+      kind = Node::Kind::Structure;
+      // Ask ClangImporter about the builtin type's Swift name.
+      if (auto ts =
+              clang_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>()) {
+        if (clang_type == ts->GetPointerSizedIntType(true))
+          swift_name = "Int";
+        else if (clang_type == ts->GetPointerSizedIntType(false))
+          swift_name = "UInt";
+        else
+          swift_name =
+              swift::importer::getClangTypeNameForOmission(
+                  ts->getASTContext(), ClangUtil::GetQualType(clang_type))
+                  .Name;
+        module_name = swift::STDLIB_NAME;
+      }
       break;
-
-    // Check if this is an extended vector type.
-    if (!llvm::isa<clang::DependentSizedExtVectorType>(ptr) &&
-        !llvm::isa<clang::ExtVectorType>(ptr))
+    case eTypeClassArray: {
+      // Ideally we would refactor ClangImporter::ImportType to use an
+      // abstract TypeBuilder and reuse it here.
+      auto *array_type = llvm::dyn_cast<clang::ConstantArrayType>(
+          ClangUtil::GetQualType(clang_type).getTypePtr());
+      if (!array_type)
+        break;
+      auto elem_type = array_type->getElementType();
+      auto size = array_type->getSize().getZExtValue();
+      if (size > 4096)
+        break;
+      auto *tuple = dem.createNode(Node::Kind::Tuple);
+      NodePointer element_type = GetClangTypeNode(
+          {clang_type.GetTypeSystem(), elem_type.getAsOpaquePtr()}, dem,
+          flavor);
+      if (!element_type)
+        return nullptr;
+      for (unsigned i = 0; i < size; ++i) {
+        NodePointer tuple_element = dem.createNode(Node::Kind::TupleElement);
+        NodePointer type = dem.createNode(Node::Kind::Type);
+        type->addChild(element_type, dem);
+        tuple_element->addChild(type, dem);
+        tuple->addChild(tuple_element, dem);
+      }
+      return tuple;
+    }
+    case eTypeClassTypedef:
+      kind = Node::Kind::TypeAlias;
+      pointee = {};
       break;
+    case eTypeClassVector: {
+      CompilerType element_type;
+      uint64_t size;
+      bool is_vector = clang_type.IsVectorType(&element_type, &size);
+      if (!is_vector)
+        break;
 
-    NodePointer element_type_node = GetClangTypeNode(element_type, dem);
-    if (!element_type_node)
-      return nullptr;
-    llvm::SmallVector<NodePointer, 1> elements({element_type_node});
-    return CreateBoundGenericStruct("SIMD" + std::to_string(size),
-                                    swift::STDLIB_NAME, elements, dem);
-  }
-  default:
-    break;
+      auto qual_type = ClangUtil::GetQualType(clang_type);
+      const auto *ptr = qual_type.getTypePtrOrNull();
+      if (!ptr)
+        break;
+
+      // Check if this is an extended vector type.
+      if (!llvm::isa<clang::DependentSizedExtVectorType>(ptr) &&
+          !llvm::isa<clang::ExtVectorType>(ptr))
+        break;
+
+      NodePointer element_type_node =
+          GetClangTypeNode(element_type, dem, flavor);
+      if (!element_type_node)
+        return nullptr;
+      llvm::SmallVector<NodePointer, 1> elements({element_type_node});
+      return CreateBoundGenericStruct("SIMD" + std::to_string(size),
+                                      swift::STDLIB_NAME, elements, dem);
+    }
+    default:
+      break;
+    }
   }
   NodePointer module =
       dem.createNodeWithAllocatedText(Node::Kind::Module, module_name);
@@ -1641,7 +1698,7 @@ TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
     for (unsigned alias_depth = 0; alias_depth < 64; ++alias_depth) {
       auto node_clangtype = ResolveTypeAlias(dem, node, flavor);
       if (CompilerType clang_type = node_clangtype.second) {
-        if (auto result = GetClangTypeNode(clang_type, dem))
+        if (auto result = GetClangTypeNode(clang_type, dem, flavor))
           return result;
         // Failed to convert that clang type into a demangle node.
         return node;
@@ -2143,8 +2200,9 @@ uint32_t TypeSystemSwiftTypeRef::CollectTypeInfo(
     }
     if ((type_class & eTypeClassBuiltin)) {
       swift_flags &= ~eTypeIsStructUnion;
-      swift_flags |= CollectTypeInfo(dem, GetClangTypeNode(clang_type, dem),
-                                     flavor, unresolved_typealias);
+      swift_flags |=
+          CollectTypeInfo(dem, GetClangTypeNode(clang_type, dem, flavor),
+                          flavor, unresolved_typealias);
       return;
     }
   };
@@ -4731,13 +4789,13 @@ TypeSystemSwiftTypeRef::GetDescriptorFinder(ExecutionContextScope *exe_scope) {
   return llvm::cast<DWARFASTParserSwift>(GetDWARFParser());
 }
 
-swift::Demangle::NodePointer
-TypeSystemSwiftTypeRef::GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
-                                             CompilerType clang_type) {
+swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetClangTypeTypeNode(
+    swift::Demangle::Demangler &dem, CompilerType clang_type,
+    swift::Mangle::ManglingFlavor flavor) {
   assert(clang_type.GetTypeSystem().isa_and_nonnull<TypeSystemClang>() &&
          "expected a clang type");
   using namespace swift::Demangle;
-  NodePointer node = GetClangTypeNode(clang_type, dem);
+  NodePointer node = GetClangTypeNode(clang_type, dem, flavor);
   if (!node)
     return nullptr;
   NodePointer type = dem.createNode(Node::Kind::Type);
@@ -4754,7 +4812,8 @@ CompilerType TypeSystemSwiftTypeRef::ConvertClangTypeToSwiftType(
     return {};
 
   swift::Demangle::Demangler dem;
-  swift::Demangle::NodePointer node = GetClangTypeTypeNode(dem, clang_type);
+  swift::Demangle::NodePointer node =
+      GetClangTypeTypeNode(dem, clang_type, flavor);
   CompilerType result = RemangleAsType(dem, node, flavor);
   m_imported_type_map.Insert(result.GetMangledTypeName().AsCString(nullptr),
                              clang_type);
@@ -6148,7 +6207,7 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
       type_node->addChild(resolved, dem);
     } else {
       NodePointer clang_node =
-          GetClangTypeNode(std::get<CompilerType>(pair), dem);
+          GetClangTypeNode(std::get<CompilerType>(pair), dem, flavor);
       if (!clang_node)
         return {};
       type_node->addChild(clang_node, dem);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -661,11 +661,12 @@ protected:
                            bool &unresolved_typealias);
 
   swift::Demangle::NodePointer
-  GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem);
+  GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem,
+                   swift::Mangle::ManglingFlavor flavor);
 
   swift::Demangle::NodePointer
-  GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
-                       CompilerType clang_type);
+  GetClangTypeTypeNode(swift::Demangle::Demangler &dem, CompilerType clang_type,
+                       swift::Mangle::ManglingFlavor flavor);
 
   virtual ExecutionContextRef
   GetExecutionContextForType(lldb::opaque_compiler_type_t type) {

--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
@@ -8,7 +8,6 @@ from lldbsuite.test.decorators import *
 
 class TestExternalProviderExtraInhabitants(TestBase):
 
-    @skipEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
     def test(self):


### PR DESCRIPTION
TypeSystemSwiftTypeRef textually includes the compiler's
lib/ClangImporter/MappedTypes.def and applied every row unconditionally, with no
mangling-flavor check. Embedded Swift doesn't have overlays for types
that are not on the swift standard library (for example, CGFloat), so
this failed to produce the correct type name.

rdar://184659844
