### PR TITLE
[cherry-pick stable/23.x][lldb][test] Fix tests sharing dict between test variants

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -3038,7 +3038,7 @@ public:
   CommandObjectLanguageSwiftTaskInfo(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "info",
                             "Print info about the Task being run on the "
-                            "current thread or the Task at the given address."
+                            "current thread or the Task at the given address.",
                             "language swift task info [<address>]") {
     AddSimpleArgumentList(eArgTypeAddress, eArgRepeatOptional);
   }

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -62,7 +62,9 @@ class TestCase(lldbtest.TestBase):
                 breakpoints.add(bp.GetID())
         return breakpoints
 
-    unwind_fail_range_cache = dict()
+    def setUp(self):
+        lldbtest.TestBase.setUp(self)
+        self.unwind_fail_range_cache = {}
 
     # There are challenges when unwinding Q funclets ("await resume"): LLDB cannot
     # detect the transition point where x22 stops containing the indirect context,
@@ -74,11 +76,11 @@ class TestCase(lldbtest.TestBase):
     # includes such instructions, so the test may skip checks while stopped in them.
     def compute_unwind_fail_range(self, function, target):
         name = function.GetName()
-        if name in TestCase.unwind_fail_range_cache:
-            return TestCase.unwind_fail_range_cache[name]
+        if name in self.unwind_fail_range_cache:
+            return self.unwind_fail_range_cache[name]
 
         if "await resume" not in function.GetName():
-            TestCase.unwind_fail_range_cache[name] = range(0)
+            self.unwind_fail_range_cache[name] = range(0)
             return range(0)
 
         first_pc_after_prologue = function.GetStartAddress()
@@ -120,7 +122,7 @@ class TestCase(lldbtest.TestBase):
             first_bad_instr.GetAddress().GetFileAddress(),
             first_good_instr.GetAddress().GetFileAddress(),
         )
-        TestCase.unwind_fail_range_cache[name] = fail_range
+        self.unwind_fail_range_cache[name] = fail_range
         return fail_range
 
     def should_skip_Q_funclet(self, thread):
@@ -163,7 +165,7 @@ class TestCase(lldbtest.TestBase):
                 return thread, bpid
         return None, None
 
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_recursive_q_funclets/TestSwiftAsyncUnwindRecursiveQFunclets.py
@@ -8,7 +8,6 @@ class TestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    unwind_fail_range_cache = dict()
 
     @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
     @swiftTest


### PR DESCRIPTION
TestSwiftAsyncUnwindAllInstructions and
TestSwiftAsyncUnwindRecursiveQFunclets both set an ivar dict that was
shared between test variants. This happened to work without embedded
swift because all variants shared the same mapping.

Assisted-by: Claude

rdar://184858822

(cherry picked from commit dfb3286aa423fdf551fa66b806061ff9337c8e70)
