### PR TITLE
[clang] Keep the CAS alive as long as the in-memory module cache

### DIFF
--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -101,6 +101,8 @@ class ASTUnit {
   IntrusiveRefCntPtr<DiagnosticsEngine>   Diagnostics;
   IntrusiveRefCntPtr<FileManager>         FileMgr;
   IntrusiveRefCntPtr<SourceManager>       SourceMgr;
+  std::shared_ptr<cas::ObjectStore> CAS;
+  std::shared_ptr<cas::ActionCache> ActionCache;
   std::shared_ptr<ModuleCache> ModCache;
   std::unique_ptr<HeaderSearch>           HeaderInfo;
   IntrusiveRefCntPtr<TargetInfo>          Target;
@@ -110,8 +112,6 @@ class ASTUnit {
   std::unique_ptr<HeaderSearchOptions> HSOpts;
   std::shared_ptr<PreprocessorOptions>    PPOpts;
   IntrusiveRefCntPtr<ASTReader> Reader;
-  std::shared_ptr<cas::ObjectStore> CAS;
-  std::shared_ptr<cas::ActionCache> ActionCache;
   bool HadModuleLoaderFatalFailure = false;
   bool StorePreamblesInMemory = false;
 

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -1077,6 +1077,15 @@ public:
             std::shared_ptr<llvm::cas::ActionCache>>
   getOrCreateCASDatabases(DiagnosticsEngine *Diags = nullptr);
 
+  /// Get the CAS databases if they have already been created or set, otherwise
+  /// a pair of null pointers. Unlike \c getOrCreateCASDatabases() this does not
+  /// open a CAS that is not being used.
+  std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+            std::shared_ptr<llvm::cas::ActionCache>>
+  getCASDatabases() const {
+    return {CAS, ActionCache};
+  }
+
   void setCASDatabases(std::shared_ptr<llvm::cas::ObjectStore> CAS,
                        std::shared_ptr<llvm::cas::ActionCache> Cache);
 };

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1132,6 +1132,11 @@ bool ASTUnit::Parse(std::shared_ptr<PCHContainerOperations> PCHContainerOps,
   auto Clang = std::make_unique<CompilerInstance>(CCInvocation,
                                                   std::move(PCHContainerOps));
 
+  // Reuse the CAS this ASTUnit already has, so that module files the instance
+  // loads out of it keep pointing into a live CAS once the instance is gone.
+  if (CAS && ActionCache)
+    Clang->setCASDatabases(CAS, ActionCache);
+
   // Clean up on error, disengage it if the function returns successfully.
   llvm::scope_exit CleanOnError([&]() {
     // Remove the overridden buffer we used for the preamble.
@@ -1432,6 +1437,14 @@ void ASTUnit::transferASTDataFromCompilerInstance(CompilerInstance &CI) {
     Target = CI.getTargetPtr();
   Reader = CI.getASTReader();
   ModCache = CI.getModuleCachePtr();
+  // Module files in the module cache can point into the CAS they were loaded
+  // from, so take over the CAS the instance opened for itself as well. When
+  // this ASTUnit already has one, the instance was given the same one.
+  if (auto [InstanceCAS, InstanceActionCache] = CI.getCASDatabases();
+      InstanceCAS) {
+    CAS = std::move(InstanceCAS);
+    ActionCache = std::move(InstanceActionCache);
+  }
   HadModuleLoaderFatalFailure = CI.hadModuleLoaderFatalFailure();
   if (Invocation != CI.getInvocationPtr()) {
     // This happens when Parse creates a copy of \c Invocation to modify.

--- a/clang/lib/Frontend/Rewrite/FrontendActions.cpp
+++ b/clang/lib/Frontend/Rewrite/FrontendActions.cpp
@@ -244,6 +244,10 @@ public:
     CompilerInstance Instance(
         std::make_shared<CompilerInvocation>(CI.getInvocation()),
         CI.getPCHContainerOperations(), CI.getModuleCachePtr());
+    // Share the CAS with the outer instance, which owns the module cache this
+    // instance loads CAS-backed module files into.
+    if (auto [CAS, ActionCache] = CI.getCASDatabases(); CAS)
+      Instance.setCASDatabases(std::move(CAS), std::move(ActionCache));
     Instance.setVirtualFileSystem(CI.getVirtualFileSystemPtr());
     Instance.createDiagnostics(
         new ForwardingDiagnosticConsumer(CI.getDiagnosticClient()),

--- a/clang/test/CAS/libclang-implicit-modules-explicit-cas-module.c
+++ b/clang/test/CAS/libclang-implicit-modules-explicit-cas-module.c
@@ -1,0 +1,52 @@
+// Implicit modules build that also loads an explicit CAS-backed module file,
+// driven through libclang. Outer.pcm records Inner's cache key, so Inner is
+// read out of the CAS rather than from disk.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-include-tree-full -cas-path %t/cas > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name Inner > %t/Inner.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Outer > %t/Outer.rsp
+// RUN: %clang @%t/Inner.rsp
+// RUN: %clang @%t/Outer.rsp -o %t/Outer.pcm
+
+// RUN: c-index-test -test-load-source all -fmodules -fimplicit-module-maps \
+// RUN:   -fmodules-cache-path=%t/mcp -I %t -fmodule-file=Outer=%t/Outer.pcm \
+// RUN:   -Xclang -fcas-path -Xclang %t/cas %t/tu.c 2>&1 | FileCheck %s
+
+// CHECK: inner.h:1:12: VarDecl=inner_var
+// CHECK: inner.h:2:8: StructDecl=InnerType
+// CHECK: outer.h:2:12: VarDecl=outer_var
+// CHECK: tu.c:2:5: FunctionDecl=use
+// CHECK: tu.c:2:24: TypeRef=struct InnerType
+// CHECK: tu.c:2:43: DeclRefExpr=inner_var
+// CHECK: tu.c:2:55: DeclRefExpr=outer_var
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only -fmodules DIR/tu.c -I DIR -fmodules-cache-path=DIR/module-cache",
+    "file": "DIR/tu.c"
+  }
+]
+
+//--- module.modulemap
+module Inner { header "inner.h" }
+module Outer { header "outer.h" export * }
+
+//--- inner.h
+extern int inner_var;
+struct InnerType { int x; };
+
+//--- outer.h
+#include "inner.h"
+extern int outer_var;
+
+//--- tu.c
+#include "outer.h"
+int use(void) { struct InnerType t; t.x = inner_var + outer_var; return t.x; }


### PR DESCRIPTION
Module files loaded from the CAS are added to the in-memory module cache as
buffers that may alias storage the ObjectStore owns, so the cache must not
outlive the store. That does not hold for the module cache an ASTUnit takes
over from the CompilerInstance it parses with: libclang crashed reading a
module file after the parse had finished and the instance, along with the CAS
it opened for itself, was gone.

Have ASTUnit take over the instance's CAS together with its module cache, and
hand its own CAS to the instances it creates so there is a single store per
ASTUnit. Do the same for the instance RewriteIncludesAction creates to rewrite
a module file, which borrows the outer instance's module cache.

