### PR TITLE
[LLDB] Fix more dependency tracking bugs in the testsuite

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -698,7 +698,7 @@ endif
 %.o: %.c %.d $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.cpp %.d $(PCH_OUTPUT) $(SWIFT_CXX_HEADER) $(call tool_prereq,$(CXX))
+%.o: %.cpp %.d $(PCH_OUTPUT) $(SWIFT_CXX_HEADER) $(call tool_prereq,$(CXX_PATH))
 	$(CXX) $(PCHFLAGS) $(CXXFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
 %.o: %.m %.d $(call tool_prereq,$(CC))

--- a/lldb/test/API/lang/swift/clangimporter/Werror/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/Makefile
@@ -6,7 +6,8 @@ all: libDylib.dylib a.out
 
 include Makefile.rules
 
-libDylib.dylib: dylib.swift
+libDylib.dylib: dylib.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" BASENAME=$(shell basename $< .swift) \
 		-f $(SRCDIR)/dylib.mk all
 

--- a/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/Makefile
@@ -17,7 +17,8 @@ all: libdylib.dylib a.out
 
 include Makefile.rules
 
-libdylib.dylib: dylib.swift
+libdylib.dylib: dylib.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		DYLIB_NAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/Makefile
@@ -6,7 +6,8 @@ all: libDylib.dylib a.out
 
 include Makefile.rules
 
-libDylib.dylib: dylib.swift
+libDylib.dylib: dylib.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" BASENAME=$(shell basename $< .swift) \
 		-f $(SRCDIR)/dylib.mk all
 

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
@@ -15,13 +15,15 @@ include Makefile.rules
 # swift modules talk Objective-C to the conflicting swift module to
 # make the conflict possible.
 
-libDylib.dylib: Dylib.swift
+libDylib.dylib: Dylib.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES X=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
-libConflict.dylib: Conflict.swift
+libConflict.dylib: Conflict.swift \
+                   $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES X=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/Makefile
@@ -13,7 +13,8 @@ all: libdylib.dylib a.out
 
 include Makefile.rules
 
-libdylib.dylib: dylib.swift
+libdylib.dylib: dylib.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		DYLIB_NAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/Makefile
@@ -13,7 +13,8 @@ all: libdylib.dylib a.out
 include Makefile.rules
 SWIFTFLAGS += -Xcc -I$(SRCDIR)/Bar -I. -Xcc -I$(SRCDIR)/Foo
 
-libdylib.dylib: dylib.swift
+libdylib.dylib: dylib.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES X=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		DYLIB_NAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/Makefile
@@ -13,7 +13,8 @@ ifneq "$(CODESIGN)" ""
 endif
 
 
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/Makefile
@@ -10,7 +10,8 @@ include Makefile.rules
 OVERLAY_CONTENT := { "version": 0, "roots": [] }
 OVERLAY := $(BUILDDIR)/overlay.yaml
 
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call RM_F,$(OVERLAY))
 	$(call ECHO_TO_FILE,'$(OVERLAY_CONTENT)',$(OVERLAY))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/Makefile
@@ -11,7 +11,8 @@ ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
 
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call MKDIR_P,$(BUILDDIR)/$(shell basename $< .swift))
 	"$(MAKE)" MAKE_DSYM=YES X=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
@@ -10,7 +10,8 @@ all: libFoo.dylib libBar.dylib a.out
 
 include Makefile.rules
 
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/Makefile
@@ -14,7 +14,8 @@ ifneq "$(CODESIGN)" ""
 endif
 	mv $(BOTDIR) $(USERDIR)
 
-libFoo.dylib: Foo.swift
+libFoo.dylib: Foo.swift \
+              $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call MKDIR_P,$(BOTDIR))
 	$(call CP_R,$(SRCDIR)/Foo,$(BOTDIR)/)
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/test/API/lang/swift/clashing_abi_name/Makefile
+++ b/lldb/test/API/lang/swift/clashing_abi_name/Makefile
@@ -6,7 +6,8 @@ all: libLibrary.dylib a.out
 
 include Makefile.rules
 
-libLibrary.dylib: Library.swift
+libLibrary.dylib: Library.swift \
+                  $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=Library \

--- a/lldb/test/API/lang/swift/cross_module_extension/Makefile
+++ b/lldb/test/API/lang/swift/cross_module_extension/Makefile
@@ -8,14 +8,16 @@ all: libmoda.dylib libmodb.dylib main
 include Makefile.rules
 
 
-libmoda.dylib: moda.swift
+libmoda.dylib: moda.swift \
+               $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 
-libmodb.dylib: modb.swift
+libmodb.dylib: modb.swift \
+               $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/Makefile
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/Makefile
@@ -7,5 +7,6 @@ all: libFoo.dylib $(EXE)
 
 include Makefile.rules
 
-libFoo.dylib: Foo.swift
+libFoo.dylib: Foo.swift \
+              $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=NO VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all

