### PR TITLE
[lldb] fix InitFile.test

### DIFF
--- a/lldb/test/Shell/SwiftREPL/InitFile.test
+++ b/lldb/test/Shell/SwiftREPL/InitFile.test
@@ -4,8 +4,8 @@
 
 // RUN: export HOME=%t
 // RUN: mkdir -p %t
-// RUN: echo 'br set -f main.c -l 123' > ~/.lldbinit
-// RUN: echo 'br set -f swift-repl.c -l 456' > ~/.lldbinit-swift-repl
+// RUN: echo 'br set -f main.c -l 123' > %t/.lldbinit
+// RUN: echo 'br set -f swift-repl.c -l 456' > %t/.lldbinit-swift-repl
 // RUN: %lldb-init --repl < %s 2>&1 | FileCheck %s
 
 :br list


### PR DESCRIPTION
lit's internal shell doesn't expand `~`, so `echo ... > ~/.lldbinit` wrote to a literal file named `~` instead of `$HOME/.lldbinit`. Redirect to `%t/.lldbinit` instead.