### PR TITLE
[LLDB] Add Swift tool prerequesites to Makefile.rules 

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -169,6 +169,14 @@ ifeq "$(HOST_OS)" "Windows_NT"
        override CXX := $(QUOTE)$(CXX)$(QUOTE)
 endif
 
+# Dependency tracking for build tools. For example, if a build rule
+# use uses $(CC) to compile a source file, add
+#
+#    $(call tool_prereq $(CC))
+#
+# as a dependency to the rule.
+tool_prereq = $(wildcard $(firstword $(1)))
+
 #----------------------------------------------------------------------
 # Handle SDKROOT for the cross platform builds.
 #----------------------------------------------------------------------
@@ -595,7 +603,10 @@ endif
 #----------------------------------------------------------------------
 # Make the dSYM file from the executable if $(MAKE_DSYM) != "NO"
 #----------------------------------------------------------------------
-$(DSYM) : $(EXE)
+$(DSYM) : $(EXE) \
+          $(call tool_prereq,$(DS)) \
+          $(call tool_prereq,$(OBJCOPY)) \
+          $(call tool_prereq,$(DWP))
 ifeq "$(OS)" "Darwin"
 ifneq "$(MAKE_DSYM)" "NO"
 	"$(DS)" $(DSFLAGS) -o "$(DSYM)" "$(EXE)"
@@ -681,20 +692,20 @@ endif # !USESWIFTDRIVER
 #----------------------------------------------------------------------
 
 ifneq "$(PCH_OUTPUT)" ""
-$(PCH_OUTPUT) : $(PCH_CXX_SOURCE)
+$(PCH_OUTPUT) : $(PCH_CXX_SOURCE) $(call tool_prereq,$(CXX))
 	$(CXX) $(CXXFLAGS) -x c++-header -o $@ $<
 endif
 
-%.o: %.c %.d
+%.o: %.c %.d $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.cpp %.d $(PCH_OUTPUT) $(SWIFT_CXX_HEADER)
+%.o: %.cpp %.d $(PCH_OUTPUT) $(SWIFT_CXX_HEADER) $(call tool_prereq,$(CXX))
 	$(CXX) $(PCHFLAGS) $(CXXFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.m %.d
+%.o: %.m %.d $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.mm %.d
+%.o: %.mm %.d $(call tool_prereq,$(CXX))
 	$(CXX) $(CXXFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
 #----------------------------------------------------------------------

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -275,20 +275,22 @@ endif
 
 # The Swift object files are named .swift.o so they don't conflict
 # with the wrapped Swift module $(MODULENAME).o
-$(SWIFT_OBJECTS): $(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES)
+$(SWIFT_OBJECTS): $(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES) \
+                  $(call tool_prereq,$(SWIFTC)) \
+                  $(call tool_prereq,$(SWIFT))
 ifneq "$(SWIFT_WMO)" "1"
 	@echo "### Generating output file map"
-	$(PYTHON) $(THIS_FILE_DIR)/gen-output-map.py $^ $(patsubst %,$(BUILDDIR)/%,$(SWIFT_OBJECTS)) >$(BUILDDIR)/$(MODULENAME)-output-file-map.json
+	$(PYTHON) $(THIS_FILE_DIR)/gen-output-map.py $(filter %.swift,$^) $(patsubst %,$(BUILDDIR)/%,$(SWIFT_OBJECTS)) >$(BUILDDIR)/$(MODULENAME)-output-file-map.json
 endif
-	@echo "### Compiling" $^
+	@echo "### Compiling" $(filter %.swift,$^)
 	@echo "### Swift driver expanded incovation will be:"
-	$(SWIFTC) -emit-object $^ $(SWIFTC_OUTPUT) \
+	$(SWIFTC) -emit-object $(filter %.swift,$^) $(SWIFTC_OUTPUT) \
 	  $(SWIFTFLAGS) $(SWIFT_HFLAGS) $(PARSE_AS_LIBRARY) \
 	  -module-name $(MODULENAME) \
           -emit-module-path $(BUILDDIR)/$(MODULENAME).swiftmodule \
 	  $(SWIFT_INTERFACE_FLAGS) -###
 	@echo "### Swift driver invocation:"
-	$(SWIFTC) -emit-object $^ $(SWIFTC_OUTPUT) \
+	$(SWIFTC) -emit-object $(filter %.swift,$^) $(SWIFTC_OUTPUT) \
 	  $(SWIFTFLAGS) $(SWIFT_HFLAGS) $(PARSE_AS_LIBRARY) \
 	  -module-name $(MODULENAME) \
           -emit-module-path $(BUILDDIR)/$(MODULENAME).swiftmodule \
@@ -307,7 +309,7 @@ else
 SWIFTMODULE =
 LD_SWIFTFLAGS =
 endif
-$(EXE): $(OBJECTS)
+$(EXE): $(OBJECTS) $(call tool_prereq,$(SWIFTC))
 	@echo "### Linking" $(EXE)
 	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(OBJECTS) $(SWIFT_LINK_FLAGS) -o "$(EXE)"
 ifneq "$(CODESIGN)" ""
@@ -321,9 +323,9 @@ ifeq "$(HIDE_SWIFTMODULE)" ""
 WRAPPED_SWIFTMODULE = $(MODULENAME).o
 endif
 
-$(EXE): $(OBJECTS)
+$(EXE): $(OBJECTS) $(call tool_prereq,$(SWIFTC))
 	@echo "### Linking" $(EXE)
-	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(WRAPPED_SWIFTMODULE) $^ $(SWIFT_LINK_FLAGS) -o "$(EXE)"
+	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(WRAPPED_SWIFTMODULE) $(OBJECTS) $(SWIFT_LINK_FLAGS) -o "$(EXE)"
 ifneq "$(HIDE_SWIFTMODULE)" ""
 	rm -f $(MODULENAME).swiftmodule
 endif
@@ -347,7 +349,9 @@ DYLIB_OBJECTS += $(BUILDDIR)/$(MODULENAME).o
 endif
 endif # Darwin
 
-$(DYLIB_FILENAME) : $(DYLIB_OBJECTS) $(MODULE_INTERFACE)
+$(DYLIB_FILENAME) : $(DYLIB_OBJECTS) $(MODULE_INTERFACE) \
+                    $(call tool_prereq,$(SWIFTC)) \
+                    $(call tool_prereq,$(DS))
 	@echo "### Linking dynamic library $(DYLIB_NAME)"
 ifneq "$(FRAMEWORK)" ""
 	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Headers)


### PR DESCRIPTION
This is necessary since the shared build infrastructure no longer
automatically deletes the build directory on each test run.