### PR TITLE
[lldb] fix TestSwiftDWARFImporter-Swift.py

### DIFF
--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -6,6 +6,7 @@ import os
 
 
 class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
+    SHARED_BUILD_TESTCASE = False
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 


### PR DESCRIPTION
This test doesn't set `SHARED_BUILD_TESTCASE = False`, so its 4 variants share one build directory. The custom `build()` override deletes the `include/` directory (containing the generated `Library-Swift.h`) after each build, so later variants reuse the stale `libLibrary.dylib` without regenerating the header, failing with `'Library-Swift.h' file not found`.