### PR TITLE
[Cherry-pick into next] [lldb] Restore unconditional PCM validation logging

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1942,10 +1942,10 @@ void SwiftASTContext::ConfigureModuleValidation(
 #endif
   }
 
-  if (!validate_pcm) {
+  if (!validate_pcm)
     extra_args.push_back("-fno-modules-check-relocated");
-    LOG_PRINTF(GetLog(LLDBLog::Types), "PCM validation is disabled");
-  }
+  LOG_PRINTF(GetLog(LLDBLog::Types), "PCM validation is %s",
+             validate_pcm ? "enabled" : "disabled");
 }
 
 void SwiftASTContext::AddExtraClangArgs(

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -18,6 +18,10 @@ import os
 import shutil
 
 class TestSwiftRewriteClangPaths(TestBase):
+    # testWithoutRemap deletes the remapping plist out of the .dSYM, which make
+    # does not regenerate, so the test functions cannot share a build directory.
+    SHARED_BUILD_TESTCASE = False
+
     @requireNotEmbeddedSwift
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))


### PR DESCRIPTION
```
commit a5089b9266dc969ec4794c1374ba5af8f535032a
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Aug 12 15:31:47 2026 -0700

    [lldb] Restore unconditional PCM validation logging
    
    db0d74739531 cherry-picked a re-landing of the PCM validation rework
    that carried the pre-fix body of ConfigureModuleValidation, silently
    reverting 0cd99a4a247f. With the log confined to the !validate_pcm
    branch it is never emitted in an asserts build, where NDEBUG is
    undefined and validate_pcm is therefore always true, and
    TestSwiftFModuleFlags fails on its first CHECK.
    
    Also correct the polarity: the message 0cd99a4a247f restored reported
    "disabled" when validation was enabled and vice versa.
    
    Assisted-by: Claude

commit 021f09cd36f125e6d5c5416e37ae3b957094567c
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Aug 12 15:32:01 2026 -0700

    [lldb][test] Opt TestSwiftRewriteClangPaths out of SHARED_BUILD_TESTCASE
    
    testWithoutRemap deletes the remapping plist from the .dSYM to check
    that path remapping does not succeed by accident. make does not
    regenerate it, so with a build directory shared across the class the
    test passes on a clean tree and fails on every subsequent run with a
    find_plist assertion.
    
    Assisted-by: Claude
```
