### PR TITLE
[Cherry-pick into next] [LLDB] Restore SwiftLanguage::GetInstanceName

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -136,6 +136,8 @@ public:
 
   bool SymbolNameFitsToLanguage(const Mangled &mangled) const override;
 
+  llvm::StringRef GetInstanceName() override { return "self"; }
+
   bool HandleFrameFormatVariable(const SymbolContext &sc,
                                  const ExecutionContext *exe_ctx,
                                  FormatEntity::Entry::Type type,


### PR DESCRIPTION
```
commit 991268cf435d841862cf6e3a54facd7e7de8af4d
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Aug 12 16:11:33 2026 -0700

    [LLDB] Restore SwiftLanguage::GetInstanceName
    
    Assisted-by: claude
```
