### PR TITLE
[Cherry-pick into next] [LLDB] Add Swift tool prerequesites to Makefile.rules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -280,20 +280,22 @@ endif
 
 # The Swift object files are named .swift.o so they don't conflict
 # with the wrapped Swift module $(MODULENAME).o
-$(SWIFT_OBJECTS): $(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES)
+$(SWIFT_OBJECTS): $(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES) \
+                  $(call tool_prereq,$(SWIFTC)) \
+                  $(call tool_prereq,$(SWIFT))
 ifneq "$(SWIFT_WMO)" "1"
 	@echo "### Generating output file map"
-	$(PYTHON) $(THIS_FILE_DIR)/gen-output-map.py $^ $(patsubst %,$(BUILDDIR)/%,$(SWIFT_OBJECTS)) >$(BUILDDIR)/$(MODULENAME)-output-file-map.json
+	$(PYTHON) $(THIS_FILE_DIR)/gen-output-map.py $(filter %.swift,$^) $(patsubst %,$(BUILDDIR)/%,$(SWIFT_OBJECTS)) >$(BUILDDIR)/$(MODULENAME)-output-file-map.json
 endif
-	@echo "### Compiling" $^
+	@echo "### Compiling" $(filter %.swift,$^)
 	@echo "### Swift driver expanded incovation will be:"
-	$(SWIFTC) -emit-object $^ $(SWIFTC_OUTPUT) \
+	$(SWIFTC) -emit-object $(filter %.swift,$^) $(SWIFTC_OUTPUT) \
 	  $(SWIFTFLAGS) $(SWIFT_HFLAGS) $(PARSE_AS_LIBRARY) \
 	  -module-name $(MODULENAME) \
           -emit-module-path $(BUILDDIR)/$(MODULENAME).swiftmodule \
 	  $(SWIFT_INTERFACE_FLAGS) -###
 	@echo "### Swift driver invocation:"
-	$(SWIFTC) -emit-object $^ $(SWIFTC_OUTPUT) \
+	$(SWIFTC) -emit-object $(filter %.swift,$^) $(SWIFTC_OUTPUT) \
 	  $(SWIFTFLAGS) $(SWIFT_HFLAGS) $(PARSE_AS_LIBRARY) \
 	  -module-name $(MODULENAME) \
           -emit-module-path $(BUILDDIR)/$(MODULENAME).swiftmodule \
@@ -312,7 +314,7 @@ else
 SWIFTMODULE =
 LD_SWIFTFLAGS =
 endif
-$(EXE): $(OBJECTS)
+$(EXE): $(OBJECTS) $(call tool_prereq,$(SWIFTC))
 	@echo "### Linking" $(EXE)
 	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(OBJECTS) $(SWIFT_LINK_FLAGS) -o "$(EXE)"
 ifneq "$(CODESIGN)" ""
@@ -326,9 +328,9 @@ ifeq "$(HIDE_SWIFTMODULE)" ""
 WRAPPED_SWIFTMODULE = $(MODULENAME).o
 endif
 
-$(EXE): $(OBJECTS)
+$(EXE): $(OBJECTS) $(call tool_prereq,$(SWIFTC))
 	@echo "### Linking" $(EXE)
-	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(WRAPPED_SWIFTMODULE) $^ $(SWIFT_LINK_FLAGS) -o "$(EXE)"
+	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(WRAPPED_SWIFTMODULE) $(OBJECTS) $(SWIFT_LINK_FLAGS) -o "$(EXE)"
 ifneq "$(HIDE_SWIFTMODULE)" ""
 	rm -f $(MODULENAME).swiftmodule
 endif
@@ -352,7 +354,9 @@ DYLIB_OBJECTS += $(BUILDDIR)/$(MODULENAME).o
 endif
 endif # Darwin
 
-$(DYLIB_FILENAME) : $(DYLIB_OBJECTS) $(MODULE_INTERFACE)
+$(DYLIB_FILENAME) : $(DYLIB_OBJECTS) $(MODULE_INTERFACE) \
+                    $(call tool_prereq,$(SWIFTC)) \
+                    $(call tool_prereq,$(DS))
 	@echo "### Linking dynamic library $(DYLIB_NAME)"
 ifneq "$(FRAMEWORK)" ""
 	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Headers)


### PR DESCRIPTION
```
commit 1d2c8b93a45e98f3ab8dbd2de73bf1690531c9ac
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Aug 12 11:09:59 2026 -0700

    [LLDB] Add Swift tool prerequesites to Makefile.rules
    
    This is necessary since the shared build infrastructure no longer
    automatically deletes the build directory on each test run.
```
