### PR TITLE
[Cherry-pick into next] [LLDB] Add deployment target

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
@@ -321,13 +321,14 @@ lldb::ValueObjectSP lldb_private::formatters::swift::
   if (ValueObjectSP transparent_sp = some->Clone(ConstString()))
     some = transparent_sp;
 
+  // Children inherit this flag, and it makes GetExpressionPath() emit a raw
+  // address instead of a path.
+  some->SetSyntheticChildrenGenerated(false);
+
   if (some->HasSyntheticValue())
     some = some->GetSyntheticValue();
 
-  auto child = some->GetChildAtIndex(idx, true);
-  if (child && some->IsSyntheticChildrenGenerated())
-    child->SetSyntheticChildrenGenerated(true);
-  return child;
+  return some->GetChildAtIndex(idx, true);
 }
 
 lldb::ChildCacheState

--- a/lldb/test/API/lang/swift/variadic_generics_metatype/Makefile
+++ b/lldb/test/API/lang/swift/variadic_generics_metatype/Makefile
@@ -1,3 +1,6 @@
 SWIFT_SOURCES := main.swift
 
+# Parameter packs in generic types require a newer runtime.
+SWIFT_DEPLOYMENT_TARGET := 26
+
 include Makefile.rules


### PR DESCRIPTION
```
commit ebaa38145524788da35ca075aa1c140a89cad6f2
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Aug 13 19:40:53 2026 -0700

    [LLDB] Add deployment target
    
    Assisted-by: claude

commit 6e37e1c6c63fe775b4c4b15bdd0d6b5ee6761bf4
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Aug 13 20:07:07 2026 -0700

    [LLDB] Fix Optional payload expression paths
    
    ProjectEnum builds the payload with GetSyntheticChildAtOffset, which marks
    it synthetic-children-generated. Children inherit that flag, and
    GetExpressionPath() renders such values as a raw address, so every leaf of
    an Optional printed as (*( (Swift.Int *)0x...)) instead of plain.a.
    
    This only manifests since 94667a71db02, which routes GetParent() through a
    logical parent for synthetic-generated children, which is why the test
    passes on stable/21.x.
    
    Assisted-by: Claude
```
