### PR TITLE
[BoundsSafety] regenerate soft-trap tests with ptrauth module flags

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/soft-traps/call_minimal.c
+++ b/clang/test/BoundsSafety/CodeGen/soft-traps/call_minimal.c
@@ -16,7 +16,7 @@
 #include <ptrcheck.h>
 
 // UNOPT-LABEL: define dso_local i32 @read(
-// UNOPT-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-NEXT:  [[ENTRY:.*:]]
 // UNOPT-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -46,17 +46,17 @@
 // UNOPT-NEXT:    call preserve_allcc void @__bounds_safety_soft_trap() #[[ATTR2]], !annotation [[META1]]
 // UNOPT-NEXT:    br label %[[CONT2]], !annotation [[META1]]
 // UNOPT:       [[CONT2]]:
-// UNOPT-NEXT:    [[TMP4:%.*]] = icmp uge ptr [[ARRAYIDX]], [[WIDE_PTR_LB]], !annotation [[META3:![0-9]+]]
-// UNOPT-NEXT:    br i1 [[TMP4]], label %[[CONT4:.*]], label %[[TRAP3:.*]], !prof [[PROF2]], !annotation [[META3]]
+// UNOPT-NEXT:    [[TMP4:%.*]] = icmp uge ptr [[ARRAYIDX]], [[WIDE_PTR_LB]], !annotation [[META2:![0-9]+]]
+// UNOPT-NEXT:    br i1 [[TMP4]], label %[[CONT4:.*]], label %[[TRAP3:.*]], !prof [[PROF2]], !annotation [[META2]]
 // UNOPT:       [[TRAP3]]:
-// UNOPT-NEXT:    call preserve_allcc void @__bounds_safety_soft_trap() #[[ATTR2]], !annotation [[META3]]
-// UNOPT-NEXT:    br label %[[CONT4]], !annotation [[META3]]
+// UNOPT-NEXT:    call preserve_allcc void @__bounds_safety_soft_trap() #[[ATTR2]], !annotation [[META2]]
+// UNOPT-NEXT:    br label %[[CONT4]], !annotation [[META2]]
 // UNOPT:       [[CONT4]]:
 // UNOPT-NEXT:    [[TMP5:%.*]] = load i32, ptr [[ARRAYIDX]], align 4
 // UNOPT-NEXT:    ret i32 [[TMP5]]
 //
 // OPT-LABEL: define dso_local i32 @read(
-// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // OPT-NEXT:  [[ENTRY:.*:]]
 // OPT-NEXT:    [[AGG_TEMP_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[PTR]], align 8
 // OPT-NEXT:    [[AGG_TEMP_SROA_2_0_PTR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[PTR]], i64 8
