### PR TITLE
[lldb][test] Adapt 3 async tests for embedded swift

### DIFF
--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -7,12 +7,18 @@ class TestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     @skipIf(oslist=['windows'])
     def test(self):
         """Test `frame variable` in async functions"""
         self.build()
+
+        # Embedded Swift monomorphizes inner<T> into a mandatory
+        # specialization, so only assert dynamic resolution where a 
+        # generic function actually survives.
+        use_dynamic = not self.isEmbeddedSwift()
 
         source_file = lldb.SBFileSpec("main.swift")
         target, process, _, _ = lldbutil.run_to_source_breakpoint(
@@ -26,7 +32,7 @@ class TestCase(lldbtest.TestBase):
         b = frame.FindVariable("b")
         self.assertFalse(b.IsValid())
         d = frame.FindVariable("d")
-        lldbutil.check_variable(self, d, use_dynamic=True, value='23')
+        lldbutil.check_variable(self, d, use_dynamic=use_dynamic, value='23')
 
         # The first breakpoint resolves to multiple locations, but only the
         # first location is needed. Now that we've stopped, delete it to
@@ -47,4 +53,4 @@ class TestCase(lldbtest.TestBase):
         self.assertTrue(b.IsValid())
         self.assertGreater(b.unsigned, 0)
         d = frame.FindVariable("d")
-        lldbutil.check_variable(self, d, use_dynamic=True, value='23')
+        lldbutil.check_variable(self, d, use_dynamic=use_dynamic, value='23')

--- a/lldb/test/API/lang/swift/async/frame/variable/main.swift
+++ b/lldb/test/API/lang/swift/async/frame/variable/main.swift
@@ -4,7 +4,8 @@ func randInt(_ i: Int) async -> Int {
 
 func inner<T>(_ t: T) async {
   // d is dynamically allocated by swift_task_alloc() because its size
-  // is unknown.
+  // is unknown. (Not in embedded Swift, which monomorphizes inner<T> and
+  // stores d inline in the async context.)
   let d = t
   let a = await randInt(30)
   print("break one")

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
@@ -67,7 +67,8 @@ class TestCase(lldbtest.TestBase):
             myvar = frame.FindVariable("myvar")
             lldbutil.check_variable(self, myvar, False, value=expected_value)
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):
@@ -98,7 +99,8 @@ class TestCase(lldbtest.TestBase):
 
         # Now stop at the Q funclet right after the await to ASYNC___1
         target.DeleteAllBreakpoints()
-        target.BreakpointCreateByName("$s1a12ASYNC___2___SiyYaFTQ0_")
+        target.BreakpointCreateByName(
+            self.swiftMangledName("$s1a12ASYNC___2___SiyYaFTQ0_"))
         process.Continue()
         async_frames = process.GetSelectedThread().frames
         self.check_cfas(async_frames, process)

--- a/lldb/test/API/lang/swift/async/variables/Makefile
+++ b/lldb/test/API/lang/swift/async/variables/Makefile
@@ -1,4 +1,3 @@
 SWIFT_SOURCES := main.swift
 SWIFT_CONCURRENCY := 1
-SWIFTFLAGS_EXTRAS := -Xfrontend -enable-upcoming-feature -Xfrontend NonisolatedNonsendingByDefault
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/variables/TestSwiftAsyncVariables.py
+++ b/lldb/test/API/lang/swift/async/variables/TestSwiftAsyncVariables.py
@@ -8,7 +8,8 @@ class TestSwiftAsyncVariables(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     @skipIf(oslist=['windows'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/variables/main.swift
+++ b/lldb/test/API/lang/swift/async/variables/main.swift
@@ -2,9 +2,9 @@ import Swift
 func use<T>(_ t: T) {}
 func sink<T>(_ t: T) {}
 
-func split() async {}
+nonisolated(nonsending) func split() async {}
 
-func f(_ xs: [Int?]) async {
+nonisolated(nonsending) func f(_ xs: [Int?]) async {
   for x in xs {
     let x = x!
     sink(x) // break here


### PR DESCRIPTION
TestSwiftAsyncVariables:

Commit 3e06ac3ffd73 added NonisolatedNonsendingByDefault flag to the test
"so that the entry funclet is no longer empty." The flag doesn't work in
embedded swift, because the flag also hits Main.main, which embedded rejects
for @main because it has no MainActor to keep main isolated. Instead, mark the
functions as nonisolated(nonsending) which has the same effect, but
compiles in embedded.

TestSwiftAsyncFrameVar:
Because embedded swift monomorphizes, there's no dynamic type resolution
to be done. Adapt the test to do dynamic type resolution only on regular swift mode.

TestSwiftAsyncFrameVarMultipleFrames:
Break by mangled name respecting embedded swift's mangled name.

Assisted-by: claude