### PR TITLE
[Cherry-pick into stable/23.x] [lldb][CMake] Give the staged lldb-defines.h a build rule (#216394)

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -308,8 +308,6 @@ set(generated_public_headers ${LLDB_OBJ_DIR}/include/lldb/API/SBLanguages.h)
 file(GLOB root_public_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-*.h)
 file(GLOB root_private_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-private*.h)
 list(REMOVE_ITEM root_public_headers ${root_private_headers})
-# Skip the initial copy of lldb-defines.h. The fixed version is generated at build time.
-list(REMOVE_ITEM root_public_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-defines.h)
 
 add_custom_command(
   OUTPUT ${lldb_header_staging_dir}
@@ -335,7 +333,12 @@ foreach(header
   get_filename_component(basename ${header} NAME)
   set(staged_header ${lldb_header_staging_dir}/${basename})
 
-  if(unifdef_EXECUTABLE)
+  if(basename STREQUAL "lldb-defines.h")
+    set(copy_command "${Python3_EXECUTABLE}"
+        ${LLDB_SOURCE_DIR}/scripts/version-header-fix.py
+        -i ${header} -o ${staged_header}
+        -m ${LLDB_VERSION_MAJOR} -n ${LLDB_VERSION_MINOR} -p ${LLDB_VERSION_PATCH})
+  elseif(unifdef_EXECUTABLE)
     # unifdef returns 0 when the file is unchanged and 1 if something was changed.
     # That means if we successfully remove SWIG code, the build system believes
     # that the command has failed and stops. This is undesirable.
@@ -369,9 +372,6 @@ foreach(header
   endif()
 endforeach()
 
-add_custom_command(TARGET liblldb-header-staging POST_BUILD
-  COMMAND "${Python3_EXECUTABLE}" ${LLDB_SOURCE_DIR}/scripts/version-header-fix.py -i ${LLDB_SOURCE_DIR}/include/lldb/lldb-defines.h -o ${lldb_header_staging_dir}/lldb-defines.h -m ${LLDB_VERSION_MAJOR} -n ${LLDB_VERSION_MINOR} -p ${LLDB_VERSION_PATCH}
-)
 add_dependencies(liblldb liblldb-header-staging)
 
 if(LLDB_BUILD_FRAMEWORK)

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -338,7 +338,8 @@ foreach(header
         ${LLDB_SOURCE_DIR}/scripts/version-header-fix.py
         -i ${header} -o ${staged_header}
         -m ${LLDB_VERSION_MAJOR} -n ${LLDB_VERSION_MINOR} -p ${LLDB_VERSION_PATCH})
-  elseif(unifdef_EXECUTABLE)
+  endif()
+  if(unifdef_EXECUTABLE)
     # unifdef returns 0 when the file is unchanged and 1 if something was changed.
     # That means if we successfully remove SWIG code, the build system believes
     # that the command has failed and stops. This is undesirable.


### PR DESCRIPTION
```
commit fc145527a539be71d15fca3bc10618196e84f4cf
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Aug 14 13:43:36 2026 -0700

    [lldb][CMake] Give the staged lldb-defines.h a build rule (#216394)
    
    a05b232076ed dropped lldb-defines.h from the header staging loop so that
    the source header is never copied, leaving the staged copy to be
    produced by a POST_BUILD command on liblldb-header-staging. Ninja cannot
    see files produced that way, and LLDBRPCHeaders.cmake depends on the
    staged path directly, so a clean build with LLDB_BUILD_LLDBRPC enabled
    fails to even load the graph:
    
      ninja: error: 'include/lldb/lldb-defines.h', needed by
      'tools/lldb-rpc/DerivedHeaders/lldb-rpc-defines.h', missing and no
      known rule to make it
    
    Dropping the header from the loop also removed it from
    lldb_staged_headers and from LLDB.framework/Headers, even though
    SBDefines.h includes it.
    
    Stage the header through version-header-fix.py from inside the loop
    instead. The script reads the source header and writes a fresh staged
    copy, so the source tree can still be read-only, and the staged header
    gets a rule that dependents can rely on.
    
    Assisted-by: Claude

commit 99690a356c8c059db73786adecd827d7f20e3297
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Aug 14 13:49:13 2026 -0700

    [LLDB] Remove fallthrough (#216398)
    
    Address post-commit feedback on
    https://github.com/llvm/llvm-project/commit/8ad0f7cf78f12b51e91d3799593a1d766b6ab6a6.
```