@@ -102,13 +102,19 @@ int read(int* __bidi_indexable ptr, int idx) {
 // OPT: attributes #[[ATTR0]] = { nounwind "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 // OPT: attributes #[[ATTR1]] = { nomerge nounwind }
 //.
+// UNOPT: [[META16:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT: [[META1]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
 // UNOPT: [[PROF2]] = !{!"branch_weights", i32 1048575, i32 1}
-// UNOPT: [[META3]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
+// UNOPT: [[META2]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 //.
+// OPT: [[META16:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// OPT: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// OPT: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // OPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
-// OPT: [[ERRNO_TBAA:![0-9]+]] = !{[[META_ERRNO:![0-9]+]], [[META2:![0-9]+]], i64 0}
+// OPT: [[META1:![0-9]+]] = !{[[META_ERRNO:![0-9]+]], [[META2:![0-9]+]], i64 0}
 // OPT: [[META_ERRNO]] = !{!"__libc_errno", [[META2]], i64 0}
 // OPT: [[META2]] = !{!"int", [[META3:![0-9]+]], i64 0}
 // OPT: [[META3]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}

--- a/clang/test/BoundsSafety/CodeGen/soft-traps/call_minimal_with_ubsan.c
+++ b/clang/test/BoundsSafety/CodeGen/soft-traps/call_minimal_with_ubsan.c
@@ -53,7 +53,7 @@
 // UNOPT-TFR: @[[GLOB0:[0-9]+]] = private unnamed_addr constant { i16, i16, [6 x i8] } { i16 0, i16 11, [6 x i8] c"'int'\00" }
 //.
 // UNOPT-LABEL: define dso_local i32 @read(
-// UNOPT-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-NEXT:  [[ENTRY:.*:]]
 // UNOPT-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -108,7 +108,7 @@
 // UNOPT-NEXT:    ret i32 [[TMP11]]
 //
 // UNOPT-TF-LABEL: define dso_local i32 @read(
-// UNOPT-TF-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-TF-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-TF-NEXT:  [[ENTRY:.*:]]
 // UNOPT-TF-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-TF-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -163,7 +163,7 @@
 // UNOPT-TF-NEXT:    ret i32 [[TMP11]]
 //
 // UNOPT-TFR-LABEL: define dso_local i32 @read(
-// UNOPT-TFR-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-TFR-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-TFR-NEXT:  [[ENTRY:.*:]]
 // UNOPT-TFR-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-TFR-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -218,7 +218,7 @@
 // UNOPT-TFR-NEXT:    ret i32 [[TMP11]]
 //
 // OPT-LABEL: define dso_local i32 @read(
-// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // OPT-NEXT:  [[ENTRY:.*:]]
 // OPT-NEXT:    [[TMP0:%.*]] = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[IDX]], i32 [[OTHER]]), !nosanitize [[META5:![0-9]+]]
 // OPT-NEXT:    [[TMP1:%.*]] = extractvalue { i32, i1 } [[TMP0]], 1, !nosanitize [[META5]]
@@ -289,36 +289,48 @@ int read(int* __bidi_indexable ptr, int idx, int other) {
 // OPT: attributes #[[ATTR3]] = { nomerge noreturn nounwind }
 // OPT: attributes #[[ATTR4]] = { nomerge nounwind }
 //.
+// UNOPT: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT: [[META19:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT: [[META1]] = !{}
 // UNOPT: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
 // UNOPT: [[META3]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
 // UNOPT: [[META4]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 //.
+// UNOPT-TF: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT-TF: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT-TF: [[META19:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT-TF: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT-TF: [[META1]] = !{}
 // UNOPT-TF: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
 // UNOPT-TF: [[META3]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
 // UNOPT-TF: [[META4]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 //.
+// UNOPT-TFR: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT-TFR: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT-TFR: [[META19:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT-TFR: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT-TFR: [[META1]] = !{}
 // UNOPT-TFR: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
 // UNOPT-TFR: [[META3]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
 // UNOPT-TFR: [[META4]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 //.
+// OPT: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// OPT: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// OPT: [[META19:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // OPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
-// OPT: [[ERRNO_TBAA:![0-9]+]] = !{[[META_ERRNO:![0-9]+]], [[META2:![0-9]+]], i64 0}
-// OPT: [[META_ERRNO]] = !{!"__libc_errno", [[META2]], i64 0}
-// OPT: [[META2]] = !{!"int", [[META3:![0-9]+]], i64 0}
-// OPT: [[META3]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}
-// OPT: [[META4]] = !{!"Simple C/C++ TBAA"}
+// OPT: [[META1:![0-9]+]] = !{[[META2:![0-9]+]], [[META3:![0-9]+]], i64 0}
+// OPT: [[META2]] = !{!"__libc_errno", [[META3]], i64 0}
+// OPT: [[META3]] = !{!"int", [[META4:![0-9]+]], i64 0}
+// OPT: [[META4]] = !{!"omnipotent char", [[META20:![0-9]+]], i64 0}
+// OPT: [[META20]] = !{!"Simple C/C++ TBAA"}
 // OPT: [[META5]] = !{}
 // OPT: [[META6:![0-9]+]] = !{!"branch_weights", i32 1, i32 1048575}
 // OPT: [[INTPTR_TBAA7]] = !{[[META8:![0-9]+]], [[META8]], i64 0}
 // OPT: [[META8]] = !{!"p1 int", [[META9:![0-9]+]], i64 0}
-// OPT: [[META9]] = !{!"any pointer", [[META3]], i64 0}
+// OPT: [[META9]] = !{!"any pointer", [[META4]], i64 0}
 // OPT: [[META10]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
 // OPT: [[META11]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
-// OPT: [[INT_TBAA1]] = !{[[META2]], [[META2]], i64 0}
+// OPT: [[INT_TBAA1]] = !{[[META3]], [[META3]], i64 0}
 //.

--- a/clang/test/BoundsSafety/CodeGen/soft-traps/call_with_str.c
+++ b/clang/test/BoundsSafety/CodeGen/soft-traps/call_with_str.c
@@ -38,7 +38,7 @@
 // OPT: @trap.reason.2 = private unnamed_addr constant [41 x i8] c"indexing below lower bound in 'ptr[idx]'\00", align 4
 //.
 // UNOPT-LABEL: define dso_local i32 @read(
-// UNOPT-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-NEXT:  [[ENTRY:.*:]]
 // UNOPT-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -78,7 +78,7 @@
 // UNOPT-NEXT:    ret i32 [[TMP5]]
 //
 // UNOPT-TF-LABEL: define dso_local i32 @read(
-// UNOPT-TF-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-TF-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-TF-NEXT:  [[ENTRY:.*:]]
 // UNOPT-TF-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-TF-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -118,7 +118,7 @@
 // UNOPT-TF-NEXT:    ret i32 [[TMP5]]
 //
 // OPT-LABEL: define dso_local i32 @read(
-// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // OPT-NEXT:  [[ENTRY:.*:]]
 // OPT-NEXT:    [[AGG_TEMP_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[PTR]], align 8
 // OPT-NEXT:    [[AGG_TEMP_SROA_2_0_PTR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[PTR]], i64 8
@@ -420,30 +420,39 @@ int read_cb(int*__counted_by(count) ptr, int count) {
 // OPT: attributes #[[ATTR2]] = { nomerge nounwind }
 // OPT: attributes #[[ATTR3]] = { nounwind }
 //.
+// UNOPT: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT: [[META2:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT: [[META1]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
-// UNOPT: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
+// UNOPT: [[META_ERRNO:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
 // UNOPT: [[META3]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 // UNOPT: [[META4]] = !{!"bounds-safety-generic"}
 //.
+// UNOPT-TF: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT-TF: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT-TF: [[META2:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT-TF: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT-TF: [[META1]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
-// UNOPT-TF: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
+// UNOPT-TF: [[META_ERRNO:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
 // UNOPT-TF: [[META3]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 // UNOPT-TF: [[META4]] = !{!"bounds-safety-generic"}
 //.
+// OPT: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// OPT: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// OPT: [[META2:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // OPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
-// OPT: [[ERRNO_TBAA:![0-9]+]] = !{[[META_ERRNO:![0-9]+]], [[META2:![0-9]+]], i64 0}
-// OPT: [[META_ERRNO]] = !{!"__libc_errno", [[META2]], i64 0}
-// OPT: [[META2]] = !{!"int", [[META3:![0-9]+]], i64 0}
-// OPT: [[META3]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}
-// OPT: [[META4]] = !{!"Simple C/C++ TBAA"}
+// OPT: [[META1:![0-9]+]] = !{[[META_ERRNO:![0-9]+]], [[META3:![0-9]+]], i64 0}
+// OPT: [[META_ERRNO]] = !{!"__libc_errno", [[META3]], i64 0}
+// OPT: [[META3]] = !{!"int", [[META4:![0-9]+]], i64 0}
+// OPT: [[META4]] = !{!"omnipotent char", [[META19:![0-9]+]], i64 0}
+// OPT: [[META19]] = !{!"Simple C/C++ TBAA"}
 // OPT: [[INTPTR_TBAA5]] = !{[[META6:![0-9]+]], [[META6]], i64 0}
 // OPT: [[META6]] = !{!"p1 int", [[META7:![0-9]+]], i64 0}
-// OPT: [[META7]] = !{!"any pointer", [[META3]], i64 0}
+// OPT: [[META7]] = !{!"any pointer", [[META4]], i64 0}
 // OPT: [[META8]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
 // OPT: [[META9:![0-9]+]] = !{!"branch_weights", i32 1, i32 1048575}
 // OPT: [[META10]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
-// OPT: [[INT_TBAA1]] = !{[[META2]], [[META2]], i64 0}
+// OPT: [[INT_TBAA1]] = !{[[META3]], [[META3]], i64 0}
 // OPT: [[META11]] = !{!"bounds-safety-generic"}
 //.

--- a/clang/test/BoundsSafety/CodeGen/soft-traps/call_with_str_custom_func.c
+++ b/clang/test/BoundsSafety/CodeGen/soft-traps/call_with_str_custom_func.c
@@ -21,7 +21,7 @@
 // OPT: @trap.reason.2 = private unnamed_addr constant [41 x i8] c"indexing below lower bound in 'ptr[idx]'\00", align 4
 //.
 // UNOPT-LABEL: define dso_local i32 @read(
-// UNOPT-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-NEXT:  [[ENTRY:.*:]]
 // UNOPT-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -61,7 +61,7 @@
 // UNOPT-NEXT:    ret i32 [[TMP5]]
 //
 // OPT-LABEL: define dso_local i32 @read(
-// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // OPT-NEXT:  [[ENTRY:.*:]]
 // OPT-NEXT:    [[AGG_TEMP_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[PTR]], align 8
 // OPT-NEXT:    [[AGG_TEMP_SROA_2_0_PTR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[PTR]], i64 8
@@ -103,22 +103,28 @@ int read(int* __bidi_indexable ptr, int idx) {
 // OPT: attributes #[[ATTR0]] = { nounwind "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 // OPT: attributes #[[ATTR1]] = { nomerge nounwind }
 //.
+// UNOPT: [[META16:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT: [[META2:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT: [[META1]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
-// UNOPT: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
+// UNOPT: [[META_ERRNO:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
 // UNOPT: [[META3]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 //.
+// OPT: [[META16:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// OPT: [[META17:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// OPT: [[META2:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // OPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
-// OPT: [[ERRNO_TBAA:![0-9]+]] = !{[[META_ERRNO:![0-9]+]], [[META2:![0-9]+]], i64 0}
-// OPT: [[META_ERRNO]] = !{!"__libc_errno", [[META2]], i64 0}
-// OPT: [[META2]] = !{!"int", [[META3:![0-9]+]], i64 0}
-// OPT: [[META3]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}
+// OPT: [[META1:![0-9]+]] = !{[[META_ERRNO:![0-9]+]], [[META3:![0-9]+]], i64 0}
+// OPT: [[META_ERRNO]] = !{!"__libc_errno", [[META3]], i64 0}
+// OPT: [[META3]] = !{!"int", [[META18:![0-9]+]], i64 0}
+// OPT: [[META18]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}
 // OPT: [[META4]] = !{!"Simple C/C++ TBAA"}
 // OPT: [[INTPTR_TBAA5]] = !{[[META6:![0-9]+]], [[META6]], i64 0}
 // OPT: [[META6]] = !{!"p1 int", [[META7:![0-9]+]], i64 0}
-// OPT: [[META7]] = !{!"any pointer", [[META3]], i64 0}
+// OPT: [[META7]] = !{!"any pointer", [[META18]], i64 0}
 // OPT: [[META8]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
 // OPT: [[META9:![0-9]+]] = !{!"branch_weights", i32 1, i32 1048575}
 // OPT: [[META10]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
-// OPT: [[INT_TBAA1]] = !{[[META2]], [[META2]], i64 0}
+// OPT: [[INT_TBAA1]] = !{[[META3]], [[META3]], i64 0}
 //.

--- a/clang/test/BoundsSafety/CodeGen/soft-traps/call_with_str_with_ubsan.c
+++ b/clang/test/BoundsSafety/CodeGen/soft-traps/call_with_str_with_ubsan.c
@@ -66,7 +66,7 @@
 // OPT: @trap.reason.2 = private unnamed_addr constant [41 x i8] c"indexing below lower bound in 'ptr[tmp]'\00", align 4
 //.
 // UNOPT-LABEL: define dso_local i32 @read(
-// UNOPT-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-NEXT:  [[ENTRY:.*:]]
 // UNOPT-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -121,7 +121,7 @@
 // UNOPT-NEXT:    ret i32 [[TMP11]]
 //
 // UNOPT-TF-LABEL: define dso_local i32 @read(
-// UNOPT-TF-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-TF-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-TF-NEXT:  [[ENTRY:.*:]]
 // UNOPT-TF-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-TF-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -176,7 +176,7 @@
 // UNOPT-TF-NEXT:    ret i32 [[TMP11]]
 //
 // UNOPT-TFR-LABEL: define dso_local i32 @read(
-// UNOPT-TFR-SAME: ptr noundef align 8 dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
+// UNOPT-TFR-SAME: ptr nofree noundef align 8 dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) #[[ATTR0:[0-9]+]] {
 // UNOPT-TFR-NEXT:  [[ENTRY:.*:]]
 // UNOPT-TFR-NEXT:    [[PTR_INDIRECT_ADDR:%.*]] = alloca ptr, align 8
 // UNOPT-TFR-NEXT:    [[IDX_ADDR:%.*]] = alloca i32, align 4
@@ -231,16 +231,16 @@
 // UNOPT-TFR-NEXT:    ret i32 [[TMP11]]
 //
 // OPT-LABEL: define dso_local i32 @read(
-// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// OPT-SAME: ptr nofree noundef readonly align 8 captures(none) dead_on_return dereferenceable(24) [[PTR:%.*]], i32 noundef [[IDX:%.*]], i32 noundef [[OTHER:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // OPT-NEXT:  [[ENTRY:.*:]]
-// OPT-NEXT:    [[TMP0:%.*]] = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[IDX]], i32 [[OTHER]]), !nosanitize [[META5:![0-9]+]]
-// OPT-NEXT:    [[TMP1:%.*]] = extractvalue { i32, i1 } [[TMP0]], 1, !nosanitize [[META5]]
-// OPT-NEXT:    br i1 [[TMP1]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!prof ![0-9]+}}, !nosanitize [[META5]]
+// OPT-NEXT:    [[TMP0:%.*]] = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[IDX]], i32 [[OTHER]]), !nosanitize [[META21:![0-9]+]]
+// OPT-NEXT:    [[TMP1:%.*]] = extractvalue { i32, i1 } [[TMP0]], 1, !nosanitize [[META21]]
+// OPT-NEXT:    br i1 [[TMP1]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!prof ![0-9]+}}, !nosanitize [[META21]]
 // OPT:       [[TRAP]]:
-// OPT-NEXT:    tail call void @llvm.ubsantrap(i8 0) #[[ATTR4:[0-9]+]], !nosanitize [[META5]]
-// OPT-NEXT:    unreachable, !nosanitize [[META5]]
+// OPT-NEXT:    tail call void @llvm.ubsantrap(i8 0) #[[ATTR4:[0-9]+]], !nosanitize [[META21]]
+// OPT-NEXT:    unreachable, !nosanitize [[META21]]
 // OPT:       [[CONT]]:
-// OPT-NEXT:    [[TMP2:%.*]] = extractvalue { i32, i1 } [[TMP0]], 0, !nosanitize [[META5]]
+// OPT-NEXT:    [[TMP2:%.*]] = extractvalue { i32, i1 } [[TMP0]], 0, !nosanitize [[META21]]
 // OPT-NEXT:    [[AGG_TEMP_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[PTR]], align 8
 // OPT-NEXT:    [[AGG_TEMP_SROA_2_0_PTR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[PTR]], i64 8
 // OPT-NEXT:    [[AGG_TEMP_SROA_2_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP_SROA_2_0_PTR_SROA_IDX]], align 8
@@ -676,12 +676,12 @@ void receive_cb(int*__counted_by(count) ptr, int count);
 // OPT-LABEL: define dso_local noundef i32 @read_cb(
 // OPT-SAME: ptr noundef [[PTR:%.*]], i32 noundef [[COUNT:%.*]], i32 noundef [[OTHER:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // OPT-NEXT:  [[ENTRY:.*:]]
-// OPT-NEXT:    [[TMP0:%.*]] = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[COUNT]], i32 [[OTHER]]), !nosanitize [[META5]]
-// OPT-NEXT:    [[TMP1:%.*]] = extractvalue { i32, i1 } [[TMP0]], 1, !nosanitize [[META5]]
-// OPT-NEXT:    br i1 [[TMP1]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!prof ![0-9]+}}, !nosanitize [[META5]]
+// OPT-NEXT:    [[TMP0:%.*]] = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[COUNT]], i32 [[OTHER]]), !nosanitize [[META21]]
+// OPT-NEXT:    [[TMP1:%.*]] = extractvalue { i32, i1 } [[TMP0]], 1, !nosanitize [[META21]]
+// OPT-NEXT:    br i1 [[TMP1]], label %[[TRAP:.*]], label %[[CONT:.*]], {{!prof ![0-9]+}}, !nosanitize [[META21]]
 // OPT:       [[TRAP]]:
-// OPT-NEXT:    tail call void @llvm.ubsantrap(i8 0) #[[ATTR4]], !nosanitize [[META5]]
-// OPT-NEXT:    unreachable, !nosanitize [[META5]]
+// OPT-NEXT:    tail call void @llvm.ubsantrap(i8 0) #[[ATTR4]], !nosanitize [[META21]]
+// OPT-NEXT:    unreachable, !nosanitize [[META21]]
 // OPT:       [[CONT]]:
 // OPT-NEXT:    [[CMP_NOT:%.*]] = icmp slt i32 [[COUNT]], 0, !annotation [[META12:![0-9]+]]
 // OPT-NEXT:    br i1 [[CMP_NOT]], label %[[TRAP50:.*]], label %[[CONT51:.*]], !annotation [[META12]]
@@ -689,7 +689,7 @@ void receive_cb(int*__counted_by(count) ptr, int count);
 // OPT-NEXT:    tail call preserve_allcc void @__bounds_safety_soft_trap_s(ptr null) #[[ATTR5]], !annotation [[META12]]
 // OPT-NEXT:    br label %[[CONT51]], !annotation [[META12]]
 // OPT:       [[CONT51]]:
-// OPT-NEXT:    [[TMP2:%.*]] = extractvalue { i32, i1 } [[TMP0]], 0, !nosanitize [[META5]]
+// OPT-NEXT:    [[TMP2:%.*]] = extractvalue { i32, i1 } [[TMP0]], 0, !nosanitize [[META21]]
 // OPT-NEXT:    tail call void @receive_cb(ptr noundef [[PTR]], i32 noundef [[COUNT]]) #[[ATTR6:[0-9]+]]
 // OPT-NEXT:    ret i32 [[TMP2]]
 //
@@ -732,6 +732,9 @@ int read_cb(int*__counted_by(count) ptr, int count, int other) {
 // OPT: attributes #[[ATTR5]] = { nomerge nounwind }
 // OPT: attributes #[[ATTR6]] = { nounwind }
 //.
+// UNOPT: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT: [[META19:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT: [[META20:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT: [[META1]] = !{}
 // UNOPT: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
@@ -739,6 +742,9 @@ int read_cb(int*__counted_by(count) ptr, int count, int other) {
 // UNOPT: [[META4]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 // UNOPT: [[META5]] = !{!"bounds-safety-generic"}
 //.
+// UNOPT-TF: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT-TF: [[META19:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT-TF: [[META20:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT-TF: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT-TF: [[META1]] = !{}
 // UNOPT-TF: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
@@ -746,6 +752,9 @@ int read_cb(int*__counted_by(count) ptr, int count, int other) {
 // UNOPT-TF: [[META4]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 // UNOPT-TF: [[META5]] = !{!"bounds-safety-generic"}
 //.
+// UNOPT-TFR: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// UNOPT-TFR: [[META19:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNOPT-TFR: [[META20:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // UNOPT-TFR: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
 // UNOPT-TFR: [[META1]] = !{}
 // UNOPT-TFR: [[META2:![0-9]+]] = !{!"branch_weights", i32 1048575, i32 1}
@@ -753,19 +762,22 @@ int read_cb(int*__counted_by(count) ptr, int count, int other) {
 // UNOPT-TFR: [[META4]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
 // UNOPT-TFR: [[META5]] = !{!"bounds-safety-generic"}
 //.
+// OPT: [[META18:![0-9]+]] = !{i32 1, !"ptrauth-elf-got", i32 0}
+// OPT: [[META19:![0-9]+]] = !{i32 1, !"ptrauth-init-fini", i32 0}
+// OPT: [[META20:![0-9]+]] = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 // OPT: [[META0:![0-9]+]] = !{!"{{.*}}clang version {{.*}}"}
-// OPT: [[ERRNO_TBAA:![0-9]+]] = !{[[META_ERRNO:![0-9]+]], [[META2:![0-9]+]], i64 0}
-// OPT: [[META_ERRNO]] = !{!"__libc_errno", [[META2]], i64 0}
-// OPT: [[META2]] = !{!"int", [[META3:![0-9]+]], i64 0}
-// OPT: [[META3]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}
-// OPT: [[META4]] = !{!"Simple C/C++ TBAA"}
-// OPT: [[META5]] = !{}
+// OPT: [[META1:![0-9]+]] = !{[[META2:![0-9]+]], [[META3:![0-9]+]], i64 0}
+// OPT: [[META2]] = !{!"__libc_errno", [[META3]], i64 0}
+// OPT: [[META3]] = !{!"int", [[META4:![0-9]+]], i64 0}
+// OPT: [[META4]] = !{!"omnipotent char", [[META5:![0-9]+]], i64 0}
+// OPT: [[META5]] = !{!"Simple C/C++ TBAA"}
+// OPT: [[META21]] = !{}
 // OPT: [[META6:![0-9]+]] = !{!"branch_weights", i32 1, i32 1048575}
 // OPT: [[INTPTR_TBAA7]] = !{[[META8:![0-9]+]], [[META8]], i64 0}
 // OPT: [[META8]] = !{!"p1 int", [[META9:![0-9]+]], i64 0}
-// OPT: [[META9]] = !{!"any pointer", [[META3]], i64 0}
+// OPT: [[META9]] = !{!"any pointer", [[META4]], i64 0}
 // OPT: [[META10]] = !{!"bounds-safety-check-ptr-le-upper-bound"}
 // OPT: [[META11]] = !{!"bounds-safety-check-ptr-ge-lower-bound"}
-// OPT: [[INT_TBAA1]] = !{[[META2]], [[META2]], i64 0}
+// OPT: [[INT_TBAA1]] = !{[[META3]], [[META3]], i64 0}
 // OPT: [[META12]] = !{!"bounds-safety-generic"}
 //.


### PR DESCRIPTION
Upstream commit "[PAC][clang] Fix ptrauth module flags behavior" (39fefb706834fa8e171b0c699b6e91e4d4a0d831,
https://github.com/llvm/llvm-project/pull/204226), emits the ptrauth-elf-got / ptrauth-init-fini /
ptrauth-init-fini-address-discrimination module flags unconditionally (value 0 when the feature is off) for AArch64 ELF modules. Some of our tests mistakenly use the non-canonical triple `arm64-apple-iphoneos` (instead of `arm64-apple-ios`), which resolves to unknown-OS and therefore defaults to the ELF object format. A separate change will bulk update test cases to use the correct triple.

These files also carry the dereferenceable/nofree changes from https://github.com/llvm/llvm-project/pull/213347, which cannot be split into separately-passing commits since both were merged before the tests were updated for either.

rdar://184550269