--- a/lldb/test/API/lang/swift/expression/objc_context/Makefile
+++ b/lldb/test/API/lang/swift/expression/objc_context/Makefile
@@ -9,7 +9,8 @@ all: libFoo.dylib $(EXE)
 
 include Makefile.rules
 
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/Makefile
@@ -12,11 +12,13 @@ all: clean SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
 
 include Makefile.rules
 
-SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
+SomeLibraryCore.swiftmodule: SomeLibraryCore.swift \
+                             $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" BASENAME=$(shell basename $@ .swiftmodule) \
 		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all
 
-SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
+SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule \
+                         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" BASENAME=$(shell basename $@ .swiftmodule) \
 		VPATH=$(SRCDIR) LD_EXTRAS="-L$(BUILDDIR) $(SHLIB_RPATH)" -f $(SRCDIR)/../dylib.mk all
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/Makefile
@@ -6,12 +6,14 @@ all: clean SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
 
 include Makefile.rules
 
-SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
+SomeLibraryCore.swiftmodule: SomeLibraryCore.swift \
+                             $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" BASENAME=$(shell basename $@ .swiftmodule) \
 		SWIFTFLAGS_EXTRAS=-enable-library-evolution \
 		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all
 
-SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
+SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule \
+                         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" BASENAME=$(shell basename $@ .swiftmodule) \
 		SWIFTFLAGS_EXTRAS=-enable-library-evolution \
 		VPATH=$(SRCDIR) LD_EXTRAS="-L$(BUILDDIR) -Xlinker -rpath -Xlinker $(BUILDDIR)" -f $(SRCDIR)/../dylib.mk all

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/Makefile
@@ -7,7 +7,8 @@ all: clean SomeLibrary.swiftmodule a.out
 
 include Makefile.rules
 
-SomeLibrary.swiftmodule: SomeLibrary.swift
+SomeLibrary.swiftmodule: SomeLibrary.swift \
+                         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" BASENAME=$(shell basename $@ .swiftmodule) \
 		SWIFTFLAGS_EXTRAS=$(LIBRARY_SWIFTFLAGS_EXTRAS) \
 		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all

--- a/lldb/test/API/lang/swift/optional_of_resilient/Makefile
+++ b/lldb/test/API/lang/swift/optional_of_resilient/Makefile
@@ -6,7 +6,8 @@ include Makefile.rules
 LD_EXTRAS = -lmod -L$(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 
-libmod.dylib: mod.swift
+libmod.dylib: mod.swift \
+              $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=mod \

--- a/lldb/test/API/lang/swift/private_generic_type/Makefile
+++ b/lldb/test/API/lang/swift/private_generic_type/Makefile
@@ -6,7 +6,8 @@ include Makefile.rules
 LD_EXTRAS = -lPublic -lPrivate -L$(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 
-libPrivate.dylib: Private.swift
+libPrivate.dylib: Private.swift \
+                  $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=Private \
@@ -17,7 +18,8 @@ libPrivate.dylib: Private.swift
 		DYLIB_SWIFT_SOURCES:=Private.swift \
 		-f $(MAKEFILE_RULES)
 
-libPublic.dylib: Public.swift
+libPublic.dylib: Public.swift \
+                 $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=Public \

--- a/lldb/test/API/lang/swift/private_import/Makefile
+++ b/lldb/test/API/lang/swift/private_import/Makefile
@@ -6,13 +6,15 @@ include Makefile.rules
 LD_EXTRAS = -lLibrary -L$(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 
-libInvisible.dylib: Invisible.swift
+libInvisible.dylib: Invisible.swift \
+                    $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=Invisible DEBUG_INFO_FLAG=-gnone \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
-libLibrary.dylib: Library.swift
+libLibrary.dylib: Library.swift \
+                  $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=Library \

--- a/lldb/test/API/lang/swift/resilience/Makefile
+++ b/lldb/test/API/lang/swift/resilience/Makefile
@@ -3,7 +3,8 @@ all: libmod.a.dylib libmod.b.dylib main.a main.b
 
 include Makefile.rules
 
-libmod.%.dylib: mod.%.swift
+libmod.%.dylib: mod.%.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call LN_SF,$<,mod.swift)
 	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -###
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/test/API/lang/swift/swift_version/Makefile
+++ b/lldb/test/API/lang/swift/swift_version/Makefile
@@ -10,7 +10,8 @@ include Makefile.rules
 MOD5_FLAGS = -swift-version 5
 MOD4_FLAGS = -swift-version 4
 
-libmod%.dylib: mod%.swift
+libmod%.dylib: mod%.swift \
+               $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		SWIFTFLAGS_EXTRAS="$(MOD$*_FLAGS)" \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \


### PR DESCRIPTION
(cherry picked from commit a7f47a109b35458af748b93c899e7e46195bee5f)

 Conflicts:
	lldb/packages/Python/lldbsuite/test/make/Makefile.rules