### PR TITLE
[lldb] Disable TestFrameProviderCircularDependency.py while working on a fix

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
@@ -46,7 +46,6 @@ class FrameProviderCircularDependencyTestCase(TestBase):
 
         return target, thread
 
-    @expectedFailureAll(oslist=["linux"], archs=["arm$"])
     def test_circular_dependency_with_function_replacement(self):
         """
         Test the circular dependency fix with a provider that replaces function names.

--- a/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
@@ -47,7 +47,6 @@ class FrameProviderCircularDependencyTestCase(TestBase):
         return target, thread
 
     @expectedFailureAll(oslist=["linux"], archs=["arm$"])
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     def test_circular_dependency_with_function_replacement(self):
         """
         Test the circular dependency fix with a provider that replaces function names.
@@ -115,7 +114,7 @@ class FrameProviderCircularDependencyTestCase(TestBase):
         )
 
         # Verify we can call methods on all frames (no circular dependency!).
-        for i in range(new_frame_count):
+        for i in range(min(new_frame_count, 3)):
             frame = thread.GetFrameAtIndex(i)
             self.assertIsNotNone(frame, f"Frame {i} should exist")
             # These calls should not trigger circular dependency.

--- a/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
@@ -164,6 +164,7 @@ class FrameProviderCircularDependencyTestCase(TestBase):
             )
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
+    @skipIf(bugnumber="https://github.com/llvm/llvm-project/pull/208992")
     def test_circular_dependency_evaluate_expression_in_get_frame(self):
         """
         Test that calling EvaluateExpression in get_frame_at_index doesn't


### PR DESCRIPTION
This cherry-picks few PRs from upstream and fixes and skips some flaky tests that affect Swift PR testing.
