### PR TITLE
[LLDB] Update macCatalyst tests broken by the switch to -mtargetos=

### DIFF
--- a/lldb/test/API/lang/swift/macCatalystFramework/Makefile
+++ b/lldb/test/API/lang/swift/macCatalystFramework/Makefile
@@ -2,7 +2,11 @@
 # macOS (arm64-apple-macosx) Swift framework.
 C_SOURCES := main.c
 LD_EXTRAS := -F. -framework Framework
-CFLAGS_EXTRAS = -target $(ARCH)-apple-ios26.0-macabi
+# Override ARCH_CFLAGS rather than adding to CFLAGS_EXTRAS: clang rejects
+# -target together with the -mtargetos= the builder derives from the host
+# triple. The Framework sub-make below still picks up the plain macOS
+# -mtargetos= from the command line, which is what it wants.
+override ARCH_CFLAGS := -target $(ARCH)-apple-ios26.0-macabi
 
 all: Framework.framework/Versions/A/Framework a.out
 

--- a/lldb/test/API/macosx/macCatalyst/Makefile
+++ b/lldb/test/API/macosx/macCatalyst/Makefile
@@ -1,6 +1,9 @@
 C_SOURCES := main.c
 
-CFLAGS_EXTRAS := -target $(ARCH)-apple-ios13.1-macabi
+# The test passes the macCatalyst triple in via TRIPLE. Override ARCH_CFLAGS so
+# it wins over the -mtargetos= the builder derives from the host triple, which
+# clang rejects in combination with the -target below.
+override ARCH_CFLAGS := -target $(TRIPLE)
 
 USE_SYSTEM_STDLIB := 1
 

--- a/lldb/test/API/macosx/macCatalystAppMacOSFramework/Makefile
+++ b/lldb/test/API/macosx/macCatalystAppMacOSFramework/Makefile
@@ -1,7 +1,11 @@
 C_SOURCES := main.c
 LD_EXTRAS := -L. -lfoo
 
-CFLAGS_EXTRAS := -target $(ARCH)-apple-ios13.0-macabi
+# Override ARCH_CFLAGS rather than adding to CFLAGS_EXTRAS: clang rejects
+# -target together with the -mtargetos= the builder derives from the host
+# triple. The libfoo sub-make below still picks up the plain macOS
+# -mtargetos= from the command line, which is what it wants.
+override ARCH_CFLAGS := -target $(ARCH)-apple-ios13.0-macabi
 
 # FIXME: rdar://problem/54986190
 override CC_TYPE=clang


### PR DESCRIPTION
Since f5e2b8b1df07 ("[lldb] Rally around triple rather than arch in the API tests") the Darwin builder passes ARCH_CFLAGS=-mtargetos=<os><version> on the make command line, derived from --triple.