### PR TITLE
[Cherry-pick into next] [LLDB] Ad even more dependency tracking in Swift tests

### DIFF
--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/Makefile
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/Makefile
@@ -9,7 +9,8 @@ all: libinvisible.dylib $(EXE)
 
 include Makefile.rules
 
-libinvisible.dylib: Invisible.swift
+libinvisible.dylib: Invisible.swift \
+                    $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=Invisible \
 		DYLIB_SWIFT_SOURCES="Invisible.swift" \

--- a/lldb/test/API/lang/swift/clangimporter/explicit_mixed_cc1/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/explicit_mixed_cc1/Makefile
@@ -7,7 +7,8 @@ all: B.swift.o $(EXE)
 
 include Makefile.rules
 
-B.swift.o: B.swift
+B.swift.o: B.swift \
+           $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		SWIFT_SOURCES=B.swift \

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
@@ -7,7 +7,8 @@ all: libDylib a.out
 include Makefile.rules
 
 # Note that this is being built with implicit modules!
-libDylib: Dylib.swift
+libDylib: Dylib.swift \
+          $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call MKDIR_P,$(BUILDDIR)/$(shell basename $< .swift))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -17,8 +17,11 @@ class TestSwiftClangImporterExplicitNoImplicit(TestBase):
         Test flipping on/off implicit modules.
         """
         self.build()
+        mod_cache = self.getBuildArtifact("IMPLICIT-CLANG-MODULE-CACHE")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
         self.expect('settings set symbols.clang-modules-cache-path '
-                    + self.getBuildArtifact("IMPLICIT-CLANG-MODULE-CACHE"))
+                    + mod_cache)
         lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'),
                                           extra_images=['Dylib'])

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Makefile
@@ -10,7 +10,8 @@ SWIFTFLAGS_EXTRAS=$(BAR_FLAGS) \
   -F$(BUILDDIR) -framework Framework -L$(BUILDDIR) \
   -Xlinker -rpath -Xlinker $(BUILDDIR)
 
-Framework.framework: Framework.swift
+Framework.framework: Framework.swift \
+                     $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) -C $(BUILDDIR) VPATH=$(VPATH) \
                 MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/Makefile
@@ -6,7 +6,8 @@ SWIFT_OBJC_INTEROP := 1
 
 include Makefile.rules
 
-a.out: main.m libFoo.dylib libBar.dylib
+a.out: main.m libFoo.dylib libBar.dylib \
+       $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -lBar -L$(shell pwd) -o $@ $<
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"

--- a/lldb/test/API/lang/swift/clangimporter/missing_pch/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/missing_pch/Makefile
@@ -8,7 +8,8 @@ all: libFoo.dylib $(EXE)
 include Makefile.rules
 
 OVERLAY := $(BUILDDIR)/overlay.yaml
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call ECHO_TO_FILE,'struct S {};',$(BUILDDIR)/header.h)
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \

--- a/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objc_internal_property_redecl/Makefile
@@ -11,7 +11,8 @@ SWIFTFLAGS_EXTRAS = \
 
 TestFramework.framework: TestFramework.swift TestFramework.h \
                          TestFramework_Private.h \
-                         module.modulemap module.private.modulemap
+                         module.modulemap module.private.modulemap \
+                         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) -C $(BUILDDIR) VPATH=$(VPATH) \
 		MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \

--- a/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objc_runtime_ivars/Makefile
@@ -5,7 +5,8 @@ all: aTestFramework.framework/Versions/A/aTestFramework a.out a.out.dSYM
 
 include Makefile.rules
 
-aTestFramework.framework/Versions/A/aTestFramework : aTestFramework.mm
+aTestFramework.framework/Versions/A/aTestFramework : aTestFramework.mm \
+                                                    $(call tool_prereq,$(CXX_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		MAKE_DSYM=YES DYLIB_ONLY=YES \
 		FRAMEWORK=aTestFramework DYLIB_CXX_SOURCES=aTestFramework.mm \

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/Makefile
@@ -5,7 +5,8 @@ SWIFT_OBJC_INTEROP := 1
 
 include Makefile.rules
 
-a.out: main.m libFoo.dylib libBar.dylib
+a.out: main.m libFoo.dylib libBar.dylib \
+       $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -lBar -L$(shell pwd) -o $@ $<
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/Makefile
@@ -5,7 +5,8 @@ include Makefile.rules
 
 BUILD_SDK := $(BUILDDIR)/LocalSDK/$(shell basename $(SDKROOT))
 
-$(EXE): $(SWIFT_SOURCES)
+$(EXE): $(SWIFT_SOURCES) \
+        $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call RM_RF,$(BUILDDIR)/LocalSDK)
 	$(call ECHO,"Symlinking iOS SDK into build directory as a fake macOS SDK")
 	$(call MKDIR_P,$(BUILDDIR)/LocalSDK)

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/Makefile
@@ -12,7 +12,8 @@ LD_EXTRAS += -lLibrary -L.
 
 .PHONY: libLibrary
 
-libLibrary:
+libLibrary: \
+            $(call tool_prereq,$(CC))
 	"$(MAKE)" -f $(SRCDIR)/Library.mk VPATH=$(SRCDIR) -I $(SRCDIR)
 
 clean::

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/Makefile
@@ -7,7 +7,8 @@ BUILDDIR := $(realpath $(shell pwd))
 BOTDIR := $(BUILDDIR)/buildbot
 USERDIR := $(BUILDDIR)/user
 
-a.out: main.m libFoo.dylib
+a.out: main.m libFoo.dylib \
+       $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -L$(shell pwd) -o $@ $<
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/Makefile
@@ -22,7 +22,8 @@ ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
 
-main.o: main.m libFoo.a libBar.a
+main.o: main.m libFoo.a libBar.a \
+        $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -c -o $@ $< \
 		-I$(shell pwd)
 

--- a/lldb/test/API/lang/swift/cross_module_extension_self/Makefile
+++ b/lldb/test/API/lang/swift/cross_module_extension_self/Makefile
@@ -9,7 +9,8 @@ include Makefile.rules
 # DYLIB_HIDE_SWIFTMODULE together with no reflection metadata makes it
 # impossible to lay out `self`.
 .PHONY: dylib
-dylib: Lib.swift
+dylib: Lib.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) -C $(BUILDDIR) VPATH=$(SRCDIR) \
 		CC=$(CC) SWIFTC=$(SWIFTC) ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		DYLIB_HIDE_SWIFTMODULE=YES \

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/Makefile
@@ -8,7 +8,8 @@ all: libDylib.dylib a.out
 
 include Makefile.rules
 
-libDylib.dylib: Dylib.swift
+libDylib.dylib: Dylib.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/deployment_target/Makefile
+++ b/lldb/test/API/lang/swift/deployment_target/Makefile
@@ -11,14 +11,16 @@ include Makefile.rules
 a.out: main.swift libNewerTarget.dylib
 
 
-dlopen_module: dlopen_module.m libNewerTarget.dylib
+dlopen_module: dlopen_module.m libNewerTarget.dylib \
+               $(call tool_prereq,$(CC))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		CXX= \
 		OBJC_SOURCES=dlopen_module.m \
 		EXE=dlopen_module \
 		LD_EXTRAS="-framework Foundation -mtargetos=macosx10.8"
 
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES \
 		DYLIB_NAME=$(patsubst lib%.dylib,%,$@) \

--- a/lldb/test/API/lang/swift/different_clang_flags/Makefile
+++ b/lldb/test/API/lang/swift/different_clang_flags/Makefile
@@ -7,7 +7,8 @@ all: libmoda.dylib libmodb.dylib main
 
 include Makefile.rules
 
-lib%.dylib:
+lib%.dylib: \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) VPATH=$(VPATH)/$*_dir \
 		SWIFTFLAGS_EXTRAS=-I$(dir $<)/cdeps \
                 MAKE_DSYM=YES DYLIB_ONLY=YES \

--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/Makefile
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/Makefile
@@ -10,7 +10,8 @@ include Makefile.rules
 
 objc.o: libLibrary.dylib
 
-libLibrary.dylib: Library.swift
+libLibrary.dylib: Library.swift \
+                  $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_SWIFT_SOURCES=Library.swift \
 		DYLIB_NAME=Library \

--- a/lldb/test/API/lang/swift/enable_testing/Makefile
+++ b/lldb/test/API/lang/swift/enable_testing/Makefile
@@ -6,7 +6,8 @@ include Makefile.rules
 LD_EXTRAS = -lPublic -L$(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 
-libPublic.dylib: Public.swift
+libPublic.dylib: Public.swift \
+                 $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=Public \

--- a/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/Makefile
@@ -11,7 +11,8 @@ secret.h:
 
 include Makefile.rules
 
-B.framework:
+B.framework: \
+             $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) SRCDIR=$(SRCDIR) \

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Makefile
@@ -7,7 +7,8 @@ all: Dylib $(EXE)
 include Makefile.rules
 
 .PHONY: Dylib
-Dylib:
+Dylib: \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/Makefile
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/Makefile
@@ -3,7 +3,8 @@ SWIFTFLAGS_EXTRAS := -I.
 LD_EXTRAS = -lLibrary -L$(BUILDDIR)
 all: libLibrary.dylib a.out
 
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=NO DYLIB_ONLY=YES \
 		DYLIB_HIDE_SWIFTMODULE=YES \
 		DYLIB_NAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/expression/equality_operators/Makefile
+++ b/lldb/test/API/lang/swift/expression/equality_operators/Makefile
@@ -7,7 +7,8 @@ all: libfooey.dylib three
 
 include Makefile.rules
 
-libfooey.dylib: one.swift two.swift
+libfooey.dylib: one.swift two.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=fooey \
 		DYLIB_SWIFT_SOURCES="one.swift two.swift" \

--- a/lldb/test/API/lang/swift/expression/error_missing_type/Makefile
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/Makefile
@@ -4,7 +4,8 @@ SWIFTFLAGS_EXTRAS := -I.
 LD_EXTRAS = -lLibrary -L$(BUILDDIR)
 all: libLibrary.dylib a.out
 
-lib%.dylib: %.swift
+lib%.dylib: %.swift \
+            $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=NO DYLIB_ONLY=YES \
 		DYLIB_HIDE_SWIFTMODULE=YES \
 		DYLIB_NAME=$(shell basename $< .swift) \

--- a/lldb/test/API/lang/swift/expression/import_search_paths/Makefile
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/Makefile
@@ -14,7 +14,8 @@ all: libDirect $(EXE)
 
 include Makefile.rules
 
-libHidden: $(SRCDIR)/hidden/Indirect.swift
+libHidden: $(SRCDIR)/hidden/Indirect.swift \
+           $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call MKDIR_P,$(BUILDDIR)/hidden)
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		-C $(BUILDDIR)/hidden VPATH=$(SRCDIR)/hidden \
@@ -25,7 +26,8 @@ libHidden: $(SRCDIR)/hidden/Indirect.swift
 		SWIFTFLAGS_EXTRAS="-gnone" \
 		MAKE_DSYM=NO
 
-libDirect: $(SRCDIR)/Direct.swift libHidden
+libDirect: $(SRCDIR)/Direct.swift libHidden \
+           $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES \
 		DYLIB_NAME=Direct \

--- a/lldb/test/API/lang/swift/expression/no_debuginfo/Makefile
+++ b/lldb/test/API/lang/swift/expression/no_debuginfo/Makefile
@@ -8,7 +8,8 @@ all: dylib $(EXE)
 include Makefile.rules
 
 .PHONY: dylib
-dylib:
+dylib: \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/framework_paths/Makefile
+++ b/lldb/test/API/lang/swift/framework_paths/Makefile
@@ -7,7 +7,8 @@ all: Direct.framework $(EXE)
 
 include Makefile.rules
 
-Discovered.framework: Discovered.h
+Discovered.framework: Discovered.h \
+                      $(call tool_prereq,$(CC))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES \
 		DYLIB_NAME=Discovered \
@@ -16,7 +17,8 @@ Discovered.framework: Discovered.h
 		FRAMEWORK_MODULES=$(SRCDIR)/module.modulemap \
 		FRAMEWORK=Discovered
 
-Direct.framework: $(SRCDIR)/Direct.swift.in Discovered.framework
+Direct.framework: $(SRCDIR)/Direct.swift.in Discovered.framework \
+                  $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call MKDIR_P,$(BUILDDIR)/secret_path)
 	$(call CP,$<,$(BUILDDIR)/Direct.swift)
 	mv Discovered.framework $(BUILDDIR)/secret_path

--- a/lldb/test/API/lang/swift/import_spi/Makefile
+++ b/lldb/test/API/lang/swift/import_spi/Makefile
@@ -7,7 +7,8 @@ all: A.swiftmodule $(EXE)
 
 include Makefile.rules
 
-A.swiftmodule: $(SRCDIR)/A.swift B.swiftmodule
+A.swiftmodule: $(SRCDIR)/A.swift B.swiftmodule \
+               $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES \
 		DYLIB_NAME=A \
@@ -16,7 +17,8 @@ A.swiftmodule: $(SRCDIR)/A.swift B.swiftmodule
 		SWIFTFLAGS_EXTRAS=-I$(BUILDDIR) \
 		LD_EXTRAS="-L$(BUILDDIR) -lB"
 
-B.swiftmodule: $(SRCDIR)/B.swift
+B.swiftmodule: $(SRCDIR)/B.swift \
+               $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES \
 		DYLIB_NAME=B \

--- a/lldb/test/API/lang/swift/late_dylib/Makefile
+++ b/lldb/test/API/lang/swift/late_dylib/Makefile
@@ -6,7 +6,8 @@ all: dylib $(EXE)
 include Makefile.rules
 
 .PHONY: dylib
-dylib:
+dylib: \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/Makefile
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/Makefile
@@ -6,7 +6,8 @@ all: dylib $(EXE)
 include Makefile.rules
 
 .PHONY: dylib
-dylib:
+dylib: \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/late_expr_dylib/Makefile
+++ b/lldb/test/API/lang/swift/late_expr_dylib/Makefile
@@ -6,7 +6,8 @@ all: Dylib $(EXE)
 include Makefile.rules
 
 .PHONY: Dylib
-Dylib:
+Dylib: \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/Makefile
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/Makefile
@@ -10,7 +10,8 @@ all: dylib $(EXE)
 include Makefile.rules
 
 .PHONY: dylib
-dylib:
+dylib: \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/lazy_framework/Makefile
+++ b/lldb/test/API/lang/swift/lazy_framework/Makefile
@@ -6,7 +6,8 @@ all: Lazy.framework $(EXE)
 
 include Makefile.rules
 
-Lazy.framework: $(SRCDIR)/Lazy.swift
+Lazy.framework: $(SRCDIR)/Lazy.swift \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=Lazy \
 		DYLIB_SWIFT_SOURCES=Lazy.swift \

--- a/lldb/test/API/lang/swift/macCatalystFramework/Makefile
+++ b/lldb/test/API/lang/swift/macCatalystFramework/Makefile
@@ -13,7 +13,8 @@ all: Framework.framework/Versions/A/Framework a.out
 include Makefile.rules
 
 # The framework is built for plain macOS -- note the macosx -target.
-Framework.framework/Versions/A/Framework: $(SRCDIR)/Framework.swift
+Framework.framework/Versions/A/Framework: $(SRCDIR)/Framework.swift \
+                                          $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	touch Framework.h
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 	    MAKE_DSYM=YES \

--- a/lldb/test/API/lang/swift/macro/Makefile
+++ b/lldb/test/API/lang/swift/macro/Makefile
@@ -12,7 +12,8 @@ all: libMacro.dylib libMacroImpl.dylib $(EXE)
 
 include Makefile.rules
 
-libMacro.dylib:
+libMacro.dylib: \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \
@@ -25,7 +26,8 @@ libMacro.dylib:
 		all
 	$(RM) $(BUILDDIR)/Macro.swiftinterface
 
-libMacroImpl.dylib:
+libMacroImpl.dylib: \
+                    $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/module_search_paths/Makefile
+++ b/lldb/test/API/lang/swift/module_search_paths/Makefile
@@ -4,6 +4,7 @@ all: module-build
 include Makefile.rules
 
 # This is an extra dependency that does NOT get linked into the EXE.
-module-build:
+module-build: \
+              $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		SWIFT_SOURCES=module.swift EXE=Module

--- a/lldb/test/API/lang/swift/noncopyable_field_reflection/Makefile
+++ b/lldb/test/API/lang/swift/noncopyable_field_reflection/Makefile
@@ -13,7 +13,8 @@ all: dylib $(EXE)
 .PHONY: dylib
 
 include Makefile.rules
-dylib: lib.swift
+dylib: lib.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=Lib \
 		DYLIB_SWIFT_SOURCES="lib.swift" \

--- a/lldb/test/API/lang/swift/objc_superclass_no_debug_info/Makefile
+++ b/lldb/test/API/lang/swift/objc_superclass_no_debug_info/Makefile
@@ -7,7 +7,8 @@ include Makefile.rules
 LD_EXTRAS = -lMyLib -L$(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR) -I$(SRCDIR) -Xcc -fmodule-map-file=$(SRCDIR)/module.modulemap
 
-libMyObjCBase.dylib: $(SRCDIR)/MyObjCBase.m $(SRCDIR)/MyObjCBase.h
+libMyObjCBase.dylib: $(SRCDIR)/MyObjCBase.m $(SRCDIR)/MyObjCBase.h \
+                     $(call tool_prereq,$(CC))
 	$(CC) -isysroot "$(SDKROOT)" -g0 -c $(SRCDIR)/MyObjCBase.m \
 		-o $(BUILDDIR)/MyObjCBase.o
 	$(CC) -isysroot "$(SDKROOT)" -dynamiclib -lobjc \
@@ -18,7 +19,8 @@ ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$(BUILDDIR)/libMyObjCBase.dylib"
 endif
 
-libMyLib.dylib: $(SRCDIR)/MyLib.swift libMyObjCBase.dylib
+libMyLib.dylib: $(SRCDIR)/MyLib.swift libMyObjCBase.dylib \
+                $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		VPATH=$(SRCDIR) \
 		MAKE_DSYM=NO \

--- a/lldb/test/API/lang/swift/opaque_return_resilient/Makefile
+++ b/lldb/test/API/lang/swift/opaque_return_resilient/Makefile
@@ -9,7 +9,8 @@ all: dylib $(EXE)
 
 include Makefile.rules
 
-dylib: lib.swift
+dylib: lib.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=OpaqueLib \
 		DYLIB_SWIFT_SOURCES="lib.swift" \

--- a/lldb/test/API/lang/swift/opaque_return_resilient_collection/Makefile
+++ b/lldb/test/API/lang/swift/opaque_return_resilient_collection/Makefile
@@ -9,7 +9,8 @@ all: dylib $(EXE)
 
 include Makefile.rules
 
-dylib: lib.swift
+dylib: lib.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=OpaqueLib \
 		DYLIB_SWIFT_SOURCES="lib.swift" \

--- a/lldb/test/API/lang/swift/optional_error_handling/Makefile
+++ b/lldb/test/API/lang/swift/optional_error_handling/Makefile
@@ -8,7 +8,8 @@ all: Library $(EXE)
 include Makefile.rules
 
 .PHONY: Library
-Library:
+Library: \
+         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) SRCDIR=$(SRCDIR) \

--- a/lldb/test/API/lang/swift/other_arch_dylib/Makefile
+++ b/lldb/test/API/lang/swift/other_arch_dylib/Makefile
@@ -10,7 +10,8 @@ all: OtherArch.framework/Versions/A/OtherArch $(EXE)
 
 include Makefile.rules
 
-OtherArch.framework/Versions/A/OtherArch: $(SRCDIR)/OtherArch.swift
+OtherArch.framework/Versions/A/OtherArch: $(SRCDIR)/OtherArch.swift \
+                                          $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	touch OtherArch.h
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 	    MAKE_DSYM=YES \

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/Makefile
@@ -16,7 +16,8 @@ setup:
 	$(call MKDIR_P,libs)
 	$(call CP,$(SRCDIR)/libs/A.swift,libs/AA.swift)
 
-sharedA:
+sharedA: \
+         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(DYLIB_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) VPATH=$(BUILDDIR) SWIFTSDKROOT=$(SWIFTSDKROOT) \
 		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/Makefile
@@ -22,19 +22,22 @@ setup:
 	$(call CP,$(SRCDIR)/libs/C.swift,libs/CC.swift)
 	$(call ECHO_TO_FILE,'$(SWIFTSDKROOT)',$(BUILDDIR)/sdk-root.txt)
 
-sharedA:
+sharedA: \
+         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT="$(SWIFTSDKROOT)" \
 		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=AA -f $(SRCDIR)/libs/Makefile
 
-sharedB:
+sharedB: \
+         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT="$(SWIFTSDKROOT)" \
 		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=BB SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" LD_EXTRAS="-L$(BUILDDIR) -lAA" -f $(SRCDIR)/libs/Makefile
 
-sharedC:
+sharedC: \
+         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT="$(SWIFTSDKROOT)" \
 		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/Makefile
@@ -17,7 +17,8 @@ setup:
 	$(call CP,$(SRCDIR)/libs/B.swift,libs/BB.swift)
 	$(call CP,$(SRCDIR)/libs/C.swift,libs/CC.swift)
 
-staticA:
+staticA: \
+         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	# Because we override VPATH to point to the build directory, we need to pass
 	# down SWIFTC too (it's default value is relative to VPATH)
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
@@ -26,7 +27,8 @@ staticA:
 		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=AA -f $(SRCDIR)/libs/Makefile static_only
 
-staticB:
+staticB: \
+         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
 		SWIFTSDKROOT=$(SWIFTSDKROOT) \
@@ -34,7 +36,8 @@ staticB:
 		BASENAME=BB SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" \
 		LD_EXTRAS="-L$(BUILDDIR)" -f $(SRCDIR)/libs/Makefile static_only
 
-staticC:
+staticC: \
+         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
 		SWIFTSDKROOT=$(SWIFTSDKROOT) \

--- a/lldb/test/API/lang/swift/path_with_colons/Makefile
+++ b/lldb/test/API/lang/swift/path_with_colons/Makefile
@@ -1,2 +1,3 @@
-all:
+all: \
+     $(call tool_prereq,$(CC))
 	"$(MAKE)" -C "pro:ject"

--- a/lldb/test/API/lang/swift/playgrounds-repl/dylib/Makefile
+++ b/lldb/test/API/lang/swift/playgrounds-repl/dylib/Makefile
@@ -1,6 +1,7 @@
 all: Dylib.framework
 
-Dylib.framework: Dylib.swift
+Dylib.framework: Dylib.swift \
+                 $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		FRAMEWORK=Dylib \
 		DYLIB_SWIFT_SOURCES=Dylib.swift \

--- a/lldb/test/API/lang/swift/playgrounds/Makefile
+++ b/lldb/test/API/lang/swift/playgrounds/Makefile
@@ -12,19 +12,22 @@ PlaygroundStub: libPlaygroundsRuntime.dylib Dylib.framework AuxSources.framework
 
 include Makefile.rules
 
-libPlaygroundsRuntime.dylib: PlaygroundsRuntime.swift
+libPlaygroundsRuntime.dylib: PlaygroundsRuntime.swift \
+                             $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_SWIFT_SOURCES=PlaygroundsRuntime.swift \
 		DYLIB_NAME=PlaygroundsRuntime
 
-Dylib.framework: Dylib.swift
+Dylib.framework: Dylib.swift \
+                 $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		FRAMEWORK=Dylib \
 		DYLIB_SWIFT_SOURCES=Dylib.swift \
 		DYLIB_NAME=Dylib \
 		SWIFTFLAGS_EXTRAS="-Xcc -DNEW_OPTION_FROM_DYLIB=1"
 
-AuxSources.framework: AuxSources.swift
+AuxSources.framework: AuxSources.swift \
+                      $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		FRAMEWORK=AuxSources \
 		DYLIB_SWIFT_SOURCES=AuxSources.swift \

--- a/lldb/test/API/lang/swift/private_discriminator/Makefile
+++ b/lldb/test/API/lang/swift/private_discriminator/Makefile
@@ -6,7 +6,8 @@ all: libBuilder.dylib $(EXE)
 
 include Makefile.rules
 
-libGeneric.dylib: $(SRCDIR)/Generic.swift
+libGeneric.dylib: $(SRCDIR)/Generic.swift \
+                  $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES \
 		DYLIB_NAME=Generic \
@@ -14,7 +15,8 @@ libGeneric.dylib: $(SRCDIR)/Generic.swift
 		DYLIB_MODULENAME=Generic \
 		SWIFTFLAGS_EXTRAS=-enable-library-evolution
 
-libBuilder.dylib: $(SRCDIR)/Builder.swift libGeneric.dylib
+libBuilder.dylib: $(SRCDIR)/Builder.swift libGeneric.dylib \
+                  $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES \
 		DYLIB_NAME=Builder \

--- a/lldb/test/API/lang/swift/reflection_loading/Makefile
+++ b/lldb/test/API/lang/swift/reflection_loading/Makefile
@@ -8,7 +8,8 @@ all: dylib $(EXE)
 .PHONY: dylib
 
 include Makefile.rules
-dylib: lib.swift
+dylib: lib.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=dynamic_lib \
 		DYLIB_SWIFT_SOURCES="lib.swift" \

--- a/lldb/test/API/lang/swift/reflection_only/Makefile
+++ b/lldb/test/API/lang/swift/reflection_only/Makefile
@@ -9,7 +9,8 @@ all: dylib $(EXE)
 .PHONY: dylib
 
 include Makefile.rules
-dylib: lib.swift
+dylib: lib.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=dynamic_lib \
 		DYLIB_SWIFT_SOURCES="lib.swift" \

--- a/lldb/test/API/lang/swift/resilience_other_module/Makefile
+++ b/lldb/test/API/lang/swift/resilience_other_module/Makefile
@@ -6,7 +6,8 @@ include Makefile.rules
 LD_EXTRAS = -lWithDebInfo -lWithoutDebInfo -L$(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 
-libWithDebInfo.dylib: WithDebInfo.swift
+libWithDebInfo.dylib: WithDebInfo.swift \
+                      $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=WithDebInfo \
@@ -16,7 +17,8 @@ libWithDebInfo.dylib: WithDebInfo.swift
 		DYLIB_SWIFT_SOURCES:=WithDebInfo.swift \
 		-f $(MAKEFILE_RULES)
 
-libWithoutDebInfo.dylib: WithoutDebInfo.swift
+libWithoutDebInfo.dylib: WithoutDebInfo.swift \
+                         $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=WithoutDebInfo \

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/Makefile
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/Makefile
@@ -6,7 +6,8 @@ include Makefile.rules
 LD_EXTRAS = -lModWithClass -L$(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 
-libModWithClass.dylib: ModWithClass.swift libModWithSuper.dylib
+libModWithClass.dylib: ModWithClass.swift libModWithSuper.dylib \
+                       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=ModWithClass \
@@ -17,7 +18,8 @@ libModWithClass.dylib: ModWithClass.swift libModWithSuper.dylib
 		DYLIB_SWIFT_SOURCES:=ModWithClass.swift \
 		-f $(MAKEFILE_RULES)
 
-libModWithSuper.dylib: ModWithSuper.swift
+libModWithSuper.dylib: ModWithSuper.swift \
+                       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=ModWithSuper \

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/Makefile
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/Makefile
@@ -8,7 +8,8 @@ include Makefile.rules
 LD_EXTRAS = -lImpl -L$(BUILDDIR) -Xlinker -add_ast_path -Xlinker Impl.swiftmodule
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 
-ImplB: ImplB.swift
+ImplB: ImplB.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call ECHO,"Building an out-of-date swift interface")
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
@@ -20,7 +21,8 @@ ImplB: ImplB.swift
 	mv Impl.swiftinterface ImplB.swiftinterface
 	$(call RM,Impl.swiftmodule Impl.private.swiftinterface libImpl.dylib )
 
-ImplA: ImplB ImplA.swift
+ImplA: ImplB ImplA.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
@@ -33,7 +35,8 @@ ImplA: ImplB ImplA.swift
 	$(call RM,ImplA.swift.o ImplB.swift.o)
 	mv ImplB.swiftinterface Impl.swiftinterface
 
-Postprocess:
+Postprocess: \
+             $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	$(call ECHO,"Compiling Impl.swiftinterfact to Impl.swiftmodule")
 	$(call ECHO_TO_FILE,'import Impl',trigger.swift)
 	$(SWIFT_FE) $(SWIFT_FEFLAGS) -module-cache-path cache -c trigger.swift -o trigger -I.

--- a/lldb/test/API/lang/swift/static_framework/Makefile
+++ b/lldb/test/API/lang/swift/static_framework/Makefile
@@ -8,7 +8,8 @@ all: $(FRAMEWORKS) dylib $(EXE)
 
 include Makefile.rules
 
-lib%.a: %.swift
+lib%.a: %.swift \
+        $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=static \
 		SWIFT_SOURCES=$(patsubst lib%.a,%.swift,$@) \
@@ -27,7 +28,8 @@ lib%.a: %.swift
 	mv $(BUILDDIR)/$(patsubst lib%.a,%.swiftmodule,$<) $(BUILDDIR)/$@/Modules/$(patsubst lib%.a,%.swiftmodule,$<)/$(ARCH)-apple-macos.swiftmodule
 	mv $(BUILDDIR)/$(patsubst lib%.a,%.swiftinterface,$<) $(BUILDDIR)/$@/Modules/
 
-dylib: Dylib.swift
+dylib: Dylib.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=Dylib \
 		DYLIB_SWIFT_SOURCES=Dylib.swift \

--- a/lldb/test/API/lang/swift/static_linking/macOS/Makefile
+++ b/lldb/test/API/lang/swift/static_linking/macOS/Makefile
@@ -15,14 +15,16 @@ include Makefile.rules
 # we're not specifying SWIFT_SOURCES, and thus don't get the SDK.
 SWIFTFLAGS+=-sdk "$(SWIFTSDKROOT)"
 
-$(EXE): objc_main.m A.swift.o B.swift.o
+$(EXE): objc_main.m A.swift.o B.swift.o \
+        $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH)) $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) -c -I. $< -fobjc-arc -o $(BUILDDIR)/objc_main.o
 	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) -o $@ $(BUILDDIR)/objc_main.o $(BUILDDIR)/A.swift.o $(BUILDDIR)/B.swift.o -L$(BUILDDIR) -Xlinker -add_ast_path -Xlinker A.swiftmodule -Xlinker -add_ast_path -Xlinker B.swiftmodule
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
 
-%.swift.o: %.swift
+%.swift.o: %.swift \
+           $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=$(patsubst %.swift.o,%,$@) \
 		SWIFT_SOURCES=$(patsubst %.swift.o,%.swift,$@) \

--- a/lldb/test/API/lang/swift/typealias/Makefile
+++ b/lldb/test/API/lang/swift/typealias/Makefile
@@ -7,7 +7,8 @@ all: dylib $(EXE)
 include Makefile.rules
 
 .PHONY: dylib
-dylib:
+dylib: \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/typealias_othermodule/Makefile
+++ b/lldb/test/API/lang/swift/typealias_othermodule/Makefile
@@ -6,7 +6,8 @@ all: Dylib $(EXE)
 include Makefile.rules
 
 .PHONY: Dylib
-Dylib:
+Dylib: \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \

--- a/lldb/test/API/lang/swift/xcode_sdk/Makefile
+++ b/lldb/test/API/lang/swift/xcode_sdk/Makefile
@@ -11,7 +11,8 @@ LD_EXTRAS := ignored.o
 all: ignored.o $(EXE)
 
 # Artificially inject a wrong SDK into a C file to test that it is being ignored.
-ignored.o: ignored.c
+ignored.o: ignored.c \
+           $(call tool_prereq,$(CC))
 	$(CC) -target $(ARCH)-apple-macos  -c $< -o $@ \
 	  -isysroot $(shell xcrun --sdk iphonesimulator --show-sdk-path)
 

--- a/lldb/test/API/repl/cpp_exceptions/Makefile
+++ b/lldb/test/API/repl/cpp_exceptions/Makefile
@@ -6,7 +6,8 @@ all: sdkroot.txt libWrapper.dylib a.out
 
 include Makefile.rules
 
-libCppLib.dylib: CppLib/CppLib.cpp
+libCppLib.dylib: CppLib/CppLib.cpp \
+                 $(call tool_prereq,$(CXX_PATH))
 	$(call MKDIR_P,CppLib)
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=CppLib DYLIB_ONLY=YES CXXFLAGS_EXTRAS=-fPIC \
@@ -16,7 +17,8 @@ ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -f -s - "$@"
 endif
 
-libWrapper.dylib: libCppLib.dylib
+libWrapper.dylib: libCppLib.dylib \
+                  $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=Wrapper DYLIB_SWIFT_SOURCES=wrapper.swift \
 		LD_EXTRAS="$(LD_EXTRAS)" \


### PR DESCRIPTION
```
commit 0849bde93bb1abc7f7fb42ea1a6706449add920b
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Aug 13 18:22:28 2026 -0700

    [LLDB] Ad even more dependency tracking in Swift tests
    
    Assisted-by: claude
```
