### PR TITLE
[CAS] Add ObjectStore::getStandaloneMemoryBuffer() (#215360)

### DIFF
--- a/llvm/docs/ContentAddressableStorage.md
+++ b/llvm/docs/ContentAddressableStorage.md
@@ -61,6 +61,12 @@ of error handling. The class APIs also provide convenient methods to
 access underlying data. The lifetime of the underlying data is equal to
 the lifetime of the instance of `ObjectStore` unless explicitly copied.
 
+To get a lifetime-extended buffer, call `getStandaloneMemoryBuffer()`, which
+returns a `MemoryBuffer` that remains valid after the `ObjectStore` is
+destroyed. A CAS can provide a customized implementation that is cheaper than
+a copy; the on-disk CAS re-reads the object's file where it has one, which
+lets the pages be shared and reclaimed rather than charged to the process.
+
 ### CASID
 
 `CASID` is the hash identifier for CASObjects. It owns the underlying
@@ -106,6 +112,10 @@ ones.
 
 To add your own implementation, you just need to add a subclass to
 `llvm::cas::ObjectStore` and implement all its pure virtual methods.
+`getStandaloneMemoryBufferImpl()` is an optional customization point; it
+copies by default, so override it only if the implementation can hand out
+storage that outlives itself.
+
 To be interchangeable with LLVM ObjectStore, the new CAS implementation
 needs to conform to following contracts:
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -587,6 +587,12 @@ Performance enhancements:
 
 ### Other Changes
 
+* `cas::ObjectStore::getMemoryBuffer()` was documented as returning a buffer
+  whose lifetime is independent of the CAS, but the buffer it returns may alias
+  storage the CAS owns and so cannot outlive it. The documentation now matches
+  the behavior, and the new `getStandaloneMemoryBuffer()` provides a buffer that
+  does stay valid after the `ObjectStore` is destroyed.
+
 ## External Open Source Projects Using LLVM {{env.config.release}}
 
 ## Additional Information

--- a/llvm/include/llvm-c/CAS/PluginAPI_functions.h
+++ b/llvm/include/llvm-c/CAS/PluginAPI_functions.h
@@ -293,6 +293,29 @@ LLCAS_PUBLIC llcas_data_t llcas_loaded_object_get_data(llcas_cas_t,
                                                        llcas_loaded_object_t);
 
 /**
+ * \returns a data buffer for the provided \c llcas_loaded_object_t that stays
+ * valid after the \c llcas_cas_t is disposed of. The buffer pointer must be
+ * 8-byte aligned and \c NULL terminated. It must be released via
+ * \c llcas_standalone_data_dispose, which may outlive the \c llcas_cas_t.
+ *
+ * This is an optimization over copying the buffer returned by
+ * \c llcas_loaded_object_get_data: an implementation that can hand out storage
+ * outliving itself, e.g. a mapping of a file it does not keep open, avoids the
+ * copy. Implementing it is optional, and requires
+ * \c llcas_standalone_data_dispose to be implemented as well.
+ */
+LLCAS_PUBLIC llcas_data_t
+    llcas_loaded_object_get_standalone_data(llcas_cas_t, llcas_loaded_object_t);
+
+/**
+ * Releases a buffer returned by \c llcas_loaded_object_get_standalone_data.
+ *
+ * This may be called after the \c llcas_cas_t that produced the buffer has
+ * been disposed of, so it must not depend on it.
+ */
+LLCAS_PUBLIC void llcas_standalone_data_dispose(llcas_data_t);
+
+/**
  * \returns the references of the provided \c llcas_loaded_object_t.
  */
 LLCAS_PUBLIC llcas_object_refs_t

--- a/llvm/include/llvm-c/CAS/PluginAPI_types.h
+++ b/llvm/include/llvm-c/CAS/PluginAPI_types.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #define LLCAS_VERSION_MAJOR 0
-#define LLCAS_VERSION_MINOR 1
+#define LLCAS_VERSION_MINOR 2
 
 typedef struct llcas_cas_options_s *llcas_cas_options_t;
 typedef struct llcas_cas_s *llcas_cas_t;

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -31,6 +31,7 @@ namespace cas {
 
 class ObjectStore;
 class ObjectProxy;
+class ActionCache;
 
 using AsyncProxyValue = AsyncValue<ObjectProxy>;
 
@@ -84,7 +85,9 @@ using AsyncProxyValue = AsyncValue<ObjectProxy>;
 /// lifetime tradeoffs:
 ///
 /// - \a getData() accesses data without exposing lifetime at all.
-/// - \a getMemoryBuffer() returns a \a MemoryBuffer whose lifetime
+/// - \a getMemoryBuffer() returns a \a MemoryBuffer that may alias storage
+///   owned by the CAS, so it must not outlive the \a ObjectStore.
+/// - \a getStandaloneMemoryBuffer() returns a \a MemoryBuffer whose lifetime
 ///   is independent of the CAS (it can live longer).
 /// - \a getDataString() return StringRef with lifetime is guaranteed to last as
 ///   long as \a ObjectStore.
@@ -179,6 +182,17 @@ protected:
   storeFromOpenFileImpl(sys::fs::file_t FD,
                         std::optional<sys::fs::file_status> Status);
 
+  /// Customization point for \a getStandaloneMemoryBuffer(). The default
+  /// implementation copies the data, which always satisfies the lifetime
+  /// requirement; implementations that can hand out storage outliving
+  /// themselves, e.g. a mapping of a file they do not keep open, should
+  /// override this to avoid the copy. Must not return \c nullptr: fall back
+  /// to \c ObjectStore::getStandaloneMemoryBufferImpl() where the cheaper
+  /// path does not apply.
+  virtual std::unique_ptr<MemoryBuffer>
+  getStandaloneMemoryBufferImpl(ObjectHandle Node, StringRef Name,
+                                bool RequiresNullTerminator);
+
   /// Get a lifetime-extended StringRef pointing at \p Data.
   ///
   /// Depending on the CAS implementation, this may involve in-memory storage
@@ -187,13 +201,24 @@ protected:
     return toStringRef(getData(Node));
   }
 
-  /// Get a lifetime-extended MemoryBuffer pointing at \p Data.
+  /// Get a MemoryBuffer pointing at \p Data.
   ///
-  /// Depending on the CAS implementation, this may involve in-memory storage
-  /// overhead.
+  /// The buffer may alias storage owned by this ObjectStore, in which case it
+  /// is only valid for as long as the store is.
   std::unique_ptr<MemoryBuffer>
   getMemoryBuffer(ObjectHandle Node, StringRef Name = "",
                   bool RequiresNullTerminator = true);
+
+  /// Get a MemoryBuffer for \p Node that stays valid after this ObjectStore is
+  /// destroyed.
+  ///
+  /// May be more expensive than \a getMemoryBuffer(), which is free to alias
+  /// storage the store already has mapped; prefer that one whenever the buffer
+  /// cannot outlive the store. Never returns \c nullptr: copying the data
+  /// always satisfies the lifetime requirement.
+  std::unique_ptr<MemoryBuffer>
+  getStandaloneMemoryBuffer(ObjectHandle Node, StringRef Name = "",
+                            bool RequiresNullTerminator = true);
 
   /// Read all the refs from object in a SmallVector.
   virtual void readRefs(ObjectHandle Node,
@@ -342,6 +367,11 @@ public:
   getMemoryBuffer(StringRef Name = "",
                   bool RequiresNullTerminator = true) const;
 
+  /// Get a MemoryBuffer that stays valid after the CAS is destroyed.
+  LLVM_ABI std::unique_ptr<MemoryBuffer>
+  getStandaloneMemoryBuffer(StringRef Name = "",
+                            bool RequiresNullTerminator = true) const;
+
   /// Get the content of the node. Valid as long as the CAS is valid.
   StringRef getData() const { return CAS->getDataString(H); }
 
@@ -423,9 +453,16 @@ using ObjectStoreCreateFuncTy = Expected<
     const Twine &);
 void registerCASURLScheme(StringRef Prefix, ObjectStoreCreateFuncTy *Func);
 
-/// Create \c ObjectStore and \c ActionCache instances using the plugin
-/// interface.
-Expected<std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
+/// Create \c ObjectStore and \c ActionCache instances backed by a plugin that
+/// implements the C API in \c "llvm-c/CAS/PluginAPI_functions.h".
+///
+/// \param PluginPath path of the dynamic library to load.
+/// \param OnDiskPath local path that the plugin should use for any on-disk
+/// resources/caches.
+/// \param PluginArgs name/value pairs passed to the plugin as custom options;
+/// they are opaque to the client.
+LLVM_ABI Expected<
+    std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
 createPluginCASDatabases(
     StringRef PluginPath, StringRef OnDiskPath,
     ArrayRef<std::pair<std::string, std::string>> PluginArgs);

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -22,6 +22,10 @@
 #include "llvm/CAS/OnDiskTrieRawHashMap.h"
 #include <atomic>
 
+namespace llvm {
+class MemoryBuffer;
+} // namespace llvm
+
 namespace llvm::cas::ondisk {
 
 /// Standard 8 byte reference inside OnDiskGraphDB.
@@ -353,6 +357,17 @@ public:
   /// delete the underlying file, the path is provided only for reading/copying.
   LLVM_ABI FileBackedData
   getInternalFileBackedObjectData(ObjectHandle Node) const;
+
+  /// Get a MemoryBuffer for \p Node's data that stays valid after this
+  /// database is destroyed.
+  ///
+  /// Objects stored in a file of their own are re-read from it rather than
+  /// copied out of this database's mapping, which lets the pages be shared and
+  /// reclaimed rather than charged to this process. The rest are copied. Never
+  /// returns \c nullptr.
+  LLVM_ABI std::unique_ptr<MemoryBuffer>
+  getStandaloneMemoryBuffer(ObjectHandle Node, StringRef Name,
+                            bool RequiresNullTerminator) const;
 
   /// \returns Total size of stored objects.
   ///

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -90,6 +90,19 @@ ObjectStore::getMemoryBuffer(ObjectHandle Node, StringRef Name,
       RequiresNullTerminator);
 }
 
+std::unique_ptr<MemoryBuffer>
+ObjectStore::getStandaloneMemoryBuffer(ObjectHandle Node, StringRef Name,
+                                       bool RequiresNullTerminator) {
+  return getStandaloneMemoryBufferImpl(Node, Name, RequiresNullTerminator);
+}
+
+std::unique_ptr<MemoryBuffer>
+ObjectStore::getStandaloneMemoryBufferImpl(ObjectHandle Node, StringRef Name,
+                                           bool RequiresNullTerminator) {
+  return MemoryBuffer::getMemBufferCopy(
+      toStringRef(getData(Node, RequiresNullTerminator)), Name);
+}
+
 void ObjectStore::readRefs(ObjectHandle Node,
                            SmallVectorImpl<ObjectRef> &Refs) const {
   consumeError(forEachRef(Node, [&Refs](ObjectRef Ref) -> Error {
@@ -350,6 +363,12 @@ std::unique_ptr<MemoryBuffer>
 ObjectProxy::getMemoryBuffer(StringRef Name,
                              bool RequiresNullTerminator) const {
   return CAS->getMemoryBuffer(H, Name, RequiresNullTerminator);
+}
+
+std::unique_ptr<MemoryBuffer>
+ObjectProxy::getStandaloneMemoryBuffer(StringRef Name,
+                                       bool RequiresNullTerminator) const {
+  return CAS->getStandaloneMemoryBuffer(H, Name, RequiresNullTerminator);
 }
 
 static Expected<

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/IOSandbox.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 
 using namespace llvm;
@@ -44,6 +45,10 @@ public:
   Expected<ObjectRef> storeFromFile(StringRef Path) final;
 
   Error exportDataToFile(ObjectHandle Node, StringRef Path) const final;
+
+  std::unique_ptr<MemoryBuffer>
+  getStandaloneMemoryBufferImpl(ObjectHandle Node, StringRef Name,
+                                bool RequiresNullTerminator) final;
 
   void print(raw_ostream &OS) const final;
   Error validate(bool CheckHash) const final;
@@ -164,6 +169,13 @@ Expected<ObjectRef> OnDiskCAS::storeFromFile(StringRef Path) {
   if (Error E = DB->storeFile(*StoredID, Path))
     return E;
   return convertRef(*StoredID);
+}
+
+std::unique_ptr<MemoryBuffer>
+OnDiskCAS::getStandaloneMemoryBufferImpl(ObjectHandle Node, StringRef Name,
+                                         bool RequiresNullTerminator) {
+  return DB->getStandaloneMemoryBuffer(convertHandle(Node), Name,
+                                       RequiresNullTerminator);
 }
 
 Error OnDiskCAS::exportDataToFile(ObjectHandle Node, StringRef Path) const {

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -371,6 +371,15 @@ public:
   OnDiskGraphDB::FileBackedData
   getInternalFileBackedObjectData(StringRef RootPath) const;
 
+  /// Read this object's data from its file again, so the result does not
+  /// reference \a Region and stays valid after this object is gone.
+  ///
+  /// \returns \c nullptr when it does not apply, and the caller is
+  /// expected to copy instead.
+  std::unique_ptr<MemoryBuffer>
+  getStandaloneMemoryBuffer(StringRef RootPath, StringRef Name,
+                            bool RequiresNullTerminator) const;
+
   StandaloneDataInMemory(std::unique_ptr<sys::fs::mapped_file_region> Region,
                          TrieRecord::StorageKind SK, FileOffset IndexOffset)
       : Region(std::move(Region)), SK(SK), IndexOffset(IndexOffset) {
@@ -1291,6 +1300,23 @@ OnDiskGraphDB::getInternalFileBackedObjectData(ObjectHandle Node) const {
   }
 }
 
+std::unique_ptr<MemoryBuffer>
+OnDiskGraphDB::getStandaloneMemoryBuffer(ObjectHandle Node, StringRef Name,
+                                         bool RequiresNullTerminator) const {
+  // Only an object with a file to itself can be read back on its own; one in
+  // the shared data pool is a subrange of a file holding unrelated objects.
+  auto SDIMOrRecord = getStandaloneDataOrDataRecord(DataPool, Node);
+  if (auto **SDIM =
+          std::get_if<const StandaloneDataInMemory *>(&SDIMOrRecord)) {
+    if (std::unique_ptr<MemoryBuffer> Standalone =
+            (*SDIM)->getStandaloneMemoryBuffer(RootPath, Name,
+                                               RequiresNullTerminator))
+      return Standalone;
+  }
+
+  return MemoryBuffer::getMemBufferCopy(toStringRef(getObjectData(Node)), Name);
+}
+
 Expected<std::optional<ObjectHandle>>
 OnDiskGraphDB::load(ObjectID ExternalRef) {
   InternalRef Ref = getInternalRef(ExternalRef);
@@ -1461,6 +1487,63 @@ StandaloneDataInMemory::getInternalFileBackedObjectData(
                                     std::string(Path), IsFileNulTerminated}};
   }
   llvm_unreachable("Unknown StorageKind enum");
+}
+
+namespace {
+/// A MemoryBuffer exposing a subrange of another buffer's bytes, under its own
+/// name.
+class AdoptedMemoryBuffer final : public MemoryBuffer {
+public:
+  AdoptedMemoryBuffer(std::unique_ptr<MemoryBuffer> Buffer, StringRef Name,
+                      uint64_t Offset, uint64_t Size)
+      : Buffer(std::move(Buffer)), Name(Name.str()) {
+    const char *Start = this->Buffer->getBufferStart() + Offset;
+    init(Start, Start + Size, /*RequiresNullTerminator=*/false);
+  }
+
+  StringRef getBufferIdentifier() const final { return Name; }
+
+  BufferKind getBufferKind() const final { return Buffer->getBufferKind(); }
+
+private:
+  std::unique_ptr<MemoryBuffer> Buffer;
+  std::string Name;
+};
+} // end anonymous namespace
+
+std::unique_ptr<MemoryBuffer> StandaloneDataInMemory::getStandaloneMemoryBuffer(
+    StringRef RootPath, StringRef Name, bool RequiresNullTerminator) const {
+  // A plain leaf's file is exactly the data, with no nul after it to map. The
+  // other kinds have one: a record's own terminator, or the one appended to a
+  // "leaf+0".
+  if (RequiresNullTerminator && SK == TrieRecord::StorageKind::StandaloneLeaf)
+    return nullptr;
+
+  // Read the file again instead of sharing \a Region, whose lifetime is tied
+  // to this object. These files are written once and never modified, so the
+  // second read sees the same bytes. Whether that ends up mapping the file or
+  // copying it is up to MemoryBuffer; either way the result stands alone.
+  SmallString<256> Path;
+  ::getStandalonePath(RootPath, TrieRecord::getStandaloneFilePrefix(SK),
+                      IndexOffset, Path);
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+  ErrorOr<std::unique_ptr<MemoryBuffer>> Mapped =
+      MemoryBuffer::getFile(Path, /*IsText=*/false,
+                            /*RequiresNullTerminator=*/false,
+                            /*IsVolatile=*/false);
+  if (!Mapped)
+    return nullptr;
+
+  // Find the data within the mapping. A leaf's file holds just the data; a
+  // record's also holds its header and refs.
+  OnDiskContent Content = getContent();
+  ArrayRef<char> Data = Content.getData();
+  uint64_t Offset = Content.Record ? Data.data() - Region->data() : 0;
+  if (Offset + Data.size() > (*Mapped)->getBufferSize())
+    return nullptr;
+
+  return std::make_unique<AdoptedMemoryBuffer>(std::move(*Mapped), Name, Offset,
+                                               Data.size());
 }
 
 static Expected<MappedTempFile>

--- a/llvm/lib/CAS/PluginAPI.h
+++ b/llvm/lib/CAS/PluginAPI.h
@@ -1,9 +1,15 @@
-//===- PluginAPI.h ----------------------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Defines \c llcas_functions_t, the table of function pointers that is
+/// populated by looking up the \c llcas_* symbols of a loaded CAS plugin.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIB_CAS_PLUGINAPI_H
@@ -40,7 +46,7 @@ struct llcas_functions_t {
 
   int64_t (*cas_get_ondisk_size)(llcas_cas_t, char **error);
 
-  bool (*cas_set_ondisk_size_limit)(llcas_cas_t, uint64_t size_limit,
+  bool (*cas_set_ondisk_size_limit)(llcas_cas_t, int64_t size_limit,
                                     char **error);
 
   bool (*cas_prune_ondisk_data)(llcas_cas_t, char **error);
@@ -81,6 +87,11 @@ struct llcas_functions_t {
 
   llcas_object_refs_t (*loaded_object_get_refs)(llcas_cas_t,
                                                 llcas_loaded_object_t);
+
+  llcas_data_t (*loaded_object_get_standalone_data)(llcas_cas_t,
+                                                    llcas_loaded_object_t);
+
+  void (*standalone_data_dispose)(llcas_data_t);
 
   size_t (*object_refs_get_count)(llcas_cas_t, llcas_object_refs_t);
 

--- a/llvm/lib/CAS/PluginAPI_functions.def
+++ b/llvm/lib/CAS/PluginAPI_functions.def
@@ -1,7 +1,19 @@
-
-// Format is Name/required. If 'required' is true then loading will fail if the
-// symbol is missing, otherwise loading will continue and the function pointer
-// will be null. Order is lexicographically by name.
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// The list of functions that make up the LLVM CAS plugin API.
+///
+/// Format is Name/required. If 'required' is true then loading will fail if the
+/// symbol is missing, otherwise loading will continue and the function pointer
+/// will be null. Order is lexicographically by name.
+///
+//===----------------------------------------------------------------------===//
 
 CASPLUGINAPI_FUNCTION(actioncache_get_for_digest, true)
 CASPLUGINAPI_FUNCTION(actioncache_get_for_digest_async, true)
@@ -25,16 +37,18 @@ CASPLUGINAPI_FUNCTION(cas_options_set_ondisk_path, true)
 CASPLUGINAPI_FUNCTION(cas_options_set_option, true)
 CASPLUGINAPI_FUNCTION(cas_prune_ondisk_data, false)
 CASPLUGINAPI_FUNCTION(cas_set_ondisk_size_limit, false)
+CASPLUGINAPI_FUNCTION(cas_store_from_filepath, false)
 CASPLUGINAPI_FUNCTION(cas_store_object, true)
 CASPLUGINAPI_FUNCTION(cas_validate, false)
-CASPLUGINAPI_FUNCTION(cas_store_from_filepath, false)
 CASPLUGINAPI_FUNCTION(digest_parse, true)
 CASPLUGINAPI_FUNCTION(digest_print, true)
 CASPLUGINAPI_FUNCTION(get_plugin_version, true)
+CASPLUGINAPI_FUNCTION(loaded_object_export_data_to_filepath, false)
 CASPLUGINAPI_FUNCTION(loaded_object_get_data, true)
 CASPLUGINAPI_FUNCTION(loaded_object_get_refs, true)
-CASPLUGINAPI_FUNCTION(loaded_object_export_data_to_filepath, false)
+CASPLUGINAPI_FUNCTION(loaded_object_get_standalone_data, false)
 CASPLUGINAPI_FUNCTION(object_refs_get_count, true)
 CASPLUGINAPI_FUNCTION(object_refs_get_id, true)
 CASPLUGINAPI_FUNCTION(objectid_get_digest, true)
+CASPLUGINAPI_FUNCTION(standalone_data_dispose, false)
 CASPLUGINAPI_FUNCTION(string_dispose, true)

--- a/llvm/lib/CAS/PluginCAS.cpp
+++ b/llvm/lib/CAS/PluginCAS.cpp
@@ -1,9 +1,15 @@
-//===- PluginCAS.cpp --------------------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implements \c ObjectStore and \c ActionCache on top of a dynamically loaded
+/// plugin that provides the C API in \c "llvm-c/CAS/PluginAPI_functions.h".
+///
 //===----------------------------------------------------------------------===//
 
 #include "PluginAPI.h"
@@ -13,6 +19,7 @@
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -87,7 +94,7 @@ Expected<std::shared_ptr<PluginCASContext>> PluginCASContext::create(
 #undef CASPLUGINAPI_FUNCTION
 
   llcas_cas_options_t c_opts = Functions.cas_options_create();
-  llvm::scope_exit _([&]() { Functions.cas_options_dispose(c_opts); });
+  scope_exit DisposeOptions([&]() { Functions.cas_options_dispose(c_opts); });
 
   Functions.cas_options_set_client_version(c_opts, LLCAS_VERSION_MAJOR,
                                            LLCAS_VERSION_MINOR);
@@ -146,6 +153,9 @@ public:
   size_t getNumRefs(ObjectHandle Node) const final;
   ArrayRef<char> getData(ObjectHandle Node,
                          bool RequiresNullTerminator = false) const final;
+  std::unique_ptr<MemoryBuffer>
+  getStandaloneMemoryBufferImpl(ObjectHandle Node, StringRef Name,
+                                bool RequiresNullTerminator) final;
   Error validateObject(const CASID &ID) final {
     // Not supported yet. Always return success.
     return Error::success();
@@ -291,6 +301,7 @@ Expected<bool> PluginObjectStore::isMaterialized(ObjectRef Ref) const {
   case LLCAS_LOOKUP_RESULT_ERROR:
     return Ctx->errorAndDispose(c_err);
   }
+  llvm_unreachable("unknown llcas_lookup_result_t value");
 }
 
 Expected<std::optional<ObjectHandle>>
@@ -420,6 +431,53 @@ ArrayRef<char> PluginObjectStore::getData(ObjectHandle Node,
   llcas_data_t c_data = Ctx->Functions.loaded_object_get_data(
       Ctx->c_cas, llcas_loaded_object_t{Node.getInternalRef(*this)});
   return ArrayRef((const char *)c_data.data, c_data.size);
+}
+
+namespace {
+/// A MemoryBuffer over a plugin's standalone buffer, which it releases when
+/// destroyed. It holds the dispose function directly rather than the
+/// \c llcas_cas_t, since the point of the buffer is to outlive that.
+class PluginStandaloneMemoryBuffer final : public MemoryBuffer {
+public:
+  using DisposeFn = void (*)(llcas_data_t);
+
+  PluginStandaloneMemoryBuffer(llcas_data_t Data, StringRef Name,
+                               DisposeFn Dispose)
+      : Data(Data), Name(Name.str()), Dispose(Dispose) {
+    const char *Start = static_cast<const char *>(Data.data);
+    init(Start, Start + Data.size, /*RequiresNullTerminator=*/true);
+  }
+
+  ~PluginStandaloneMemoryBuffer() override { Dispose(Data); }
+
+  StringRef getBufferIdentifier() const final { return Name; }
+
+  BufferKind getBufferKind() const final { return MemoryBuffer_Malloc; }
+
+private:
+  llcas_data_t Data;
+  std::string Name;
+  DisposeFn Dispose;
+};
+} // namespace
+
+std::unique_ptr<MemoryBuffer> PluginObjectStore::getStandaloneMemoryBufferImpl(
+    ObjectHandle Node, StringRef Name, bool RequiresNullTerminator) {
+  // Both halves are needed: without the disposer there is no way to release
+  // what the getter hands out.
+  if (!Ctx->Functions.loaded_object_get_standalone_data ||
+      !Ctx->Functions.standalone_data_dispose)
+    return ObjectStore::getStandaloneMemoryBufferImpl(Node, Name,
+                                                      RequiresNullTerminator);
+
+  llcas_data_t c_data = Ctx->Functions.loaded_object_get_standalone_data(
+      Ctx->c_cas, llcas_loaded_object_t{Node.getInternalRef(*this)});
+  if (!c_data.data)
+    return ObjectStore::getStandaloneMemoryBufferImpl(Node, Name,
+                                                      RequiresNullTerminator);
+
+  return std::make_unique<PluginStandaloneMemoryBuffer>(
+      c_data, Name, Ctx->Functions.standalone_data_dispose);
 }
 
 Error PluginObjectStore::setSizeLimit(std::optional<uint64_t> SizeLimit) {

--- a/llvm/tools/libCASPluginTest/CMakeLists.txt
+++ b/llvm/tools/libCASPluginTest/CMakeLists.txt
@@ -1,3 +1,10 @@
+# The plugin is implemented on top of UnifiedOnDiskCache, which is only
+# functional when the on-disk CAS is enabled, and it is only useful as a shared
+# library, which requires PIC objects.
+if (NOT LLVM_ENABLE_ONDISK_CAS OR NOT LLVM_ENABLE_PIC)
+  return()
+endif()
+
 set(LLVM_LINK_COMPONENTS
   CAS
   Support
@@ -9,4 +16,7 @@ set(SOURCES
 
 set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libCASPluginTest.exports)
 
-add_llvm_library(CASPluginTest SHARED ${SOURCES})
+# Only loaded by CAS unit tests out of the build tree.
+add_llvm_library(CASPluginTest SHARED BUILDTREE_ONLY ${SOURCES}
+  LINK_LIBS ${LLVM_PTHREAD_LIB}
+)

--- a/llvm/tools/libCASPluginTest/libCASPluginTest.cpp
+++ b/llvm/tools/libCASPluginTest/libCASPluginTest.cpp
@@ -1,13 +1,18 @@
-//===- llvm/tools/libCASPluginTest/libCASPluginTest.cpp ---------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// Implementation of the LLVM CAS plugin API, for testing purposes.
-//
+///
+/// \file
+/// Implementation of the LLVM CAS plugin API, for testing purposes.
+///
+/// It is backed by \c UnifiedOnDiskCache and can optionally be given a second
+/// on-disk path via the \c upstream-path option, which it uses to simulate
+/// "uploading"/"downloading" objects to/from a distributed CAS.
+///
 //===----------------------------------------------------------------------===//
 
 #include "llvm-c/CAS/PluginAPI_functions.h"
@@ -18,12 +23,30 @@
 #include "llvm/Support/CBindingWrapping.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/ThreadPool.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SHA1.h"
+#include "llvm/Support/ThreadPool.h"
+#include <mutex>
 
 using namespace llvm;
 using namespace llvm::cas;
 using namespace llvm::cas::ondisk;
+
+namespace llvm::cas::ondisk {
+/// Declared in the private "OnDiskCommon.h"; see \c setSmallMaxMappingSize.
+void setMaxMappingSize(uint64_t Size);
+} // namespace llvm::cas::ondisk
+
+/// This plugin exists only for testing, and a test process can create many
+/// instances of it. Keep the on-disk mappings small so that they stay cheap;
+/// the default sizes are measured in gigabytes per instance.
+///
+/// This has to happen inside the plugin: it links its own copy of LLVMCAS, so
+/// the setting the test binary applies to itself does not reach us.
+static void setSmallMaxMappingSize() {
+  static std::once_flag Flag;
+  std::call_once(Flag, [] { setMaxMappingSize(100 * 1024 * 1024); });
+}
 
 static char *copyNewMallocString(StringRef Str) {
   char *c_str = (char *)malloc(Str.size() + 1);
@@ -376,6 +399,7 @@ CASWrapper::downstreamKey(ArrayRef<uint8_t> Key) {
 
 llcas_cas_t llcas_cas_create(llcas_cas_options_t c_opts, char **error) {
   auto &Opts = *unwrap(c_opts);
+  setSmallMaxMappingSize();
   Expected<std::unique_ptr<UnifiedOnDiskCache>> DB = UnifiedOnDiskCache::open(
       Opts.OnDiskPath, /*SizeLimit=*/std::nullopt,
       PluginCASContext::getHashName(), sizeof(HashType));
@@ -616,6 +640,42 @@ llcas_data_t llcas_loaded_object_get_data(llcas_cas_t c_cas,
   ondisk::ObjectHandle Obj = ondisk::ObjectHandle(c_obj.opaque);
   auto Data = CAS.getObjectData(Obj);
   return llcas_data_t{Data.data(), Data.size()};
+}
+
+/// The \c MemoryBuffer objects handed out by
+/// \c llcas_loaded_object_get_standalone_data, keyed by the bytes the C API
+/// reports, so \c llcas_standalone_data_dispose can find the owner again. The
+/// C API passes back only the buffer, and these outlive the \c llcas_cas_t, so
+/// they cannot be tracked on it.
+/// Intentionally leaked, since a buffer may be disposed of during static
+/// destruction, after a non-leaked map would already be gone.
+static std::mutex StandaloneBuffersLock;
+static auto *StandaloneBuffers =
+    new DenseMap<const void *, std::unique_ptr<MemoryBuffer>>();
+
+llcas_data_t
+llcas_loaded_object_get_standalone_data(llcas_cas_t c_cas,
+                                        llcas_loaded_object_t c_obj) {
+  auto &CAS = unwrap(c_cas)->DB->getGraphDB();
+  ondisk::ObjectHandle Obj = ondisk::ObjectHandle(c_obj.opaque);
+  // The underlying database already knows how to produce a buffer that does
+  // not reference it, so use that rather than copying the data again. The
+  // plugin API requires a nul terminator, which costs a copy for the objects
+  // whose file has no byte to spare for one.
+  std::unique_ptr<MemoryBuffer> Buffer = CAS.getStandaloneMemoryBuffer(
+      Obj, /*Name=*/"", /*RequiresNullTerminator=*/true);
+  const char *Data = Buffer->getBufferStart();
+  size_t Size = Buffer->getBufferSize();
+  {
+    std::lock_guard<std::mutex> Lock(StandaloneBuffersLock);
+    (*StandaloneBuffers)[Data] = std::move(Buffer);
+  }
+  return llcas_data_t{Data, Size};
+}
+
+void llcas_standalone_data_dispose(llcas_data_t c_data) {
+  std::lock_guard<std::mutex> Lock(StandaloneBuffersLock);
+  StandaloneBuffers->erase(c_data.data);
 }
 
 llcas_object_refs_t llcas_loaded_object_get_refs(llcas_cas_t c_cas,

--- a/llvm/tools/libCASPluginTest/libCASPluginTest.exports
+++ b/llvm/tools/libCASPluginTest/libCASPluginTest.exports
@@ -25,7 +25,9 @@ llcas_digest_print
 llcas_get_plugin_version
 llcas_loaded_object_get_data
 llcas_loaded_object_get_refs
+llcas_loaded_object_get_standalone_data
 llcas_object_refs_get_count
 llcas_object_refs_get_id
 llcas_objectid_get_digest
+llcas_standalone_data_dispose
 llcas_string_dispose

--- a/llvm/unittests/CAS/ActionCacheTest.cpp
+++ b/llvm/unittests/CAS/ActionCacheTest.cpp
@@ -25,7 +25,7 @@ using namespace llvm::unittest::cas;
 
 TEST_P(CASTest, ActionCacheHit) {
   std::shared_ptr<ObjectStore> CAS = createObjectStore();
-  std::unique_ptr<ActionCache> Cache = createActionCache();
+  std::shared_ptr<ActionCache> Cache = createActionCache();
 
   std::optional<ObjectProxy> ID;
   ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID), Succeeded());
@@ -40,7 +40,7 @@ TEST_P(CASTest, ActionCacheHit) {
 
 TEST_P(CASTest, ActionCacheMiss) {
   std::shared_ptr<ObjectStore> CAS = createObjectStore();
-  std::unique_ptr<ActionCache> Cache = createActionCache();
+  std::shared_ptr<ActionCache> Cache = createActionCache();
 
   std::optional<ObjectProxy> ID1, ID2;
   ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID1), Succeeded());
@@ -63,7 +63,7 @@ TEST_P(CASTest, ActionCacheMiss) {
 
 TEST_P(CASTest, ActionCacheRewrite) {
   std::shared_ptr<ObjectStore> CAS = createObjectStore();
-  std::unique_ptr<ActionCache> Cache = createActionCache();
+  std::shared_ptr<ActionCache> Cache = createActionCache();
 
   std::optional<ObjectProxy> ID1, ID2;
   ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID1), Succeeded());
@@ -109,7 +109,7 @@ TEST_F(OnDiskCASTest, ActionCacheResultInvalid) {
 
 TEST_P(CASTest, ActionCacheAsync) {
   std::shared_ptr<ObjectStore> CAS = createObjectStore();
-  std::unique_ptr<ActionCache> Cache = createActionCache();
+  std::shared_ptr<ActionCache> Cache = createActionCache();
 
   {
     std::optional<ObjectProxy> ID;

--- a/llvm/unittests/CAS/CASTestConfig.h
+++ b/llvm/unittests/CAS/CASTestConfig.h
@@ -38,7 +38,7 @@ public:
 
 struct CASTestingEnv {
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
-  std::unique_ptr<llvm::cas::ActionCache> Cache;
+  std::shared_ptr<llvm::cas::ActionCache> Cache;
   std::unique_ptr<llvm::unittest::cas::MockEnv> Env;
   std::optional<llvm::unittest::TempDir> Temp;
 };
@@ -102,7 +102,7 @@ protected:
       Envs.emplace_back(std::move(TD.Env));
     return std::move(TD.CAS);
   }
-  std::unique_ptr<llvm::cas::ActionCache> createActionCache() {
+  std::shared_ptr<llvm::cas::ActionCache> createActionCache() {
     auto TD = GetParam()(++(*NextCASIndex));
     if (TD.Temp)
       Dirs.push_back(std::move(*TD.Temp));

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -12,9 +12,12 @@ set(ONDISK_CAS_TEST_SOURCES
   OnDiskDataAllocatorTest.cpp
   OnDiskKeyValueDBTest.cpp
   OnDiskTrieRawHashMapTest.cpp
-  PluginCASTest.cpp
   ProgramTest.cpp
   UnifiedOnDiskCacheTest.cpp
+  )
+
+set(PLUGIN_CAS_TEST_SOURCES
+  PluginCASTest.cpp
   )
 
 set(REMOTE_CACHE_TEST_SOURCES
@@ -23,11 +26,18 @@ set(REMOTE_CACHE_TEST_SOURCES
 
 set(LLVM_OPTIONAL_SOURCES
   ${ONDISK_CAS_TEST_SOURCES}
+  ${PLUGIN_CAS_TEST_SOURCES}
   ${REMOTE_CACHE_TEST_SOURCES}
   )
 
 if (NOT LLVM_ENABLE_ONDISK_CAS)
   unset(ONDISK_CAS_TEST_SOURCES)
+endif()
+
+# The plugin tests need the libCASPluginTest shared library, which is not
+# always built (it requires the on-disk CAS and PIC).
+if (NOT TARGET CASPluginTest)
+  unset(PLUGIN_CAS_TEST_SOURCES)
 endif()
 
 if (NOT LLVM_CAS_ENABLE_REMOTE_CACHE)
@@ -57,8 +67,20 @@ add_llvm_unittest(CASTests
   TreeSchemaTest.cpp
 
   ${ONDISK_CAS_TEST_SOURCES}
+  ${PLUGIN_CAS_TEST_SOURCES}
   ${REMOTE_CACHE_TEST_SOURCES}
   )
 
 target_link_libraries(CASTests PRIVATE LLVMTestingSupport)
-add_dependencies(CASTests CASPluginTest)
+
+if (TARGET CASPluginTest)
+  add_dependencies(CASTests CASPluginTest)
+  # Symlink the plugin library next to the test executable so getCASPluginPath()
+  # can locate it with a single parent_path regardless of the generator type.
+  add_custom_command(TARGET CASTests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+            $<TARGET_FILE:CASPluginTest>
+            $<TARGET_FILE_DIR:CASTests>/$<TARGET_FILE_PREFIX:CASPluginTest>CASPluginTest$<TARGET_FILE_SUFFIX:CASPluginTest>
+    VERBATIM
+  )
+endif()

--- a/llvm/unittests/CAS/ObjectStoreTest.cpp
+++ b/llvm/unittests/CAS/ObjectStoreTest.cpp
@@ -8,6 +8,8 @@
 
 #include "llvm/CAS/ObjectStore.h"
 #include "OnDiskCommonUtils.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -275,7 +277,7 @@ TEST_P(CASTest, NodesBig) {
 }
 
 TEST_P(CASTest, FileAPIs) {
-  auto CAS = createObjectStore();
+  std::shared_ptr<ObjectStore> CAS = createObjectStore();
 
   auto runCommonTests =
       [&CAS](function_ref<std::unique_ptr<unittest::TempFile>(char)>
@@ -383,14 +385,15 @@ TEST_P(CASTest, BlobsParallel) {
   ASSERT_NO_FATAL_FAILURE(testBlobsParallel1(*CAS, Size));
 }
 
+#ifdef EXPENSIVE_CHECKS
 TEST_P(CASTest, BlobsBigParallel) {
   std::shared_ptr<ObjectStore> CAS = createObjectStore();
   // 100k is large enough to be standalone files in our on-disk cas.
   uint64_t Size = 100ULL * 1024;
   ASSERT_NO_FATAL_FAILURE(testBlobsParallel1(*CAS, Size));
 }
+#endif // EXPENSIVE_CHECKS
 
-#if LLVM_ENABLE_ONDISK_CAS
 #ifndef _WIN32 // create_link won't work for directories on Windows
 TEST_F(OnDiskCASTest, OnDiskCASBlobsParallelMultiCAS) {
   // This test intentionally uses symlinked paths to the same CAS to subvert the
@@ -449,6 +452,7 @@ TEST_F(OnDiskCASTest, OnDiskCASBlobsBigParallelMultiCAS) {
   ASSERT_NO_FATAL_FAILURE(testBlobsParallel(*CAS1, *CAS2, *CAS3, *CAS4, Size));
 }
 #endif // _WIN32
+#endif // LLVM_ENABLE_THREADS
 
 TEST_F(OnDiskCASTest, OnDiskCASDiskSize) {
   unittest::TempDir Temp("on-disk-cas", /*Unique=*/true);
@@ -497,6 +501,150 @@ TEST_F(OnDiskCASTest, OnDiskCASDiskSize) {
   CAS.reset();
   CheckFileSizes(/*Mapped=*/false);
 }
-#endif // LLVM_ENABLE_ONDISK_CAS
-#endif // LLVM_ENABLE_THREADS
 
+TEST_P(CASTest, StandaloneMemoryBufferOutlivesCAS) {
+  // The buffer has to stay readable after the last reference to the store is
+  // gone. Cover both sides of the size threshold that decides whether an
+  // on-disk CAS embeds an object in its shared data pool or gives it a file of
+  // its own, since only the latter can be mapped.
+  for (uint64_t Size : {uint64_t(64), uint64_t(100 * 1024)}) {
+    std::shared_ptr<ObjectStore> CAS = createObjectStore();
+    std::string Data(Size, '\a');
+    Data.front() = 'b';
+    Data.back() = 'e';
+
+    std::optional<ObjectProxy> Proxy;
+    ASSERT_THAT_ERROR(CAS->createProxy({}, Data).moveInto(Proxy), Succeeded());
+    std::unique_ptr<MemoryBuffer> Buffer =
+        Proxy->getStandaloneMemoryBuffer("name");
+    ASSERT_TRUE(Buffer);
+    EXPECT_EQ("name", Buffer->getBufferIdentifier());
+
+    Proxy.reset();
+    CAS.reset();
+
+    // Read every page, not just the ends, so a mapping that lost its backing
+    // store faults here rather than silently passing.
+    ASSERT_EQ(Size, Buffer->getBufferSize());
+    EXPECT_EQ(Data, Buffer->getBuffer());
+  }
+}
+
+TEST_P(CASTest, StandaloneMemoryBufferNullTerminated) {
+  std::shared_ptr<ObjectStore> CAS = createObjectStore();
+  // Cover both sides of the size threshold that decides whether an on-disk CAS
+  // gives an object a file of its own or embeds it in the shared data pool,
+  // and include exact multiples of the page size: a mapping ending on a page
+  // boundary has no zero-filled slack to serve as the terminator.
+  uint64_t PageSize = sys::Process::getPageSizeEstimate();
+  for (uint64_t Size : {uint64_t(64), uint64_t(60000), uint64_t(65535),
+                        uint64_t(100 * 1024), PageSize, 4 * PageSize}) {
+    std::string Data(Size, 'z');
+    std::optional<ObjectProxy> Proxy;
+    ASSERT_THAT_ERROR(CAS->createProxy({}, Data).moveInto(Proxy), Succeeded());
+    std::unique_ptr<MemoryBuffer> Buffer = Proxy->getStandaloneMemoryBuffer(
+        "name", /*RequiresNullTerminator=*/true);
+    ASSERT_TRUE(Buffer);
+    ASSERT_EQ(Size, Buffer->getBufferSize());
+    EXPECT_EQ('\0', *Buffer->getBufferEnd());
+    EXPECT_EQ(Data, Buffer->getBuffer());
+  }
+}
+
+TEST_P(CASTest, StandaloneMemoryBufferWithoutNullTerminator) {
+  std::shared_ptr<ObjectStore> CAS = createObjectStore();
+  uint64_t PageSize = sys::Process::getPageSizeEstimate();
+  for (uint64_t Size : {uint64_t(64), uint64_t(60000), uint64_t(65535),
+                        uint64_t(100 * 1024), PageSize, 4 * PageSize}) {
+    std::string Data(Size, 'q');
+    Data.front() = 'b';
+    Data.back() = 'e';
+    std::optional<ObjectProxy> Proxy;
+    ASSERT_THAT_ERROR(CAS->createProxy({}, Data).moveInto(Proxy), Succeeded());
+    std::unique_ptr<MemoryBuffer> Buffer = Proxy->getStandaloneMemoryBuffer(
+        "name", /*RequiresNullTerminator=*/false);
+    ASSERT_TRUE(Buffer);
+    ASSERT_EQ(Size, Buffer->getBufferSize());
+    EXPECT_EQ(Data, Buffer->getBuffer());
+  }
+}
+
+TEST_F(OnDiskCASTest, StandaloneMemoryBufferSurvivesDeletedCAS) {
+  // The point of a standalone buffer is that clients can drop the store,
+  // letting its lock go so the CAS can be pruned, and still read what they
+  // loaded. Deleting the whole directory is the strongest form of that: a
+  // mapping keeps the file alive until it is unmapped.
+  unittest::TempDir Temp("on-disk-cas", /*Unique=*/true);
+
+  std::string SmallData(64, 's');
+  std::string BigData(100ULL * 1024, 'b');
+  BigData.back() = 'e';
+
+  std::unique_ptr<MemoryBuffer> SmallBuffer, BigBuffer;
+  {
+    std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>> DBs;
+    ASSERT_THAT_ERROR(
+        createOnDiskUnifiedCASDatabases(Temp.path()).moveInto(DBs),
+        Succeeded());
+    std::optional<ObjectProxy> Small, Big;
+    ASSERT_THAT_ERROR(DBs.first->createProxy({}, SmallData).moveInto(Small),
+                      Succeeded());
+    ASSERT_THAT_ERROR(DBs.first->createProxy({}, BigData).moveInto(Big),
+                      Succeeded());
+    SmallBuffer =
+        Small->getStandaloneMemoryBuffer("", /*RequiresNullTerminator=*/false);
+    BigBuffer =
+        Big->getStandaloneMemoryBuffer("", /*RequiresNullTerminator=*/false);
+    ASSERT_TRUE(SmallBuffer);
+    ASSERT_TRUE(BigBuffer);
+  }
+
+  // Windows refuses to delete a file while it is still mapped, so only check
+  // the deleted case where unlinking a mapped file is allowed.
+#ifndef _WIN32
+  ASSERT_EQ(std::error_code(), sys::fs::remove_directories(Temp.path()));
+  ASSERT_FALSE(sys::fs::exists(Temp.path()));
+#endif
+
+  EXPECT_EQ(SmallData, SmallBuffer->getBuffer());
+  EXPECT_EQ(BigData, BigBuffer->getBuffer());
+
+  // The big object gets a file of its own, so it should be mapped rather than
+  // copied -- that is the whole point of not holding the store open. (The
+  // small one is embedded in the shared data pool, which is always copied.)
+  EXPECT_EQ(MemoryBuffer::MemoryBuffer_MMap, BigBuffer->getBufferKind());
+  EXPECT_EQ(MemoryBuffer::MemoryBuffer_Malloc, SmallBuffer->getBufferKind());
+}
+
+TEST_F(OnDiskCASTest, StandaloneMemoryBufferRecordWithRefs) {
+  // An object with refs that is too big for the pool gets a file of its own
+  // too, but one holding a record: a header and the refs, then the data and a
+  // nul. It can still be mapped, at an offset, and the nul it already has
+  // means even a caller wanting a terminator does not force a copy.
+  unittest::TempDir Temp("on-disk-cas", /*Unique=*/true);
+
+  std::string Data(100ULL * 1024, 'r');
+  Data.back() = 'e';
+
+  std::unique_ptr<MemoryBuffer> Buffer;
+  {
+    std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>> DBs;
+    ASSERT_THAT_ERROR(
+        createOnDiskUnifiedCASDatabases(Temp.path()).moveInto(DBs),
+        Succeeded());
+    std::optional<ObjectProxy> Child, Parent;
+    ASSERT_THAT_ERROR(DBs.first->createProxy({}, "child").moveInto(Child),
+                      Succeeded());
+    ASSERT_THAT_ERROR(
+        DBs.first->createProxy({Child->getRef()}, Data).moveInto(Parent),
+        Succeeded());
+    Buffer = Parent->getStandaloneMemoryBuffer("name");
+    ASSERT_TRUE(Buffer);
+  }
+
+  EXPECT_EQ(MemoryBuffer::MemoryBuffer_MMap, Buffer->getBufferKind());
+  EXPECT_EQ("name", Buffer->getBufferIdentifier());
+  ASSERT_EQ(Data.size(), Buffer->getBufferSize());
+  EXPECT_EQ(Data, Buffer->getBuffer());
+  EXPECT_EQ('\0', *Buffer->getBufferEnd());
+}

--- a/llvm/unittests/CAS/PluginCASTest.cpp
+++ b/llvm/unittests/CAS/PluginCASTest.cpp
@@ -5,10 +5,18 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Tests the plugin-backed \c ObjectStore and \c ActionCache against the mock
+/// plugin implementation in \c llvm/tools/libCASPluginTest.
+///
+//===----------------------------------------------------------------------===//
 
+#include "CASTestConfig.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
@@ -16,27 +24,46 @@
 
 using namespace llvm;
 using namespace llvm::cas;
+using namespace llvm::unittest::cas;
 
-// See llvm/utils/unittest/UnitTestMain/TestMain.cpp
+// HWASan does not tag the globals of a dlopen'ed library with glibc, so the
+// plugin faults as soon as it touches one of its own globals.
+// FIXME: Re-enable once https://github.com/llvm/llvm-project/issues/57206 is
+// fixed.
+#if !LLVM_HWADDRESS_SANITIZER_BUILD
+
 extern const char *TestMainArgv0;
+static std::string TestStringArg1("castest-string-arg1");
 
-// Just a reachable symbol to ease resolving of the executable's path.
-static std::string TestStringArg1("plugincas-test-string-arg1");
-
+/// \returns the path of the libCASPluginTest dynamic library, which implements
+/// the CAS plugin API for testing purposes.
 static std::string getCASPluginPath() {
   std::string Executable =
       sys::fs::getMainExecutable(TestMainArgv0, &TestStringArg1);
-  llvm::SmallString<256> PathBuf(sys::path::parent_path(
-      sys::path::parent_path(sys::path::parent_path(Executable))));
-#ifndef _WIN32
-  std::string LibName = "libCASPluginTest";
-  sys::path::append(PathBuf, "lib", LibName + LLVM_PLUGIN_EXT);
+  llvm::SmallString<256> PathBuf(sys::path::parent_path(Executable));
+#if !defined(_WIN32) || defined(__MINGW32__)
+  sys::path::append(PathBuf, "libCASPluginTest" LLVM_PLUGIN_EXT);
 #else
-  std::string LibName = "CASPluginTest";
-  sys::path::append(PathBuf, "bin", LibName + LLVM_PLUGIN_EXT);
+  sys::path::append(PathBuf, "CASPluginTest" LLVM_PLUGIN_EXT);
 #endif
   return std::string(PathBuf);
 }
+
+static CASTestingEnv createPlugin(int I) {
+  unittest::TempDir Temp("plugin-cas", /*Unique=*/true);
+  std::optional<
+      std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
+      DBs;
+  EXPECT_THAT_ERROR(createPluginCASDatabases(getCASPluginPath(), Temp.path(),
+                                             /*PluginArgs=*/{})
+                        .moveInto(DBs),
+                    Succeeded());
+  if (!DBs)
+    return CASTestingEnv{nullptr, nullptr, nullptr, std::move(Temp)};
+  return CASTestingEnv{std::move(DBs->first), std::move(DBs->second), nullptr,
+                       std::move(Temp)};
+}
+INSTANTIATE_TEST_SUITE_P(PluginCAS, CASTest, ::testing::Values(createPlugin));
 
 TEST(PluginCASTest, isMaterialized) {
   unittest::TempDir Temp("plugin-cas", /*Unique=*/true);
@@ -66,7 +93,8 @@ TEST(PluginCASTest, isMaterialized) {
     ASSERT_THAT_ERROR(CAS->isMaterialized(*ID2Ref).moveInto(IsMaterialized),
                       Succeeded());
     EXPECT_TRUE(IsMaterialized);
-    ASSERT_THAT_ERROR(AC->put(*ID1, *ID2, /*Globally=*/true), Succeeded());
+    ASSERT_THAT_ERROR(AC->put(*ID1, *ID2, /*CanBeDistributed=*/true),
+                      Succeeded());
   }
 
   // Clear "local" cache.
@@ -86,7 +114,7 @@ TEST(PluginCASTest, isMaterialized) {
 
     std::optional<CASID> ID1, ID2;
     ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID1), Succeeded());
-    ASSERT_THAT_ERROR(AC->get(*ID1, /*Globally=*/true).moveInto(ID2),
+    ASSERT_THAT_ERROR(AC->get(*ID1, /*CanBeDistributed=*/true).moveInto(ID2),
                       Succeeded());
     std::optional<ObjectRef> ID2Ref = CAS->getReference(*ID2);
     ASSERT_TRUE(ID2Ref);
@@ -102,3 +130,5 @@ TEST(PluginCASTest, isMaterialized) {
     EXPECT_TRUE(IsMaterialized);
   }
 }
+
+#endif /* !LLVM_HWADDRESS_SANITIZER_BUILD */


### PR DESCRIPTION
getMemoryBuffer() is documented as returning a buffer "whose lifetime is independent of the CAS (it can live longer)", but it is implemented with MemoryBuffer::getMemBuffer() over whatever getData() returns. For an on-disk CAS that is a pointer into the store's own mapping, so the buffer dies with the store. Fix the comment to say what it does, and add getStandaloneMemoryBuffer() for callers that need the documented behavior.

The default implementation copies, which always satisfies the lifetime requirement, so ObjectStore implementations are correct without changes. An implementation that can hand out storage outliving itself overrides getStandaloneMemoryBufferImpl() to avoid the copy.

OnDiskGraphDB does that for objects big enough to have a file of their own, reading that file again rather than sharing the mapping it already has, so the result stays valid even once the CAS directory is pruned and its pages can be shared and reclaimed rather than charged to the process. Everything else is copied, including the case where a null terminator is required but the file has no byte to spare for it.

A plugin CAS gets the same ability through two new optional functions, llcas_loaded_object_get_standalone_data() and its counterpart llcas_standalone_data_dispose().

(cherry picked from commit 121e0c9328e37f71d55ca4744caa255f3ef74812)