### PR TITLE
[Cherry-pick into stable/23.x] [GlobalISel] Fix stale debug location in tryCombineTrunc

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
@@ -262,7 +262,7 @@ public:
     using namespace llvm::MIPatternMatch;
     assert(MI.getOpcode() == TargetOpcode::G_TRUNC);
 
-    Builder.setInstr(MI);
+    Builder.setInstrAndDebugLoc(MI);
     Register DstReg = MI.getOperand(0).getReg();
     const LLT DstTy = MRI.getType(DstReg);
     Register SrcReg = lookThroughCopyInstrs(MI.getOperand(1).getReg());

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
@@ -384,7 +384,7 @@ public:
 
     if (MachineInstr *DefMI = getOpcodeDef(TargetOpcode::G_IMPLICIT_DEF,
                                            MI.getOperand(1).getReg(), MRI)) {
-      Builder.setInstr(MI);
+      Builder.setInstrAndDebugLoc(MI);
       Register DstReg = MI.getOperand(0).getReg();
       LLT DstTy = MRI.getType(DstReg);
 
@@ -460,7 +460,7 @@ public:
                     .Action == LegalizeActions::MoreElements)
           return false;
 
-        Builder.setInstr(MI);
+        Builder.setInstrAndDebugLoc(MI);
         auto NewUnmerge = Builder.buildUnmerge(UnmergeTy, CastSrcReg);
 
         for (unsigned I = 0; I != NumDefs; ++I) {
@@ -501,7 +501,7 @@ public:
         }
 
         // Build new unmerge
-        Builder.setInstr(MI);
+        Builder.setInstrAndDebugLoc(MI);
         Builder.buildUnmerge(DstRegs, CastSrcReg);
         UpdatedDefs.append(DstRegs.begin(), DstRegs.begin() + NewNumDefs);
         markInstAndDefDead(MI, CastMI, DeadInsts);
@@ -1165,7 +1165,7 @@ public:
       if (NumDefs % NumMergeRegs != 0)
         return false;
 
-      Builder.setInstr(MI);
+      Builder.setInstrAndDebugLoc(MI);
       // Transform to UNMERGEs, for example
       //   %1 = G_MERGE_VALUES %4, %5
       //   %9, %10, %11, %12 = G_UNMERGE_VALUES %1
@@ -1215,7 +1215,7 @@ public:
       if (ConvertOp != 0 || NumMergeRegs % NumDefs != 0)
         return false;
 
-      Builder.setInstr(MI);
+      Builder.setInstrAndDebugLoc(MI);
       // Transform to MERGEs
       //   %6 = G_MERGE_VALUES %17, %18, %19, %20
       //   %7, %8 = G_UNMERGE_VALUES %6
@@ -1248,7 +1248,7 @@ public:
       }
 
       if (ConvertOp) {
-        Builder.setInstr(MI);
+        Builder.setInstrAndDebugLoc(MI);
 
         for (unsigned Idx = 0; Idx < NumDefs; ++Idx) {
           Register DefReg = MI.getOperand(Idx).getReg();
@@ -1268,7 +1268,7 @@ public:
              "Bitcast and the other kinds of conversions should "
              "have happened earlier");
 
-      Builder.setInstr(MI);
+      Builder.setInstrAndDebugLoc(MI);
       for (unsigned Idx = 0; Idx < NumDefs; ++Idx) {
         Register DstReg = MI.getOperand(Idx).getReg();
         Register SrcReg = MergeI->getOperand(Idx + 1).getReg();
@@ -1329,7 +1329,7 @@ public:
       return false;
 
     // TODO: We could modify MI in place in most cases.
-    Builder.setInstr(MI);
+    Builder.setInstrAndDebugLoc(MI);
     Builder.buildExtract(DstReg, MergeI->getOperand(MergeSrcIdx + 1).getReg(),
                          Offset - MergeSrcIdx * MergeSrcSize);
     UpdatedDefs.push_back(DstReg);

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-trunc-debugloc.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-trunc-debugloc.mir
@@ -1,0 +1,52 @@
+# RUN: llc -verify-machineinstrs -mtriple arm64-apple-macosx -run-pass=legalizer %s -o - | FileCheck %s
+
+# Folding G_TRUNC results in G_CONSTANT i8 0, which is already in the CSE map,
+# so the combiner emits a COPY.
+#
+# CHECK-LABEL: name: f
+# CHECK: [[ZERO:%[0-9]+]]:_(i8) = G_CONSTANT i8 0
+#
+# Test that the COPY does not inherit the location left in the shared builder by
+# the G_ANYEXT folded just before it.
+#
+# This should have no location:
+# CHECK: [[BYTE:%[0-9]+]]:_(i8) = COPY [[ZERO]](i8){{$}}
+# CHECK: G_STORE [[BYTE]](i8), %{{[0-9]+}}(p0)
+#
+# The instruction that does own a location keeps it.
+# CHECK: G_STORE %{{[0-9]+}}(i32), %{{[0-9]+}}(p0), debug-location
+
+--- |
+  define void @f() !dbg !4 {
+  entry:
+    ret void
+  }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!2}
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, emissionKind: FullDebug)
+  !1 = !DIFile(filename: "t.c", directory: "/")
+  !2 = !{i32 2, !"Debug Info Version", i32 3}
+  !4 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 13, type: !6, scopeLine: 13, spFlags: DISPFlagDefinition, unit: !0)
+  !6 = !DISubroutineType(types: !7)
+  !7 = !{}
+  !8 = !DILocation(line: 20, column: 11, scope: !4)
+
+...
+---
+name:            f
+body:             |
+  bb.1.entry:
+    %0:_(p0) = G_IMPLICIT_DEF
+    %1:_(i8) = G_CONSTANT i8 0
+    G_STORE %1(i8), %0(p0) :: (store (i8))
+    %2:_(i64) = G_CONSTANT i64 0
+    %3:_(i8) = G_TRUNC %2(i64)
+    G_STORE %3(i8), %0(p0) :: (store (i8))
+    %4:_(i1) = G_CONSTANT i1 false, debug-location !8
+    %5:_(i32) = G_ANYEXT %4(i1), debug-location !8
+    G_STORE %5(i32), %0(p0), debug-location !8 :: (store (i32))
+    RET_ReallyLR
+
+...


### PR DESCRIPTION
```
commit 131a64624f315f3c00fef4ceeaa28baf92d11c82
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Aug 14 14:17:37 2026 -0700

    [GlobalISel] Fix stale debug location in tryCombineTrunc
    
    LegalizationArtifactCombiner shares one MachineIRBuilder across all
    combines, and setInstr() only moves the insert point: it leaves the
    builder's DebugLoc pointing at whatever instruction was combined
    previously. Instructions built for an artifact that carries no location
    of its own therefore inherit an unrelated statement's location.
    
    rdar://184762794
    
    Assisted-by: claude

commit 11a4524db925b7b9d3d655bf5491db0c1e31d8df
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Aug 14 15:05:05 2026 -0700

    [GlobalISel] Use setInstrAndDebugLoc in artifact combines (NFCI)
    
    The remaining setInstr() call sites in LegalizationArtifactCombiner only
    move the insert point, leaving whatever DebugLoc the previous combine
    left in the shared builder. Each replaces MI in place, so MI's location
    is the one to build with.
    
    No test changes: instrumenting these eight sites over llvm/test with
    X86, ARM, AArch64 and AMDGPU enabled shows the builder's location
    already matches MI's on all 67504 invocations, so the two calls are
    equivalent here for the in-tree tests. This guards against that
    ceasing to hold when combine ordering changes.
    
    Assisted-by: claude
```
