### PR TITLE
[lldb] Avoid data race when clearing an OptionValue (#208471)

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -102,7 +102,10 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign);
 
-  virtual void Clear() = 0;
+  void Clear() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ClearImpl();
+  }
 
   virtual lldb::OptionValueSP
   DeepCopy(const lldb::OptionValueSP &new_parent) const;
@@ -350,6 +353,8 @@ protected:
   // DeepCopy to it. Inherit from Cloneable to avoid doing this manually.
   virtual lldb::OptionValueSP Clone() const = 0;
 
+  virtual void ClearImpl() = 0;
+
   class DefaultValueFormat {
   public:
     DefaultValueFormat(Stream &stream) : stream(stream) {
@@ -372,6 +377,8 @@ protected:
                                 // set from the command line or as a setting,
                                 // versus if we just have the default value that
                                 // was already populated in the option value.
+  mutable std::mutex m_mutex;
+
 private:
   std::optional<ArchSpec> GetArchSpecValue() const;
   bool SetArchSpecValue(ArchSpec arch_spec);
@@ -412,8 +419,6 @@ private:
   bool SetFormatEntityValue(const FormatEntity::Entry &entry);
 
   const RegularExpression *GetRegexValue() const;
-
-  mutable std::mutex m_mutex;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Interpreter/OptionValueArch.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArch.h
@@ -12,6 +12,7 @@
 #include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/CompletionRequest.h"
+#include <mutex>
 
 namespace lldb_private {
 
@@ -44,11 +45,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   void AutoComplete(CommandInterpreter &interpreter,
@@ -71,6 +67,11 @@ public:
   void SetDefaultValue(const ArchSpec &value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   ArchSpec m_current_value;
   ArchSpec m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueArray.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArray.h
@@ -35,11 +35,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_values.clear();
-    m_value_was_set = false;
-  }
-
   lldb::OptionValueSP
   DeepCopy(const lldb::OptionValueSP &new_parent) const override;
 
@@ -115,6 +110,11 @@ public:
   Status SetArgs(const Args &args, VarSetOperationType op);
 
 protected:
+  void ClearImpl() override {
+    m_values.clear();
+    m_value_was_set = false;
+  }
+
   typedef std::vector<lldb::OptionValueSP> collection;
 
   uint32_t m_type_mask;

--- a/lldb/include/lldb/Interpreter/OptionValueBoolean.h
+++ b/lldb/include/lldb/Interpreter/OptionValueBoolean.h
@@ -37,11 +37,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   void AutoComplete(CommandInterpreter &interpreter,
                     CompletionRequest &request) override;
 
@@ -78,6 +73,11 @@ public:
   void SetDefaultValue(bool value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   bool m_current_value;
   bool m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueChar.h
+++ b/lldb/include/lldb/Interpreter/OptionValueChar.h
@@ -38,11 +38,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -61,6 +56,11 @@ public:
   void SetDefaultValue(char value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   char m_current_value;
   char m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueDictionary.h
+++ b/lldb/include/lldb/Interpreter/OptionValueDictionary.h
@@ -40,11 +40,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_values.clear();
-    m_value_was_set = false;
-  }
-
   lldb::OptionValueSP
   DeepCopy(const lldb::OptionValueSP &new_parent) const override;
 
@@ -77,6 +72,11 @@ public:
   Status SetArgs(const Args &args, VarSetOperationType op);
 
 protected:
+  void ClearImpl() override {
+    m_values.clear();
+    m_value_was_set = false;
+  }
+
   uint32_t m_type_mask;
   OptionEnumValues m_enum_values;
   llvm::StringMap<lldb::OptionValueSP> m_values;

--- a/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
+++ b/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
@@ -47,11 +47,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   void AutoComplete(CommandInterpreter &interpreter,
@@ -75,6 +70,11 @@ public:
 protected:
   void SetEnumerations(const OptionEnumValues &enumerators);
   void DumpEnum(Stream &strm, enum_type value);
+
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
 
   enum_type m_current_value;
   enum_type m_default_value;

--- a/lldb/include/lldb/Interpreter/OptionValueFileColonLine.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileColonLine.h
@@ -35,12 +35,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_file_spec.Clear();
-    m_line_number = LLDB_INVALID_LINE_NUMBER;
-    m_column_number = LLDB_INVALID_COLUMN_NUMBER;
-  }
-
   void SetFile(const FileSpec &file_spec) { m_file_spec = file_spec; }
   void SetLine(uint32_t line) { m_line_number = line; }
   void SetColumn(uint32_t column) { m_column_number = column; }
@@ -55,6 +49,12 @@ public:
   void SetCompletionMask(uint32_t mask) { m_completion_mask = mask; }
 
 protected:
+  void ClearImpl() override {
+    m_file_spec.Clear();
+    m_line_number = LLDB_INVALID_LINE_NUMBER;
+    m_column_number = LLDB_INVALID_COLUMN_NUMBER;
+  }
+
   FileSpec m_file_spec;
   uint32_t m_line_number = LLDB_INVALID_LINE_NUMBER;
   uint32_t m_column_number = LLDB_INVALID_COLUMN_NUMBER;

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
@@ -43,13 +43,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-    m_data_sp.reset();
-    m_data_mod_time = llvm::sys::TimePoint<>();
-  }
-
   void AutoComplete(CommandInterpreter &interpreter,
                     CompletionRequest &request) override;
 
@@ -77,6 +70,13 @@ public:
   void SetCompletionMask(uint32_t mask) { m_completion_mask = mask; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+    m_data_sp.reset();
+    m_data_mod_time = llvm::sys::TimePoint<>();
+  }
+
   FileSpec m_current_value;
   FileSpec m_default_value;
   lldb::DataBufferSP m_data_sp;

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
@@ -39,35 +39,35 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value.Clear();
-    m_value_was_set = false;
-  }
-
   bool IsAggregateValue() const override { return true; }
 
   // Subclass specific functions
 
   FileSpecList GetCurrentValue() const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_rmutex);
     return m_current_value;
   }
 
   void SetCurrentValue(const FileSpecList &value) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_rmutex);
     m_current_value = value;
   }
 
   void AppendCurrentValue(const FileSpec &value) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_rmutex);
     m_current_value.Append(value);
   }
 
 protected:
   lldb::OptionValueSP Clone() const override;
 
