### PR TITLE
[lldb] fix EnvVars.test

### DIFF
--- a/lldb/test/Shell/SwiftREPL/EnvVars.test
+++ b/lldb/test/Shell/SwiftREPL/EnvVars.test
@@ -2,7 +2,7 @@
 // REQUIRES: system-darwin
 // REQUIRES: swift
 
-// RUN: FOO=foo %lldb --repl -O 'settings set target.inherit-env true' < %s 2>&1 \
+// RUN: env FOO=foo %lldb --repl -O 'settings set target.inherit-env true' < %s 2>&1 \
 // RUN: | FileCheck %s
 
 import Foundation


### PR DESCRIPTION
lit's internal shell requires the `env` prefix for inline environment variable assignments; `FOO=foo %lldb` failed with "command not found".