### PR TITLE
[cherry-pick next][lldb] Bind archetypes from embedded Swift's metadata symbols

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -765,6 +765,13 @@ protected:
   GetTypeFromMetadataAddressEmbedded(lldb::addr_t metadata_addr,
                                      TypeSystemSwiftTypeRef &ts);
 
+  /// Resolves the type whose metadata is at \p metadata_addr, using whichever
+  /// representation \p flavor implies.
+  llvm::Expected<const swift::reflection::TypeRef &>
+  GetTypeRefFromMetadataAddress(lldb::addr_t metadata_addr,
+                                TypeSystemSwiftTypeRef &ts,
+                                swift::Mangle::ManglingFlavor flavor);
+
   /// Resolves the type a "type metadata for T" symbol names, and whether the
   /// symbol names full metadata rather than type metadata.
   llvm::Expected<std::pair<CompilerType, bool>>

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2443,6 +2443,27 @@ SwiftLanguageRuntime::GetTypeFromMetadataAddressEmbedded(
   return type;
 }
 
+llvm::Expected<const swift::reflection::TypeRef &>
+SwiftLanguageRuntime::GetTypeRefFromMetadataAddress(
+    lldb::addr_t metadata_addr, TypeSystemSwiftTypeRef &ts,
+    swift::Mangle::ManglingFlavor flavor) {
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return llvm::createStringError("no reflection context");
+
+  if (flavor != swift::Mangle::ManglingFlavor::Embedded)
+    return reflection_ctx->ReadTypeFromMetadata(metadata_addr,
+                                                ts.GetDescriptorFinder());
+
+  // Embedded swift path.
+  llvm::Expected<CompilerType> type_or_err =
+      GetTypeFromMetadataAddressEmbedded(metadata_addr, ts);
+  if (!type_or_err)
+    return type_or_err.takeError();
+  return reflection_ctx->GetTypeRef(
+      type_or_err->GetMangledTypeName().GetStringRef());
+}
+
 llvm::Expected<lldb::addr_t>
 SwiftLanguageRuntime::UnwrapClassReferenceIfNeeded(CompilerType type,
                                                    lldb::addr_t addr) {
@@ -3285,8 +3306,8 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
         GetTypeMetadataForTypeNameAndFrame(mdvar_name.GetString(), stack_frame);
     if (!metadata_location)
       return;
-    auto type_ref_or_err = reflection_ctx->ReadTypeFromMetadata(
-        *metadata_location, ts.GetDescriptorFinder());
+    auto type_ref_or_err =
+        GetTypeRefFromMetadataAddress(*metadata_location, ts, flavor);
     if (!type_ref_or_err) {
       LLDB_LOG_ERRORV(
           GetLog(LLDBLog::Expressions | LLDBLog::Types),

--- a/lldb/test/API/lang/swift/embedded/protocol_extension_self/Makefile
+++ b/lldb/test/API/lang/swift/embedded/protocol_extension_self/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/protocol_extension_self/TestSwiftEmbeddedProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/embedded/protocol_extension_self/TestSwiftEmbeddedProtocolExtensionSelf.py
@@ -1,0 +1,26 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedProtocolExtensionSelf(TestBase):
+    @skipEmbeddedSwiftOnWindows
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+
+        # The archetype is concretized while resolving the dynamic type, which
+        # is what binding it against the metadata symbol makes possible.
+        self.expect("frame variable self", substrs=["(a.C)", "number = 42"])
+        lldbutil.check_variable(self, thread.frames[0].FindVariable("self"),
+                                use_dynamic=True, typename="a.C",
+                                num_children=1)
+
+        lldbutil.continue_to_breakpoint(process, bkpt)
+        self.expect("frame variable self", substrs=["(a.D)", "other = 99"])
+        lldbutil.check_variable(self, thread.frames[0].FindVariable("self"),
+                                use_dynamic=True, typename="a.D",
+                                num_children=1)

--- a/lldb/test/API/lang/swift/embedded/protocol_extension_self/main.swift
+++ b/lldb/test/API/lang/swift/embedded/protocol_extension_self/main.swift
@@ -1,0 +1,27 @@
+// Inside a class-bound protocol extension the static type of `self` is the
+// generic archetype τ_0_0, so inspecting it at all requires binding that
+// archetype to the concrete type the caller passed.
+protocol P: AnyObject {
+    func payload() -> Int
+}
+
+class C: P {
+    let number = 42
+    func payload() -> Int { number }
+}
+
+class D: P {
+    let other = 99
+    func payload() -> Int { other }
+}
+
+extension P {
+    func useSelf() {
+        print("break here")
+    }
+}
+
+let c: P = C()
+c.useSelf()
+let d: P = D()
+d.useSelf()

--- a/lldb/test/API/lang/swift/invalid_self_type/TestSwiftInvalidSelfType.py
+++ b/lldb/test/API/lang/swift/invalid_self_type/TestSwiftInvalidSelfType.py
@@ -5,8 +5,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftInvalidSelfType(TestBase):
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
-    @skipEmbeddedSwift
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
BindGenericTypeParameters always tries to read metadata to bind the
generic type parameter. Fix that by using the type's mangling flavor to
dispatch to the proper reading function.

Assisted-by: claude

rdar://184643430

(cherry picked from commit 2cfe42d4a5ec8afe7dbc996fe288d2c776b27df5)
