### PR TITLE
[cherry-pick stable/23.x][lldb] Stop clobbering the type name in getTypeAndDie's diagnostic

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -187,12 +187,13 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
     }
   }
   if (!lldb_type) {
-    std::tie(lldb_type, type) = DWARFASTParserSwift::ResolveTypeAlias(type);
-    if (lldb_type) {
+    auto [alias_lldb_type, alias_type] =
+        DWARFASTParserSwift::ResolveTypeAlias(type);
+    if (alias_lldb_type) {
       auto *dwarf =
-          llvm::cast<SymbolFileDWARF>(lldb_type->GetSymbolFile());
-      auto die = dwarf->GetDIE(lldb_type->GetID());
-      return {{type, die}};
+          llvm::cast<SymbolFileDWARF>(alias_lldb_type->GetSymbolFile());
+      auto die = dwarf->GetDIE(alias_lldb_type->GetID());
+      return {{alias_type, die}};
     }
   }
   if (!lldb_type) {


### PR DESCRIPTION
[lldb] Stop clobbering the type name in getTypeAndDie's diagnostic

(cherry picked from commit 6a48a7157170fa3f74b18ff25a7061f74761f1f3)
