### PR TITLE
[LLDB] Add missing imports in test

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 import lldb
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbtest as lldbtest


### PR DESCRIPTION
Prior to shared builds the lines using these modules were dead.