### PR TITLE
[lldb][Swift] Fix task info command help text

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -3025,7 +3025,7 @@ public:
   CommandObjectLanguageSwiftTaskInfo(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "info",
                             "Print info about the Task being run on the "
-                            "current thread or the Task at the given address."
+                            "current thread or the Task at the given address.",
                             "language swift task info [<address>]") {
     AddSimpleArgumentList(eArgTypeAddress, eArgRepeatOptional);
   }


### PR DESCRIPTION
Fixes the help text for `language swift task info`.

The command syntax string was accidentally concatenated with the help text,
causing the output to show `address.language swift task info [<address>]`.

Verified with:

`lldb -b -o 'help language swift task info' -o 'quit'`