### PR TITLE
[lldb][embedded] Fix frame recognizer hardcoding desktop swift mangling flavor

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.cpp
@@ -14,6 +14,7 @@
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#include "swift/Demangling/ManglingMacros.h"
 #include "swift/Strings.h"
 
 using namespace lldb;
@@ -242,7 +243,11 @@ void RegisterSwiftFrameRecognizers(Process &process) {
         Mangled::NamePreference::ePreferDemangledWithoutArguments, false);
   }
   {
-    auto symbol_regex_sp = std::make_shared<RegularExpression>("^\\$s.*");
+    // Match both mangling flavors: "$s" for regular Swift and "$e" for
+    // embedded Swift. The recognizer itself is flavor-agnostic, since it
+    // decides from the demangle tree.
+    auto symbol_regex_sp = std::make_shared<RegularExpression>(
+        "^(\\" MANGLING_PREFIX_STR "|\\" MANGLING_PREFIX_EMBEDDED_STR ").*");
     auto srf_sp = std::make_shared<SwiftHiddenFrameRecognizer>();
     manager.AddRecognizer(srf_sp, module_regex_sp, symbol_regex_sp,
                           Mangled::NamePreference::ePreferMangled, false);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -32,6 +32,8 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Status.h"
 
+#include "swift/Demangling/ManglingMacros.h"
+
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
 
 #include "clang/AST/DeclObjC.h"
@@ -254,7 +256,8 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
   if (!compiler_type && die.Tag() == llvm::dwarf::DW_TAG_typedef) {
     // Handle Archetypes, which are typedefs to RawPointerType.
     llvm::StringRef typedef_name = GetTypedefName(die);
-    if (typedef_name.starts_with("$sBp")) {
+    if (typedef_name.starts_with(MANGLING_PREFIX_STR "Bp") ||
+        typedef_name.starts_with(MANGLING_PREFIX_EMBEDDED_STR "Bp")) {
       preferred_name = name;
       compiler_type = m_swift_typesystem.GetTypeFromMangledTypename(
           ConstString(typedef_name));

--- a/lldb/test/API/lang/swift/async/unwind/hidden_frames/TestSwiftAsyncHiddenFrames.py
+++ b/lldb/test/API/lang/swift/async/unwind/hidden_frames/TestSwiftAsyncHiddenFrames.py
@@ -8,7 +8,7 @@ class TestSwiftAsyncHiddenFrames(lldbtest.TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=['windows',])
     def test(self):


### PR DESCRIPTION
Also drive-by fix another hardcoding inside DWARFASTParserSwift.cpp for
Builtin.RawPointer type.

Assisted-by: Claude

rdar://184278873
