### PR TITLE
[cherry-pick next][lldb] Don't let a DW_AT_specification's byte size override the referring DIE's

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -161,7 +161,15 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
           }
         } break;
         case llvm::dwarf::DW_AT_byte_size:
-          dwarf_byte_size = form_value.Unsigned();
+          // Like DW_AT_linkage_name above, this could be a type with a
+          // DW_AT_specification pointing at the unsubstituted generic type,
+          // whose DW_AT_byte_size is meaningless (it is emitted as 0 because
+          // the size of an unbound generic isn't known). Don't let it
+          // overwrite the size of the referring DIE, which describes the
+          // substituted type. GetAttributes() guarantees that the attributes
+          // of the referring DIE come before those of the specification.
+          if (!dwarf_byte_size)
+            dwarf_byte_size = form_value.Unsigned();
           break;
         case llvm::dwarf::DW_AT_type:
           if (die.Tag() == llvm::dwarf::DW_TAG_const_type)

--- a/lldb/test/API/lang/swift/expression/constant/TestSwiftExpressionConstantMaterialization.py
+++ b/lldb/test/API/lang/swift/expression/constant/TestSwiftExpressionConstantMaterialization.py
@@ -7,9 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExpressionConstantMaterialization(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    # In embedded Swift the Swift compiler emits the DW_AT_byte_size
-    # for Optional as 0, which is incorrect.
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test constants can be materialized"""


### PR DESCRIPTION
DWARFASTParserSwift::ParseTypeFromDWARF collects attributes with
DWARFDIE::GetAttributes(), which defaults to Recurse::yes and therefore also
returns the attributes of any DIE reached through DW_AT_specification.

With -gdwarf-types the Swift compiler describes a bound generic as a "sized
container" DIE that points at the unsubstituted generic declaration.

The specification DIE describes `Optional<t_0_0>`, whose size is not known, so
it carries DW_AT_byte_size 0. Because the DW_AT_byte_size case assigned
unconditionally, that 0 clobbered the referring DIE's correct 0x08, and the
resulting Type reported a size of zero.

rdar://184553768

(cherry picked from commit 44d7e3ae35a4d1b1722f147ce1605a76e70fb0e9)
