### PR TITLE
[lldb][test] Opt three more Swift tests out of SHARED_BUILD_TESTCASE

### DIFF
--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -22,6 +22,10 @@ import time
 
 @skipIfDarwin # rdar://problem/54322424 Sometimes failing, sometimes truncated output.
 class TestMainExecutable(TestBase):
+    # The test functions build the library with and without library evolution,
+    # which a shared build directory would not rebuild.
+    SHARED_BUILD_TESTCASE = False
+
     def launch_info(self):
         info = lldb.SBLaunchInfo([])
 

--- a/lldb/test/API/lang/swift/meta/TestSwiftMeta.py
+++ b/lldb/test/API/lang/swift/meta/TestSwiftMeta.py
@@ -17,6 +17,9 @@ import lldbsuite.test.lldbtest as lldbtest
 import os
 
 class TestSwiftMeta(lldbtest.TestBase):
+    # Asserting on the on-disk build layout requires a build directory that is
+    # not shared with the other debug info variants.
+    SHARED_BUILD_TESTCASE = False
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -18,6 +18,10 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftInterfaceDSYM(TestBase):
+    # The test functions build with different dSYM configurations and delete
+    # artifacts out of the build directory, so each one needs its own.
+    SHARED_BUILD_TESTCASE = False
+
     @swiftTest
     @requireNotEmbeddedSwift # library evolution cannot be enabled with embedded Swift
     @skipIf(archs=no_match("x86_64"))

--- a/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
+++ b/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
@@ -7,6 +7,10 @@ import os
 
 class TestSwiftXcodeSDK(lldbtest.TestBase):
 
+    # The test functions build for different target triples, which a shared
+    # build directory would not rebuild.
+    SHARED_BUILD_TESTCASE = False
+
     mydir = lldbtest.TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 


### PR DESCRIPTION
TestSwiftXcodeSDK, TestSwiftInterfaceDSYM and TestMainExecutable each build with parameters that differ between test functions.

Assisted-by: Claude