### PR TITLE
Windows: Enable previously failing SwiftREPL tests

### DIFF
--- a/lldb/test/Shell/SwiftREPL/Deadlock.test
+++ b/lldb/test/Shell/SwiftREPL/Deadlock.test
@@ -1,5 +1,4 @@
 // REQUIRES: swift
-// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/Dict.test
+++ b/lldb/test/Shell/SwiftREPL/Dict.test
@@ -1,6 +1,5 @@
 // Test that the dictionary data formatter works in the REPL.
 // REQUIRES: swift
-// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 

--- a/lldb/test/Shell/SwiftREPL/MetatypeRepl.test
+++ b/lldb/test/Shell/SwiftREPL/MetatypeRepl.test
@@ -1,5 +1,4 @@
 // REQUIRES: swift
-// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
+++ b/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
@@ -1,5 +1,4 @@
 // REQUIRES: swift
-// XFAIL: system-windows
 
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -18,10 +18,6 @@ xfail lldb-shell :: SwiftREPL/ClosureScope.test
 
 ### Tests that pass locally, but fail in CI reliably ###
 
-# https://github.com/swiftlang/llvm-project/issues/9539
-xfail lldb-shell :: SwiftREPL/SimpleExpressions.test
-xfail lldb-shell :: SwiftREPL/enum-singlecase.test
-
 xfail lldb-api :: source-manager/TestSourceManager.py
 
 # https://github.com/swiftlang/llvm-project/issues/9620


### PR DESCRIPTION
Enabling Swift library evolution in the toolchain build fixes these tests. Swift library evolution is enabled in swiftlang/swift#91379.

Fixes #9539