### PR TITLE
[lldb] Run the continuation formatter tests in embedded Swift

### DIFF
--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -7,7 +7,8 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_unsafe_continuation_printing(self):
         """Print an UnsafeContinuation and verify its children."""
@@ -34,7 +35,8 @@ class TestCase(TestBase):
             ],
         )
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_checked_continuation_printing(self):
         """Print an CheckedContinuation and verify its children."""


### PR DESCRIPTION
The task inside a continuation is presented as an UnsafeCurrentTask. Nothing
in an embedded Swift target described that type, so the formatter could not
read the task pointer out of it and the children came back empty.

The compiler now emits DWARF for the type whether or not the program names
it, so these tests pass in the embedded variant.

Assisted-by: claude
