### PR TITLE
Cherrypick parallel symbol changes

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -565,7 +565,8 @@ public:
   static Status
   GetSharedModule(const ModuleSpec &module_spec, lldb::ModuleSP &module_sp,
                   llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
-                  bool *did_create_ptr, bool invoke_locate_callback = true);
+                  bool *did_create_ptr, bool invoke_locate_callback = true,
+                  bool invoke_symbol_locators = true);
 
   // BEGIN CAS
   struct CAS {

--- a/lldb/include/lldb/Core/ModuleSpec.h
+++ b/lldb/include/lldb/Core/ModuleSpec.h
@@ -224,7 +224,7 @@ public:
     if (m_arch.IsValid()) {
       if (dumped_something)
         strm.PutCString(", ");
-      strm.Printf("arch = ");
+      strm.PutCString("arch = ");
       m_arch.DumpTriple(strm.AsRawOstream());
       dumped_something = true;
     }

--- a/lldb/include/lldb/Symbol/SymbolLocator.h
+++ b/lldb/include/lldb/Symbol/SymbolLocator.h
@@ -15,10 +15,13 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/UUID.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Error.h"
 
 #include <optional>
+#include <string>
 #include <system_error>
+#include <vector>
 
 namespace lldb_private {
 
@@ -49,6 +52,9 @@ public:
     /// Allow contacting an external symbol server when the local searches come
     /// up empty.
     bool external_lookup = false;
+
+    /// How to name this binary in a progress report.
+    std::string description;
   };
 
   /// What a search found.
@@ -82,12 +88,25 @@ public:
   static llvm::Expected<Result> Locate(const Request &request,
                                        const FileSpecList &search_paths);
 
+  /// The platform hooks run on the calling thread, in order. Only the plugin
+  /// searches may run concurrently.
+  ///
+  /// \return One result per request, in the order the requests were given.
+  static std::vector<llvm::Expected<Result>>
+  Locate(llvm::ArrayRef<Request> requests, const FileSpecList &search_paths,
+         bool parallel);
+
   /// Locate the symbol file for the given UUID on a background thread. This
   /// function returns immediately. Under the hood it uses the debugger's
   /// thread pool to call DownloadObjectAndSymbolFile. If a symbol file is
   /// found, this will notify all target which contain the module with the
   /// given UUID.
   static void DownloadSymbolFileAsync(const UUID &uuid);
+
+private:
+  /// Must stay callable concurrently.
+  static llvm::Expected<Result>
+  LocateWithPlugins(const Request &request, const FileSpecList &search_paths);
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Symbol/SymbolLocator.h
+++ b/lldb/include/lldb/Symbol/SymbolLocator.h
@@ -42,6 +42,10 @@ public:
     /// What to look for.
     ModuleSpec module_spec;
 
+    /// A platform that may know where the binary is. The locator plugins have
+    /// no Platform of their own to consult.
+    lldb::PlatformSP platform;
+
     /// Allow contacting an external symbol server when the local searches come
     /// up empty.
     bool external_lookup = false;

--- a/lldb/include/lldb/Symbol/SymbolLocator.h
+++ b/lldb/include/lldb/Symbol/SymbolLocator.h
@@ -9,14 +9,74 @@
 #ifndef LLDB_SYMBOL_SYMBOLLOCATOR_H
 #define LLDB_SYMBOL_SYMBOLLOCATOR_H
 
+#include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginInterface.h"
+#include "lldb/Target/Statistics.h"
+#include "lldb/Utility/Status.h"
 #include "lldb/Utility/UUID.h"
+
+#include "llvm/Support/Error.h"
+
+#include <optional>
+#include <system_error>
 
 namespace lldb_private {
 
 class SymbolLocator : public PluginInterface {
 public:
   SymbolLocator() = default;
+
+  /// A binary was not found and nothing could say why. Distinct from every
+  /// other error so that a caller composing its own message for a plain miss
+  /// cannot mistake a real failure for one.
+  class NotFound : public llvm::ErrorInfo<NotFound> {
+  public:
+    static char ID;
+
+    void log(llvm::raw_ostream &os) const override;
+    std::error_code convertToErrorCode() const override;
+  };
+
+  /// One binary to search for.
+  struct Request {
+    /// What to look for.
+    ModuleSpec module_spec;
+
+    /// Allow contacting an external symbol server when the local searches come
+    /// up empty.
+    bool external_lookup = false;
+  };
+
+  /// What a search found.
+  struct Result {
+    /// The binary, and its symbol file if there is one to be had.
+    ModuleSpec module_spec;
+
+    /// What an external symbol server had to say about the symbols, even
+    /// though the binary itself was found. Recorded rather than reported, so
+    /// that it reaches the user in the caller's order, and so has to be
+    /// consumed even by a caller that does not report it.
+    std::optional<llvm::Error> symbol_error;
+
+    /// Where the time went, to be merged into the Module once it exists.
+    StatisticsMap statistics;
+  };
+
+  /// Find a binary and, if possible, its symbols.
+  ///
+  /// Mutates no Target and no Process, which is what lets a caller holding
+  /// several binaries search for all of them before installing any.
+  ///
+  /// \return
+  ///     Where the binary is, or an error if it could not be found at all.
+  ///     Finding the binary but not its symbols is a success, with
+  ///     Result::symbol_error carrying whatever a symbol server had to say
+  ///     about them.
+  ///
+  ///     A miss carries an external symbol server's explanation if it gave
+  ///     one, and is a NotFound when nothing could say why.
+  static llvm::Expected<Result> Locate(const Request &request,
+                                       const FileSpecList &search_paths);
 
   /// Locate the symbol file for the given UUID on a background thread. This
   /// function returns immediately. Under the hood it uses the debugger's

--- a/lldb/include/lldb/Target/DynamicLoader.h
+++ b/lldb/include/lldb/Target/DynamicLoader.h
@@ -216,12 +216,11 @@ public:
                                              lldb::addr_t base_addr,
                                              bool base_addr_is_offset);
 
-  /// A binary to find and load into a Target, and the state that finding it
-  /// produces.
+  /// A binary to find and load into a Target.
   ///
-  /// Loading a binary is split into LocateBinaries and LoadBinaryInTarget so
-  /// that a caller with many binaries can search for all of them before adding
-  /// any of them to the Target.
+  /// The leading fields are inputs, filled in by the caller.  The trailing
+  /// fields are outputs: searching for the binary records its results in them,
+  /// and loading the binary into the Target consumes them.
   struct BinarySpec {
     /// Name of the binary, if available.  If no matching binary can be found on
     /// the debug host, a module may be created out of live memory and given
@@ -286,8 +285,11 @@ public:
   /// Given an address, try to read the binary out of memory, get the UUID, find
   /// the file if possible and load it unslid, or add the memory module.
   ///
-  /// May force an expensive search on the computer to find the binary by UUID.
-  /// To load more than one binary, use LocateBinaries and LoadBinaryInTarget.
+  /// May force an expensive search on the host system to find the binary by
+  /// UUID.  To load more than one binary, use LocateBinaries and
+  /// LoadBinaryInTarget instead: the search is the expensive part, and those
+  /// let all of the searching happen before any of the binaries are added to
+  /// the Target.
   ///
   /// \param[in] process
   ///     The process to add this binary to.
@@ -304,7 +306,8 @@ public:
 
   /// Search for a batch of binaries, without mutating the Target.
   ///
-  /// The entries are independent: a binary that cannot be found leaves its
+  /// The entries are searched for independently, and stay in the order they
+  /// were given in.  A binary that cannot be found leaves its
   /// BinarySpec::module_sp empty and has no effect on the others.  Its
   /// BinarySpec::memory_module_sp is set only when the binary's header had to
   /// be read out of memory to get the UUID.  Nothing is registered with the
@@ -324,10 +327,10 @@ public:
   /// load address.
   ///
   /// This mutates the Target and may read the process' memory, so it has to be
-  /// called for one binary at a time.  Call it in the caller's own order rather
-  /// than in the order the searches finished: the order decides the Target's
-  /// module order, which binary gets to set the Target's architecture, and the
-  /// order in which messages reach the user.
+  /// called for one binary at a time.  Call it over the batch in the order the
+  /// batch was built in: that order decides the Target's module order, which
+  /// binary gets to set the Target's architecture, and the order in which
+  /// messages reach the user.
   ///
   /// Whether a failure is worth telling the user about is left to the caller,
   /// which knows whether it went looking for a binary that has to be there.  A

--- a/lldb/include/lldb/Target/DynamicLoader.h
+++ b/lldb/include/lldb/Target/DynamicLoader.h
@@ -20,8 +20,12 @@
 #include "lldb/lldb-private-enumerations.h"
 #include "lldb/lldb-types.h"
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Error.h"
+
 #include <cstddef>
 #include <cstdint>
+#include <string>
 namespace lldb_private {
 class ModuleList;
 class Process;
@@ -212,72 +216,134 @@ public:
                                              lldb::addr_t base_addr,
                                              bool base_addr_is_offset);
 
-  /// Find/load a binary into lldb given a UUID and the address where it is
-  /// loaded in memory, or a slide to be applied to the file address.
-  /// May force an expensive search on the computer to find the binary by
-  /// UUID, should not be used for a large number of binaries - intended for
-  /// an environment where there may be one, or a few, binaries resident in
-  /// memory.
+  /// A binary to find and load into a Target, and the state that finding it
+  /// produces.
   ///
-  /// Given a UUID, search for a binary and load it at the address provided,
-  /// or with the slide applied, or at the file address unslid.
+  /// Loading a binary is split into LocateBinaries and LoadBinaryInTarget so
+  /// that a caller with many binaries can search for all of them before adding
+  /// any of them to the Target.
+  struct BinarySpec {
+    /// Name of the binary, if available.  If no matching binary can be found on
+    /// the debug host, a module may be created out of live memory and given
+    /// this name.  If empty, a name is constructed from the address the binary
+    /// is loaded at.
+    std::string name;
+
+    /// UUID of the binary to be loaded.  May be empty, in which case, if a load
+    /// address is supplied, the binary is read out of memory to get a UUID to
+    /// look for.  There is a performance cost to doing this, it is not
+    /// preferable.
+    UUID uuid;
+
+    /// Address where the binary should be loaded, or read out of memory.  Or a
+    /// slide value, to be applied to the file addresses of the binary.
+    lldb::addr_t value = LLDB_INVALID_ADDRESS;
+
+    /// A flag indicating that \a value is an address, or an offset to be
+    /// applied to the file addresses.
+    bool value_is_offset = false;
+
+    /// Allow the search to do a possibly expensive external search for the
+    /// ObjectFile and/or SymbolFile.
+    bool force_symbol_search = false;
+
+    /// Whether ModulesDidLoad should be called once the binary has been added
+    /// to the Target.  A caller loading several binaries may prefer to batch
+    /// those up.
+    bool notify = false;
+
+    /// Whether the address of the binary should be set in the Target if it is
+    /// added.  A caller that wants to set the section addresses individually
+    /// leaves this false, and is then responsible for setting the load address
+    /// for the binary or its segments in the Target.
+    bool set_address_in_target = false;
+
+    /// If no better binary image can be found, allow reading the binary out of
+    /// memory, if possible, and create the Module based on that.  May be slow
+    /// to read a binary out of memory, and for unusual environments, there may
+    /// be no symbols mapped in memory at all.
+    bool allow_memory_image_last_resort = false;
+
+    /// The module found for the binary, or empty if it was not found.  It is
+    /// not registered with the Target until LoadBinaryInTarget.
+    lldb::ModuleSP module_sp;
+
+    /// The binary as it was read out of the process' memory, if it had to be,
+    /// so that it is not read a second time.
+    lldb::ModuleSP memory_module_sp;
+
+    /// What an external symbol server had to say about this binary.  The search
+    /// records it rather than reporting it, so that it reaches the user in the
+    /// caller's order.
+    Status error;
+  };
+
+  /// Find a binary and load it into a Target.
   ///
-  /// Given an address, try to read the binary out of memory, get the UUID,
-  /// find the file if possible and load it unslid, or add the memory module.
+  /// Given a UUID, search for a binary and load it at the address provided, or
+  /// with the slide applied, or at the file address unslid.
+  ///
+  /// Given an address, try to read the binary out of memory, get the UUID, find
+  /// the file if possible and load it unslid, or add the memory module.
+  ///
+  /// May force an expensive search on the computer to find the binary by UUID.
+  /// To load more than one binary, use LocateBinaries and LoadBinaryInTarget.
   ///
   /// \param[in] process
   ///     The process to add this binary to.
   ///
-  /// \param[in] name
-  ///     Name of the binary, if available.  If this method cannot find a
-  ///     matching binary on the debug host, it may create a memory module
-  ///     out of live memory, and the provided name will be used.  If an
-  ///     empty StringRef is provided, a name will be constructed for the module
-  ///     based on the address it is loaded at.
-  ///
-  /// \param[in] uuid
-  ///     UUID of the binary to be loaded.  UUID may be empty, and if a
-  ///     load address is supplied, will read the binary from memory, get
-  ///     a UUID and try to find a local binary.  There is a performance
-  ///     cost to doing this, it is not preferable.
-  ///
-  /// \param[in] value
-  ///     Address where the binary should be loaded, or read out of memory.
-  ///     Or a slide value, to be applied to the file addresses of the binary.
-  ///
-  /// \param[in] value_is_offset
-  ///     A flag indicating that \p value is an address, or an offset to
-  ///     be applied to the file addresses.
-  ///
-  /// \param[in] force_symbol_search
-  ///     Allow the search to do a possibly expensive external search for
-  ///     the ObjectFile and/or SymbolFile.
-  ///
-  /// \param[in] notify
-  ///     Whether ModulesDidLoad should be called when a binary has been added
-  ///     to the Target.  The caller may prefer to batch up these when loading
-  ///     multiple binaries.
-  ///
-  /// \param[in] set_address_in_target
-  ///     Whether the address of the binary should be set in the Target if it
-  ///     is added.  The caller may want to set the section addresses
-  ///     individually, instead of loading the binary the entire based on the
-  ///     start address or slide.  The caller is responsible for setting the
-  ///     load address for the binary or its segments in the Target if it passes
-  ///     true.
-  ///
-  /// \param[in] allow_memory_image_last_resort
-  ///     If no better binary image can be found, allow reading the binary
-  ///     out of memory, if possible, and create the Module based on that.
-  ///     May be slow to read a binary out of memory, and for unusual
-  ///     environments, may be no symbols mapped in memory at all.
+  /// \param[in,out] bin_spec
+  ///     The binary to find and load, with its input fields filled in by the
+  ///     caller.
   ///
   /// \return
-  ///     Returns a shared pointer for the Module that has been added.
-  static lldb::ModuleSP LoadBinaryWithUUIDAndAddress(
-      Process *process, llvm::StringRef name, UUID uuid, lldb::addr_t value,
-      bool value_is_offset, bool force_symbol_search, bool notify,
-      bool set_address_in_target, bool allow_memory_image_last_resort);
+  ///     The module that was added to the Target, or an error saying why the
+  ///     binary could not be found and loaded.
+  static llvm::Expected<lldb::ModuleSP>
+  LocateAndLoadBinary(Process *process, BinarySpec &bin_spec);
+
+  /// Search for a batch of binaries, without mutating the Target.
+  ///
+  /// The entries are independent: a binary that cannot be found leaves its
+  /// BinarySpec::module_sp empty and has no effect on the others.  Its
+  /// BinarySpec::memory_module_sp is set only when the binary's header had to
+  /// be read out of memory to get the UUID.  Nothing is registered with the
+  /// Target, see LoadBinaryInTarget.
+  ///
+  /// \param[in] process
+  ///     The process the binaries belong to.  Used to read a binary's header
+  ///     out of memory when its UUID isn't known, and otherwise only read from.
+  ///
+  /// \param[in,out] bin_specs
+  ///     The binaries to search for, with their input fields filled in by the
+  ///     caller.
+  static void LocateBinaries(Process *process,
+                             llvm::MutableArrayRef<BinarySpec> bin_specs);
+
+  /// Add a binary that LocateBinaries searched for to the Target, and set its
+  /// load address.
+  ///
+  /// This mutates the Target and may read the process' memory, so it has to be
+  /// called for one binary at a time.  Call it in the caller's own order rather
+  /// than in the order the searches finished: the order decides the Target's
+  /// module order, which binary gets to set the Target's architecture, and the
+  /// order in which messages reach the user.
+  ///
+  /// Whether a failure is worth telling the user about is left to the caller,
+  /// which knows whether it went looking for a binary that has to be there.  A
+  /// symbol server's word on a binary that was found anyway is reported here.
+  ///
+  /// \param[in] process
+  ///     The process to add this binary to.
+  ///
+  /// \param[in,out] bin_spec
+  ///     A binary that LocateBinaries has searched for.
+  ///
+  /// \return
+  ///     The module that was added to the Target, or an error saying why the
+  ///     binary could not be found and loaded.
+  static llvm::Expected<lldb::ModuleSP>
+  LoadBinaryInTarget(Process *process, BinarySpec &bin_spec);
 
   /// Get information about the shared cache for a process, if possible.
   ///

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -333,6 +333,24 @@ public:
                   llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                   bool *did_create_ptr);
 
+  /// Find a module's files on this host.
+  ///
+  /// The symbol locator plugins have no Platform to consult, so a platform
+  /// that knows where its binaries live answers here instead.
+  ///
+  /// An answer ends the search, so an override owns what the plugins would
+  /// otherwise have been asked for: the files it names have to exist, and have
+  /// to be the ones \a module_spec describes.
+  ///
+  /// \return
+  ///     Where the files are, or std::nullopt if this platform has nothing to
+  ///     say about this module.
+  virtual std::optional<ModuleSpec>
+  FindModuleFiles(const ModuleSpec &module_spec,
+                  const FileSpecList &search_paths, StatisticsMap &statistics) {
+    return std::nullopt;
+  }
+
   void CallLocateModuleCallbackIfSet(const ModuleSpec &module_spec,
                                      lldb::ModuleSP &module_sp,
                                      FileSpec &symbol_file_spec,

--- a/lldb/source/API/SBAddressRangeList.cpp
+++ b/lldb/source/API/SBAddressRangeList.cpp
@@ -85,7 +85,7 @@ bool SBAddressRangeList::GetDescription(SBStream &description,
     if (is_first) {
       is_first = false;
     } else {
-      stream.Printf(", ");
+      stream.PutCString(", ");
     }
     GetAddressRangeAtIndex(i).GetDescription(description, target);
   }

--- a/lldb/source/API/SBMemoryRegionInfo.cpp
+++ b/lldb/source/API/SBMemoryRegionInfo.cpp
@@ -169,7 +169,7 @@ bool SBMemoryRegionInfo::GetDescription(SBStream &description) {
   strm.Printf(m_opaque_up->GetReadable() ? "R" : "-");
   strm.Printf(m_opaque_up->GetWritable() ? "W" : "-");
   strm.Printf(m_opaque_up->GetExecutable() ? "X" : "-");
-  strm.Printf("]");
+  strm.PutCString("]");
 
   return true;
 }

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -988,7 +988,7 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
       // don't generally know how to set them until the target is run.
       if (m_resolver_sp->getResolverID() !=
           BreakpointResolver::ExceptionResolver)
-        s->Printf(", locations = 0 (pending)");
+        s->PutCString(", locations = 0 (pending)");
     }
 
     m_options.GetDescription(s, level);
@@ -1000,7 +1000,7 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
       if (!m_name_list.empty()) {
         s->EOL();
         s->Indent();
-        s->Printf("Names:");
+        s->PutCString("Names:");
         s->EOL();
         s->IndentMore();
         for (llvm::StringRef name : m_name_list.keys()) {
@@ -1017,7 +1017,7 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
   case lldb::eDescriptionLevelInitial:
     s->Printf("Breakpoint %i: ", GetID());
     if (num_locations == 0) {
-      s->Printf("no locations (pending).");
+      s->PutCString("no locations (pending).");
     } else if (num_locations == 1 && !show_locations) {
       // There is only one location, so we'll just print that location
       // information.
@@ -1045,9 +1045,9 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
   if (show_locations && level != lldb::eDescriptionLevelBrief) {
     if ((display_type & eDisplayHeader) != 0) {
       if ((display_type & eDisplayFacade) != 0)
-        s->Printf("Facade locations:\n");
+        s->PutCString("Facade locations:\n");
       else
-        s->Printf("Implementation Locations\n");
+        s->PutCString("Implementation Locations\n");
     }
     s->IndentMore();
     for (size_t i = 0; i < num_locations; ++i) {

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -653,8 +653,8 @@ void BreakpointLocation::GetDescription(Stream *s,
   if (!is_scripted_desc) {
     if (m_address.IsSectionOffset() &&
         (level == eDescriptionLevelFull || level == eDescriptionLevelInitial))
-      s->Printf(", ");
-    s->Printf("address = ");
+      s->PutCString(", ");
+    s->PutCString("address = ");
 
     ExecutionContextScope *exe_scope = nullptr;
     Target *target = &m_owner.GetTarget();
@@ -677,7 +677,7 @@ void BreakpointLocation::GetDescription(Stream *s,
           resolved_address.CalculateSymbolContextSymbol();
       if (resolved_symbol) {
         if (level == eDescriptionLevelFull || level == eDescriptionLevelInitial)
-          s->Printf(", ");
+          s->PutCString(", ");
         else if (level == lldb::eDescriptionLevelVerbose) {
           s->EOL();
           s->Indent();

--- a/lldb/source/Breakpoint/BreakpointLocationList.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocationList.cpp
@@ -207,7 +207,7 @@ void BreakpointLocationList::GetDescription(Stream *s,
   collection::iterator pos, end = m_locations.end();
 
   for (pos = m_locations.begin(); pos != end; ++pos) {
-    s->Printf(" ");
+    s->PutCString(" ");
     (*pos)->GetDescription(s, level);
   }
 }

--- a/lldb/source/Breakpoint/BreakpointOptions.cpp
+++ b/lldb/source/Breakpoint/BreakpointOptions.cpp
@@ -522,10 +522,10 @@ void BreakpointOptions::GetDescription(Stream *s,
     s->Printf("%sabled ", m_enabled ? "en" : "dis");
 
     if (m_one_shot)
-      s->Printf("one-shot ");
+      s->PutCString("one-shot ");
 
     if (m_auto_continue)
-      s->Printf("auto-continue ");
+      s->PutCString("auto-continue ");
 
     if (m_thread_spec_up)
       m_thread_spec_up->GetDescription(s, level);

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -405,12 +405,12 @@ void BreakpointResolverName::GetDescription(Stream *s) {
       s->Printf("name = '%s'", unique_lookups[0].GetCString());
     else {
       size_t num_names = unique_lookups.size();
-      s->Printf("names = {");
+      s->PutCString("names = {");
       for (size_t i = 0; i < num_names; i++) {
         s->Printf("%s'%s'", (i == 0 ? "" : ", "),
                   unique_lookups[i].GetCString());
       }
-      s->Printf("}");
+      s->PutCString("}");
     }
   }
   if (m_language != eLanguageTypeUnknown) {

--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -279,7 +279,7 @@ bool Watchpoint::DumpSnapshots(Stream *s, const char *prefix) const {
   if (m_watch_read && !m_watch_modify && !m_watch_write)
     return printed_anything;
 
-  s->Printf("\n");
+  s->PutCString("\n");
   s->Printf("Watchpoint %u hit:\n", GetID());
 
   StreamString values_ss;
@@ -310,7 +310,7 @@ bool Watchpoint::DumpSnapshots(Stream *s, const char *prefix) const {
 
   if (m_new_value_sp) {
     if (values_ss.GetSize())
-      values_ss.Printf("\n");
+      values_ss.PutCString("\n");
 
     if (auto *new_value_cstr = m_new_value_sp->GetValueAsCString())
       values_ss.Printf("new value: %s", new_value_cstr);
@@ -334,7 +334,7 @@ bool Watchpoint::DumpSnapshots(Stream *s, const char *prefix) const {
   }
 
   if (values_ss.GetSize()) {
-    s->Printf("%s", values_ss.GetData());
+    s->PutCString(values_ss.GetData());
     printed_anything = true;
   }
 
@@ -364,7 +364,7 @@ void Watchpoint::DumpWithLevel(Stream *s,
       if (ProcessSP process_sp = m_target.GetProcessSP()) {
         auto &resourcelist = process_sp->GetWatchpointResourceList();
         size_t idx = 0;
-        s->Printf("\n    watchpoint resources:");
+        s->PutCString("\n    watchpoint resources:");
         for (WatchpointResourceSP &wpres : resourcelist.Sites()) {
           if (wpres->ConstituentsContains(this)) {
             s->Printf("\n       #%zu: ", idx);

--- a/lldb/source/Breakpoint/WatchpointList.cpp
+++ b/lldb/source/Breakpoint/WatchpointList.cpp
@@ -213,7 +213,7 @@ void WatchpointList::GetDescription(Stream *s, lldb::DescriptionLevel level) {
   wp_collection::iterator pos, end = m_watchpoints.end();
 
   for (pos = m_watchpoints.begin(); pos != end; ++pos) {
-    s->Printf(" ");
+    s->PutCString(" ");
     (*pos)->Dump(s);
   }
 }

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -1085,7 +1085,7 @@ OptionValueSP Instruction::ReadDictionary(FILE *in_file, Stream &out_stream) {
 
 bool Instruction::TestEmulation(Stream &out_stream, const char *file_name) {
   if (!file_name) {
-    out_stream.Printf("Instruction::TestEmulation:  Missing file_name.");
+    out_stream.PutCString("Instruction::TestEmulation:  Missing file_name.");
     return false;
   }
   FILE *test_file = FileSystem::Instance().Fopen(file_name, "r");
@@ -1157,9 +1157,9 @@ bool Instruction::TestEmulation(Stream &out_stream, const char *file_name) {
         insn_emulator_up->TestEmulation(out_stream, arch, data_dictionary);
 
   if (success)
-    out_stream.Printf("Emulation test succeeded.");
+    out_stream.PutCString("Emulation test succeeded.");
   else
-    out_stream.Printf("Emulation test failed.");
+    out_stream.PutCString("Emulation test failed.");
 
   return success;
 }

--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -161,7 +161,7 @@ static lldb::offset_t DumpInstructions(const DataExtractor &DE, Stream *s,
         s->Printf("failed to decode instructions at 0x%" PRIx64 ".", addr);
     }
   } else
-    s->Printf("invalid target");
+    s->PutCString("invalid target");
 
   return offset;
 }
@@ -174,31 +174,31 @@ static bool TryDumpSpecialEscapedChar(Stream &s, const char c) {
   switch (c) {
   case '\033':
     // Common non-standard escape code for 'escape'.
-    s.Printf("\\e");
+    s.PutCString("\\e");
     return true;
   case '\a':
-    s.Printf("\\a");
+    s.PutCString("\\a");
     return true;
   case '\b':
-    s.Printf("\\b");
+    s.PutCString("\\b");
     return true;
   case '\f':
-    s.Printf("\\f");
+    s.PutCString("\\f");
     return true;
   case '\n':
-    s.Printf("\\n");
+    s.PutCString("\\n");
     return true;
   case '\r':
-    s.Printf("\\r");
+    s.PutCString("\\r");
     return true;
   case '\t':
-    s.Printf("\\t");
+    s.PutCString("\\t");
     return true;
   case '\v':
-    s.Printf("\\v");
+    s.PutCString("\\v");
     return true;
   case '\0':
-    s.Printf("\\0");
+    s.PutCString("\\0");
     return true;
   default:
     return false;
@@ -484,7 +484,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
       const uint64_t ch = DE.GetMaxU64Bitfield(&offset, item_byte_size,
                                                item_bit_size, item_bit_offset);
       if (llvm::isPrint(ch))
-        s->Printf("%c", (char)ch);
+        s->PutChar((char)ch);
       else if (item_format != eFormatCharPrintable) {
         if (!TryDumpSpecialEscapedChar(*s, ch)) {
           if (item_byte_size == 1)
@@ -554,7 +554,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
       const char *cstr = DE.GetCStr(&offset);
 
       if (!cstr) {
-        s->Printf("NULL");
+        s->PutCString("NULL");
         offset = LLDB_INVALID_OFFSET;
       } else {
         s->PutChar('\"');
@@ -754,14 +754,14 @@ lldb::offset_t lldb_private::DumpDataExtractor(
         llvm::APFloat ap_float(DE.GetFloat(&offset));
         ap_float.convertToHexString(float_cstr, 0, false,
                                     llvm::APFloat::rmNearestTiesToEven);
-        s->Printf("%s", float_cstr);
+        s->PutCString(float_cstr);
         break;
       } else if (sizeof(double) == item_byte_size) {
         char float_cstr[256];
         llvm::APFloat ap_float(DE.GetDouble(&offset));
         ap_float.convertToHexString(float_cstr, 0, false,
                                     llvm::APFloat::rmNearestTiesToEven);
-        s->Printf("%s", float_cstr);
+        s->PutCString(float_cstr);
         break;
       } else {
         s->Printf("error: unsupported byte size (%" PRIu64

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -356,7 +356,7 @@ ModuleSP DynamicLoader::LoadBinaryWithUUIDAndAddress(
   } else {
     if (force_symbol_search) {
       lldb::StreamUP s = target.GetDebugger().GetAsyncErrorStream();
-      s->Printf("Unable to find file");
+      s->PutCString("Unable to find file");
       if (!name.empty())
         s->Printf(" %s", name.str().c_str());
       if (uuid.IsValid())
@@ -367,7 +367,7 @@ ModuleSP DynamicLoader::LoadBinaryWithUUIDAndAddress(
         else
           s->Printf(" at address 0x%" PRIx64, value);
       }
-      s->Printf("\n");
+      s->PutCString("\n");
     }
     LLDB_LOGF(log,
               "Unable to find binary %s with UUID %s and load it at "

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -271,6 +271,7 @@ static void SearchForBinary(Target &target, DynamicLoader::BinarySpec &bin_spec,
   // Search for the binary and its symbols.
   SymbolLocator::Request request;
   request.module_spec = module_spec;
+  request.platform = target.GetPlatform();
   request.external_lookup = bin_spec.force_symbol_search;
 
   llvm::Expected<SymbolLocator::Result> located =

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -354,9 +354,11 @@ DynamicLoader::LoadBinaryInTarget(Process *process, BinarySpec &bin_spec) {
   }
 
   // A binary was found, but a symbol server may still have had something to say
-  // about its symbols.
+  // about its symbols.  Name the binary: a symbol locator's error is not
+  // required to identify what it was asked to look for.
   if (search_error)
     *target.GetDebugger().GetAsyncErrorStream()
+        << GetBinaryDescription(bin_spec) << ": "
         << llvm::toString(std::move(search_error)) << "\n";
 
   // Ensure the Target has an architecture set in case

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -13,7 +13,6 @@
 #include "lldb/Core/ModuleList.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
-#include "lldb/Core/Progress.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SymbolLocator.h"
@@ -26,10 +25,13 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/lldb-private-interfaces.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <cassert>
@@ -245,13 +247,11 @@ GetBinaryNotFoundMessage(const DynamicLoader::BinarySpec &bin_spec) {
   return msg.GetString().str();
 }
 
-/// Search for a binary with a known UUID, and create a module for it.
+/// Reads the Target, so it has to be called for one binary at a time.
 ///
-/// Does not mutate the Target, but does read from it, and reaches the global
-/// shared module list, the symbol locator plugins, and a locate module callback
-/// the user may have installed.
-static void SearchForBinary(Target &target, DynamicLoader::BinarySpec &bin_spec,
-                            const FileSpecList &search_paths) {
+/// \return What to search for, or nothing when the binary is already in hand.
+static std::optional<SymbolLocator::Request>
+PrepareSearch(Target &target, DynamicLoader::BinarySpec &bin_spec) {
   ModuleSpec module_spec;
   module_spec.SetTarget(target.shared_from_this());
   module_spec.GetUUID() = bin_spec.uuid;
@@ -266,19 +266,23 @@ static void SearchForBinary(Target &target, DynamicLoader::BinarySpec &bin_spec,
                               /*invoke_locate_callback=*/true,
                               /*invoke_symbol_locators=*/false);
   if (bin_spec.module_sp && bin_spec.module_sp->GetSymbolFileFileSpec())
-    return;
+    return std::nullopt;
 
-  // Search for the binary and its symbols.
   SymbolLocator::Request request;
   request.module_spec = module_spec;
   request.platform = target.GetPlatform();
   request.external_lookup = bin_spec.force_symbol_search;
+  request.description = GetBinaryDescription(bin_spec);
+  return request;
+}
 
-  llvm::Expected<SymbolLocator::Result> located =
-      SymbolLocator::Locate(request, search_paths);
+/// The module is not registered with the Target until LoadBinaryInTarget.
+static void FinishSearch(DynamicLoader::BinarySpec &bin_spec,
+                         llvm::Expected<SymbolLocator::Result> located) {
   if (!located) {
-    // This function's caller names the binary it could not find, so a plain
-    // miss needs nothing added to it. An explanation from a symbol server does.
+    // Loading a binary that was never found already reports that, so a bare
+    // not-found error would only say it a second time. Any other error says
+    // something that report cannot.
     llvm::Error error = located.takeError();
     if (error.isA<SymbolLocator::NotFound>())
       llvm::consumeError(std::move(error));
@@ -287,14 +291,9 @@ static void SearchForBinary(Target &target, DynamicLoader::BinarySpec &bin_spec,
     return;
   }
 
-  // A binary was found. Its symbols are another matter, and the caller reports
-  // that in its own order.
   if (located->symbol_error)
     bin_spec.error = Status::FromError(std::move(*located->symbol_error));
 
-  // Create a module for what was found, sharing it with any other Target that
-  // asks for the same binary. The module is not registered with this Target
-  // until LoadBinaryInTarget. The locators have run, so don't run them again.
   ModuleSP located_module_sp;
   ModuleList::GetSharedModule(located->module_spec, located_module_sp, nullptr,
                               nullptr, /*invoke_locate_callback=*/false,
@@ -324,14 +323,29 @@ void DynamicLoader::LocateBinaries(
   Target &target = process->GetTarget();
   const FileSpecList search_paths = Target::GetDefaultDebugFileSearchPaths();
 
+  // Reading a binary's UUID out of memory has to happen on this thread, and
+  // before any search, so that a binary whose UUID is not known yet still joins
+  // the batch.
+  llvm::SmallVector<BinarySpec *> to_search;
+  std::vector<SymbolLocator::Request> requests;
   for (BinarySpec &bin_spec : bin_specs) {
     if (!bin_spec.uuid.IsValid() && !bin_spec.value_is_offset)
       FindBinaryUUIDInMemory(process, bin_spec);
     if (!bin_spec.uuid.IsValid())
       continue;
-    Progress progress("Locating binary", GetBinaryDescription(bin_spec));
-    SearchForBinary(target, bin_spec, search_paths);
+    if (std::optional<SymbolLocator::Request> request =
+            PrepareSearch(target, bin_spec)) {
+      to_search.push_back(&bin_spec);
+      requests.push_back(std::move(*request));
+    }
   }
+
+  std::vector<llvm::Expected<SymbolLocator::Result>> located =
+      SymbolLocator::Locate(requests, search_paths,
+                            target.GetParallelModuleLoad());
+
+  for (auto [bin_spec, result] : llvm::zip_equal(to_search, located))
+    FinishSearch(*bin_spec, std::move(result));
 }
 
 llvm::Expected<ModuleSP>

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -26,8 +26,10 @@
 #include "lldb/lldb-private-interfaces.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 
 #include <memory>
+#include <string>
 
 #include <cassert>
 
@@ -211,172 +213,205 @@ static ModuleSP ReadUnnamedMemoryModule(Process *process, addr_t addr,
   return *module_sp_or_err;
 }
 
-ModuleSP DynamicLoader::LoadBinaryWithUUIDAndAddress(
-    Process *process, llvm::StringRef name, UUID uuid, addr_t value,
-    bool value_is_offset, bool force_symbol_search, bool notify,
-    bool set_address_in_target, bool allow_memory_image_last_resort) {
-  ModuleSP memory_module_sp;
-  ModuleSP module_sp;
-  PlatformSP platform_sp = process->GetTarget().GetPlatform();
-  Target &target = process->GetTarget();
-  Status error;
-
-  StreamString prog_str;
-  if (!name.empty()) {
-    prog_str << name.str() << " ";
+static std::string
+GetBinaryDescription(const DynamicLoader::BinarySpec &bin_spec) {
+  StreamString desc;
+  if (!bin_spec.name.empty())
+    desc << bin_spec.name << " ";
+  if (bin_spec.uuid.IsValid())
+    desc << bin_spec.uuid.GetAsString();
+  if (!bin_spec.value_is_offset && bin_spec.value != LLDB_INVALID_ADDRESS) {
+    desc << " at 0x";
+    desc.PutHex64(bin_spec.value);
   }
-  if (uuid.IsValid())
-    prog_str << uuid.GetAsString();
-  if (value_is_offset == 0 && value != LLDB_INVALID_ADDRESS) {
-    prog_str << " at 0x";
-    prog_str.PutHex64(value);
-  }
+  return desc.GetString().str();
+}
 
-  if (!uuid.IsValid() && !value_is_offset) {
-    memory_module_sp = ReadUnnamedMemoryModule(process, value, name);
-
-    if (memory_module_sp) {
-      uuid = memory_module_sp->GetUUID();
-      if (uuid.IsValid()) {
-        prog_str << " ";
-        prog_str << uuid.GetAsString();
-      }
-    }
+static std::string
+GetBinaryNotFoundMessage(const DynamicLoader::BinarySpec &bin_spec) {
+  StreamString msg;
+  msg << "Unable to find file";
+  if (!bin_spec.name.empty())
+    msg << " " << bin_spec.name;
+  if (bin_spec.uuid.IsValid())
+    msg << " with UUID " << bin_spec.uuid.GetAsString();
+  if (bin_spec.value != LLDB_INVALID_ADDRESS) {
+    if (bin_spec.value_is_offset)
+      msg.Printf(" with slide 0x%" PRIx64, bin_spec.value);
+    else
+      msg.Printf(" at address 0x%" PRIx64, bin_spec.value);
   }
+  return msg.GetString().str();
+}
+
+/// Search for a binary with a known UUID, and create a module for it.
+///
+/// Does not mutate the Target, but does read from it, and reaches the global
+/// shared module list, the symbol locator plugins, and a locate module callback
+/// the user may have installed.
+static void SearchForBinary(Target &target, DynamicLoader::BinarySpec &bin_spec,
+                            const FileSpecList &search_paths) {
   ModuleSpec module_spec;
   module_spec.SetTarget(target.shared_from_this());
-  module_spec.GetUUID() = uuid;
-  FileSpec name_filespec(name);
+  module_spec.GetUUID() = bin_spec.uuid;
+  FileSpec name_filespec(bin_spec.name);
   if (FileSystem::Instance().Exists(name_filespec))
     module_spec.GetFileSpec() = name_filespec;
 
-  if (uuid.IsValid()) {
-    Progress progress("Locating binary", prog_str.GetString().str());
+  // Has lldb already seen a module with this UUID?
+  // Or have external lookup enabled in DebugSymbols on macOS.
+  Status error = ModuleList::GetSharedModule(module_spec, bin_spec.module_sp,
+                                             nullptr, nullptr);
 
-    // Has lldb already seen a module with this UUID?
-    // Or have external lookup enabled in DebugSymbols on macOS.
-    if (!module_sp)
-      error =
-          ModuleList::GetSharedModule(module_spec, module_sp, nullptr, nullptr);
-
-    // Can lldb's symbol/executable location schemes
-    // find an executable and symbol file.
-    if (!module_sp) {
-      FileSpecList search_paths = Target::GetDefaultDebugFileSearchPaths();
-      StatisticsMap symbol_locator_map;
-      module_spec.GetSymbolFileSpec() =
-          PluginManager::LocateExecutableSymbolFile(module_spec, search_paths,
-                                                    symbol_locator_map);
-      ModuleSpec objfile_module_spec =
-          PluginManager::LocateExecutableObjectFile(module_spec,
-                                                    symbol_locator_map);
-      module_spec.GetFileSpec() = objfile_module_spec.GetFileSpec();
-      if (FileSystem::Instance().Exists(module_spec.GetFileSpec()) &&
-          FileSystem::Instance().Exists(module_spec.GetSymbolFileSpec())) {
-        module_sp = std::make_shared<Module>(module_spec);
-      }
-
-      if (module_sp) {
-        module_sp->GetSymbolLocatorStatistics().merge(symbol_locator_map);
-      }
+  // Can lldb's symbol/executable location schemes find an executable and
+  // symbol file.
+  if (!bin_spec.module_sp) {
+    StatisticsMap symbol_locator_map;
+    module_spec.GetSymbolFileSpec() = PluginManager::LocateExecutableSymbolFile(
+        module_spec, search_paths, symbol_locator_map);
+    ModuleSpec objfile_module_spec = PluginManager::LocateExecutableObjectFile(
+        module_spec, symbol_locator_map);
+    module_spec.GetFileSpec() = objfile_module_spec.GetFileSpec();
+    if (FileSystem::Instance().Exists(module_spec.GetFileSpec()) &&
+        FileSystem::Instance().Exists(module_spec.GetSymbolFileSpec())) {
+      bin_spec.module_sp = std::make_shared<Module>(module_spec);
     }
 
-    // If we haven't found a binary, or we don't have a SymbolFile, see
-    // if there is an external search tool that can find it.
-    if (!module_sp || !module_sp->GetSymbolFileFileSpec()) {
-      PluginManager::DownloadObjectAndSymbolFile(module_spec, error,
-                                                 force_symbol_search);
-      if (FileSystem::Instance().Exists(module_spec.GetFileSpec())) {
-        module_sp = std::make_shared<Module>(module_spec);
-      } else if (force_symbol_search && error.AsCString("") &&
-                 error.AsCString("")[0] != '\0') {
-        *target.GetDebugger().GetAsyncErrorStream() << error.AsCString();
-      }
+    if (bin_spec.module_sp) {
+      bin_spec.module_sp->GetSymbolLocatorStatistics().merge(
+          symbol_locator_map);
     }
-
-    // If we only found the executable, create a Module based on that.
-    if (!module_sp && FileSystem::Instance().Exists(module_spec.GetFileSpec()))
-      module_sp = std::make_shared<Module>(module_spec);
   }
+
+  // If we haven't found a binary, or we don't have a SymbolFile, see
+  // if there is an external search tool that can find it.
+  if (!bin_spec.module_sp || !bin_spec.module_sp->GetSymbolFileFileSpec()) {
+    PluginManager::DownloadObjectAndSymbolFile(module_spec, error,
+                                               bin_spec.force_symbol_search);
+    if (FileSystem::Instance().Exists(module_spec.GetFileSpec())) {
+      bin_spec.module_sp = std::make_shared<Module>(module_spec);
+    } else if (bin_spec.force_symbol_search && error.Fail()) {
+      bin_spec.error = std::move(error);
+    }
+  }
+
+  // If we only found the executable, create a Module based on that.
+  if (!bin_spec.module_sp &&
+      FileSystem::Instance().Exists(module_spec.GetFileSpec()))
+    bin_spec.module_sp = std::make_shared<Module>(module_spec);
+}
+
+static void FindBinaryUUIDInMemory(Process *process,
+                                   DynamicLoader::BinarySpec &bin_spec) {
+  bin_spec.memory_module_sp =
+      ReadUnnamedMemoryModule(process, bin_spec.value, bin_spec.name);
+  if (bin_spec.memory_module_sp)
+    bin_spec.uuid = bin_spec.memory_module_sp->GetUUID();
+}
+
+void DynamicLoader::LocateBinaries(
+    Process *process, llvm::MutableArrayRef<BinarySpec> bin_specs) {
+  Target &target = process->GetTarget();
+  const FileSpecList search_paths = Target::GetDefaultDebugFileSearchPaths();
+
+  for (BinarySpec &bin_spec : bin_specs) {
+    if (!bin_spec.uuid.IsValid() && !bin_spec.value_is_offset)
+      FindBinaryUUIDInMemory(process, bin_spec);
+    if (!bin_spec.uuid.IsValid())
+      continue;
+    Progress progress("Locating binary", GetBinaryDescription(bin_spec));
+    SearchForBinary(target, bin_spec, search_paths);
+  }
+}
+
+llvm::Expected<ModuleSP>
+DynamicLoader::LoadBinaryInTarget(Process *process, BinarySpec &bin_spec) {
+  Target &target = process->GetTarget();
+
+  // The error belongs to this function now: every path below either reports it
+  // or folds it into the failure.
+  llvm::Error search_error = bin_spec.error.takeError();
 
   // If we couldn't find the binary anywhere else, as a last resort,
   // read it out of memory.
-  if (allow_memory_image_last_resort && !module_sp.get() &&
-      value != LLDB_INVALID_ADDRESS && !value_is_offset) {
-    if (!memory_module_sp)
-      memory_module_sp = ReadUnnamedMemoryModule(process, value, name);
-    if (memory_module_sp)
-      module_sp = memory_module_sp;
+  if (bin_spec.allow_memory_image_last_resort && !bin_spec.module_sp &&
+      bin_spec.value != LLDB_INVALID_ADDRESS && !bin_spec.value_is_offset) {
+    if (!bin_spec.memory_module_sp)
+      bin_spec.memory_module_sp =
+          ReadUnnamedMemoryModule(process, bin_spec.value, bin_spec.name);
+    if (bin_spec.memory_module_sp)
+      bin_spec.module_sp = bin_spec.memory_module_sp;
   }
 
   Log *log = GetLog(LLDBLog::DynamicLoader);
-  if (module_sp.get()) {
-    // Ensure the Target has an architecture set in case
-    // we need it while processing this binary/eh_frame/debug info.
-    if (!target.GetArchitecture().IsValid())
-      target.SetArchitecture(module_sp->GetArchitecture());
-    target.GetImages().AppendIfNeeded(module_sp, false);
-
-    bool changed = false;
-    if (set_address_in_target) {
-      if (module_sp->GetObjectFile()) {
-        if (value != LLDB_INVALID_ADDRESS) {
-          LLDB_LOGF(log,
-                    "DynamicLoader::LoadBinaryWithUUIDAndAddress Loading "
-                    "binary %s UUID %s at %s 0x%" PRIx64,
-                    name.str().c_str(), uuid.GetAsString().c_str(),
-                    value_is_offset ? "offset" : "address", value);
-          module_sp->SetLoadAddress(target, value, value_is_offset, changed);
-        } else {
-          // No address/offset/slide, load the binary at file address,
-          // offset 0.
-          LLDB_LOGF(log,
-                    "DynamicLoader::LoadBinaryWithUUIDAndAddress Loading "
-                    "binary %s UUID %s at file address",
-                    name.str().c_str(), uuid.GetAsString().c_str());
-          module_sp->SetLoadAddress(target, 0, true /* value_is_slide */,
-                                    changed);
-        }
-      } else {
-        // In-memory image, load at its true address, offset 0.
-        LLDB_LOGF(log,
-                  "DynamicLoader::LoadBinaryWithUUIDAndAddress Loading binary "
-                  "%s UUID %s from memory at address 0x%" PRIx64,
-                  name.str().c_str(), uuid.GetAsString().c_str(), value);
-        module_sp->SetLoadAddress(target, 0, true /* value_is_slide */,
-                                  changed);
-      }
-    }
-
-    if (notify) {
-      ModuleList added_module;
-      added_module.Append(module_sp, false);
-      target.ModulesDidLoad(added_module);
-    }
-  } else {
-    if (force_symbol_search) {
-      lldb::StreamUP s = target.GetDebugger().GetAsyncErrorStream();
-      s->PutCString("Unable to find file");
-      if (!name.empty())
-        s->Printf(" %s", name.str().c_str());
-      if (uuid.IsValid())
-        s->Printf(" with UUID %s", uuid.GetAsString().c_str());
-      if (value != LLDB_INVALID_ADDRESS) {
-        if (value_is_offset)
-          s->Printf(" with slide 0x%" PRIx64, value);
-        else
-          s->Printf(" at address 0x%" PRIx64, value);
-      }
-      s->PutCString("\n");
-    }
-    LLDB_LOGF(log,
-              "Unable to find binary %s with UUID %s and load it at "
-              "%s 0x%" PRIx64,
-              name.str().c_str(), uuid.GetAsString().c_str(),
-              value_is_offset ? "offset" : "address", value);
+  if (!bin_spec.module_sp) {
+    std::string message = GetBinaryNotFoundMessage(bin_spec);
+    LLDB_LOG(log, "{0}", message);
+    llvm::Error error = llvm::createStringError(message);
+    if (search_error)
+      return llvm::joinErrors(std::move(search_error), std::move(error));
+    return std::move(error);
   }
 
-  return module_sp;
+  // A binary was found, but a symbol server may still have had something to say
+  // about its symbols.
+  if (search_error)
+    *target.GetDebugger().GetAsyncErrorStream()
+        << llvm::toString(std::move(search_error)) << "\n";
+
+  // Ensure the Target has an architecture set in case
+  // we need it while processing this binary/eh_frame/debug info.
+  if (!target.GetArchitecture().IsValid())
+    target.SetArchitecture(bin_spec.module_sp->GetArchitecture());
+  target.GetImages().AppendIfNeeded(bin_spec.module_sp, false);
+
+  bool changed = false;
+  if (bin_spec.set_address_in_target) {
+    if (bin_spec.module_sp->GetObjectFile()) {
+      if (bin_spec.value != LLDB_INVALID_ADDRESS) {
+        LLDB_LOGF(log,
+                  "DynamicLoader::LoadBinaryInTarget Loading "
+                  "binary %s UUID %s at %s 0x%" PRIx64,
+                  bin_spec.name.c_str(), bin_spec.uuid.GetAsString().c_str(),
+                  bin_spec.value_is_offset ? "offset" : "address",
+                  bin_spec.value);
+        bin_spec.module_sp->SetLoadAddress(target, bin_spec.value,
+                                           bin_spec.value_is_offset, changed);
+      } else {
+        // No address/offset/slide, load the binary at file address,
+        // offset 0.
+        LLDB_LOGF(log,
+                  "DynamicLoader::LoadBinaryInTarget Loading "
+                  "binary %s UUID %s at file address",
+                  bin_spec.name.c_str(), bin_spec.uuid.GetAsString().c_str());
+        bin_spec.module_sp->SetLoadAddress(target, 0, true /* value_is_slide */,
+                                           changed);
+      }
+    } else {
+      // In-memory image, load at its true address, offset 0.
+      LLDB_LOGF(log,
+                "DynamicLoader::LoadBinaryInTarget Loading binary "
+                "%s UUID %s from memory at address 0x%" PRIx64,
+                bin_spec.name.c_str(), bin_spec.uuid.GetAsString().c_str(),
+                bin_spec.value);
+      bin_spec.module_sp->SetLoadAddress(target, 0, true /* value_is_slide */,
+                                         changed);
+    }
+  }
+
+  if (bin_spec.notify) {
+    ModuleList added_module;
+    added_module.Append(bin_spec.module_sp, false);
+    target.ModulesDidLoad(added_module);
+  }
+
+  return bin_spec.module_sp;
+}
+
+llvm::Expected<ModuleSP>
+DynamicLoader::LocateAndLoadBinary(Process *process, BinarySpec &bin_spec) {
+  LocateBinaries(process, bin_spec);
+  return LoadBinaryInTarget(process, bin_spec);
 }
 
 int64_t DynamicLoader::ReadUnsignedIntWithSizeInBytes(addr_t addr,

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -16,6 +16,7 @@
 #include "lldb/Core/Progress.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Symbol/ObjectFile.h"
+#include "lldb/Symbol/SymbolLocator.h"
 #include "lldb/Target/MemoryRegionInfo.h"
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
@@ -258,47 +259,55 @@ static void SearchForBinary(Target &target, DynamicLoader::BinarySpec &bin_spec,
   if (FileSystem::Instance().Exists(name_filespec))
     module_spec.GetFileSpec() = name_filespec;
 
-  // Has lldb already seen a module with this UUID?
-  // Or have external lookup enabled in DebugSymbols on macOS.
-  Status error = ModuleList::GetSharedModule(module_spec, bin_spec.module_sp,
-                                             nullptr, nullptr);
+  // Has lldb already seen a module with this UUID? A module whose symbols are
+  // already in hand is the answer, and searching would only find them again.
+  // Without them the search still has something to add.
+  ModuleList::GetSharedModule(module_spec, bin_spec.module_sp, nullptr, nullptr,
+                              /*invoke_locate_callback=*/true,
+                              /*invoke_symbol_locators=*/false);
+  if (bin_spec.module_sp && bin_spec.module_sp->GetSymbolFileFileSpec())
+    return;
 
-  // Can lldb's symbol/executable location schemes find an executable and
-  // symbol file.
-  if (!bin_spec.module_sp) {
-    StatisticsMap symbol_locator_map;
-    module_spec.GetSymbolFileSpec() = PluginManager::LocateExecutableSymbolFile(
-        module_spec, search_paths, symbol_locator_map);
-    ModuleSpec objfile_module_spec = PluginManager::LocateExecutableObjectFile(
-        module_spec, symbol_locator_map);
-    module_spec.GetFileSpec() = objfile_module_spec.GetFileSpec();
-    if (FileSystem::Instance().Exists(module_spec.GetFileSpec()) &&
-        FileSystem::Instance().Exists(module_spec.GetSymbolFileSpec())) {
-      bin_spec.module_sp = std::make_shared<Module>(module_spec);
-    }
+  // Search for the binary and its symbols.
+  SymbolLocator::Request request;
+  request.module_spec = module_spec;
+  request.external_lookup = bin_spec.force_symbol_search;
 
-    if (bin_spec.module_sp) {
-      bin_spec.module_sp->GetSymbolLocatorStatistics().merge(
-          symbol_locator_map);
-    }
+  llvm::Expected<SymbolLocator::Result> located =
+      SymbolLocator::Locate(request, search_paths);
+  if (!located) {
+    // This function's caller names the binary it could not find, so a plain
+    // miss needs nothing added to it. An explanation from a symbol server does.
+    llvm::Error error = located.takeError();
+    if (error.isA<SymbolLocator::NotFound>())
+      llvm::consumeError(std::move(error));
+    else
+      bin_spec.error = Status::FromError(std::move(error));
+    return;
   }
 
-  // If we haven't found a binary, or we don't have a SymbolFile, see
-  // if there is an external search tool that can find it.
-  if (!bin_spec.module_sp || !bin_spec.module_sp->GetSymbolFileFileSpec()) {
-    PluginManager::DownloadObjectAndSymbolFile(module_spec, error,
-                                               bin_spec.force_symbol_search);
-    if (FileSystem::Instance().Exists(module_spec.GetFileSpec())) {
-      bin_spec.module_sp = std::make_shared<Module>(module_spec);
-    } else if (bin_spec.force_symbol_search && error.Fail()) {
-      bin_spec.error = std::move(error);
-    }
-  }
+  // A binary was found. Its symbols are another matter, and the caller reports
+  // that in its own order.
+  if (located->symbol_error)
+    bin_spec.error = Status::FromError(std::move(*located->symbol_error));
 
-  // If we only found the executable, create a Module based on that.
-  if (!bin_spec.module_sp &&
-      FileSystem::Instance().Exists(module_spec.GetFileSpec()))
-    bin_spec.module_sp = std::make_shared<Module>(module_spec);
+  // Create a module for what was found, sharing it with any other Target that
+  // asks for the same binary. The module is not registered with this Target
+  // until LoadBinaryInTarget. The locators have run, so don't run them again.
+  ModuleSP located_module_sp;
+  ModuleList::GetSharedModule(located->module_spec, located_module_sp, nullptr,
+                              nullptr, /*invoke_locate_callback=*/false,
+                              /*invoke_symbol_locators=*/false);
+
+  // A located binary always yields a module, whatever ObjectFile makes of the
+  // file, because the caller has nowhere else to record what the search found.
+  if (!located_module_sp)
+    located_module_sp = std::make_shared<Module>(located->module_spec);
+
+  // Published only now, so that a search that came up empty leaves whatever the
+  // shared module list had in hand.
+  bin_spec.module_sp = std::move(located_module_sp);
+  bin_spec.module_sp->GetSymbolLocatorStatistics().merge(located->statistics);
 }
 
 static void FindBinaryUUIDInMemory(Process *process,

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -437,7 +437,7 @@ void FormatEntity::Entry::Dump(Stream &s, int depth) const {
   if (number != 0)
     s.Printf("number = %" PRIu64 " (0x%" PRIx64 "), ", number, number);
   if (deref)
-    s.Printf("deref = true, ");
+    s.PutCString("deref = true, ");
   s.EOL();
   for (const auto &children : children_stack) {
     for (const auto &child : children)
@@ -461,7 +461,7 @@ static bool RunScriptFormatKeyword(Stream &s, const SymbolContext *sc,
       if (script_interpreter->RunScriptFormatKeyword(script_function_name, t,
                                                      script_output, error) &&
           error.Success()) {
-        s.Printf("%s", script_output.c_str());
+        s.PutCString(script_output.c_str());
         return true;
       } else {
         s.Printf("<error: %s>", error.AsCString());
@@ -2057,12 +2057,12 @@ bool FormatEntity::Formatter::Format(const Entry &entry, Stream &s,
           Address pc;
           pc.SetLoadAddress(pc_loadaddr, m_exe_ctx->GetTargetPtr());
           if (pc == *m_addr) {
-            s.Printf("-> ");
+            s.PutCString("-> ");
             return true;
           }
         }
       }
-      s.Printf("   ");
+      s.PutCString("   ");
       return true;
     }
     return false;

--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -134,9 +134,9 @@ IOHandlerConfirm::IOHandlerConfirm(Debugger &debugger, llvm::StringRef prompt,
   StreamString prompt_stream;
   prompt_stream.PutCString(prompt);
   if (m_default_response)
-    prompt_stream.Printf(": [Y/n] ");
+    prompt_stream.PutCString(": [Y/n] ");
   else
-    prompt_stream.Printf(": [y/N] ");
+    prompt_stream.PutCString(": [y/N] ");
 
   SetPrompt(prompt_stream.GetString());
 }
@@ -359,7 +359,7 @@ bool IOHandlerEditline::GetLine(std::string &line, bool &interrupted) {
     if (prompt && prompt[0]) {
       if (m_output_sp) {
         LockedStreamFile locked_stream = m_output_sp->Lock();
-        locked_stream.Printf("%s", prompt);
+        locked_stream.PutCString(prompt);
       }
     }
   }

--- a/lldb/source/Core/IOHandlerCursesGUI.cpp
+++ b/lldb/source/Core/IOHandlerCursesGUI.cpp
@@ -7254,7 +7254,7 @@ public:
           else if (mnemonic != nullptr && operands != nullptr)
             strm.Printf("%-8s %s", mnemonic, operands);
           else if (mnemonic != nullptr)
-            strm.Printf("%s", mnemonic);
+            strm.PutCString(mnemonic);
 
           int right_pad = 1;
           window.PutCStringTruncated(

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -485,7 +485,7 @@ void Mangled::DumpDebug(Stream *s) const {
   s->Printf("%*p: Mangled mangled = ", static_cast<int>(sizeof(void *) * 2),
             static_cast<const void *>(this));
   m_mangled.DumpDebug(s);
-  s->Printf(", demangled = ");
+  s->PutCString(", demangled = ");
   m_demangled.DumpDebug(s);
 }
 

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1406,7 +1406,8 @@ size_t ModuleList::RemoveOrphanSharedModules(bool mandatory) {
 Status
 ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
                             llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
-                            bool *did_create_ptr, bool invoke_locate_callback) {
+                            bool *did_create_ptr, bool invoke_locate_callback,
+                            bool invoke_symbol_locators) {
   SharedModuleList &shared_module_list = GetSharedModuleList();
   std::lock_guard<std::recursive_mutex> guard(shared_module_list.GetMutex());
   char path[PATH_MAX];
@@ -1556,9 +1557,18 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
     }
   }
 
-  // Either the file didn't exist where at the path, or no path was given, so
-  // we now have to use more extreme measures to try and find the appropriate
-  // module.
+  // Either the file didn't exist where at the path, or no path was given, so we
+  // now either have to use more extreme measures to try and find the
+  // appropriate module or end our search here.
+  if (!invoke_symbol_locators) {
+    std::string uuid_str;
+    if (uuid_ptr && uuid_ptr->IsValid())
+      uuid_str = uuid_ptr->GetAsString();
+    if (!uuid_str.empty())
+      return Status::FromErrorStringWithFormatv(
+          "cannot locate module for UUID '{}'", uuid_str);
+    return Status::FromErrorString("cannot locate module");
+  }
 
   // Fixup the incoming path in case the path points to a valid file, yet the
   // arch or UUID (if one was passed in) don't match.

--- a/lldb/source/Core/SearchFilter.cpp
+++ b/lldb/source/Core/SearchFilter.cpp
@@ -555,7 +555,7 @@ void SearchFilterByModuleList::Search(Searcher &searcher) {
 void SearchFilterByModuleList::GetDescription(Stream *s) {
   size_t num_modules = m_module_spec_list.GetSize();
   if (num_modules == 1) {
-    s->Printf(", module = ");
+    s->PutCString(", module = ");
     s->PutCString(
         m_module_spec_list.GetFileSpecAtIndex(0).GetFilename().nonEmptyOr(
             "<Unknown>"));
@@ -785,7 +785,7 @@ void SearchFilterByModuleListAndCU::Search(Searcher &searcher) {
 void SearchFilterByModuleListAndCU::GetDescription(Stream *s) {
   size_t num_modules = m_module_spec_list.GetSize();
   if (num_modules == 1) {
-    s->Printf(", module = ");
+    s->PutCString(", module = ");
     s->PutCString(
         m_module_spec_list.GetFileSpecAtIndex(0).GetFilename().nonEmptyOr(
             "<Unknown>"));

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -296,12 +296,12 @@ size_t SourceManager::DisplaySourceLinesWithLineNumbersUsingLastFile(
         // Display caret cursor.
         std::string src_line;
         last_file_sp->GetLine(line, src_line);
-        s->Printf("    \t");
+        s->PutCString("    \t");
         // Insert a space for every non-tab character in the source line.
         for (size_t i = 0; i + 1 < column && i < src_line.length(); ++i)
           s->PutChar(src_line[i] == '\t' ? '\t' : ' ');
         // Now add the caret.
-        s->Printf("^\n");
+        s->PutCString("^\n");
       }
       if (this_line_size == 0) {
         m_last_line = UINT32_MAX;

--- a/lldb/source/DataFormatters/FormattersHelpers.cpp
+++ b/lldb/source/DataFormatters/FormattersHelpers.cpp
@@ -435,7 +435,7 @@ lldb_private::formatters::GetArrayAddressOrPointerValue(ValueObject &valobj) {
 void lldb_private::formatters::DumpCxxSmartPtrPointerSummary(
     Stream &stream, ValueObject &ptr, const TypeSummaryOptions &options) {
   if (ptr.GetValueAsUnsigned(0) == 0) {
-    stream.Printf("nullptr");
+    stream.PutCString("nullptr");
     return;
   }
 

--- a/lldb/source/DataFormatters/StringPrinter.cpp
+++ b/lldb/source/DataFormatters/StringPrinter.cpp
@@ -263,9 +263,9 @@ static bool DumpEncodedBufferToStream(
   assert(dump_options.GetStream() && "need a Stream to print the string to");
   Stream &stream(*dump_options.GetStream());
   if (dump_options.GetPrefixToken() != nullptr)
-    stream.Printf("%s", dump_options.GetPrefixToken());
+    stream.PutCString(dump_options.GetPrefixToken());
   if (dump_options.GetQuote() != 0)
-    stream.Printf("%c", dump_options.GetQuote());
+    stream.PutChar(dump_options.GetQuote());
   auto data(dump_options.GetData());
   auto source_size(dump_options.GetSourceSize());
   if (data.GetByteSize() && data.GetDataStart() && data.GetDataEnd()) {
@@ -358,20 +358,20 @@ static bool DumpEncodedBufferToStream(
           return false;
 
         for (unsigned c = 0; c < printable_size; c++)
-          stream.Printf("%c", *(printable_bytes + c));
+          stream.PutChar(*(printable_bytes + c));
         utf8_data_ptr = (uint8_t *)next_data;
       } else {
-        stream.Printf("%c", *utf8_data_ptr);
+        stream.PutChar(*utf8_data_ptr);
         utf8_data_ptr++;
       }
     }
   }
   if (dump_options.GetQuote() != 0)
-    stream.Printf("%c", dump_options.GetQuote());
+    stream.PutChar(dump_options.GetQuote());
   if (dump_options.GetSuffixToken() != nullptr)
-    stream.Printf("%s", dump_options.GetSuffixToken());
+    stream.PutCString(dump_options.GetSuffixToken());
   if (dump_options.GetIsTruncated())
-    stream.Printf("...");
+    stream.PutCString("...");
   return true;
 }
 

--- a/lldb/source/DataFormatters/TypeCategory.cpp
+++ b/lldb/source/DataFormatters/TypeCategory.cpp
@@ -303,7 +303,7 @@ std::string TypeCategoryImpl::GetDescription() {
   StreamString stream;
   stream.Printf("%s (%s", GetName(), (IsEnabled() ? "enabled" : "disabled"));
   StreamString lang_stream;
-  lang_stream.Printf(", applicable for language(s): ");
+  lang_stream.PutCString(", applicable for language(s): ");
   bool print_lang = false;
   for (size_t idx = 0; idx < GetNumLanguages(); idx++) {
     const lldb::LanguageType lang = GetLanguageAtIndex(idx);

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -84,7 +84,7 @@ std::string TypeFilterImpl::GetDescription() {
     sstr.Printf("    %s\n", GetExpressionPathAtIndex(i));
   }
 
-  sstr.Printf("}");
+  sstr.PutCString("}");
   return std::string(sstr.GetString());
 }
 

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -345,7 +345,7 @@ void ValueObjectPrinter::PrintDecl() {
     if (!varName.Empty())
       m_stream->Printf("%s =", varName.GetData());
     else if (ShouldShowName())
-      m_stream->Printf(" =");
+      m_stream->PutCString(" =");
   }
 }
 
@@ -446,7 +446,7 @@ bool ValueObjectPrinter::PrintValueAndSummaryIfNeeded(bool &value_printed,
       // combination means "could not resolve a type" and the default failure
       // mode is quite ugly
       if (!m_compiler_type.IsValid()) {
-        m_stream->Printf(" <could not resolve type>");
+        m_stream->PutCString(" <could not resolve type>");
         return false;
       }
 

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -306,7 +306,7 @@ bool lldb_private::formatters::VectorTypeSummaryProvider(
     const char *child_value = child_sp->GetValueAsCString();
     if (child_value && *child_value) {
       if (first) {
-        s.Printf("%s", child_value);
+        s.PutCString(child_value);
         first = false;
       } else {
         s.Printf(", %s", child_value);

--- a/lldb/source/Expression/IRInterpreter.cpp
+++ b/lldb/source/Expression/IRInterpreter.cpp
@@ -135,7 +135,7 @@ public:
   std::string SummarizeValue(const Value *value) {
     lldb_private::StreamString ss;
 
-    ss.Printf("%s", PrintValue(value).c_str());
+    ss.PutCString(PrintValue(value).c_str());
 
     ValueMap::iterator i = m_values.find(value);
 

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -353,14 +353,14 @@ public:
                        m_persistent_variable_sp->GetName());
 
     {
-      dump_stream.Printf("Pointer:\n");
+      dump_stream.PutCString("Pointer:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);
@@ -370,14 +370,14 @@ public:
     }
 
     {
-      dump_stream.Printf("Target:\n");
+      dump_stream.PutCString("Target:\n");
 
       lldb::addr_t target_address;
 
       map.ReadPointerFromMemory(&target_address, load_addr, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DataBufferHeap data(
             llvm::expectedToOptional(m_persistent_variable_sp->GetByteSize())
@@ -391,7 +391,7 @@ public:
             err);
 
         if (!err.Success()) {
-          dump_stream.Printf("  <could not be read>\n");
+          dump_stream.PutCString("  <could not be read>\n");
         } else {
           DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                        target_address);
@@ -732,14 +732,14 @@ public:
     lldb::addr_t ptr = LLDB_INVALID_ADDRESS;
 
     {
-      dump_stream.Printf("Pointer:\n");
+      dump_stream.PutCString("Pointer:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DataExtractor extractor(data.GetBytes(), data.GetByteSize(),
                                 map.GetByteOrder(), map.GetAddressByteSize());
@@ -756,13 +756,13 @@ public:
     }
 
     if (m_temporary_allocation == LLDB_INVALID_ADDRESS) {
-      dump_stream.Printf("Points to process memory:\n");
+      dump_stream.PutCString("Points to process memory:\n");
     } else {
-      dump_stream.Printf("Temporary allocation:\n");
+      dump_stream.PutCString("Temporary allocation:\n");
     }
 
     if (ptr == LLDB_INVALID_ADDRESS) {
-      dump_stream.Printf("  <could not be be found>\n");
+      dump_stream.PutCString("  <could not be be found>\n");
     } else {
       DataBufferHeap data(m_temporary_allocation_size, 0);
 
@@ -770,7 +770,7 @@ public:
                      m_temporary_allocation_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);
@@ -1170,14 +1170,14 @@ public:
     lldb::addr_t ptr = LLDB_INVALID_ADDRESS;
 
     {
-      dump_stream.Printf("Pointer:\n");
+      dump_stream.PutCString("Pointer:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DataExtractor extractor(data.GetBytes(), data.GetByteSize(),
                                 map.GetByteOrder(), map.GetAddressByteSize());
@@ -1194,13 +1194,13 @@ public:
     }
 
     if (m_temporary_allocation == LLDB_INVALID_ADDRESS) {
-      dump_stream.Printf("Points to process memory:\n");
+      dump_stream.PutCString("Points to process memory:\n");
     } else {
-      dump_stream.Printf("Temporary allocation:\n");
+      dump_stream.PutCString("Temporary allocation:\n");
     }
 
     if (ptr == LLDB_INVALID_ADDRESS) {
-      dump_stream.Printf("  <could not be be found>\n");
+      dump_stream.PutCString("  <could not be be found>\n");
     } else {
       DataBufferHeap data(m_temporary_allocation_size, 0);
 
@@ -1208,7 +1208,7 @@ public:
                      m_temporary_allocation_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);
@@ -1335,14 +1335,14 @@ public:
                        m_symbol.GetName());
 
     {
-      dump_stream.Printf("Pointer:\n");
+      dump_stream.PutCString("Pointer:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);
@@ -1502,14 +1502,14 @@ public:
                        m_register_info.name);
 
     {
-      dump_stream.Printf("Value:\n");
+      dump_stream.PutCString("Value:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);

--- a/lldb/source/Expression/REPL.cpp
+++ b/lldb/source/Expression/REPL.cpp
@@ -99,7 +99,7 @@ void REPL::IOHandlerActivated(IOHandler &io_handler, bool interactive) {
   if (process_sp && process_sp->IsAlive())
     return;
   LockedStreamFile locked_stream = io_handler.GetErrorStreamFileSP()->Lock();
-  locked_stream.Printf("REPL requires a running target process.\n");
+  locked_stream.PutCString("REPL requires a running target process.\n");
   io_handler.SetIsDone(true);
 }
 
@@ -436,7 +436,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
               locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_FG_COLOR_RED));
               locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_CTRL_BOLD));
             }
-            locked_error_stream.Printf("Execution interrupted. ");
+            locked_error_stream.PutCString("Execution interrupted. ");
             if (useColors)
               locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_CTRL_NORMAL));
             locked_error_stream.Printf(
@@ -468,7 +468,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
             break;
 
           case lldb::eExpressionTimedOut:
-            locked_error_stream.Printf("error: timeout\n");
+            locked_error_stream.PutCString("error: timeout\n");
             if (error.AsCString())
               locked_error_stream.Printf("error: %s\n", error.AsCString());
             break;

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -359,7 +359,7 @@ bool ProcessLaunchInfo::ConvertArgumentsForLaunchingInShell(
         // There should only be one argument that is the shell command itself
         // to be used as is
         if (argv[0] && !argv[1])
-          shell_command.Printf("%s", argv[0]);
+          shell_command.PutCString(argv[0]);
         else
           return false;
       } else {

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6690,17 +6690,22 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
 bool ObjectFileMachO::LoadCoreFileImages(lldb_private::Process &process) {
   MachOCorefileAllImageInfos image_infos = GetCorefileAllImageInfos();
   Log *log = GetLog(LLDBLog::Object | LLDBLog::DynamicLoader);
-  Status error;
 
   bool found_platform_binary = false;
   ModuleList added_modules;
-  for (MachOCorefileImageEntry &image : image_infos.all_image_infos) {
-    ModuleSP module_sp, local_filesystem_module_sp;
 
+  llvm::SmallVector<const MachOCorefileImageEntry *> pending_images;
+  std::vector<DynamicLoader::BinarySpec> pending_specs;
+
+  for (MachOCorefileImageEntry &image : image_infos.all_image_infos) {
     // If this is a platform binary, it has been loaded (or registered with
     // the DynamicLoader to be loaded), we don't need to do any further
     // processing.  We're not going to call ModulesDidLoad on this in this
     // method, so notify==true.
+    //
+    // Setting up a platform binary can replace the Target's platform and
+    // dynamic loader, so no image is searched for until this loop has run to
+    // the end.
     if (process.GetTarget()
             .GetDebugger()
             .GetPlatformList()
@@ -6724,74 +6729,85 @@ bool ObjectFileMachO::LoadCoreFileImages(lldb_private::Process &process) {
 
     // We have either a UUID, or we have a load address which
     // and can try to read load commands and find a UUID.
-    if (image.uuid.IsValid() ||
-        (!value_is_offset && value != LLDB_INVALID_ADDRESS)) {
-      DynamicLoader::BinarySpec bin_spec;
-      bin_spec.name = image.filename;
-      bin_spec.uuid = image.uuid;
-      bin_spec.value = value;
-      bin_spec.value_is_offset = value_is_offset;
-      bin_spec.force_symbol_search = image.currently_executing;
-      bin_spec.notify = false;
-      // Userland Darwin binaries will have segment load addresses via
-      // the `all image infos` LC_NOTE.
-      bin_spec.set_address_in_target = image.segment_load_addresses.empty();
-      bin_spec.allow_memory_image_last_resort =
-          !image.segment_load_addresses.empty();
-      if (llvm::Expected<ModuleSP> located =
-              DynamicLoader::LocateAndLoadBinary(&process, bin_spec)) {
-        module_sp = *located;
-      } else if (bin_spec.force_symbol_search) {
-        *process.GetTarget().GetDebugger().GetAsyncErrorStream()
-            << llvm::toString(located.takeError()) << "\n";
-      } else {
-        // A corefile image that isn't on this machine is routine, and
-        // LocateAndLoadBinary has already logged it.
-        llvm::consumeError(located.takeError());
-      }
+    if (!image.uuid.IsValid() &&
+        (value_is_offset || value == LLDB_INVALID_ADDRESS))
+      continue;
+
+    DynamicLoader::BinarySpec bin_spec;
+    bin_spec.name = image.filename;
+    bin_spec.uuid = image.uuid;
+    bin_spec.value = value;
+    bin_spec.value_is_offset = value_is_offset;
+    bin_spec.force_symbol_search = image.currently_executing;
+    bin_spec.notify = false;
+    // Userland Darwin binaries will have segment load addresses via
+    // the `all image infos` LC_NOTE.
+    bin_spec.set_address_in_target = image.segment_load_addresses.empty();
+    bin_spec.allow_memory_image_last_resort =
+        !image.segment_load_addresses.empty();
+
+    pending_images.push_back(&image);
+    pending_specs.push_back(std::move(bin_spec));
+  }
+
+  DynamicLoader::LocateBinaries(&process, pending_specs);
+
+  for (auto [image, bin_spec] :
+       llvm::zip_equal(pending_images, pending_specs)) {
+    ModuleSP module_sp;
+    if (llvm::Expected<ModuleSP> loaded =
+            DynamicLoader::LoadBinaryInTarget(&process, bin_spec)) {
+      module_sp = *loaded;
+    } else if (bin_spec.force_symbol_search) {
+      *process.GetTarget().GetDebugger().GetAsyncErrorStream()
+          << llvm::toString(loaded.takeError()) << "\n";
+    } else {
+      // A corefile image that isn't on this machine is routine, and has
+      // already been logged.
+      llvm::consumeError(loaded.takeError());
     }
 
-    // We have a ModuleSP to load in the Target.  Load it at the
-    // correct address/slide and notify/load scripting resources.
-    if (module_sp) {
-      added_modules.Append(module_sp, false /* notify */);
+    if (!module_sp)
+      continue;
 
-      // We have a list of segment load address
-      if (image.segment_load_addresses.size() > 0) {
-        if (log) {
-          std::string uuidstr = image.uuid.GetAsString();
-          log->Printf("ObjectFileMachO::LoadCoreFileImages adding binary '%s' "
-                      "UUID %s with section load addresses",
-                      module_sp->GetFileSpec().GetPath().c_str(),
-                      uuidstr.c_str());
-        }
-        ObjectFile *objfile = module_sp->GetObjectFile();
-        SectionList *sectlist = objfile ? objfile->GetSectionList() : nullptr;
-        for (auto name_vmaddr_tuple : image.segment_load_addresses) {
-          if (sectlist) {
-            SectionSP sect_sp =
-                sectlist->FindSectionByName(std::get<0>(name_vmaddr_tuple));
-            if (sect_sp) {
-              process.GetTarget().SetSectionLoadAddress(
-                  sect_sp, std::get<1>(name_vmaddr_tuple));
-            }
+    added_modules.Append(module_sp, false /* notify */);
+
+    // We have a list of segment load address
+    if (image->segment_load_addresses.size() > 0) {
+      if (log) {
+        std::string uuidstr = image->uuid.GetAsString();
+        log->Printf("ObjectFileMachO::LoadCoreFileImages adding binary '%s' "
+                    "UUID %s with section load addresses",
+                    module_sp->GetFileSpec().GetPath().c_str(),
+                    uuidstr.c_str());
+      }
+      ObjectFile *objfile = module_sp->GetObjectFile();
+      SectionList *sectlist = objfile ? objfile->GetSectionList() : nullptr;
+      for (auto name_vmaddr_tuple : image->segment_load_addresses) {
+        if (sectlist) {
+          SectionSP sect_sp =
+              sectlist->FindSectionByName(std::get<0>(name_vmaddr_tuple));
+          if (sect_sp) {
+            process.GetTarget().SetSectionLoadAddress(
+                sect_sp, std::get<1>(name_vmaddr_tuple));
           }
         }
-      } else {
-        if (log) {
-          std::string uuidstr = image.uuid.GetAsString();
-          log->Printf("ObjectFileMachO::LoadCoreFileImages adding binary '%s' "
-                      "UUID %s with %s 0x%" PRIx64,
-                      module_sp->GetFileSpec().GetPath().c_str(),
-                      uuidstr.c_str(),
-                      value_is_offset ? "slide" : "load address", value);
-        }
-        bool changed;
-        module_sp->SetLoadAddress(process.GetTarget(), value, value_is_offset,
-                                  changed);
       }
+    } else {
+      if (log) {
+        std::string uuidstr = image->uuid.GetAsString();
+        log->Printf("ObjectFileMachO::LoadCoreFileImages adding binary '%s' "
+                    "UUID %s with %s 0x%" PRIx64,
+                    module_sp->GetFileSpec().GetPath().c_str(), uuidstr.c_str(),
+                    bin_spec.value_is_offset ? "slide" : "load address",
+                    bin_spec.value);
+      }
+      bool changed;
+      module_sp->SetLoadAddress(process.GetTarget(), bin_spec.value,
+                                bin_spec.value_is_offset, changed);
     }
   }
+
   if (added_modules.GetSize() > 0) {
     process.GetTarget().ModulesDidLoad(added_modules);
     process.Flush();

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6710,6 +6710,7 @@ bool ObjectFileMachO::LoadCoreFileImages(lldb_private::Process &process) {
                 "ObjectFileMachO::%s binary at 0x%" PRIx64
                 " is a platform binary, has been handled by a Platform plugin.",
                 __FUNCTION__, image.load_address);
+      found_platform_binary = true;
       continue;
     }
 
@@ -6764,8 +6765,9 @@ bool ObjectFileMachO::LoadCoreFileImages(lldb_private::Process &process) {
                       module_sp->GetFileSpec().GetPath().c_str(),
                       uuidstr.c_str());
         }
+        ObjectFile *objfile = module_sp->GetObjectFile();
+        SectionList *sectlist = objfile ? objfile->GetSectionList() : nullptr;
         for (auto name_vmaddr_tuple : image.segment_load_addresses) {
-          SectionList *sectlist = module_sp->GetObjectFile()->GetSectionList();
           if (sectlist) {
             SectionSP sect_sp =
                 sectlist->FindSectionByName(std::get<0>(name_vmaddr_tuple));

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6725,16 +6725,29 @@ bool ObjectFileMachO::LoadCoreFileImages(lldb_private::Process &process) {
     // and can try to read load commands and find a UUID.
     if (image.uuid.IsValid() ||
         (!value_is_offset && value != LLDB_INVALID_ADDRESS)) {
-      const bool set_load_address = image.segment_load_addresses.size() == 0;
-      const bool notify = false;
+      DynamicLoader::BinarySpec bin_spec;
+      bin_spec.name = image.filename;
+      bin_spec.uuid = image.uuid;
+      bin_spec.value = value;
+      bin_spec.value_is_offset = value_is_offset;
+      bin_spec.force_symbol_search = image.currently_executing;
+      bin_spec.notify = false;
       // Userland Darwin binaries will have segment load addresses via
       // the `all image infos` LC_NOTE.
-      const bool allow_memory_image_last_resort =
-          image.segment_load_addresses.size();
-      module_sp = DynamicLoader::LoadBinaryWithUUIDAndAddress(
-          &process, image.filename, image.uuid, value, value_is_offset,
-          image.currently_executing, notify, set_load_address,
-          allow_memory_image_last_resort);
+      bin_spec.set_address_in_target = image.segment_load_addresses.empty();
+      bin_spec.allow_memory_image_last_resort =
+          !image.segment_load_addresses.empty();
+      if (llvm::Expected<ModuleSP> located =
+              DynamicLoader::LocateAndLoadBinary(&process, bin_spec)) {
+        module_sp = *located;
+      } else if (bin_spec.force_symbol_search) {
+        *process.GetTarget().GetDebugger().GetAsyncErrorStream()
+            << llvm::toString(located.takeError()) << "\n";
+      } else {
+        // A corefile image that isn't on this machine is routine, and
+        // LocateAndLoadBinary has already logged it.
+        llvm::consumeError(located.takeError());
+      }
     }
 
     // We have a ModuleSP to load in the Target.  Load it at the

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1146,17 +1146,19 @@ void ProcessGDBRemote::LoadStubBinaries() {
   bool standalone_value_is_offset;
   if (m_gdb_comm.GetProcessStandaloneBinary(standalone_uuid, standalone_value,
                                             standalone_value_is_offset)) {
-    ModuleSP module_sp;
-
     if (standalone_uuid.IsValid()) {
-      const bool force_symbol_search = true;
-      const bool notify = true;
-      const bool set_address_in_target = true;
-      const bool allow_memory_image_last_resort = false;
-      DynamicLoader::LoadBinaryWithUUIDAndAddress(
-          this, "", standalone_uuid, standalone_value,
-          standalone_value_is_offset, force_symbol_search, notify,
-          set_address_in_target, allow_memory_image_last_resort);
+      DynamicLoader::BinarySpec bin_spec;
+      bin_spec.uuid = standalone_uuid;
+      bin_spec.value = standalone_value;
+      bin_spec.value_is_offset = standalone_value_is_offset;
+      bin_spec.force_symbol_search = true;
+      bin_spec.notify = true;
+      bin_spec.set_address_in_target = true;
+      llvm::Expected<ModuleSP> module =
+          DynamicLoader::LocateAndLoadBinary(this, bin_spec);
+      if (!module)
+        *GetTarget().GetDebugger().GetAsyncErrorStream()
+            << llvm::toString(module.takeError()) << "\n";
     }
   }
 
@@ -1170,8 +1172,6 @@ void ProcessGDBRemote::LoadStubBinaries() {
 
   std::vector<addr_t> bin_addrs = m_gdb_comm.GetProcessStandaloneBinaries();
   if (bin_addrs.size()) {
-    UUID uuid;
-    const bool value_is_slide = false;
     for (addr_t addr : bin_addrs) {
       const bool notify = true;
       // First see if this is a special platform
@@ -1183,14 +1183,17 @@ void ProcessGDBRemote::LoadStubBinaries() {
               .LoadPlatformBinaryAndSetup(this, addr, notify))
         continue;
 
-      const bool force_symbol_search = true;
-      const bool set_address_in_target = true;
-      const bool allow_memory_image_last_resort = false;
       // Second manually load this binary into the Target.
-      DynamicLoader::LoadBinaryWithUUIDAndAddress(
-          this, llvm::StringRef(), uuid, addr, value_is_slide,
-          force_symbol_search, notify, set_address_in_target,
-          allow_memory_image_last_resort);
+      DynamicLoader::BinarySpec bin_spec;
+      bin_spec.value = addr;
+      bin_spec.force_symbol_search = true;
+      bin_spec.notify = notify;
+      bin_spec.set_address_in_target = true;
+      llvm::Expected<ModuleSP> module =
+          DynamicLoader::LocateAndLoadBinary(this, bin_spec);
+      if (!module)
+        *GetTarget().GetDebugger().GetAsyncErrorStream()
+            << llvm::toString(module.takeError()) << "\n";
     }
   }
 }

--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -262,17 +262,20 @@ bool ProcessMachCore::LoadBinaryViaLowmemUUID() {
                         uuid.GetAsString().c_str(), addr);
               // We have no address specified, only a UUID.  Load it at the file
               // address.
-              const bool value_is_offset = true;
-              const bool force_symbol_search = true;
-              const bool notify = true;
-              const bool set_address_in_target = true;
-              const bool allow_memory_image_last_resort = false;
-              if (DynamicLoader::LoadBinaryWithUUIDAndAddress(
-                      this, llvm::StringRef(), uuid, 0, value_is_offset,
-                      force_symbol_search, notify, set_address_in_target,
-                      allow_memory_image_last_resort)) {
+              DynamicLoader::BinarySpec bin_spec;
+              bin_spec.uuid = uuid;
+              bin_spec.value = 0;
+              bin_spec.value_is_offset = true;
+              bin_spec.force_symbol_search = true;
+              bin_spec.notify = true;
+              bin_spec.set_address_in_target = true;
+              llvm::Expected<ModuleSP> module =
+                  DynamicLoader::LocateAndLoadBinary(this, bin_spec);
+              if (module)
                 m_dyld_plugin_name = DynamicLoaderStatic::GetPluginNameStatic();
-              }
+              else
+                *GetTarget().GetDebugger().GetAsyncErrorStream()
+                    << llvm::toString(module.takeError()) << "\n";
               // We found metadata saying which binary should be loaded; don't
               // try an exhaustive search.
               return true;
@@ -325,17 +328,20 @@ bool ProcessMachCore::LoadBinariesViaMetadata() {
       m_dyld_all_image_infos_addr = objfile_binary_value;
       m_dyld_plugin_name = DynamicLoaderMacOSXDYLD::GetPluginNameStatic();
     } else {
-      const bool force_symbol_search = true;
-      const bool notify = true;
-      const bool set_address_in_target = true;
-      const bool allow_memory_image_last_resort = false;
-      if (DynamicLoader::LoadBinaryWithUUIDAndAddress(
-              this, llvm::StringRef(), objfile_binary_uuid,
-              objfile_binary_value, objfile_binary_value_is_offset,
-              force_symbol_search, notify, set_address_in_target,
-              allow_memory_image_last_resort)) {
+      DynamicLoader::BinarySpec bin_spec;
+      bin_spec.uuid = objfile_binary_uuid;
+      bin_spec.value = objfile_binary_value;
+      bin_spec.value_is_offset = objfile_binary_value_is_offset;
+      bin_spec.force_symbol_search = true;
+      bin_spec.notify = true;
+      bin_spec.set_address_in_target = true;
+      llvm::Expected<ModuleSP> module =
+          DynamicLoader::LocateAndLoadBinary(this, bin_spec);
+      if (module)
         m_dyld_plugin_name = DynamicLoaderStatic::GetPluginNameStatic();
-      }
+      else
+        *GetTarget().GetDebugger().GetAsyncErrorStream()
+            << llvm::toString(module.takeError()) << "\n";
     }
   }
 
@@ -382,17 +388,20 @@ bool ProcessMachCore::LoadBinariesViaMetadata() {
     } else if (ident_uuid.IsValid()) {
       // We have no address specified, only a UUID.  Load it at the file
       // address.
-      const bool value_is_offset = false;
-      const bool force_symbol_search = true;
-      const bool notify = true;
-      const bool set_address_in_target = true;
-      const bool allow_memory_image_last_resort = false;
-      if (DynamicLoader::LoadBinaryWithUUIDAndAddress(
-              this, llvm::StringRef(), ident_uuid, ident_binary_addr,
-              value_is_offset, force_symbol_search, notify,
-              set_address_in_target, allow_memory_image_last_resort)) {
+      DynamicLoader::BinarySpec bin_spec;
+      bin_spec.uuid = ident_uuid;
+      bin_spec.value = ident_binary_addr;
+      bin_spec.force_symbol_search = true;
+      bin_spec.notify = true;
+      bin_spec.set_address_in_target = true;
+      llvm::Expected<ModuleSP> module =
+          DynamicLoader::LocateAndLoadBinary(this, bin_spec);
+      if (module) {
         found_binary_spec_in_metadata = true;
         m_dyld_plugin_name = DynamicLoaderStatic::GetPluginNameStatic();
+      } else {
+        *GetTarget().GetDebugger().GetAsyncErrorStream()
+            << llvm::toString(module.takeError()) << "\n";
       }
     }
 

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -89,7 +89,7 @@ bool SymbolContext::DumpStopContext(
     SymbolContext inline_parent_sc;
     Address inline_parent_addr;
     if (!show_function_name) {
-      s->Printf("<");
+      s->PutCString("<");
       dumped_something = true;
     } else {
       ConstString name;
@@ -168,7 +168,7 @@ bool SymbolContext::DumpStopContext(
     }
   } else if (symbol != nullptr) {
     if (!show_function_name) {
-      s->Printf("<");
+      s->PutCString("<");
       dumped_something = true;
     } else if (symbol->GetName()) {
       dumped_something = true;
@@ -1129,7 +1129,7 @@ void SymbolContextSpecifier::GetDescription(
   char path_str[PATH_MAX + 1];
 
   if (m_type == eNothingSpecified) {
-    s->Printf("Nothing specified.\n");
+    s->PutCString("Nothing specified.\n");
   }
 
   if (m_type == eModuleSpecified) {
@@ -1150,11 +1150,11 @@ void SymbolContextSpecifier::GetDescription(
       if (m_type == eLineEndSpecified)
         s->Printf("to line %" PRIu64 "", (uint64_t)m_end_line);
       else
-        s->Printf("to end");
+        s->PutCString("to end");
     } else if (m_type == eLineEndSpecified) {
       s->Printf(" from start to line %" PRIu64 "", (uint64_t)m_end_line);
     }
-    s->Printf(".\n");
+    s->PutCString(".\n");
   }
 
   if (m_type == eLineStartSpecified) {
@@ -1163,8 +1163,8 @@ void SymbolContextSpecifier::GetDescription(
     if (m_type == eLineEndSpecified)
       s->Printf("to line %" PRIu64 "", (uint64_t)m_end_line);
     else
-      s->Printf("to end");
-    s->Printf(".\n");
+      s->PutCString("to end");
+    s->PutCString(".\n");
   } else if (m_type == eLineEndSpecified) {
     s->Printf("From start to line %" PRIu64 ".\n", (uint64_t)m_end_line);
   }

--- a/lldb/source/Symbol/SymbolLocator.cpp
+++ b/lldb/source/Symbol/SymbolLocator.cpp
@@ -10,10 +10,12 @@
 
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Target/Platform.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/ThreadPool.h"
 
@@ -31,21 +33,12 @@ std::error_code SymbolLocator::NotFound::convertToErrorCode() const {
 }
 
 llvm::Expected<SymbolLocator::Result>
-SymbolLocator::Locate(const Request &request,
-                      const FileSpecList &search_paths) {
+SymbolLocator::LocateWithPlugins(const Request &request,
+                                 const FileSpecList &search_paths) {
   FileSystem &fs = FileSystem::Instance();
   Result result;
   ModuleSpec &module_spec = result.module_spec;
   module_spec = request.module_spec;
-
-  // The locator plugins have no Platform to consult, so ask it here.
-  if (request.platform) {
-    if (std::optional<ModuleSpec> found = request.platform->FindModuleFiles(
-            module_spec, search_paths, result.statistics)) {
-      result.module_spec = *found;
-      return result;
-    }
-  }
 
   // Can lldb's symbol and executable location schemes find them locally?
   module_spec.GetSymbolFileSpec() = PluginManager::LocateExecutableSymbolFile(
@@ -75,6 +68,78 @@ SymbolLocator::Locate(const Request &request,
   }
 
   return result;
+}
+
+static std::optional<SymbolLocator::Result>
+AskPlatform(const SymbolLocator::Request &request,
+            const FileSpecList &search_paths) {
+  if (!request.platform)
+    return std::nullopt;
+
+  SymbolLocator::Result result;
+  std::optional<ModuleSpec> found = request.platform->FindModuleFiles(
+      request.module_spec, search_paths, result.statistics);
+  if (!found)
+    return std::nullopt;
+
+  result.module_spec = *found;
+  return result;
+}
+
+llvm::Expected<SymbolLocator::Result>
+SymbolLocator::Locate(const Request &request,
+                      const FileSpecList &search_paths) {
+  if (std::optional<Result> answer = AskPlatform(request, search_paths))
+    return std::move(*answer);
+  return LocateWithPlugins(request, search_paths);
+}
+
+std::vector<llvm::Expected<SymbolLocator::Result>>
+SymbolLocator::Locate(llvm::ArrayRef<Request> requests,
+                      const FileSpecList &search_paths, bool parallel) {
+  // One slot per request, so concurrent searches never contend.
+  std::vector<std::optional<llvm::Expected<Result>>> slots(requests.size());
+  std::vector<size_t> remaining;
+
+  if (!requests.empty()) {
+    // Throttled because every search reports through this from its own thread.
+    Progress progress("Locating binaries", "", requests.size(),
+                      /*debugger=*/nullptr,
+                      Progress::kDefaultHighFrequencyReportTime);
+
+    for (auto [i, request] : llvm::enumerate(requests)) {
+      if (std::optional<Result> answer = AskPlatform(request, search_paths)) {
+        slots[i] = std::move(*answer);
+        progress.Increment(1, request.description);
+      } else {
+        remaining.push_back(i);
+      }
+    }
+
+    auto locate = [&](size_t i) {
+      slots[i] = LocateWithPlugins(requests[i], search_paths);
+      progress.Increment(1, requests[i].description);
+    };
+
+    // One search has nothing to overlap with.
+    if (parallel && remaining.size() > 1) {
+      llvm::ThreadPoolTaskGroup task_group(Debugger::GetThreadPool());
+      for (size_t i : remaining)
+        task_group.async(locate, i);
+      task_group.wait();
+    } else {
+      for (size_t i : remaining)
+        locate(i);
+    }
+  }
+
+  std::vector<llvm::Expected<Result>> results;
+  results.reserve(slots.size());
+  for (std::optional<llvm::Expected<Result>> &slot : slots) {
+    assert(slot && "every request has a result");
+    results.emplace_back(std::move(*slot));
+  }
+  return results;
 }
 
 void SymbolLocator::DownloadSymbolFileAsync(const UUID &uuid) {

--- a/lldb/source/Symbol/SymbolLocator.cpp
+++ b/lldb/source/Symbol/SymbolLocator.cpp
@@ -12,6 +12,7 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
+#include "lldb/Target/Platform.h"
 
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/ThreadPool.h"
@@ -36,6 +37,15 @@ SymbolLocator::Locate(const Request &request,
   Result result;
   ModuleSpec &module_spec = result.module_spec;
   module_spec = request.module_spec;
+
+  // The locator plugins have no Platform to consult, so ask it here.
+  if (request.platform) {
+    if (std::optional<ModuleSpec> found = request.platform->FindModuleFiles(
+            module_spec, search_paths, result.statistics)) {
+      result.module_spec = *found;
+      return result;
+    }
+  }
 
   // Can lldb's symbol and executable location schemes find them locally?
   module_spec.GetSymbolFileSpec() = PluginManager::LocateExecutableSymbolFile(

--- a/lldb/source/Symbol/SymbolLocator.cpp
+++ b/lldb/source/Symbol/SymbolLocator.cpp
@@ -10,6 +10,7 @@
 
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
 
 #include "llvm/ADT/SmallSet.h"
@@ -17,6 +18,54 @@
 
 using namespace lldb;
 using namespace lldb_private;
+
+char SymbolLocator::NotFound::ID = 0;
+
+void SymbolLocator::NotFound::log(llvm::raw_ostream &os) const {
+  os << "binary not found";
+}
+
+std::error_code SymbolLocator::NotFound::convertToErrorCode() const {
+  return std::make_error_code(std::errc::no_such_file_or_directory);
+}
+
+llvm::Expected<SymbolLocator::Result>
+SymbolLocator::Locate(const Request &request,
+                      const FileSpecList &search_paths) {
+  FileSystem &fs = FileSystem::Instance();
+  Result result;
+  ModuleSpec &module_spec = result.module_spec;
+  module_spec = request.module_spec;
+
+  // Can lldb's symbol and executable location schemes find them locally?
+  module_spec.GetSymbolFileSpec() = PluginManager::LocateExecutableSymbolFile(
+      module_spec, search_paths, result.statistics);
+  module_spec.GetFileSpec() =
+      PluginManager::LocateExecutableObjectFile(module_spec, result.statistics)
+          .GetFileSpec();
+
+  // If we're still missing either file, see if an external symbol server can
+  // provide it.
+  if (!fs.Exists(module_spec.GetFileSpec()) ||
+      !fs.Exists(module_spec.GetSymbolFileSpec())) {
+    Status error;
+    PluginManager::DownloadObjectAndSymbolFile(module_spec, error,
+                                               request.external_lookup);
+    if (error.Fail() && request.external_lookup)
+      result.symbol_error.emplace(error.takeError());
+  }
+
+  // Not finding the binary is the one hard failure. Whatever a symbol server
+  // had to say is the best explanation available for it. Without one there is
+  // nothing to add beyond the fact of the miss.
+  if (!fs.Exists(module_spec.GetFileSpec())) {
+    if (result.symbol_error)
+      return std::move(*result.symbol_error);
+    return llvm::make_error<NotFound>();
+  }
+
+  return result;
+}
 
 void SymbolLocator::DownloadSymbolFileAsync(const UUID &uuid) {
   static llvm::SmallSet<UUID, 8> g_seen_uuids;

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1221,9 +1221,9 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
   ModuleSP module_sp;
   if (CheckModule(module_sp)) {
     if (m_dynamic_type.IsValid()) {
-      strm.Printf("Dynamic:\n");
+      strm.PutCString("Dynamic:\n");
       m_dynamic_type.DumpTypeDescription(&strm);
-      strm.Printf("\nStatic:\n");
+      strm.PutCString("\nStatic:\n");
     }
     m_static_type.DumpTypeDescription(&strm);
   } else {

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -241,11 +241,11 @@ void UnwindPlan::Row::Dump(Stream &s, const UnwindPlan *unwind_plan,
   m_cfa_value.Dump(s, unwind_plan, thread);
 
   if (!m_afa_value.IsUnspecified()) {
-    s.Printf(" AFA=");
+    s.PutCString(" AFA=");
     m_afa_value.Dump(s, unwind_plan, thread);
   }
 
-  s.Printf(" => ");
+  s.PutCString(" => ");
   for (collection::const_iterator idx = m_register_locations.begin();
        idx != m_register_locations.end(); ++idx) {
     DumpRegisterName(s, unwind_plan, thread, idx->first);
@@ -512,40 +512,40 @@ void UnwindPlan::Dump(Stream &s, Thread *thread, lldb::addr_t base_addr) const {
     s.Printf("This UnwindPlan originally sourced from %s\n",
              m_source_name.GetCString());
   }
-  s.Printf("This UnwindPlan is sourced from the compiler: ");
+  s.PutCString("This UnwindPlan is sourced from the compiler: ");
   switch (m_plan_is_sourced_from_compiler) {
   case eLazyBoolYes:
-    s.Printf("yes.\n");
+    s.PutCString("yes.\n");
     break;
   case eLazyBoolNo:
-    s.Printf("no.\n");
+    s.PutCString("no.\n");
     break;
   case eLazyBoolCalculate:
-    s.Printf("not specified.\n");
+    s.PutCString("not specified.\n");
     break;
   }
-  s.Printf("This UnwindPlan is valid at all instruction locations: ");
+  s.PutCString("This UnwindPlan is valid at all instruction locations: ");
   switch (m_plan_is_valid_at_all_instruction_locations) {
   case eLazyBoolYes:
-    s.Printf("yes.\n");
+    s.PutCString("yes.\n");
     break;
   case eLazyBoolNo:
-    s.Printf("no.\n");
+    s.PutCString("no.\n");
     break;
   case eLazyBoolCalculate:
-    s.Printf("not specified.\n");
+    s.PutCString("not specified.\n");
     break;
   }
-  s.Printf("This UnwindPlan is for a trap handler function: ");
+  s.PutCString("This UnwindPlan is for a trap handler function: ");
   switch (m_plan_is_for_signal_trap) {
   case eLazyBoolYes:
-    s.Printf("yes.\n");
+    s.PutCString("yes.\n");
     break;
   case eLazyBoolNo:
-    s.Printf("no.\n");
+    s.PutCString("no.\n");
     break;
   case eLazyBoolCalculate:
-    s.Printf("not specified.\n");
+    s.PutCString("not specified.\n");
     break;
   }
   if (!m_plan_valid_ranges.empty()) {

--- a/lldb/source/Utility/Event.cpp
+++ b/lldb/source/Utility/Event.cpp
@@ -77,7 +77,7 @@ void Event::Dump(Stream *s) const {
     m_data_sp->Dump(s);
     s->PutChar('}');
   } else
-    s->Printf("<NULL>");
+    s->PutCString("<NULL>");
 }
 
 void Event::DoOnRemoval() {

--- a/lldb/source/Utility/ProcessInfo.cpp
+++ b/lldb/source/Utility/ProcessInfo.cpp
@@ -140,7 +140,7 @@ void ProcessInstanceInfo::Dump(Stream &s, UserIDResolver &resolver) const {
   s.Format("{0}", m_environment);
 
   if (m_arch.IsValid()) {
-    s.Printf("   arch = ");
+    s.PutCString("   arch = ");
     m_arch.DumpTriple(s.AsRawOstream());
     s.EOL();
   }

--- a/lldb/source/Utility/StructuredData.cpp
+++ b/lldb/source/Utility/StructuredData.cpp
@@ -197,7 +197,7 @@ void StructuredData::Boolean::GetDescription(lldb_private::Stream &s) const {
 }
 
 void StructuredData::String::GetDescription(lldb_private::Stream &s) const {
-  s.Printf("%s", m_value.empty() ? "\"\"" : m_value.c_str());
+  s.PutCString(m_value.empty() ? "\"\"" : m_value.c_str());
 }
 
 void StructuredData::Array::GetDescription(lldb_private::Stream &s) const {
@@ -283,7 +283,7 @@ void StructuredData::Dictionary::GetDescription(lldb_private::Stream &s) const {
 }
 
 void StructuredData::Null::GetDescription(lldb_private::Stream &s) const {
-  s.Printf("NULL");
+  s.PutCString("NULL");
 }
 
 void StructuredData::Generic::GetDescription(lldb_private::Stream &s) const {

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -993,7 +993,7 @@ ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
       if ((bytes_read = data.GetByteSize()) > 0) {
         total_bytes_read = bytes_read;
         for (size_t offset = 0; offset < bytes_read; offset++)
-          s.Printf("%c", *data.PeekData(offset, 1));
+          s.PutChar(*data.PeekData(offset, 1));
         if (capped_data)
           was_capped = true;
       }
@@ -1025,7 +1025,7 @@ ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
           len = cstr_len;
 
         for (size_t offset = 0; offset < bytes_read; offset++)
-          s.Printf("%c", *data.PeekData(offset, 1));
+          s.PutChar(*data.PeekData(offset, 1));
 
         if (len < k_max_buf_size)
           break;

--- a/lldb/test/API/macosx/lc-note/multiple-binary-corefile/TestMultipleBinaryCorefile.py
+++ b/lldb/test/API/macosx/lc-note/multiple-binary-corefile/TestMultipleBinaryCorefile.py
@@ -199,6 +199,31 @@ class TestMultipleBinaryCorefile(TestBase):
     @skipIf(archs=no_match(["x86_64", "arm64", "arm64e", "aarch64"]))
     @skipIfRemote
     @requireDarwin
+    def test_corefile_binaries_serial_search(self):
+        """The corefile's binaries are searched for in parallel by default.
+        Searching for them one at a time has to give the same answer, in the
+        same order, since load_corefile_and_test indexes into the module
+        list."""
+        self.initial_setup()
+
+        self.runCmd("settings set target.parallel-module-load false")
+        self.addTearDownHook(
+            lambda: self.runCmd("settings clear target.parallel-module-load")
+        )
+
+        # Register the binaries in lldb's global module cache, as
+        # test_corefile_binaries_preloaded does, so the corefile's images can
+        # be found without a symbol server.
+        target = self.dbg.CreateTarget(self.aout_exe, "", "", False, lldb.SBError())
+        self.dbg.DeleteTarget(target)
+        target = self.dbg.CreateTarget(self.libtwo_exe, "", "", False, lldb.SBError())
+        self.dbg.DeleteTarget(target)
+
+        self.load_corefile_and_test()
+
+    @skipIf(archs=no_match(["x86_64", "arm64", "arm64e", "aarch64"]))
+    @skipIfRemote
+    @requireDarwin
     def test_corefile_binaries_preloaded(self):
         self.initial_setup()
 

--- a/lldb/unittests/Core/ModuleListTest.cpp
+++ b/lldb/unittests/Core/ModuleListTest.cpp
@@ -11,7 +11,9 @@
 #include "TestingSupport/TestUtilities.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleSpec.h"
+#include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
+#include "lldb/Symbol/SymbolLocator.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/UUID.h"
 
@@ -172,4 +174,63 @@ Sections:
       }
     }
   }
+}
+
+// A symbol locator that records whether it was asked to find anything. It never
+// finds a binary, so it does not otherwise change what GetSharedModule does.
+static bool g_locate_executable_object_file_called = false;
+
+static std::optional<ModuleSpec>
+LocateExecutableObjectFile(const ModuleSpec &) {
+  g_locate_executable_object_file_called = true;
+  return {};
+}
+
+static SymbolLocator *CreateSymbolLocator() { return nullptr; }
+
+class SymbolLocatorGate : public testing::Test {
+public:
+  void SetUp() override {
+    g_locate_executable_object_file_called = false;
+    ASSERT_TRUE(PluginManager::RegisterPlugin("test", "test symbol locator",
+                                              CreateSymbolLocator,
+                                              LocateExecutableObjectFile));
+  }
+
+  void TearDown() override {
+    PluginManager::UnregisterPlugin(CreateSymbolLocator);
+  }
+
+  // A spec that names no file on disk, so GetSharedModule has to fall through
+  // to the symbol locators to have any chance of finding a binary.
+  static ModuleSpec MissingModuleSpec() {
+    ModuleSpec spec;
+    spec.GetFileSpec() = FileSpec("/nonexistent/libtest.so");
+    spec.GetArchitecture() = ArchSpec("x86_64-pc-linux");
+    spec.GetUUID() = UUID("0123456789ABCDEF", 16);
+    return spec;
+  }
+};
+
+TEST_F(SymbolLocatorGate, GetSharedModuleInvokesSymbolLocatorsByDefault) {
+  SubsystemRAII<FileSystem, ObjectFileELF> subsystems;
+
+  ModuleSP module_sp;
+  ModuleList::GetSharedModule(MissingModuleSpec(), module_sp, nullptr, nullptr);
+
+  EXPECT_TRUE(g_locate_executable_object_file_called);
+}
+
+TEST_F(SymbolLocatorGate, GetSharedModuleCanSkipSymbolLocators) {
+  SubsystemRAII<FileSystem, ObjectFileELF> subsystems;
+
+  ModuleSP module_sp;
+  Status error = ModuleList::GetSharedModule(
+      MissingModuleSpec(), module_sp, nullptr, nullptr,
+      /*invoke_locate_callback=*/true, /*invoke_symbol_locators=*/false);
+
+  EXPECT_FALSE(g_locate_executable_object_file_called);
+  // The caller still learns that nothing was found.
+  EXPECT_FALSE(module_sp);
+  EXPECT_TRUE(error.Fail());
 }

--- a/lldb/unittests/Symbol/CMakeLists.txt
+++ b/lldb/unittests/Symbol/CMakeLists.txt
@@ -18,6 +18,7 @@ add_lldb_unittest(SymbolTests
   LocateSymbolFileTest.cpp
   MangledTest.cpp
   PostfixExpressionTest.cpp
+  SymbolLocatorTest.cpp
   SymbolTest.cpp
   SymtabTest.cpp
   SymStoreTest.cpp

--- a/lldb/unittests/Symbol/SymbolLocatorTest.cpp
+++ b/lldb/unittests/Symbol/SymbolLocatorTest.cpp
@@ -7,16 +7,24 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Symbol/SymbolLocator.h"
+#include "TestingSupport/TestUtilities.h"
+#include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Target/Platform.h"
 #include "lldb/Utility/FileSpecList.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Testing/Support/Error.h"
 
 #include "gtest/gtest.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -24,10 +32,17 @@ using namespace lldb_private;
 namespace {
 
 /// Which steps of the search ran, so a test can tell where an answer came from.
+/// Written from every thread of a batch, so the flags have to be atomic.
 struct LocatorCalls {
-  bool located_symbol_file = false;
-  bool located_object_file = false;
-  bool downloaded = false;
+  std::atomic<bool> located_symbol_file = false;
+  std::atomic<bool> located_object_file = false;
+  std::atomic<bool> downloaded = false;
+
+  void Clear() {
+    located_symbol_file = false;
+    located_object_file = false;
+    downloaded = false;
+  }
 };
 
 LocatorCalls g_calls;
@@ -42,6 +57,13 @@ std::optional<FileSpec> g_symbol_file;
 /// an errno rather than a message.
 bool g_symbol_server_errno = false;
 
+/// When set, the fake locator only answers for requests carrying a UUID.
+bool g_only_with_uuid = false;
+
+/// Run by the fake locator, to let a test hold every search of a batch open at
+/// once.
+std::function<void()> g_barrier;
+
 std::optional<FileSpec> LocateExecutableSymbolFile(const ModuleSpec &,
                                                    const FileSpecList &) {
   g_calls.located_symbol_file = true;
@@ -50,7 +72,11 @@ std::optional<FileSpec> LocateExecutableSymbolFile(const ModuleSpec &,
 
 std::optional<ModuleSpec> LocateExecutableObjectFile(const ModuleSpec &spec) {
   g_calls.located_object_file = true;
+  if (g_barrier)
+    g_barrier();
   if (!g_object_file)
+    return {};
+  if (g_only_with_uuid && !spec.GetUUID().IsValid())
     return {};
   ModuleSpec located(spec);
   located.GetFileSpec() = *g_object_file;
@@ -113,6 +139,11 @@ public:
         m_fs(new llvm::vfs::InMemoryFileSystem()) {}
 
   void SetUp() override {
+    // The batch runs on the debugger's thread pool. Debugger::Initialize takes
+    // an argument, so SubsystemRAII cannot call it.
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
+                   []() { Debugger::Initialize(nullptr); });
+
     // Locate reports a binary it cannot find as an error, so a test that wants
     // a hit has to point the fake locator at a file that exists.
     FileSystem::Initialize(m_fs);
@@ -120,10 +151,12 @@ public:
     m_fs->addFileNoOwn(m_binary.GetPath(), 0, m_empty_buffer);
     m_fs->addFileNoOwn(m_symbols.GetPath(), 0, m_empty_buffer);
 
-    g_calls = LocatorCalls();
+    g_calls.Clear();
     g_object_file = std::nullopt;
     g_symbol_file = std::nullopt;
     g_symbol_server_errno = false;
+    g_only_with_uuid = false;
+    g_barrier = nullptr;
     ASSERT_TRUE(PluginManager::RegisterPlugin(
         "test", "test symbol locator", CreateSymbolLocator,
         LocateExecutableObjectFile, LocateExecutableSymbolFile,
@@ -131,6 +164,7 @@ public:
   }
 
   void TearDown() override {
+    g_barrier = nullptr;
     PluginManager::UnregisterPlugin(CreateSymbolLocator);
     HostInfo::Terminate();
     FileSystem::Terminate();
@@ -143,6 +177,10 @@ public:
   FileSpec m_binary = FileSpec("/binary", FileSpec::Style::posix);
   FileSpec m_symbols = FileSpec("/binary.dSYM", FileSpec::Style::posix);
 };
+
+std::vector<SymbolLocator::Request> MakeRequests(size_t count) {
+  return std::vector<SymbolLocator::Request>(count);
+}
 
 } // namespace
 
@@ -268,4 +306,103 @@ TEST_F(SymbolLocatorTest, ThePluginsRunWhenThePlatformHasNothingToSay) {
   ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
   EXPECT_EQ(1u, platform->find_module_files_calls);
   EXPECT_TRUE(g_calls.located_object_file);
+}
+
+TEST_F(SymbolLocatorTest, TheBatchSearchesEveryRequest) {
+  g_object_file = m_binary;
+  std::vector<SymbolLocator::Request> requests = MakeRequests(8);
+
+  std::vector<llvm::Expected<SymbolLocator::Result>> results =
+      SymbolLocator::Locate(requests, FileSpecList(), /*parallel=*/true);
+
+  ASSERT_EQ(requests.size(), results.size());
+  for (llvm::Expected<SymbolLocator::Result> &result : results) {
+    ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
+    EXPECT_EQ(m_binary, result->module_spec.GetFileSpec());
+  }
+}
+
+TEST_F(SymbolLocatorTest, TheBatchKeepsResultsInRequestOrder) {
+  // Every other request is one the locator will answer, so the results can only
+  // line up with the requests if the order is kept.
+  g_object_file = m_binary;
+  g_only_with_uuid = true;
+  std::vector<SymbolLocator::Request> requests = MakeRequests(6);
+  for (auto [i, request] : llvm::enumerate(requests))
+    if (i % 2 == 0)
+      request.module_spec.GetUUID() = UUID("0123456789ABCDEF", 16);
+
+  std::vector<llvm::Expected<SymbolLocator::Result>> results =
+      SymbolLocator::Locate(requests, FileSpecList(), /*parallel=*/true);
+
+  ASSERT_EQ(requests.size(), results.size());
+  for (auto [i, result] : llvm::enumerate(results)) {
+    if (i % 2 == 0)
+      EXPECT_THAT_EXPECTED(result, llvm::Succeeded()) << "request " << i;
+    else
+      EXPECT_THAT_EXPECTED(result, llvm::Failed()) << "request " << i;
+  }
+}
+
+TEST_F(SymbolLocatorTest, TheBatchSearchesConcurrently) {
+  // A serial batch could never get every task inside the locator at once. No
+  // more tasks than the pool can run, or the ones left queued would hang it.
+  const size_t num_requests =
+      std::min<size_t>(4, Debugger::GetThreadPool().getMaxConcurrency());
+  if (num_requests < 2)
+    GTEST_SKIP() << "the thread pool runs one task at a time";
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  size_t arrived = 0;
+  bool everyone_arrived = false;
+
+  g_barrier = [&] {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (++arrived == num_requests) {
+      everyone_arrived = true;
+      cv.notify_all();
+      return;
+    }
+    // Assert on what the waiter observed, not on the count: a late arrival
+    // would set the flag either way.
+    bool released = cv.wait_for(lock, std::chrono::seconds(10),
+                                [&] { return everyone_arrived; });
+    EXPECT_TRUE(released) << "the batch did not run concurrently";
+  };
+
+  std::vector<SymbolLocator::Request> requests = MakeRequests(num_requests);
+  std::vector<llvm::Expected<SymbolLocator::Result>> results =
+      SymbolLocator::Locate(requests, FileSpecList(), /*parallel=*/true);
+  for (llvm::Expected<SymbolLocator::Result> &result : results)
+    if (!result)
+      llvm::consumeError(result.takeError());
+
+  EXPECT_EQ(num_requests, arrived);
+}
+
+TEST_F(SymbolLocatorTest, TheSerialBatchGivesTheSameAnswers) {
+  g_object_file = m_binary;
+  std::vector<SymbolLocator::Request> requests = MakeRequests(4);
+
+  std::vector<llvm::Expected<SymbolLocator::Result>> parallel =
+      SymbolLocator::Locate(requests, FileSpecList(), /*parallel=*/true);
+  std::vector<llvm::Expected<SymbolLocator::Result>> serial =
+      SymbolLocator::Locate(requests, FileSpecList(), /*parallel=*/false);
+
+  ASSERT_EQ(parallel.size(), serial.size());
+  for (auto [p, s] : llvm::zip_equal(parallel, serial)) {
+    EXPECT_THAT_EXPECTED(p, llvm::Succeeded());
+    EXPECT_THAT_EXPECTED(s, llvm::Succeeded());
+    if (p && s)
+      EXPECT_EQ(p->module_spec.GetFileSpec(), s->module_spec.GetFileSpec());
+  }
+}
+
+TEST_F(SymbolLocatorTest, AnEmptyBatchIsNoWork) {
+  std::vector<llvm::Expected<SymbolLocator::Result>> results =
+      SymbolLocator::Locate({}, FileSpecList(), /*parallel=*/true);
+
+  EXPECT_TRUE(results.empty());
+  EXPECT_FALSE(g_calls.located_object_file);
 }

--- a/lldb/unittests/Symbol/SymbolLocatorTest.cpp
+++ b/lldb/unittests/Symbol/SymbolLocatorTest.cpp
@@ -10,6 +10,7 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
+#include "lldb/Target/Platform.h"
 #include "lldb/Utility/FileSpecList.h"
 
 #include "llvm/Support/VirtualFileSystem.h"
@@ -69,6 +70,41 @@ bool DownloadObjectAndSymbolFile(ModuleSpec &, Status &error, bool force_lookup,
 }
 
 SymbolLocator *CreateSymbolLocator() { return nullptr; }
+
+/// A platform that answers out of an index of its own, the way
+/// PlatformDarwinKernel answers for kexts.
+class IndexedPlatform : public Platform {
+public:
+  IndexedPlatform() : Platform(/*is_host_platform=*/false) {}
+
+  llvm::StringRef GetPluginName() override { return "indexed"; }
+  llvm::StringRef GetDescription() override { return "test platform"; }
+  std::vector<ArchSpec> GetSupportedArchitectures(const ArchSpec &) override {
+    return {};
+  }
+  lldb::ProcessSP Attach(ProcessAttachInfo &, Debugger &, Target *,
+                         Status &) override {
+    return nullptr;
+  }
+  void CalculateTrapHandlerSymbolNames() override {}
+  UserIDResolver &GetUserIDResolver() override {
+    return UserIDResolver::GetNoopResolver();
+  }
+
+  std::optional<ModuleSpec> FindModuleFiles(const ModuleSpec &spec,
+                                            const FileSpecList &,
+                                            StatisticsMap &) override {
+    ++find_module_files_calls;
+    if (!m_answer)
+      return {};
+    ModuleSpec found(spec);
+    found.GetFileSpec() = *m_answer;
+    return found;
+  }
+
+  std::optional<FileSpec> m_answer;
+  unsigned find_module_files_calls = 0;
+};
 
 class SymbolLocatorTest : public testing::Test {
 public:
@@ -198,4 +234,38 @@ TEST_F(SymbolLocatorTest, AnErrnoFromTheSymbolServerIsNotAPlainMiss) {
   llvm::Error error = result.takeError();
   EXPECT_FALSE(error.isA<SymbolLocator::NotFound>());
   llvm::consumeError(std::move(error));
+}
+
+TEST_F(SymbolLocatorTest, ThePlatformAnswersBeforeThePlugins) {
+  auto platform = std::make_shared<IndexedPlatform>();
+  platform->m_answer = m_binary;
+
+  SymbolLocator::Request request;
+  request.platform = platform;
+
+  llvm::Expected<SymbolLocator::Result> result =
+      SymbolLocator::Locate(request, FileSpecList());
+
+  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
+  EXPECT_EQ(1u, platform->find_module_files_calls);
+  EXPECT_EQ(m_binary, result->module_spec.GetFileSpec());
+  EXPECT_FALSE(g_calls.located_symbol_file);
+  EXPECT_FALSE(g_calls.located_object_file);
+  EXPECT_FALSE(g_calls.downloaded);
+}
+
+TEST_F(SymbolLocatorTest, ThePluginsRunWhenThePlatformHasNothingToSay) {
+  auto platform = std::make_shared<IndexedPlatform>();
+  platform->m_answer = std::nullopt;
+  g_object_file = m_binary;
+
+  SymbolLocator::Request request;
+  request.platform = platform;
+
+  llvm::Expected<SymbolLocator::Result> result =
+      SymbolLocator::Locate(request, FileSpecList());
+
+  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
+  EXPECT_EQ(1u, platform->find_module_files_calls);
+  EXPECT_TRUE(g_calls.located_object_file);
 }

--- a/lldb/unittests/Symbol/SymbolLocatorTest.cpp
+++ b/lldb/unittests/Symbol/SymbolLocatorTest.cpp
@@ -1,0 +1,201 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Symbol/SymbolLocator.h"
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Utility/FileSpecList.h"
+
+#include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+
+#include "gtest/gtest.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+namespace {
+
+/// Which steps of the search ran, so a test can tell where an answer came from.
+struct LocatorCalls {
+  bool located_symbol_file = false;
+  bool located_object_file = false;
+  bool downloaded = false;
+};
+
+LocatorCalls g_calls;
+
+/// What the object file locator claims to have found, if anything.
+std::optional<FileSpec> g_object_file;
+
+/// What the symbol file locator claims to have found, if anything.
+std::optional<FileSpec> g_symbol_file;
+
+/// When set, the symbol server fails the way a failure to launch it does, with
+/// an errno rather than a message.
+bool g_symbol_server_errno = false;
+
+std::optional<FileSpec> LocateExecutableSymbolFile(const ModuleSpec &,
+                                                   const FileSpecList &) {
+  g_calls.located_symbol_file = true;
+  return g_symbol_file;
+}
+
+std::optional<ModuleSpec> LocateExecutableObjectFile(const ModuleSpec &spec) {
+  g_calls.located_object_file = true;
+  if (!g_object_file)
+    return {};
+  ModuleSpec located(spec);
+  located.GetFileSpec() = *g_object_file;
+  return located;
+}
+
+bool DownloadObjectAndSymbolFile(ModuleSpec &, Status &error, bool force_lookup,
+                                 bool) {
+  g_calls.downloaded = true;
+  if (!force_lookup)
+    return false;
+  if (g_symbol_server_errno)
+    error = Status(std::make_error_code(std::errc::too_many_files_open));
+  else
+    error = Status::FromErrorString("the symbol server said no");
+  return false;
+}
+
+SymbolLocator *CreateSymbolLocator() { return nullptr; }
+
+class SymbolLocatorTest : public testing::Test {
+public:
+  SymbolLocatorTest()
+      : m_empty_buffer("", "<empty buffer>"),
+        m_fs(new llvm::vfs::InMemoryFileSystem()) {}
+
+  void SetUp() override {
+    // Locate reports a binary it cannot find as an error, so a test that wants
+    // a hit has to point the fake locator at a file that exists.
+    FileSystem::Initialize(m_fs);
+    HostInfo::Initialize();
+    m_fs->addFileNoOwn(m_binary.GetPath(), 0, m_empty_buffer);
+    m_fs->addFileNoOwn(m_symbols.GetPath(), 0, m_empty_buffer);
+
+    g_calls = LocatorCalls();
+    g_object_file = std::nullopt;
+    g_symbol_file = std::nullopt;
+    g_symbol_server_errno = false;
+    ASSERT_TRUE(PluginManager::RegisterPlugin(
+        "test", "test symbol locator", CreateSymbolLocator,
+        LocateExecutableObjectFile, LocateExecutableSymbolFile,
+        DownloadObjectAndSymbolFile));
+  }
+
+  void TearDown() override {
+    PluginManager::UnregisterPlugin(CreateSymbolLocator);
+    HostInfo::Terminate();
+    FileSystem::Terminate();
+  }
+
+  llvm::MemoryBufferRef m_empty_buffer;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> m_fs;
+
+  /// Files that exist, for the cases that want a hit.
+  FileSpec m_binary = FileSpec("/binary", FileSpec::Style::posix);
+  FileSpec m_symbols = FileSpec("/binary.dSYM", FileSpec::Style::posix);
+};
+
+} // namespace
+
+TEST_F(SymbolLocatorTest, MissRunsEveryStep) {
+  llvm::Expected<SymbolLocator::Result> result =
+      SymbolLocator::Locate(SymbolLocator::Request(), FileSpecList());
+
+  EXPECT_TRUE(g_calls.located_symbol_file);
+  EXPECT_TRUE(g_calls.located_object_file);
+  // Neither file was found, so the symbol server is the last resort.
+  EXPECT_TRUE(g_calls.downloaded);
+
+  // Nothing was found and no symbol server was asked, so there is nothing to
+  // say beyond the fact of the miss. The caller composes its own message.
+  ASSERT_FALSE(result);
+  llvm::Error error = result.takeError();
+  EXPECT_TRUE(error.isA<SymbolLocator::NotFound>());
+  llvm::consumeError(std::move(error));
+}
+
+TEST_F(SymbolLocatorTest, ReportsWhatThePluginsFound) {
+  g_object_file = m_binary;
+  g_symbol_file = m_symbols;
+
+  llvm::Expected<SymbolLocator::Result> result =
+      SymbolLocator::Locate(SymbolLocator::Request(), FileSpecList());
+
+  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
+  EXPECT_EQ(m_binary, result->module_spec.GetFileSpec());
+  EXPECT_EQ(m_symbols, result->module_spec.GetSymbolFileSpec());
+  // Both files were in hand, so there was nothing to ask a symbol server for.
+  EXPECT_FALSE(g_calls.downloaded);
+}
+
+TEST_F(SymbolLocatorTest, MissCarriesSymbolServerError) {
+  SymbolLocator::Request request;
+  request.external_lookup = true;
+
+  llvm::Expected<SymbolLocator::Result> result =
+      SymbolLocator::Locate(request, FileSpecList());
+
+  ASSERT_FALSE(result);
+  llvm::Error error = result.takeError();
+  EXPECT_FALSE(error.isA<SymbolLocator::NotFound>());
+  EXPECT_EQ("the symbol server said no", llvm::toString(std::move(error)));
+}
+
+TEST_F(SymbolLocatorTest, BinaryWithoutSymbolsIsASuccess) {
+  // A binary without symbols is still worth loading, and the caller still gets
+  // to tell the user why the symbols are missing.
+  g_object_file = m_binary;
+  SymbolLocator::Request request;
+  request.external_lookup = true;
+
+  llvm::Expected<SymbolLocator::Result> result =
+      SymbolLocator::Locate(request, FileSpecList());
+
+  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
+  EXPECT_EQ(m_binary, result->module_spec.GetFileSpec());
+  EXPECT_FALSE(result->module_spec.GetSymbolFileSpec());
+  ASSERT_TRUE(result->symbol_error);
+  EXPECT_EQ("the symbol server said no",
+            llvm::toString(std::move(*result->symbol_error)));
+}
+
+TEST_F(SymbolLocatorTest, SymbolFileWithoutBinaryIsAMiss) {
+  // Symbols with no binary to apply them to are of no use, so this is the hard
+  // failure and not a success carrying half an answer.
+  g_symbol_file = m_symbols;
+
+  llvm::Expected<SymbolLocator::Result> result =
+      SymbolLocator::Locate(SymbolLocator::Request(), FileSpecList());
+
+  EXPECT_THAT_EXPECTED(result, llvm::Failed());
+}
+
+TEST_F(SymbolLocatorTest, AnErrnoFromTheSymbolServerIsNotAPlainMiss) {
+  // A Status carrying an errno converts to an llvm::ECError, so an error code
+  // is not enough to tell a real failure from the miss sentinel. Failing to
+  // even launch a symbol server has to reach the user.
+  SymbolLocator::Request request;
+  request.external_lookup = true;
+  g_symbol_server_errno = true;
+
+  llvm::Expected<SymbolLocator::Result> result =
+      SymbolLocator::Locate(request, FileSpecList());
+
+  ASSERT_FALSE(result);
+  llvm::Error error = result.takeError();
+  EXPECT_FALSE(error.isA<SymbolLocator::NotFound>());
+  llvm::consumeError(std::move(error));
+}

--- a/llvm/include/llvm/DWARFLinker/AddressesMap.h
+++ b/llvm/include/llvm/DWARFLinker/AddressesMap.h
@@ -83,20 +83,45 @@ public:
   /// Erases all data.
   virtual void clear() = 0;
 
-  /// This is used for assembly files where labels may not have high_pc
-  /// but the debug map has range information from symbols.
-  struct AssemblyRange {
-    AssemblyRange(uint64_t LowPC, uint64_t HighPC)
+  /// The extent the linker gave a symbol, in source address space.
+  struct SymbolRange {
+    SymbolRange(uint64_t LowPC, uint64_t HighPC)
         : LowPC(LowPC), HighPC(HighPC) {}
     uint64_t LowPC;
     uint64_t HighPC;
   };
 
-  /// Returns the address range containing \p Addr if available.
-  /// \returns the range [LowPC, HighPC) containing Addr.
-  virtual std::optional<AssemblyRange>
-  getAssemblyRangeForAddress(uint64_t Addr) {
+  /// Returns the symbol range [LowPC, HighPC) containing \p Addr, if known.
+  virtual std::optional<SymbolRange> getSymbolRangeForAddress(uint64_t Addr) {
     return std::nullopt;
+  }
+
+  /// Returns the linked address of the first symbol placed at or after
+  /// \p LinkedAddr, if one is known.
+  virtual std::optional<uint64_t>
+  getNextLinkedSymbolStart(uint64_t LinkedAddr) {
+    return std::nullopt;
+  }
+
+  /// Constrains the source-space end of a code range, given its start \p LowPC,
+  /// its end \p HighPC as an address, and the \p Adjustment all of its
+  /// addresses shift by in the output.
+  ///
+  /// Neighbouring symbols shift by different amounts, so a range reaching past
+  /// the symbol holding its start can land inside the next symbol in the
+  /// output. Only that collision is repaired. Coverage that overlaps nothing is
+  /// left alone, and a symbol nested in the same extent is never a neighbour,
+  /// so it cannot shorten a range that legitimately spans it.
+  uint64_t constrainCodeRangeHighPC(uint64_t LowPC, uint64_t HighPC,
+                                    int64_t Adjustment) {
+    std::optional<SymbolRange> Symbol = getSymbolRangeForAddress(LowPC);
+    if (!Symbol)
+      return HighPC;
+    std::optional<uint64_t> NextStart =
+        getNextLinkedSymbolStart(Symbol->HighPC + Adjustment);
+    if (!NextStart)
+      return HighPC;
+    return std::min(HighPC, *NextStart - Adjustment);
   }
 
   /// This function checks whether variable has DWARF expression containing

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -672,7 +672,7 @@ unsigned DWARFLinker::shouldKeepSubprogramDIE(
     // function ranges when available, falling back to labels otherwise.
     if (Unit.getLanguage() == dwarf::DW_LANG_Mips_Assembler ||
         Unit.getLanguage() == dwarf::DW_LANG_Assembly) {
-      if (auto Range = RelocMgr.getAssemblyRangeForAddress(*LowPc)) {
+      if (auto Range = RelocMgr.getSymbolRangeForAddress(*LowPc)) {
         Unit.addFunctionRange(Range->LowPC, Range->HighPC, MyInfo.AddrAdjust);
       } else {
         Unit.addLabelLowPc(*LowPc, MyInfo.AddrAdjust);
@@ -698,7 +698,10 @@ unsigned DWARFLinker::shouldKeepSubprogramDIE(
   }
 
   // Replace the debug map range with a more accurate one.
-  Unit.addFunctionRange(*LowPc, *HighPc, MyInfo.AddrAdjust);
+  Unit.addFunctionRange(
+      *LowPc,
+      RelocMgr.constrainCodeRangeHighPC(*LowPc, *HighPc, MyInfo.AddrAdjust),
+      MyInfo.AddrAdjust);
   return Flags;
 }
 
@@ -1471,6 +1474,14 @@ unsigned DWARFLinker::DIECloner::cloneAddressAttribute(
     else
       return 0;
   } else {
+    // A nested scope inherits the range its parent function overran, so every
+    // range is constrained, not just the subprogram's own.
+    if (AttrSpec.Attr == dwarf::DW_AT_high_pc) {
+      if (std::optional<uint64_t> LowPC =
+              dwarf::toAddress(InputDIE.find(dwarf::DW_AT_low_pc)))
+        Addr = ObjFile.Addresses->constrainCodeRangeHighPC(*LowPC, *Addr,
+                                                           Info.PCOffset);
+    }
     *Addr += Info.PCOffset;
   }
 
@@ -1627,6 +1638,14 @@ unsigned DWARFLinker::DIECloner::cloneScalarAttribute(
         "Unsupported scalar attribute form. Dropping attribute.", File,
         &InputDIE);
     return 0;
+  }
+
+  if (AttrSpec.Attr == dwarf::DW_AT_high_pc) {
+    if (std::optional<uint64_t> LowPC =
+            dwarf::toAddress(InputDIE.find(dwarf::DW_AT_low_pc)))
+      Value = File.Addresses->constrainCodeRangeHighPC(*LowPC, *LowPC + Value,
+                                                       Info.PCOffset) -
+              *LowPC;
   }
 
   DIE::value_iterator Patch =

--- a/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
@@ -525,6 +525,16 @@ size_t DIEAttributeCloner::cloneScalarAttr(
       !OutUnit.isCompileUnit())
     return 0;
 
+  // A nested scope inherits the range its parent function overran, so every
+  // range is constrained, not just the subprogram's own.
+  if (AttrSpec.Attr == dwarf::DW_AT_high_pc && FuncAddressAdjustment) {
+    if (std::optional<uint64_t> LowPC =
+            dwarf::toAddress(InUnit.find(InputDieEntry, dwarf::DW_AT_low_pc)))
+      Value = InUnit.getContaingFile().Addresses->constrainCodeRangeHighPC(
+                  *LowPC, *LowPC + Value, *FuncAddressAdjustment) -
+              *LowPC;
+  }
+
   auto Result =
       Generator.addScalarAttribute(AttrSpec.Attr, ResultingForm, Value);
   // Record DW_AT_LLVM_stmt_sequence so the attribute value can be
@@ -656,6 +666,12 @@ size_t DIEAttributeCloner::cloneAddressAttr(
     else
       return 0;
   } else {
+    if (AttrSpec.Attr == dwarf::DW_AT_high_pc && FuncAddressAdjustment) {
+      if (std::optional<uint64_t> LowPC =
+              dwarf::toAddress(InUnit.find(InputDieEntry, dwarf::DW_AT_low_pc)))
+        Addr = InUnit.getContaingFile().Addresses->constrainCodeRangeHighPC(
+            *LowPC, *Addr, *FuncAddressAdjustment);
+    }
     if (VarAddressAdjustment)
       *Addr += *VarAddressAdjustment;
     else if (FuncAddressAdjustment)

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -952,14 +952,15 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
 
       // For assembly-language CUs there are typically no DW_TAG_subprogram
       // DIEs, so labels are the only addresses we see. Fall back to the
-      // assembly-range lookup to recover a function range for the line-table
+      // symbol-range lookup to recover a function range for the line-table
       // filter; otherwise the output line table would be empty.
       uint16_t Language = dwarf::toUnsigned(
           Entry.CU->getOrigUnit().getUnitDIE().find(dwarf::DW_AT_language), 0);
       if (Language == dwarf::DW_LANG_Mips_Assembler ||
           Language == dwarf::DW_LANG_Assembly) {
-        if (auto Range = Entry.CU->getContaingFile()
-                             .Addresses->getAssemblyRangeForAddress(*LowPc))
+        if (auto Range =
+                Entry.CU->getContaingFile().Addresses->getSymbolRangeForAddress(
+                    *LowPc))
           Entry.CU->addFunctionRange(Range->LowPC, Range->HighPC,
                                      *RelocAdjustment);
       }
@@ -974,6 +975,10 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
   if (!Info.getTrackLiveness() || DIE.getTag() == dwarf::DW_TAG_label)
     return true;
 
-  Entry.CU->addFunctionRange(*LowPc, *HighPc, *RelocAdjustment);
+  Entry.CU->addFunctionRange(
+      *LowPc,
+      Entry.CU->getContaingFile().Addresses->constrainCodeRangeHighPC(
+          *LowPc, *HighPc, *RelocAdjustment),
+      *RelocAdjustment);
   return true;
 }

--- a/llvm/test/tools/dsymutil/Inputs/subprogram-high-pc-past-symbol-dwarf2.s
+++ b/llvm/test/tools/dsymutil/Inputs/subprogram-high-pc-past-symbol-dwarf2.s
@@ -1,0 +1,72 @@
+; The DWARF 2 form of subprogram-high-pc-past-symbol.s, where DW_AT_high_pc is
+; an address rather than a length.
+
+	.text
+	.globl	_a
+	.p2align 2
+_a:
+	ret
+_filler:
+	nop
+	.globl	_b
+	.p2align 2
+_b:
+	ret
+
+	.section __DWARF,__debug_abbrev,regular,debug
+	.byte	1                       ; abbrev 1: DW_TAG_compile_unit
+	.byte	0x11
+	.byte	1                       ; DW_CHILDREN_yes
+	.byte	0x25, 0x08              ; DW_AT_producer,  DW_FORM_string
+	.byte	0x13, 0x0b              ; DW_AT_language,  DW_FORM_data1
+	.byte	0x03, 0x08              ; DW_AT_name,      DW_FORM_string
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x01              ; DW_AT_high_pc,   DW_FORM_addr
+	.byte	0, 0
+	.byte	2                       ; abbrev 2: DW_TAG_subprogram
+	.byte	0x2e
+	.byte	1                       ; DW_CHILDREN_yes
+	.byte	0x03, 0x08              ; DW_AT_name,      DW_FORM_string
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x01              ; DW_AT_high_pc,   DW_FORM_addr
+	.byte	0x3f, 0x0c              ; DW_AT_external,  DW_FORM_flag
+	.byte	0, 0
+	.byte	3                       ; abbrev 3: DW_TAG_lexical_block
+	.byte	0x0b
+	.byte	0                       ; DW_CHILDREN_no
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x01              ; DW_AT_high_pc,   DW_FORM_addr
+	.byte	0, 0
+	.byte	0
+
+	.section __DWARF,__debug_info,regular,debug
+Lcu_begin:
+	.long	Lcu_end-Lcu_version
+Lcu_version:
+	.short	2
+	.long	0
+	.byte	8
+	.byte	1                       ; DW_TAG_compile_unit
+	.asciz	"hand-written"
+	.byte	0x0c                    ; DW_LANG_C99
+	.asciz	"t.c"
+	.quad	_a
+	.quad	0xc                     ; _a, _filler and _b together
+	.byte	2                       ; DW_TAG_subprogram "a"
+	.asciz	"a"
+	.quad	_a
+	.quad	0x8                     ; four bytes past the end of _a
+	.byte	1
+	.byte	3                       ; DW_TAG_lexical_block in "a"
+	.quad	_a
+	.quad	0x8                     ; reaches as far as its parent
+	.byte	0                       ; end of "a"'s children
+	.byte	2                       ; DW_TAG_subprogram "b"
+	.asciz	"b"
+	.quad	_b
+	.quad	0xc
+	.byte	1
+	.byte	0                       ; end of "b"'s children
+	.byte	0                       ; end of the compile unit's children
+Lcu_end:
+	.subsections_via_symbols

--- a/llvm/test/tools/dsymutil/Inputs/subprogram-high-pc-past-symbol.s
+++ b/llvm/test/tools/dsymutil/Inputs/subprogram-high-pc-past-symbol.s
@@ -1,0 +1,76 @@
+; _filler is an unreferenced atom between the two functions, so the linker drops
+; it and places _b four bytes after _a. DW_AT_high_pc for _a reaches all the way
+; to _b, past the code the linker keeps for it, and the lexical block inside _a
+; ends with its parent.
+;
+; The DWARF is hand written because a producer normally agrees with the linker.
+
+	.text
+	.globl	_a
+	.p2align 2
+_a:
+	ret
+_filler:
+	nop
+	.globl	_b
+	.p2align 2
+_b:
+	ret
+
+	.section __DWARF,__debug_abbrev,regular,debug
+	.byte	1                       ; abbrev 1: DW_TAG_compile_unit
+	.byte	0x11
+	.byte	1                       ; DW_CHILDREN_yes
+	.byte	0x25, 0x08              ; DW_AT_producer,  DW_FORM_string
+	.byte	0x13, 0x0b              ; DW_AT_language,  DW_FORM_data1
+	.byte	0x03, 0x08              ; DW_AT_name,      DW_FORM_string
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x06              ; DW_AT_high_pc,   DW_FORM_data4
+	.byte	0, 0
+	.byte	2                       ; abbrev 2: DW_TAG_subprogram
+	.byte	0x2e
+	.byte	1                       ; DW_CHILDREN_yes
+	.byte	0x03, 0x08              ; DW_AT_name,      DW_FORM_string
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x06              ; DW_AT_high_pc,   DW_FORM_data4
+	.byte	0x3f, 0x0c              ; DW_AT_external,  DW_FORM_flag
+	.byte	0, 0
+	.byte	3                       ; abbrev 3: DW_TAG_lexical_block
+	.byte	0x0b
+	.byte	0                       ; DW_CHILDREN_no
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x06              ; DW_AT_high_pc,   DW_FORM_data4
+	.byte	0, 0
+	.byte	0
+
+	.section __DWARF,__debug_info,regular,debug
+Lcu_begin:
+	.long	Lcu_end-Lcu_version
+Lcu_version:
+	.short	4
+	.long	0
+	.byte	8
+	.byte	1                       ; DW_TAG_compile_unit
+	.asciz	"hand-written"
+	.byte	0x0c                    ; DW_LANG_C99
+	.asciz	"t.c"
+	.quad	_a
+	.long	0xc                     ; _a, _filler and _b together
+	.byte	2                       ; DW_TAG_subprogram "a"
+	.asciz	"a"
+	.quad	_a
+	.long	0x8                     ; four bytes past the end of _a
+	.byte	1
+	.byte	3                       ; DW_TAG_lexical_block in "a"
+	.quad	_a
+	.long	0x8                     ; reaches as far as its parent
+	.byte	0                       ; end of "a"'s children
+	.byte	2                       ; DW_TAG_subprogram "b"
+	.asciz	"b"
+	.quad	_b
+	.long	0x4
+	.byte	1
+	.byte	0                       ; end of "b"'s children
+	.byte	0                       ; end of the compile unit's children
+Lcu_end:
+	.subsections_via_symbols

--- a/llvm/test/tools/dsymutil/subprogram-high-pc-past-symbol.test
+++ b/llvm/test/tools/dsymutil/subprogram-high-pc-past-symbol.test
@@ -1,0 +1,57 @@
+# REQUIRES: aarch64-registered-target
+
+# A DW_AT_high_pc reaching past the code the linker kept for a function must be
+# cut short at the function the linker placed next, otherwise the two overlap in
+# the output and verification fails with "DIEs have overlapping address ranges".
+# A scope nested in the function inherits the overrun, so it has to be cut short
+# with its parent to stay inside it.
+
+# RUN: llvm-mc -triple arm64-apple-darwin -filetype=obj \
+# RUN:   %p/Inputs/subprogram-high-pc-past-symbol.s -o %t.o
+# RUN: echo '---' > %t.map
+# RUN: echo "triple: 'arm64-apple-darwin'" >> %t.map
+# RUN: echo 'objects:' >> %t.map
+# RUN: echo " - filename: '%/t.o'" >> %t.map
+# RUN: echo '   symbols:' >> %t.map
+# RUN: echo '     - { sym: _a, objAddr: 0x0, binAddr: 0x1000, size: 0x4 }' >> %t.map
+# RUN: echo '     - { sym: _b, objAddr: 0x8, binAddr: 0x1004, size: 0x4 }' >> %t.map
+
+# _inside starts within the code the linker kept for _a, so it is nested rather
+# than adjacent and must not cut _a short.
+
+# RUN: echo '     - { sym: _inside, binAddr: 0x1002, size: 0x2 }' >> %t.map
+# RUN: echo '...' >> %t.map
+
+# RUN: dsymutil --linker classic -y %t.map -f -o %t-classic.out
+# RUN: llvm-dwarfdump -a %t-classic.out | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t-classic.out | FileCheck %s --check-prefix=VERIFY
+
+# RUN: dsymutil --linker parallel -y %t.map -f -o %t-parallel.out
+# RUN: llvm-dwarfdump -a %t-parallel.out | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t-parallel.out | FileCheck %s --check-prefix=VERIFY
+
+# Same again with DW_AT_high_pc as an address rather than a length.
+
+# RUN: llvm-mc -triple arm64-apple-darwin -filetype=obj \
+# RUN:   %p/Inputs/subprogram-high-pc-past-symbol-dwarf2.s -o %t.o
+# RUN: dsymutil --linker classic -y %t.map -f -o %t-classic2.out
+# RUN: llvm-dwarfdump -a %t-classic2.out | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t-classic2.out | FileCheck %s --check-prefix=VERIFY
+
+# RUN: dsymutil --linker parallel -y %t.map -f -o %t-parallel2.out
+# RUN: llvm-dwarfdump -a %t-parallel2.out | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t-parallel2.out | FileCheck %s --check-prefix=VERIFY
+
+# CHECK:      DW_TAG_subprogram
+# CHECK:        DW_AT_name{{.*}}"a"
+# CHECK-NEXT:   DW_AT_low_pc{{.*}}(0x0000000000001000)
+# CHECK-NEXT:   DW_AT_high_pc{{.*}}(0x0000000000001004)
+# CHECK:        DW_TAG_lexical_block
+# CHECK-NEXT:     DW_AT_low_pc{{.*}}(0x0000000000001000)
+# CHECK-NEXT:     DW_AT_high_pc{{.*}}(0x0000000000001004)
+# CHECK:      DW_TAG_subprogram
+# CHECK:        DW_AT_name{{.*}}"b"
+# CHECK-NEXT:   DW_AT_low_pc{{.*}}(0x0000000000001004)
+# CHECK-NEXT:   DW_AT_high_pc{{.*}}(0x0000000000001008)
+
+# VERIFY: No errors.

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -126,6 +126,9 @@ private:
     /// Address ranges for symbols with sizes (used for assembly file support).
     RangesTy AddressRanges;
 
+    /// Sorted linked start addresses of the symbols with a known size.
+    std::vector<uint64_t> LinkedSymbolStarts;
+
     /// Returns list of valid relocations from \p Relocs,
     /// between \p StartOffset and \p NextOffset.
     ///
@@ -170,15 +173,22 @@ private:
       } else {
         findValidRelocsInDebugSections(Obj, DMO);
       }
-      // Populate address ranges from debug map symbols that have sizes.
-      // This is used for assembly files where labels may not have high_pc.
+      // A sizeless symbol has no known extent, so it can bound neither a range
+      // of its own nor a neighbour's. The ranges stand in for the high_pc that
+      // assembly files lack.
       for (const auto &Entry : DMO.symbols()) {
         const auto &Mapping = Entry.getValue();
-        if (Mapping.Size && Mapping.ObjectAddress)
+        if (!Mapping.Size)
+          continue;
+        LinkedSymbolStarts.push_back(Mapping.BinaryAddress);
+        if (Mapping.ObjectAddress)
           AddressRanges.insert(
               {*Mapping.ObjectAddress, *Mapping.ObjectAddress + Mapping.Size},
               int64_t(Mapping.BinaryAddress) - *Mapping.ObjectAddress);
       }
+      llvm::sort(LinkedSymbolStarts);
+      LinkedSymbolStarts.erase(llvm::unique(LinkedSymbolStarts),
+                               LinkedSymbolStarts.end());
     }
     ~AddressManager() override { clear(); }
 
@@ -239,13 +249,22 @@ private:
       ValidDebugInfoRelocs.clear();
       ValidDebugAddrRelocs.clear();
       AddressRanges.clear();
+      LinkedSymbolStarts.clear();
     }
 
-    std::optional<AssemblyRange>
-    getAssemblyRangeForAddress(uint64_t Addr) override {
+    std::optional<SymbolRange>
+    getSymbolRangeForAddress(uint64_t Addr) override {
       if (auto Range = AddressRanges.getRangeThatContains(Addr))
-        return AssemblyRange(Range->Range.start(), Range->Range.end());
+        return SymbolRange(Range->Range.start(), Range->Range.end());
       return std::nullopt;
+    }
+
+    std::optional<uint64_t>
+    getNextLinkedSymbolStart(uint64_t LinkedAddr) override {
+      auto It = llvm::lower_bound(LinkedSymbolStarts, LinkedAddr);
+      if (It == LinkedSymbolStarts.end())
+        return std::nullopt;
+      return *It;
     }
   };
 


### PR DESCRIPTION
- [lldb][NFC] Remove various Stream::Printf calls with constants (#210294)
- [lldb] Split DynamicLoader binary loading into locate and load (NFCI) (#214372)
- [lldb] Address post-commit feedback on DynamicLoader binary loading (NFC) (#214635)
- [lldb] Let callers of GetSharedModule skip symbol locating (NFC) (#214829)
- [lldb] Report a corefile whose only image is a platform binary (#214634)
- [lldb] Add a unified entry point for locating a binary and its symbols (#215391)
- [lldb] Consult the platform before the symbol locator plugins (NFC) (#215392)
- [lldb] Search for a corefile's images before loading any of them (#215393)