### PR TITLE
[cherry-pick next][lldb][test] Avoid the statically linked concurrency runtime by symbol name

### DIFF
--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(lldbtest.TestBase):
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
     def test(self):
@@ -37,7 +36,10 @@ class TestCase(lldbtest.TestBase):
         self.assertEqual(lines, {3})
 
         # Required for builds that have debug info.
+        # Avoid spurious breakpoints when debug info for the concurrency runtime is available.
         self.runCmd("settings set target.process.thread.step-avoid-libraries libswift_Concurrency.dylib")
+        # Same as above, but for embedded swift.
+        self.runCmd("settings set target.process.thread.step-avoid-regexp ^(std::|(::)?swift_)")
         thread.StepInto()
         frame = thread.frame[0]
         # Step in from `main` should progress through to `f`.


### PR DESCRIPTION
The final StepInto of this test landed in `::swift_task_alloc` instead of `f()`
when the inferior is built in embedded mode.

The test already guards against stepping into the concurrency runtime by naming
`libswift_Concurrency.dylib` in `target.process.thread.step-avoid-libraries`,
so we do the same thing, but for the embedded swift runtime functions which are
statically linked into the binary. This isn't a real bug, as it only
happens if you have debug info for the runtime.

Assisted-by: Claude

(cherry picked from commit 239531a87fc03f114fa17bb5f187fc551ca83899)
