### PR TITLE
[Cherry-pick into swift/release/6.4.x] [lldb] Isolate cas-gmodule.test from the ambient CAS configuration

### DIFF
--- a/lldb/test/Shell/SymbolFile/cas-gmodule.test
+++ b/lldb/test/Shell/SymbolFile/cas-gmodule.test
@@ -4,7 +4,11 @@
 
 # RUN: %python %S/../../../scripts/clang-explicit-module-build.py -cas-path %t/cas -- %clang_host -c -g -o %t/test.o %t/tu.c -fmodules -gmodules -fmodules-cache-path=%t/module-cache
 # RUN: %clang_host %t/test.o -o %t/main
-# RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s --check-prefix=FAIL
+# The search for a .cas-config walks up the directory tree, so a
+# caching-enabled build directory above %t would otherwise hand this run a
+# CAS. An empty CASPath terminates that search without configuring a CAS.
+# RUN: cp %t/empty-cas-config.template %t/.cas-config
+# RUN: cd %t && %lldb main -s lldb.script 2>&1 | FileCheck %s --check-prefix=FAIL
 # RUN: sed "s|DIR|%/t|g" %t/cas-config.template > %t/.cas-config
 # RUN: cd %t && %lldb main -s lldb.script 2>&1 | FileCheck %s
 
@@ -56,6 +60,11 @@ int main(void) {
   _bottom.top.x = 1;
 
   return 0; // BREAK HERE
+}
+
+//--- empty-cas-config.template
+{
+  "CASPath": ""
 }
 
 //--- cas-config.template


### PR DESCRIPTION
```
commit dc8d6bd8f92b1972609a48271899239be7cdb52e
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Aug 14 16:51:20 2026 -0700

    [lldb] Isolate cas-gmodule.test from the ambient CAS configuration
    
    The .cas-config search walks up the directory tree, so when LLDB is
    built with compilation caching enabled the test's output directory
    inherits the build directory's CAS. Prevent the test from finding an
    unrelated config file by injecting an empty one.
    
    Also run the step from %t. The script's second `target create main` uses
    a relative path, which otherwise resolves against $PATH rather than the
    test directory.
    
    Assisted-by: Claude
    (cherry picked from commit ae135c8610410701699693f844ee0879a75b6cc3)
```
