### PR TITLE
Target: Add target option for disabling `AArch64_ELFTargetObjectFile:…

### DIFF
--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -140,6 +140,7 @@ public:
         DebugStrictDwarf(false), Hotpatch(false),
         PPCGenScalarMASSEntries(false), JMCInstrument(false),
         EnableCFIFixup(false), MisExpect(false), XCOFFReadOnlyPointers(false),
+        SupportIndirectSymViaGOTPCRel_AArch64_ELF(true),
         VerifyArgABICompliance(true) {}
 
   /// DisableFramePointerElim - This returns true if frame pointer elimination
@@ -345,6 +346,10 @@ public:
   /// When set to true, const objects with relocatable address values are put
   /// into the RO data section.
   unsigned XCOFFReadOnlyPointers : 1;
+
+  /// When set to true, enables indirect symbol replacement with GOTPCREL for
+  /// AArch64/ELF. The default is `true`.
+  unsigned SupportIndirectSymViaGOTPCRel_AArch64_ELF : 1;
 
   /// When set to true, call/return argument extensions of narrow integers
   /// are verified in the target backend if it cares about them. This is

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -305,13 +305,15 @@ void AArch64TargetMachine::reset() { SubtargetMap.clear(); }
 //===----------------------------------------------------------------------===//
 // AArch64 Lowering public interface.
 //===----------------------------------------------------------------------===//
-static std::unique_ptr<TargetLoweringObjectFile> createTLOF(const Triple &TT) {
+static std::unique_ptr<TargetLoweringObjectFile>
+createTLOF(const Triple &TT, const TargetOptions &Options) {
   if (TT.isOSBinFormatMachO())
     return std::make_unique<AArch64_MachoTargetObjectFile>();
   if (TT.isOSBinFormatCOFF())
     return std::make_unique<AArch64_COFFTargetObjectFile>();
 
-  return std::make_unique<AArch64_ELFTargetObjectFile>();
+  return std::make_unique<AArch64_ELFTargetObjectFile>(
+      Options.SupportIndirectSymViaGOTPCRel_AArch64_ELF);
 }
 
 static StringRef computeDefaultCPU(const Triple &TT, StringRef CPU) {
@@ -370,7 +372,7 @@ AArch64TargetMachine::AArch64TargetMachine(const Target &T, const Triple &TT,
                                computeDefaultCPU(TT, CPU), FS, Options,
                                getEffectiveRelocModel(TT, RM),
                                getEffectiveAArch64CodeModel(TT, CM, JIT), OL),
-      TLOF(createTLOF(getTargetTriple())), isLittle(LittleEndian) {
+      TLOF(createTLOF(getTargetTriple(), Options)), isLittle(LittleEndian) {
   initAsmInfo();
 
   if (TT.isOSBinFormatMachO()) {

--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
@@ -32,7 +32,6 @@ void AArch64_ELFTargetObjectFile::Initialize(MCContext &Ctx,
                                              const TargetMachine &TM) {
   TargetLoweringObjectFileELF::Initialize(Ctx, TM);
   PLTPCRelativeSpecifier = AArch64::S_PLT;
-  SupportIndirectSymViaGOTPCRel = true;
   SupportDebugThreadLocalLocation = EmitAArch64DebugTLSLocation;
 
   // Make sure the implicitly created empty .text section has the

--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.h
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.h
@@ -20,6 +20,10 @@ class AArch64_ELFTargetObjectFile : public TargetLoweringObjectFileELF {
   void Initialize(MCContext &Ctx, const TargetMachine &TM) override;
 
 public:
+  AArch64_ELFTargetObjectFile(bool SupportIndirectSymViaGOTPCRel) {
+    this->SupportIndirectSymViaGOTPCRel = SupportIndirectSymViaGOTPCRel;
+  }
+
   const MCExpr *getIndirectSymViaGOTPCRel(const GlobalValue *GV,
                                           const MCSymbol *Sym,
                                           const MCValue &MV, int64_t Offset,


### PR DESCRIPTION
…:SupportIndirectSymViaGOTPCRel`

The gold linker that comes with
https://github.com/swiftlang/swift-docker/blob/main/swift-ci/main/ubuntu/24.04/Dockerfile (`GNU gold (GNU Binutils for Ubuntu 2.42) 1.16`) does not support this option and fails to link the standard library, so the Swift compiler needs a way to disable the option for AArch64 ELF.

See:
- https://github.com/swiftlang/llvm-project/pull/9339
- https://github.com/llvm/llvm-project/pull/78003

(cherry picked from commit b138afd1f457f16c9dbe7587e0b5ba25415972c2)