### PR TITLE
[lldb] fix No.swiftmodule-ObjC.test

### DIFF
--- a/lldb/test/Shell/Swift/Inputs/ObjCStuff.m
+++ b/lldb/test/Shell/Swift/Inputs/ObjCStuff.m
@@ -2,7 +2,7 @@
 
 @implementation ObjCClass
 - (id)init {
-  self = [NSNumber numberWithInt: 1234];
+  self = (id)[NSNumber numberWithInt: 1234];
   return self;
 }
 - (NSString * _Nonnull)debugDescription {


### PR DESCRIPTION
`ObjCStuff.m` assigns an `NSNumber*` to `self` (declared `ObjCClass*`) without a cast, which is now a hard compile error instead of a warning. Add an explicit `(id)` cast to preserve the intended runtime behavior the test exercises.