### PR TITLE
[lldb] skip duplicate DW_TAG_member DIEs when building a record layout

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -3206,6 +3206,19 @@ void DWARFASTParserClang::ParseSingleMember(
       this_field_info.bit_size = *clang_type_size * character_width;
     }
 
+    dw_offset_t this_type_die_offset =
+        attrs.encoding_form.Reference().GetOffset();
+    bool same_name = attrs.name == last_field_info.name ||
+                      (attrs.name && last_field_info.name &&
+                       llvm::StringRef(attrs.name) == last_field_info.name);
+    if (same_name && this_type_die_offset == last_field_info.type_die_offset &&
+        this_field_info.bit_offset == last_field_info.bit_offset &&
+        this_field_info.bit_size == last_field_info.bit_size) {
+      return;
+    }
+    this_field_info.name = attrs.name;
+    this_field_info.type_die_offset = this_type_die_offset;
+
     if (this_field_info.GetFieldEnd() <= last_field_info.GetEffectiveFieldEnd())
       this_field_info.SetEffectiveFieldEnd(
           last_field_info.GetEffectiveFieldEnd());

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
@@ -305,6 +305,9 @@ private:
     /// Set to 'true' if this field is DW_AT_artificial.
     bool is_artificial = false;
 
+    const char *name = nullptr;
+    dw_offset_t type_die_offset = DW_INVALID_OFFSET;
+
     FieldInfo() = default;
 
     void SetIsBitfield(bool flag) { is_bitfield = flag; }


### PR DESCRIPTION
dsymutil's parallel DWARFLinker can emit two identical `DW_TAG_member` DIEs for the same field (observed for `std::basic_string`'s internal compressed-pair member). LLDB registered a distinct `FieldDecl` for each, and Clang's record-layout builder crashes when two fields of the same type land at the same offset. Detect and skip an exact duplicate of the immediately preceding field.

Fixes:
- `lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py`