### PR TITLE
[lldb] fix add-dsym.test

### DIFF
--- a/lldb/test/Shell/SymbolFile/Inputs/a.yaml
+++ b/lldb/test/Shell/SymbolFile/Inputs/a.yaml
@@ -1,0 +1,204 @@
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x100000C
+  cpusubtype:      0x0
+  filetype:        0x2
+  ncmds:           16
+  sizeofcmds:      744
+  flags:           0x200085
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         72
+    segname:         __PAGEZERO
+    vmaddr:          0
+    vmsize:          4294967296
+    fileoff:         0
+    filesize:        0
+    maxprot:         0
+    initprot:        0
+    nsects:          0
+    flags:           0
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         232
+    segname:         __TEXT
+    vmaddr:          4294967296
+    vmsize:          16384
+    fileoff:         0
+    filesize:        16384
+    maxprot:         5
+    initprot:        5
+    nsects:          2
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x100003FB0
+        size:            8
+        offset:          0x3FB0
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         00008052C0035FD6
+      - sectname:        __unwind_info
+        segname:         __TEXT
+        addr:            0x100003FB8
+        size:            72
+        offset:          0x3FB8
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x0
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         010000001C000000000000001C000000000000001C00000002000000B03F00003400000034000000B93F00000000000034000000030000000C000100100001000000000000000002
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         72
+    segname:         __LINKEDIT
+    vmaddr:          4294983680
+    vmsize:          16384
+    fileoff:         16384
+    filesize:        802
+    maxprot:         1
+    initprot:        1
+    nsects:          0
+    flags:           0
+  - cmd:             LC_DYLD_CHAINED_FIXUPS
+    cmdsize:         16
+    dataoff:         16384
+    datasize:        56
+  - cmd:             LC_DYLD_EXPORTS_TRIE
+    cmdsize:         16
+    dataoff:         16440
+    datasize:        48
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          16496
+    nsyms:           10
+    stroff:          16656
+    strsize:         232
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       8
+    iextdefsym:      8
+    nextdefsym:      2
+    iundefsym:       10
+    nundefsym:       0
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+  - cmd:             LC_LOAD_DYLINKER
+    cmdsize:         32
+    name:            12
+    Content:         '/usr/lib/dyld'
+    ZeroPadBytes:    7
+  - cmd:             LC_UUID
+    cmdsize:         24
+    uuid:            41945CA4-5D9D-3CDE-82B4-37E4C09750B5
+  - cmd:             LC_BUILD_VERSION
+    cmdsize:         32
+    platform:        1
+    minos:           786432
+    sdk:             787456
+    ntools:          1
+    Tools:
+      - tool:            3
+        version:         53280768
+  - cmd:             LC_SOURCE_VERSION
+    cmdsize:         16
+    version:         0
+  - cmd:             LC_MAIN
+    cmdsize:         24
+    entryoff:        16304
+    stacksize:       0
+  - cmd:             LC_LOAD_DYLIB
+    cmdsize:         56
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 85943299
+      compatibility_version: 65536
+    Content:         '/usr/lib/libSystem.B.dylib'
+    ZeroPadBytes:    6
+  - cmd:             LC_FUNCTION_STARTS
+    cmdsize:         16
+    dataoff:         16488
+    datasize:        8
+  - cmd:             LC_DATA_IN_CODE
+    cmdsize:         16
+    dataoff:         16496
+    datasize:        0
+  - cmd:             LC_CODE_SIGNATURE
+    cmdsize:         16
+    dataoff:         16896
+    datasize:        290
+LinkEditData:
+  NameList:
+    - n_strx:          28
+      n_type:          0x64
+      n_sect:          0
+      n_desc:          0
+      n_value:         0
+    - n_strx:          94
+      n_type:          0x64
+      n_sect:          0
+      n_desc:          0
+      n_value:         0
+    - n_strx:          122
+      n_type:          0x66
+      n_sect:          0
+      n_desc:          1
+      n_value:         1649891386
+    - n_strx:          1
+      n_type:          0x2E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294983600
+    - n_strx:          223
+      n_type:          0x24
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294983600
+    - n_strx:          1
+      n_type:          0x24
+      n_sect:          0
+      n_desc:          0
+      n_value:         8
+    - n_strx:          1
+      n_type:          0x4E
+      n_sect:          1
+      n_desc:          0
+      n_value:         8
+    - n_strx:          1
+      n_type:          0x64
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+    - n_strx:          2
+      n_type:          0xF
+      n_sect:          1
+      n_desc:          16
+      n_value:         4294967296
+    - n_strx:          22
+      n_type:          0xF
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294983600
+  FunctionStarts:  [ 0x3FB0 ]
+...

--- a/lldb/test/Shell/SymbolFile/Inputs/dsymforuuid.sh
+++ b/lldb/test/Shell/SymbolFile/Inputs/dsymforuuid.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+echo "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//ENhttp://www.apple.com/DTDs/PropertyList-1.0.dtd\">"
+echo "<plist version=\"1.0\">"
+echo "<dict>"
+echo "    <key>41945CA4-5D9D-3CDE-82B4-37E4C09750B5</key>"
+echo "    <dict>"
+echo "        <key>DBGArchitecture</key>"
+echo "        <string>x86_64</string>"
+echo "        <key>DBGError</key>"
+echo "        <string>UUID information was not found</string>"
+echo "    </dict>"
+echo "</dict>"
+echo "</plist>"

--- a/lldb/test/Shell/SymbolFile/add-dsym.test
+++ b/lldb/test/Shell/SymbolFile/add-dsym.test
@@ -4,5 +4,5 @@
 # HELP: Syntax: add-dsym <cmd-options> <filename>
 
 # RUN: yaml2obj %S/Inputs/a.yaml -o %t.out
-# RUN: LLDB_APPLE_DSYMFORUUID_EXECUTABLE=%S/Inputs/dsymforuuid.sh %lldb %t.out -o 'add-dsym -u 41945CA4-5D9D-3CDE-82B4-37E4C09750B5' 2>&1 | FileCheck %s
+# RUN: env LLDB_APPLE_DSYMFORUUID_EXECUTABLE=%S/Inputs/dsymforuuid.sh %lldb %t.out -o 'add-dsym -u 41945CA4-5D9D-3CDE-82B4-37E4C09750B5' 2>&1 | FileCheck %s
 # CHECK: UUID information was not found


### PR DESCRIPTION
lit's internal shell requires the `env` prefix for inline environment variable assignments; `LLDB_APPLE_DSYMFORUUID_EXECUTABLE=... %lldb` failed with "command not found". Also restores `Inputs/a.yaml` and `Inputs/dsymforuuid.sh`, which a prior merge from llvm.org/main dropped.