### PR TITLE
[lldb] fix failing macOS tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -59,20 +59,6 @@ class BuilderDarwin(Builder):
         # Return extra args as a formatted string.
         return ["{}={}".format(key, value) for key, value in args.items()]
 
-    def getArchCFlags(self):
-        triple = self.getTriple()
-        if not triple:
-            return []
-
-        _, _, os, version, _ = split_triple(triple)
-
-        if os == "darwin" or not version:
-            return []
-
-        target_os = "-mtargetos={}{}".format(os, version)
-
-        return ["ARCH_CFLAGS={}".format(target_os)]
-
     def getSwiftTargetFlags(self, arch):
         if not arch:
             arch = configuration.arch

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -145,7 +145,7 @@ ifeq "$(ARCH)" ""
 endif
 
 # Use -target to pass the triple to the compiler.
-ARCH_CFLAGS := -target $(TRIPLE)
+override ARCH_CFLAGS += -target $(TRIPLE)
 
 #----------------------------------------------------------------------
 # CC defaults to clang.

--- a/lldb/test/API/lang/swift/originally_defined_in/main.swift
+++ b/lldb/test/API/lang/swift/originally_defined_in/main.swift
@@ -91,6 +91,7 @@ func f() {
     let h = ClassPair(t: Prop(), u: Prop2())
     let i = (A(), F(), Prop())
     let complex = Pair(t: E.t(Pair(t: Prop2(), u: C.D())), u: E.t(Prop()))
+    print("prologue")
     print("break here")
 }
 

--- a/lldb/test/API/lang/swift/po/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/po/uninitialized/main.swift
@@ -15,7 +15,7 @@ class POClass {
 
 func main() {
   var object: POClass
-  object = POClass() //% self.assertTrue(self.frame().FindVariable('object').GetObjectDescription() == 'error: <uninitialized>', 'po correctly detects uninitialized instances')
+  object = POClass() //% self.assertIsNone(self.frame().FindVariable('object').GetObjectDescription(), 'po correctly detects uninitialized instances')
   print("yay I am done") //% self.assertTrue('POClass:' in self.frame().FindVariable('object').GetObjectDescription())
 }
 

--- a/lldb/test/API/lang/swift/resilience/Makefile
+++ b/lldb/test/API/lang/swift/resilience/Makefile
@@ -1,6 +1,8 @@
 EXE=
 all: libmod.a.dylib libmod.b.dylib main.a main.b
 
+export USE_PRIVATE_MODULE_CACHE := YES
+
 include Makefile.rules
 
 libmod.%.dylib: mod.%.swift \

--- a/lldb/test/API/macosx/deny-attach/TestDenyAttach.py
+++ b/lldb/test/API/macosx/deny-attach/TestDenyAttach.py
@@ -11,6 +11,7 @@ class DenyAttachTestCase(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded  # PT_DENY_ATTACH attach behavior differs on ios/tvos/etc
     @skipIfAsan  # Attach tests time out inconsistently under asan.
+    @skipIfOutOfTreeDebugserver  # The PT_DENY_ATTACH handling is in debugserver.
     def test_attach_to_deny_attach_process(self):
         """Attaching to a PT_DENY_ATTACH process reports an error, not a crash."""
         self.build()


### PR DESCRIPTION
Fixes failing macOS lldb tests on `stable/23.x`.

- **`macosx/rosetta`**: `BuilderDarwin.getArchCFlags` passed `ARCH_CFLAGS` on the make command line, which overrode `ARCH_CFLAGS := -target $(TRIPLE)` in `Makefile.rules`, so clang got no `-target`. The test overrides `TRIPLE` to x86_64 but silently built arm64 and never ran translated. Dropped the Darwin override and append with `override` instead.
- **`lang/swift/po/uninitialized`**: `SBValue::GetObjectDescription()` returns `nullptr` on error since #117242, not `"error: <msg>"`. Expect `None`.
- **`lang/swift/originally_defined_in`**: `complex`'s stack zero-init is attributed to the first statement after the declarations, so the `break here` breakpoint resolved into the prologue, before anything was initialized (`a = (i = 0)`). Added a throwaway statement to take that location.
- **`lang/swift/resilience`**: the binaries reference `mod`'s explicit `.swiftmodule` in the shared module cache, which lit wipes every run while make still considers them up to date. Use `USE_PRIVATE_MODULE_CACHE`. Only reproduced under `-j8`.
- **`macosx/deny-attach`**: the `PT_DENY_ATTACH` handling is in debugserver, so a system debugserver still reports `lost connection`. Added `@skipIfOutOfTreeDebugserver`.