### PR TITLE
[lldb] restore skip decorator on TestSwiftForwardInteropExpressions

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
@@ -6,6 +6,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 
+@skipIf(bugnumber = "rdar://159675331")
 class TestSwiftForwardInteropExpressions(TestBase):
 
     def setup(self, bkpt_str):


### PR DESCRIPTION
**Root cause:** `stable/21.x` has `@skipIf(bugnumber="rdar://159675331")` on this test class for a known, already-tracked bug. That decorator is missing on `stable/23.x` (dropped somewhere along the way), so the test runs and fails instead of being skipped. Restored the decorator to match `stable/21.x` exactly.

**Fixes:**
  - `lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py`