-  mutable std::recursive_mutex m_mutex;
+  void ClearImpl() override {
+    m_current_value.Clear();
+    m_value_was_set = false;
+  }
+  // FIXME: This could use the existing m_mutex from the OptionValue
+  // parent class, but needs clean up in callsites to avoid deadlock.
+  mutable std::recursive_mutex m_rmutex;
   FileSpecList m_current_value;
 };
 

--- a/lldb/include/lldb/Interpreter/OptionValueFormat.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormat.h
@@ -37,11 +37,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -55,6 +50,11 @@ public:
   void SetDefaultValue(lldb::Format value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   lldb::Format m_current_value;
   lldb::Format m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueFormatEntity.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormatEntity.h
@@ -32,8 +32,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override;
-
   bool IsDefault() const override {
     return m_current_format == m_default_format;
   }
@@ -50,6 +48,8 @@ public:
   const FormatEntity::Entry &GetDefaultValue() const { return m_default_entry; }
 
 protected:
+  void ClearImpl() override;
+
   std::string m_current_format;
   std::string m_default_format;
   FormatEntity::Entry m_current_entry;

--- a/lldb/include/lldb/Interpreter/OptionValueLanguage.h
+++ b/lldb/include/lldb/Interpreter/OptionValueLanguage.h
@@ -39,11 +39,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -57,6 +52,11 @@ public:
   void SetDefaultValue(lldb::LanguageType value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   lldb::LanguageType m_current_value;
   lldb::LanguageType m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValuePathMappings.h
+++ b/lldb/include/lldb/Interpreter/OptionValuePathMappings.h
@@ -35,11 +35,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_path_mappings.Clear(m_notify_changes);
-    m_value_was_set = false;
-  }
-
   bool IsAggregateValue() const override { return true; }
 
   // Subclass specific functions
@@ -49,6 +44,11 @@ public:
   const PathMappingList &GetCurrentValue() const { return m_path_mappings; }
 
 protected:
+  void ClearImpl() override {
+    m_path_mappings.Clear(m_notify_changes);
+    m_value_was_set = false;
+  }
+
   PathMappingList m_path_mappings;
   bool m_notify_changes;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueProperties.h
+++ b/lldb/include/lldb/Interpreter/OptionValueProperties.h
@@ -31,8 +31,6 @@ public:
 
   Type GetType() const override { return eTypeProperties; }
 
-  void Clear() override;
-
   static lldb::OptionValuePropertiesSP
   CreateLocalCopy(const Properties &global_properties);
 
@@ -180,6 +178,8 @@ protected:
   }
 
   bool VerifyPath();
+
+  void ClearImpl() override;
 
   std::string m_name;
   std::vector<Property> m_properties;

--- a/lldb/include/lldb/Interpreter/OptionValueRegex.h
+++ b/lldb/include/lldb/Interpreter/OptionValueRegex.h
@@ -36,11 +36,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_regex = RegularExpression(m_default_regex_str);
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override {
     return m_regex.GetText() == m_default_regex_str;
   }
@@ -60,6 +55,11 @@ public:
   bool IsValid() const { return m_regex.IsValid(); }
 
 protected:
+  void ClearImpl() override {
+    m_regex = RegularExpression(m_default_regex_str);
+    m_value_was_set = false;
+  }
+
   RegularExpression m_regex;
   std::string m_default_regex_str;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueSInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueSInt64.h
@@ -43,11 +43,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -85,6 +80,11 @@ public:
   int64_t GetMaximumValue() const { return m_max_value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   int64_t m_current_value = 0;
   int64_t m_default_value = 0;
   int64_t m_min_value = std::numeric_limits<int64_t>::min();

--- a/lldb/include/lldb/Interpreter/OptionValueString.h
+++ b/lldb/include/lldb/Interpreter/OptionValueString.h
@@ -77,11 +77,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -122,6 +117,11 @@ public:
   }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   std::string m_current_value;
   std::string m_default_value;
   Flags m_options;

