### PR TITLE
[cherry-pick next][lldb] Fix decl context of a type declared in an extension

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -924,6 +924,14 @@ static bool BuildDeclContext(swift::Demangle::NodePointer node,
         {CompilerContextKind::AnyDeclContext, ConstString(type_name)});
     return true;
   }
+
+  case Node::Kind::Extension: {
+    // An Extension node is (extending module, extended type, [generic
+    // signature]).
+    if (node->getNumChildren() < 2)
+      return false;
+    return BuildDeclContext(node->getChild(1), context);
+  }
   default:
     break;
   }
@@ -3046,8 +3054,14 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
 
   swift::Demangle::Demangler dem;
   auto maybe_context = BuildDeclContext(AsMangledName(opaque_type), dem);
-  if (!maybe_context || maybe_context->empty())
+  if (!maybe_context || maybe_context->empty()) {
+    // Bailing out here means no module query is issued at all, which is easy to
+    // mistake for a failed lookup, so make it visible.
+    LLDB_LOGV(GetLog(LLDBLog::Types),
+              "Could not build the decl context of {0}",
+              AsMangledName(opaque_type));
     return {};
+  }
 
   swift::Mangle::ManglingFlavor flavor =
       SwiftLanguageRuntime::GetManglingFlavor(AsMangledName(opaque_type));

--- a/lldb/test/API/lang/swift/embedded/extension_nested_type/Makefile
+++ b/lldb/test/API/lang/swift/embedded/extension_nested_type/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/extension_nested_type/TestSwiftEmbeddedExtensionNestedType.py
+++ b/lldb/test/API/lang/swift/embedded/extension_nested_type/TestSwiftEmbeddedExtensionNestedType.py
@@ -1,0 +1,54 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedExtensionNestedType(TestBase):
+    @skipEmbeddedSwiftOnWindows
+    @skipUnlessEmbeddedSwift
+    @swiftTest
+    def test(self):
+        """Test that a type declared in an extension whose mangled decl context
+        contains an Extension node can be laid out from DWARF."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        # Control: an unconstrained same-module extension is elided by the
+        # mangler, so this has always worked.
+        plain = frame.FindVariable("plain")
+        lldbutil.check_variable(self, plain, num_children=1)
+        lldbutil.check_variable(
+            self, plain.GetChildMemberWithName("v"), value="10"
+        )
+
+        # A constrained extension of a generic struct.
+        constr = frame.FindVariable("constr")
+        lldbutil.check_variable(self, constr, num_children=1)
+        lldbutil.check_variable(
+            self, constr.GetChildMemberWithName("v"), value="20"
+        )
+
+        # A private type in a constrained extension. Reaching `hidden` requires
+        # resolving a decl context that has a private discriminator underneath
+        # the Extension node.
+        holder = frame.FindVariable("holder")
+        lldbutil.check_variable(self, holder, num_children=2)
+        lldbutil.check_variable(
+            self,
+            holder.GetChildMemberWithName("hidden").GetChildMemberWithName("w"),
+            value="30",
+        )
+        lldbutil.check_variable(
+            self, holder.GetChildMemberWithName("tag"), value="31"
+        )
+
+        # A constrained extension of a generic class.
+        cls = frame.FindVariable("cls")
+        lldbutil.check_variable(self, cls, num_children=1)
+        lldbutil.check_variable(self, cls.GetChildMemberWithName("v"), value="40")

--- a/lldb/test/API/lang/swift/embedded/extension_nested_type/main.swift
+++ b/lldb/test/API/lang/swift/embedded/extension_nested_type/main.swift
@@ -1,0 +1,65 @@
+// A type declared inside an extension has an `Extension` node in the decl
+// context of its mangled name whenever the mangler cannot elide the extension:
+// when the extension is constrained, when it is on a protocol, or when it is in
+// a different module than the type it extends. Everything here is in a single
+// module, so the constrained extensions are what produce the `Extension` node.
+
+struct Box<T> {
+  var t: T
+}
+
+extension Box {
+  // Unconstrained and in the same module: the mangler elides the extension
+  // entirely, so this type's decl context is indistinguishable from direct
+  // nesting. Control case.
+  struct InPlainExt {
+    var v: Int
+  }
+}
+
+extension Box where T == Int {
+  // Constrained, so mangled as
+  // Structure(Extension(main, BoundGenericStructure, GenericSignature), ...).
+  struct InConstrExt {
+    var v: Int
+  }
+
+  // A private type in the same extension. Its private discriminator becomes a
+  // DW_TAG_namespace between the extended nominal and the type itself.
+  private struct Hidden {
+    var w: Int
+  }
+
+  struct Holder {
+    private var hidden = Hidden(w: 30)
+    var tag = 31
+    init() {}
+  }
+}
+
+final class Ref<T> {
+  var t: T
+  init(t: T) { self.t = t }
+}
+
+extension Ref where T == Int {
+  // The extended type of a constrained extension of a generic class demangles
+  // to a BoundGenericClass rather than a BoundGenericStructure.
+  struct InClassConstrExt {
+    var v: Int
+  }
+}
+
+func main() {
+  let plain = Box<Int>.InPlainExt(v: 10)
+  let constr = Box<Int>.InConstrExt(v: 20)
+  let holder = Box<Int>.Holder()
+  let cls = Ref<Int>.InClassConstrExt(v: 40)
+  print("break here")
+  print(plain.v)
+  print(constr.v)
+  print(holder.tag)
+  print(cls.v)
+}
+
+main()


### PR DESCRIPTION
A type declared inside an extension carries an `Extension` node in the decl
context of its mangled name.

We were not handling the 'extension' node in BuildDeclContext, so
any type declared inside an extension with a where clause mentioning a
type defined elsewhere would fail.

Assisted-by: claude

rdar://184560278

(cherry picked from commit 9ecca165590d7c8b984b002086acebf66d8f34c8)
