### PR TITLE
[BoundsSafety] NFC: Use isSinglePointerType in Sema

### DIFF
--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -398,7 +398,8 @@ namespace {
         }
 
         if (!SrcIsNull && DestPTy->isPointerTypeWithBounds() &&
-            SrcPTy->isSingle() && !SrcType->isBoundsAttributedType()) {
+            SrcType->isSinglePointerType() &&
+            !SrcType->isBoundsAttributedType()) {
           if (SrcPTy->getPointeeType()->isIncompleteOrSizelessType()) {
             Self.Diag(OpRange.getBegin(),
                       diag::err_bounds_safety_incomplete_single_to_indexable)

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5422,7 +5422,8 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
       }
       // Non-arithmetic ops require a pointer to __unsafe_indexable or __single
       // pointer.
-      if (IsDBP || (PtrTy->isSafePointer() && !PtrTy->isSingle())) {
+      if (IsDBP ||
+          (PtrTy->isSafePointer() && !ValType->isSinglePointerType())) {
         unsigned DiagIndex;
         if (PtrTy->isIndexable())
           DiagIndex = 0;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11728,8 +11728,7 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
       if (Param->getType()->isCountAttributedType() ||
           Param->getType()->isDynamicRangePointerType())
         continue; // has a dynamic count, no problem
-      auto FA = Param->getType()->getAs<PointerType>()->getPointerAttributes();
-      if (FA.isSingle()) {
+      if (Param->getType()->isSinglePointerType()) {
         Diag(TSInfo->getTypeLoc().getBeginLoc(),
             diag::err_bounds_safety_array_decay_to_single) << TST;
         Diag(TSInfo->getTypeLoc().getBeginLoc(),
@@ -16642,7 +16641,7 @@ static void checkAtomicAutoPointerAttrs(Sema &S, const Decl *D) {
     if (!PtrTy)
       break;
     if (HasAutoAttr && !PtrTy->isUnspecified() && !PtrTy->isUnsafeIndexable() &&
-        !PtrTy->isSingle()) {
+        !Ty->isSinglePointerType()) {
       assert(PtrTy->isIndexable() || PtrTy->isBidiIndexable());
       unsigned DiagIndex = PtrTy->isIndexable() ? 0 : 1;
       S.Diag(D->getBeginLoc(), diag::err_bounds_safety_atomic_unsupported_attribute)

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5945,7 +5945,7 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
     // If the base of the array subscript expression is 'counted_by', it should
     // have been promoted to __bidi_indexable.
     assert(!Ty->isBoundsAttributedType());
-    if (PTy->isSingle()) {
+    if (Ty->isSinglePointerType()) {
       Expr::EvalResult RInt;
       if (!RHSExp->EvaluateAsInt(RInt, Context) || RInt.Val.getInt() != 0) {
         Diag(LLoc, diag::err_bounds_safety_pointer_subscript)
@@ -8291,8 +8291,8 @@ bool Sema::CheckDynamicCountSizeForAssignment(
     return true;
 
   Expr *CountExpr = LDCPTy->getCountExpr()->IgnoreParenCasts();
-	if (CountExpr->isValueDependent())
-		return false;
+  if (CountExpr->isValueDependent())
+    return false;
 
   auto *RHSPTy = RHSTy->getAs<PointerType>();
   auto FA =
@@ -8859,10 +8859,11 @@ static bool checkDynamicCountPointerAsParameter(Sema &S, FunctionDecl *FDecl,
               DiagTy = ArgDepInfo.getDecl()->getType();
             }
 
-	    S.Diag(Call->getExprLoc(),
-		   diag::err_bounds_safety_unsynchronized_indirect_param)
-              << ArgInfo.getDecl() << ArgInfo.isAddrOf() << ArgDepInfo.getDecl()
-              << !ArgDepInfo.isDeref() << IsDependent << DiagTy;
+            S.Diag(Call->getExprLoc(),
+                   diag::err_bounds_safety_unsynchronized_indirect_param)
+                << ArgInfo.getDecl() << ArgInfo.isAddrOf()
+                << ArgDepInfo.getDecl() << !ArgDepInfo.isDeref() << IsDependent
+                << DiagTy;
             return false;
           }
         }
@@ -12139,11 +12140,11 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
             !RHS.get()->getType()->isBoundsAttributedType() &&
             LHSType->isSafePointerType() &&
             !OrigLHSType->isValueTerminatedType()) {
-          return LHSPointer->isSingle()
+          return LHSType->isSinglePointerType()
                      ? AssignConvertType::IncompatibleUnsafeToSafePointer
                      : AssignConvertType::IncompatibleUnsafeToIndexablePointer;
         }
-        if (!IsSrcNull && RHSPointer->isSingle() &&
+        if (!IsSrcNull && RHSType->isSinglePointerType() &&
             LHSType->isPointerTypeWithBounds() &&
             !RHS.get()->getType()->isBoundsAttributedType()) {
           if (RHSPointer->getPointeeType()->isIncompleteOrSizelessType())
@@ -12179,7 +12180,7 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
         // cast logic above to be missed which would change the generated AST.
         bool IsSrcNull = RHS.get()->IgnoreParenCasts()->isNullPointerConstant(
             Context, Expr::NPC_ValueDependentIsNotNull);
-        if (!IsSrcNull && RHSPointer->isSingle() &&
+        if (!IsSrcNull && RHSType->isSinglePointerType() &&
             !RHS.get()->getType()->isBoundsAttributedType()) {
           bool IsExplicitlyBoundedPointer = LHSType->isPointerTypeWithBounds();
           if (OrigLHSType->hasAttr(attr::PtrAutoAttr)) {
@@ -12865,9 +12866,9 @@ bool Sema::allowBoundsUnsafePointerAssignment(
   // All safe pointers ABI compatible with unsafe pointers (and each other) are
   // __single pointers. Make no exception for ABI incompatible pointer type
   // mismatch.
-  if (!DestPtrTy->isSingle() && DestSafe)
+  if (!DestTy->isSinglePointerType() && DestSafe)
     return false;
-  if (!SourcePtrTy->isSingle() && SourceSafe)
+  if (!SourceValue->getType()->isSinglePointerType() && SourceSafe)
     return false;
 
   return allowBoundsUnsafeAssignment(AssignmentLoc);
@@ -14381,7 +14382,7 @@ static bool checkArithmeticBinOpBoundsSafetyPointer(Sema &S, Expr *Base,
     return false;
   }
 
-  if (PT->isSingle() && !BaseType->isBoundsAttributedType()) {
+  if (BaseType->isSinglePointerType() && !BaseType->isBoundsAttributedType()) {
     emitBoundsSafetySinglePointerArithmeticError(S, Base);
     return false;
   }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -9745,7 +9745,7 @@ static bool HandlePtrTerminatedByTypeAttr(TypeProcessingState &state,
 
     // If the pointer is unspecified, we will add __single attribute later in
     // MakeAutoPointer.
-    if (!PT->isUnspecified() && !PT->isSingle()) {
+    if (!PT->isUnspecified() && !T->isSinglePointerType()) {
       S.Diag(PAttr.getLoc(),
              diag::err_bounds_safety_terminated_by_wrong_pointer_type);
       PAttr.setInvalid();
@@ -11929,7 +11929,7 @@ QualType Sema::BuildAtomicType(QualType T, SourceLocation Loc) {
         DiagIndex = 7;
       } else if (const auto *PT = T->getAs<PointerType>()) {
         BoundsSafetyPointerAttributes FAttr = PT->getPointerAttributes();
-        if (!FAttr.isUnspecified() && !FAttr.isSingle() &&
+        if (!FAttr.isUnspecified() && !T->isSinglePointerType() &&
             !FAttr.isUnsafeIndexable()) {
           assert(FAttr.isIndexable() || FAttr.isBidiIndexable());
           DiagIndex = FAttr.isIndexable() ? 0 : 1;


### PR DESCRIPTION
Step 1 of splitting up #13651, per @hnrklssn's feedback.

Migrates Sema call sites that ask whether a pointer is `__single` from reading the ptrattr directly off `PointerType` (`PT->isSingle()`, `FAttr.isSingle()`) to `Type::isSinglePointerType()`, using the `QualType` already in scope.

`isSinglePointerType()` already handles both the current representation (ptrattr on the canonical `PointerType`) and the future sugar representation (`AttributedType(Single)` over an unspecified pointer).

No functional change and no test files are modified.

## Scope
Migrated:
- `SemaType.cpp`, `SemaCast.cpp`, `SemaChecking.cpp`, `SemaExpr.cpp`, `SemaDecl.cpp`

The `isSinglePointerType()` implementation and raw attribute checks that are not semantic type queries are intentionally unchanged.

## Testing
Total Discovered Tests: 925
  Passed           : 914
  Expectedly Failed:  11

Part of #13065.