--- a/lldb/include/lldb/Interpreter/OptionValueUInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUInt64.h
@@ -46,11 +46,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -90,6 +85,11 @@ public:
   uint64_t GetMaximumValue() const { return m_max_value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   uint64_t m_current_value = 0;
   uint64_t m_default_value = 0;
   uint64_t m_min_value = std::numeric_limits<uint64_t>::min();

--- a/lldb/include/lldb/Interpreter/OptionValueUUID.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUUID.h
@@ -37,11 +37,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    m_uuid.Clear();
-    m_value_was_set = false;
-  }
-
   // Subclass specific functions
 
   UUID &GetCurrentValue() { return m_uuid; }
@@ -54,6 +49,11 @@ public:
                     CompletionRequest &request) override;
 
 protected:
+  void ClearImpl() override {
+    m_uuid.Clear();
+    m_value_was_set = false;
+  }
+
   UUID m_uuid;
 };
 

--- a/lldb/source/Interpreter/OptionValue.cpp
+++ b/lldb/source/Interpreter/OptionValue.cpp
@@ -24,7 +24,7 @@ OptionValue::OptionValue(const OptionValue &other) {
 
 }
 
-OptionValue& OptionValue::operator=(const OptionValue &other) {
+OptionValue &OptionValue::operator=(const OptionValue &other) {
   std::scoped_lock<std::mutex, std::mutex> lock(m_mutex, other.m_mutex);
 
   m_parent_wp = other.m_parent_wp;
@@ -466,7 +466,7 @@ std::optional<ArchSpec> OptionValue::GetArchSpecValue() const {
 }
 
 bool OptionValue::SetArchSpecValue(ArchSpec arch_spec) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueArch *option_value = GetAsArch()) {
     option_value->SetCurrentValue(arch_spec, false);
     return true;

--- a/lldb/source/Interpreter/OptionValueBoolean.cpp
+++ b/lldb/source/Interpreter/OptionValueBoolean.cpp
@@ -50,8 +50,8 @@ Status OptionValueBoolean::SetValueFromString(llvm::StringRef value_str,
     bool success = false;
     bool value = OptionArgParser::ToBoolean(value_str, false, &success);
     if (success) {
-      m_value_was_set = true;
-      m_current_value = value;
+      SetOptionWasSet();
+      SetValueAs(value);
       NotifyValueChanged();
     } else {
       if (value_str.size() == 0)

--- a/lldb/source/Interpreter/OptionValueFileSpecList.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpecList.cpp
@@ -17,7 +17,7 @@ using namespace lldb_private;
 
 void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
                                         Stream &strm, uint32_t dump_mask) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_rmutex);
   if (dump_mask & eDumpOptionType)
     strm.Printf("(%s)", GetTypeAsCString());
   if (dump_mask & eDumpOptionValue) {
@@ -50,7 +50,7 @@ void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
 
 llvm::json::Value
 OptionValueFileSpecList::ToJSON(const ExecutionContext *exe_ctx) const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_rmutex);
   llvm::json::Array array;
   for (const auto &file_spec : m_current_value)
     array.emplace_back(file_spec.ToJSON());
@@ -59,7 +59,7 @@ OptionValueFileSpecList::ToJSON(const ExecutionContext *exe_ctx) const {
 
 Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
                                                    VarSetOperationType op) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_rmutex);
   Status error;
   Args args(value.str());
   const size_t argc = args.GetArgumentCount();
@@ -180,6 +180,6 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
 }
 
 OptionValueSP OptionValueFileSpecList::Clone() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_rmutex);
   return Cloneable::Clone();
 }

--- a/lldb/source/Interpreter/OptionValueFormatEntity.cpp
+++ b/lldb/source/Interpreter/OptionValueFormatEntity.cpp
@@ -28,7 +28,7 @@ OptionValueFormatEntity::OptionValueFormatEntity(const char *default_format) {
   }
 }
 
-void OptionValueFormatEntity::Clear() {
+void OptionValueFormatEntity::ClearImpl() {
   m_current_entry = m_default_entry;
   m_current_format = m_default_format;
   m_value_was_set = false;

--- a/lldb/source/Interpreter/OptionValueProperties.cpp
+++ b/lldb/source/Interpreter/OptionValueProperties.cpp
@@ -303,7 +303,7 @@ OptionValueString *OptionValueProperties::GetPropertyAtIndexAsOptionValueString(
   return nullptr;
 }
 
-void OptionValueProperties::Clear() {
+void OptionValueProperties::ClearImpl() {
   const size_t num_properties = m_properties.size();
   for (size_t i = 0; i < num_properties; ++i)
     m_properties[i].GetValue()->Clear();


### PR DESCRIPTION
The clear function guarded by the internal mutex.
This happens when we have to threads one trying to set a value and the other reseting the value.

The derived classes are forced to implement the `ClearImpl`. and base `OptionValue` hold the mutex and calls `ClearImpl` on clear.

(cherry picked from commit 5cf3b68e2f14e6b08ef09459b0613ddbb6b82054)