### PR TITLE
[lldb] always build structor-linkage-names test binaries with the explicit flag

### DIFF
--- a/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
+++ b/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
@@ -12,11 +12,6 @@ from lldbsuite.test import lldbutil
 class AbiTagStructorsTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
 
-    @skipIf(
-        compiler="clang",
-        compiler_version=["<", "22"],
-        bugnumber="Required Clang flag not supported",
-    )
     @expectedFailureAll(oslist=["windows"])
     @requireExpressionEvaluation
     def test_with_structor_linkage_names(self):
@@ -81,16 +76,7 @@ class AbiTagStructorsTestCase(TestBase):
         Test that without linkage names on structor declarations we can't call
         ABI-tagged structors.
         """
-        # In older versions of Clang the -gno-structor-decl-linkage-names
-        # behaviour was the default.
-        if self.expectedCompiler(["clang"]) and self.expectedCompilerVersion(
-            [">=", "22.0"]
-        ):
-            self.build(
-                dictionary={"CXXFLAGS_EXTRAS": "-gno-structor-decl-linkage-names"}
-            )
-        else:
-            self.build()
+        self.build(dictionary={"CXXFLAGS_EXTRAS": "-gno-structor-decl-linkage-names"})
 
         lldbutil.run_to_source_breakpoint(
             self, "Break here", lldb.SBFileSpec("main.cpp", False)
@@ -122,7 +108,6 @@ class AbiTagStructorsTestCase(TestBase):
             "expression TaggedLocal()", error=True, substrs=["Couldn't look up symbols"]
         )
 
-    @skipIf(compiler="clang", compiler_version=["<", "22"])
     @expectedFailureAll(oslist=["windows"])
     @requireExpressionEvaluation
     def test_nested_with_structor_linkage_names(self):
@@ -132,15 +117,5 @@ class AbiTagStructorsTestCase(TestBase):
     @expectedFailureAll(oslist=["windows"])
     @requireExpressionEvaluation
     def test_nested_no_structor_linkage_names(self):
-        # In older versions of Clang the -gno-structor-decl-linkage-names
-        # behaviour was the default.
-        if self.expectedCompiler(["clang"]) and self.expectedCompilerVersion(
-            [">=", "22.0"]
-        ):
-            self.build(
-                dictionary={"CXXFLAGS_EXTRAS": "-gno-structor-decl-linkage-names"}
-            )
-        else:
-            self.build()
-
+        self.build(dictionary={"CXXFLAGS_EXTRAS": "-gno-structor-decl-linkage-names"})
         self.do_nested_structor_test()

--- a/lldb/test/API/lang/cpp/expr-definition-in-dylib/TestExprDefinitionInDylib.py
+++ b/lldb/test/API/lang/cpp/expr-definition-in-dylib/TestExprDefinitionInDylib.py
@@ -8,11 +8,6 @@ from lldbsuite.test import lldbutil
 class ExprDefinitionInDylibTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
 
-    @skipIf(
-        compiler="clang",
-        compiler_version=["<", "22"],
-        bugnumber="Required Clang flag not supported",
-    )
     @skipIfWindows
     def test_with_structor_linkage_names(self):
         """
@@ -81,16 +76,7 @@ class ExprDefinitionInDylibTestCase(TestBase):
         Tests that if structor declarations don't have linkage names, we can't
         call ABI-tagged constructors. But non-tagged ones are fine.
         """
-        # In older versions of Clang the -gno-structor-decl-linkage-names
-        # behaviour was the default.
-        if self.expectedCompiler(["clang"]) and self.expectedCompilerVersion(
-            [">=", "22.0"]
-        ):
-            self.build(
-                dictionary={"CXXFLAGS_EXTRAS": "-gno-structor-decl-linkage-names"}
-            )
-        else:
-            self.build()
+        self.build(dictionary={"CXXFLAGS_EXTRAS": "-gno-structor-decl-linkage-names"})
 
         target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
         self.assertTrue(target, VALID_TARGET)


### PR DESCRIPTION
**Root cause:** Both tests gated the `-gstructor-decl-linkage-names`/`-gno-structor-decl-linkage-names` build flags on `compiler_version < 22`, assuming older Clang defaults to omitting structor linkage names.

Both flags work correctly on this toolchain at any reported version, so the version gating just picked the wrong build config. Removed the version conditionals and always build with the explicit flag.

**Fixes:**
  - `lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py`
  - `lldb/test/API/lang/cpp/expr-definition-in-dylib/TestExprDefinitionInDylib.py`