### PR TITLE
[lldb] convert po/uninitialized to a non-inline test

### DIFF
--- a/lldb/test/API/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
+++ b/lldb/test/API/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
@@ -9,9 +9,37 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ------------------------------------------------------------------------------
-import lldbsuite.test.lldbinline as lldbinline
+"""
+Test that po detects a class reference that has not been assigned yet.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[skipEmbeddedSwift,
-        swiftTest])
+
+class TestCase(TestBase):
+    @swiftTest
+    @requireNotEmbeddedSwift
+    def test_po_uninitialized(self):
+        """po reports <uninitialized> before the assignment and the instance's
+        description after it."""
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break before assignment", lldb.SBFileSpec("main.swift")
+        )
+
+        self.assertIsNone(
+            self.frame().FindVariable("object").GetObjectDescription(),
+            "po correctly detects uninitialized instances",
+        )
+        self.expect("po object", substrs=["<uninitialized>"])
+
+        lldbutil.continue_to_source_breakpoint(
+            self, process, "break after assignment", lldb.SBFileSpec("main.swift")
+        )
+
+        description = self.frame().FindVariable("object").GetObjectDescription()
+        self.assertIsNotNone(description)
+        self.assertIn("POClass:", description)

--- a/lldb/test/API/lang/swift/po/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/po/uninitialized/main.swift
@@ -15,8 +15,8 @@ class POClass {
 
 func main() {
   var object: POClass
-  object = POClass() //% self.assertTrue(self.frame().FindVariable('object').GetObjectDescription() == 'error: <uninitialized>', 'po correctly detects uninitialized instances')
-  print("yay I am done") //% self.assertTrue('POClass:' in self.frame().FindVariable('object').GetObjectDescription())
+  object = POClass() // break before assignment
+  print("yay I am done") // break after assignment
 }
 
 print("Some code here")


### PR DESCRIPTION
**Root cause:** `SBValue::GetObjectDescription()` returns `nullptr` (not an error string) when the object is uninitialized — this is intentional, existing behavior, unchanged from `stable/21.x`. The test itself was stale: it still used the old inline-test form checking `GetObjectDescription() == 'error: <uninitialized>'`, which never matched that behavior. `stable/21.x` already converted this to a proper non-inline test asserting `GetObjectDescription()` is `None`; this ports that exact conversion over.

**Fixes:**
  - `lldb/test/API/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py`