### PR TITLE
[DWARFLinker] Constrain a function's high_pc to its own symbol (#216432)

### DIFF
--- a/llvm/include/llvm/DWARFLinker/AddressesMap.h
+++ b/llvm/include/llvm/DWARFLinker/AddressesMap.h
@@ -83,20 +83,50 @@ public:
   /// Erases all data.
   virtual void clear() = 0;
 
-  /// This is used for assembly files where labels may not have high_pc
-  /// but the debug map has range information from symbols.
-  struct AssemblyRange {
-    AssemblyRange(uint64_t LowPC, uint64_t HighPC)
+  /// The extent the linker gave a symbol, in source address space.
+  struct SymbolRange {
+    SymbolRange(uint64_t LowPC, uint64_t HighPC)
         : LowPC(LowPC), HighPC(HighPC) {}
     uint64_t LowPC;
     uint64_t HighPC;
   };
 
-  /// Returns the address range containing \p Addr if available.
-  /// \returns the range [LowPC, HighPC) containing Addr.
-  virtual std::optional<AssemblyRange>
-  getAssemblyRangeForAddress(uint64_t Addr) {
+  /// Returns the symbol range [LowPC, HighPC) containing \p Addr, if known.
+  virtual std::optional<SymbolRange> getSymbolRangeForAddress(uint64_t Addr) {
     return std::nullopt;
+  }
+
+  /// Returns the linked address of the first symbol placed at or after
+  /// \p LinkedAddr, if one is known.
+  virtual std::optional<uint64_t>
+  getNextLinkedSymbolStart(uint64_t LinkedAddr) {
+    return std::nullopt;
+  }
+
+  /// Constrains the end of the code range starting at \p LowPC, whose addresses
+  /// shift by \p Adjustment in the output. \p HighPC is an address, not a
+  /// length.
+  ///
+  /// The linker places symbols independently, so a range overrunning the symbol
+  /// it starts in can cover a different one once linked. Only that overlap is
+  /// repaired.
+  uint64_t constrainCodeRangeHighPC(uint64_t LowPC, uint64_t HighPC,
+                                    int64_t Adjustment) {
+    std::optional<SymbolRange> Symbol = getSymbolRangeForAddress(LowPC);
+    if (!Symbol)
+      return HighPC;
+    assert(Symbol->LowPC <= LowPC && LowPC < Symbol->HighPC &&
+           "Symbol range must contain the address it was looked up for");
+    uint64_t LinkedSymbolHighPC = Symbol->HighPC + Adjustment;
+    assert(LinkedSymbolHighPC > Symbol->LowPC + Adjustment &&
+           "Adjusting a symbol range must preserve its order");
+    std::optional<uint64_t> NextStart =
+        getNextLinkedSymbolStart(LinkedSymbolHighPC);
+    if (!NextStart)
+      return HighPC;
+    assert(*NextStart >= LinkedSymbolHighPC &&
+           "A range must never be cut short of its own symbol");
+    return std::min(HighPC, *NextStart - Adjustment);
   }
 
   /// This function checks whether variable has DWARF expression containing

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -672,7 +672,7 @@ unsigned DWARFLinker::shouldKeepSubprogramDIE(
     // function ranges when available, falling back to labels otherwise.
     if (Unit.getLanguage() == dwarf::DW_LANG_Mips_Assembler ||
         Unit.getLanguage() == dwarf::DW_LANG_Assembly) {
-      if (auto Range = RelocMgr.getAssemblyRangeForAddress(*LowPc)) {
+      if (auto Range = RelocMgr.getSymbolRangeForAddress(*LowPc)) {
         Unit.addFunctionRange(Range->LowPC, Range->HighPC, MyInfo.AddrAdjust);
       } else {
         Unit.addLabelLowPc(*LowPc, MyInfo.AddrAdjust);
@@ -698,7 +698,10 @@ unsigned DWARFLinker::shouldKeepSubprogramDIE(
   }
 
   // Replace the debug map range with a more accurate one.
-  Unit.addFunctionRange(*LowPc, *HighPc, MyInfo.AddrAdjust);
+  Unit.addFunctionRange(
+      *LowPc,
+      RelocMgr.constrainCodeRangeHighPC(*LowPc, *HighPc, MyInfo.AddrAdjust),
+      MyInfo.AddrAdjust);
   return Flags;
 }
 
@@ -1423,6 +1426,25 @@ unsigned DWARFLinker::DIECloner::cloneBlockAttribute(
   return Die.addValue(DIEAlloc, Value)->sizeOf(OrigUnit.getFormParams());
 }
 
+/// Returns \p InputDIE's DW_AT_high_pc value \p HighPC, constrained so the code
+/// range it ends stays clear of the symbol the linker places next. \p IsLength
+/// tells whether high_pc is encoded as a length rather than an address, and
+/// \p PCOffset is the amount the range shifts by in the output.
+///
+/// A scope nested in a function inherits the overrun of the function, so it is
+/// constrained as well.
+static uint64_t constrainHighPC(const DWARFDie &InputDIE, uint64_t HighPC,
+                                bool IsLength, int64_t PCOffset,
+                                AddressesMap &Addresses) {
+  std::optional<uint64_t> LowPC =
+      dwarf::toAddress(InputDIE.find(dwarf::DW_AT_low_pc));
+  if (!LowPC)
+    return HighPC;
+  uint64_t Constrained = Addresses.constrainCodeRangeHighPC(
+      *LowPC, IsLength ? *LowPC + HighPC : HighPC, PCOffset);
+  return IsLength ? Constrained - *LowPC : Constrained;
+}
+
 unsigned DWARFLinker::DIECloner::cloneAddressAttribute(
     DIE &Die, const DWARFDie &InputDIE, AttributeSpec AttrSpec,
     unsigned AttrSize, const DWARFFormValue &Val, const CompileUnit &Unit,
@@ -1471,6 +1493,9 @@ unsigned DWARFLinker::DIECloner::cloneAddressAttribute(
     else
       return 0;
   } else {
+    if (AttrSpec.Attr == dwarf::DW_AT_high_pc)
+      Addr = constrainHighPC(InputDIE, *Addr, /*IsLength=*/false, Info.PCOffset,
+                             *ObjFile.Addresses);
     *Addr += Info.PCOffset;
   }
 
@@ -1628,6 +1653,13 @@ unsigned DWARFLinker::DIECloner::cloneScalarAttribute(
         &InputDIE);
     return 0;
   }
+
+  // A compile unit's high_pc comes from the unit's own linked range and spans
+  // every symbol in it.
+  if (AttrSpec.Attr == dwarf::DW_AT_high_pc &&
+      Die.getTag() != dwarf::DW_TAG_compile_unit)
+    Value = constrainHighPC(InputDIE, Value, /*IsLength=*/true, Info.PCOffset,
+                            *File.Addresses);
 
   DIE::value_iterator Patch =
       Die.addValue(DIEAlloc, dwarf::Attribute(AttrSpec.Attr),

--- a/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
@@ -525,6 +525,12 @@ size_t DIEAttributeCloner::cloneScalarAttr(
       !OutUnit.isCompileUnit())
     return 0;
 
+  // A compile unit's high_pc comes from the unit's own linked range and spans
+  // every symbol in it.
+  if (AttrSpec.Attr == dwarf::DW_AT_high_pc &&
+      InputDieEntry->getTag() != dwarf::DW_TAG_compile_unit)
+    Value = constrainHighPC(Value, /*IsLength=*/true);
+
   auto Result =
       Generator.addScalarAttribute(AttrSpec.Attr, ResultingForm, Value);
   // Record DW_AT_LLVM_stmt_sequence so the attribute value can be
@@ -656,6 +662,8 @@ size_t DIEAttributeCloner::cloneAddressAttr(
     else
       return 0;
   } else {
+    if (AttrSpec.Attr == dwarf::DW_AT_high_pc)
+      Addr = constrainHighPC(*Addr, /*IsLength=*/false);
     if (VarAddressAdjustment)
       *Addr += *VarAddressAdjustment;
     else if (FuncAddressAdjustment)
@@ -671,6 +679,19 @@ size_t DIEAttributeCloner::cloneAddressAttr(
       .addScalarAttribute(AttrSpec.Attr, dwarf::Form::DW_FORM_addrx,
                           OutUnit.getAsCompileUnit()->getDebugAddrIndex(*Addr))
       .second;
+}
+
+uint64_t DIEAttributeCloner::constrainHighPC(uint64_t HighPC, bool IsLength) {
+  if (!FuncAddressAdjustment)
+    return HighPC;
+  std::optional<uint64_t> LowPC =
+      dwarf::toAddress(InUnit.find(InputDieEntry, dwarf::DW_AT_low_pc));
+  if (!LowPC)
+    return HighPC;
+  uint64_t Constrained =
+      InUnit.getContaingFile().Addresses->constrainCodeRangeHighPC(
+          *LowPC, IsLength ? *LowPC + HighPC : HighPC, *FuncAddressAdjustment);
+  return IsLength ? Constrained - *LowPC : Constrained;
 }
 
 unsigned DIEAttributeCloner::finalizeAbbreviations(bool HasChildrenToClone) {

--- a/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.h
+++ b/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.h
@@ -131,6 +131,15 @@ protected:
   cloneAddressAttr(const DWARFFormValue &Val,
                    const DWARFAbbreviationDeclaration::AttributeSpec &AttrSpec);
 
+  /// Returns the input DIE's DW_AT_high_pc value \p HighPC, constrained so the
+  /// code range it ends stays clear of the symbol the linker places next. \p
+  /// IsLength tells whether high_pc is encoded as a length rather than an
+  /// address.
+  ///
+  /// A scope nested in a function inherits the overrun of the function, so it
+  /// is constrained as well.
+  uint64_t constrainHighPC(uint64_t HighPC, bool IsLength);
+
   /// Returns true if attribute should be skipped.
   bool
   shouldSkipAttribute(DWARFAbbreviationDeclaration::AttributeSpec AttrSpec);

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -952,14 +952,15 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
 
       // For assembly-language CUs there are typically no DW_TAG_subprogram
       // DIEs, so labels are the only addresses we see. Fall back to the
-      // assembly-range lookup to recover a function range for the line-table
+      // symbol-range lookup to recover a function range for the line-table
       // filter; otherwise the output line table would be empty.
       uint16_t Language = dwarf::toUnsigned(
           Entry.CU->getOrigUnit().getUnitDIE().find(dwarf::DW_AT_language), 0);
       if (Language == dwarf::DW_LANG_Mips_Assembler ||
           Language == dwarf::DW_LANG_Assembly) {
-        if (auto Range = Entry.CU->getContaingFile()
-                             .Addresses->getAssemblyRangeForAddress(*LowPc))
+        if (auto Range =
+                Entry.CU->getContaingFile().Addresses->getSymbolRangeForAddress(
+                    *LowPc))
           Entry.CU->addFunctionRange(Range->LowPC, Range->HighPC,
                                      *RelocAdjustment);
       }
@@ -974,6 +975,10 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
   if (!Info.getTrackLiveness() || DIE.getTag() == dwarf::DW_TAG_label)
     return true;
 
-  Entry.CU->addFunctionRange(*LowPc, *HighPc, *RelocAdjustment);
+  Entry.CU->addFunctionRange(
+      *LowPc,
+      Entry.CU->getContaingFile().Addresses->constrainCodeRangeHighPC(
+          *LowPc, *HighPc, *RelocAdjustment),
+      *RelocAdjustment);
   return true;
 }

--- a/llvm/test/tools/dsymutil/Inputs/subprogram-high-pc-past-symbol-dwarf2.s
+++ b/llvm/test/tools/dsymutil/Inputs/subprogram-high-pc-past-symbol-dwarf2.s
@@ -1,0 +1,72 @@
+; The DWARF 2 form of subprogram-high-pc-past-symbol.s, where DW_AT_high_pc is
+; an address rather than a length.
+
+	.text
+	.globl	_a
+	.p2align 2
+_a:
+	ret
+_filler:
+	nop
+	.globl	_b
+	.p2align 2
+_b:
+	ret
+
+	.section __DWARF,__debug_abbrev,regular,debug
+	.byte	1                       ; abbrev 1: DW_TAG_compile_unit
+	.byte	0x11
+	.byte	1                       ; DW_CHILDREN_yes
+	.byte	0x25, 0x08              ; DW_AT_producer,  DW_FORM_string
+	.byte	0x13, 0x0b              ; DW_AT_language,  DW_FORM_data1
+	.byte	0x03, 0x08              ; DW_AT_name,      DW_FORM_string
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x01              ; DW_AT_high_pc,   DW_FORM_addr
+	.byte	0, 0
+	.byte	2                       ; abbrev 2: DW_TAG_subprogram
+	.byte	0x2e
+	.byte	1                       ; DW_CHILDREN_yes
+	.byte	0x03, 0x08              ; DW_AT_name,      DW_FORM_string
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x01              ; DW_AT_high_pc,   DW_FORM_addr
+	.byte	0x3f, 0x0c              ; DW_AT_external,  DW_FORM_flag
+	.byte	0, 0
+	.byte	3                       ; abbrev 3: DW_TAG_lexical_block
+	.byte	0x0b
+	.byte	0                       ; DW_CHILDREN_no
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x01              ; DW_AT_high_pc,   DW_FORM_addr
+	.byte	0, 0
+	.byte	0
+
+	.section __DWARF,__debug_info,regular,debug
+Lcu_begin:
+	.long	Lcu_end-Lcu_version
+Lcu_version:
+	.short	2
+	.long	0
+	.byte	8
+	.byte	1                       ; DW_TAG_compile_unit
+	.asciz	"hand-written"
+	.byte	0x0c                    ; DW_LANG_C99
+	.asciz	"t.c"
+	.quad	_a
+	.quad	0xc                     ; _a, _filler and _b together
+	.byte	2                       ; DW_TAG_subprogram "a"
+	.asciz	"a"
+	.quad	_a
+	.quad	0x8                     ; four bytes past the end of _a
+	.byte	1
+	.byte	3                       ; DW_TAG_lexical_block in "a"
+	.quad	_a
+	.quad	0x8                     ; reaches as far as its parent
+	.byte	0                       ; end of "a"'s children
+	.byte	2                       ; DW_TAG_subprogram "b"
+	.asciz	"b"
+	.quad	_b
+	.quad	0xc
+	.byte	1
+	.byte	0                       ; end of "b"'s children
+	.byte	0                       ; end of the compile unit's children
+Lcu_end:
+	.subsections_via_symbols

--- a/llvm/test/tools/dsymutil/Inputs/subprogram-high-pc-past-symbol.s
+++ b/llvm/test/tools/dsymutil/Inputs/subprogram-high-pc-past-symbol.s
@@ -1,0 +1,76 @@
+; _filler is an unreferenced atom between the two functions, so the linker drops
+; it and places _b four bytes after _a. DW_AT_high_pc for _a reaches all the way
+; to _b, past the code the linker keeps for it, and the lexical block inside _a
+; ends with its parent.
+;
+; The DWARF is hand written because a producer normally agrees with the linker.
+
+	.text
+	.globl	_a
+	.p2align 2
+_a:
+	ret
+_filler:
+	nop
+	.globl	_b
+	.p2align 2
+_b:
+	ret
+
+	.section __DWARF,__debug_abbrev,regular,debug
+	.byte	1                       ; abbrev 1: DW_TAG_compile_unit
+	.byte	0x11
+	.byte	1                       ; DW_CHILDREN_yes
+	.byte	0x25, 0x08              ; DW_AT_producer,  DW_FORM_string
+	.byte	0x13, 0x0b              ; DW_AT_language,  DW_FORM_data1
+	.byte	0x03, 0x08              ; DW_AT_name,      DW_FORM_string
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x06              ; DW_AT_high_pc,   DW_FORM_data4
+	.byte	0, 0
+	.byte	2                       ; abbrev 2: DW_TAG_subprogram
+	.byte	0x2e
+	.byte	1                       ; DW_CHILDREN_yes
+	.byte	0x03, 0x08              ; DW_AT_name,      DW_FORM_string
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x06              ; DW_AT_high_pc,   DW_FORM_data4
+	.byte	0x3f, 0x0c              ; DW_AT_external,  DW_FORM_flag
+	.byte	0, 0
+	.byte	3                       ; abbrev 3: DW_TAG_lexical_block
+	.byte	0x0b
+	.byte	0                       ; DW_CHILDREN_no
+	.byte	0x11, 0x01              ; DW_AT_low_pc,    DW_FORM_addr
+	.byte	0x12, 0x06              ; DW_AT_high_pc,   DW_FORM_data4
+	.byte	0, 0
+	.byte	0
+
+	.section __DWARF,__debug_info,regular,debug
+Lcu_begin:
+	.long	Lcu_end-Lcu_version
+Lcu_version:
+	.short	4
+	.long	0
+	.byte	8
+	.byte	1                       ; DW_TAG_compile_unit
+	.asciz	"hand-written"
+	.byte	0x0c                    ; DW_LANG_C99
+	.asciz	"t.c"
+	.quad	_a
+	.long	0xc                     ; _a, _filler and _b together
+	.byte	2                       ; DW_TAG_subprogram "a"
+	.asciz	"a"
+	.quad	_a
+	.long	0x8                     ; four bytes past the end of _a
+	.byte	1
+	.byte	3                       ; DW_TAG_lexical_block in "a"
+	.quad	_a
+	.long	0x8                     ; reaches as far as its parent
+	.byte	0                       ; end of "a"'s children
+	.byte	2                       ; DW_TAG_subprogram "b"
+	.asciz	"b"
+	.quad	_b
+	.long	0x4
+	.byte	1
+	.byte	0                       ; end of "b"'s children
+	.byte	0                       ; end of the compile unit's children
+Lcu_end:
+	.subsections_via_symbols

--- a/llvm/test/tools/dsymutil/subprogram-high-pc-past-symbol.test
+++ b/llvm/test/tools/dsymutil/subprogram-high-pc-past-symbol.test
@@ -1,0 +1,88 @@
+# REQUIRES: aarch64-registered-target
+
+# A DW_AT_high_pc reaching past the code the linker kept for a function must be
+# cut short at the function the linker placed next, otherwise the two overlap in
+# the output and verification fails with "DIEs have overlapping address ranges".
+# A scope nested in the function inherits the overrun and is cut short with it.
+
+# RUN: llvm-mc -triple arm64-apple-darwin -filetype=obj \
+# RUN:   %p/Inputs/subprogram-high-pc-past-symbol.s -o %t.o
+# RUN: echo '---' > %t.map
+# RUN: echo "triple: 'arm64-apple-darwin'" >> %t.map
+# RUN: echo 'objects:' >> %t.map
+# RUN: echo " - filename: '%/t.o'" >> %t.map
+# RUN: echo '   symbols:' >> %t.map
+# RUN: echo '     - { sym: _a, objAddr: 0x0, binAddr: 0x1000, size: 0x4 }' >> %t.map
+# RUN: echo '     - { sym: _b, objAddr: 0x8, binAddr: 0x1004, size: 0x4 }' >> %t.map
+
+# _inside starts within _a's own code, so it must not cut _a short.
+
+# RUN: echo '     - { sym: _inside, binAddr: 0x1002, size: 0x2 }' >> %t.map
+# RUN: echo '...' >> %t.map
+
+# RUN: dsymutil --linker classic -y %t.map -f -o %t-classic.out
+# RUN: llvm-dwarfdump -a %t-classic.out | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t-classic.out | FileCheck %s --check-prefix=VERIFY
+
+# RUN: dsymutil --linker parallel -y %t.map -f -o %t-parallel.out
+# RUN: llvm-dwarfdump -a %t-parallel.out | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t-parallel.out | FileCheck %s --check-prefix=VERIFY
+
+# A compile unit's high_pc spans every symbol in the unit, so it is not a range
+# to constrain. These binary addresses are low enough that constraining it would
+# cut the unit short of _b.
+
+# RUN: echo '---' > %t-unit.map
+# RUN: echo "triple: 'arm64-apple-darwin'" >> %t-unit.map
+# RUN: echo 'objects:' >> %t-unit.map
+# RUN: echo " - filename: '%/t.o'" >> %t-unit.map
+# RUN: echo '   symbols:' >> %t-unit.map
+# RUN: echo '     - { sym: _a, objAddr: 0x0, binAddr: 0x4, size: 0x4 }' >> %t-unit.map
+# RUN: echo '     - { sym: _b, objAddr: 0x8, binAddr: 0x8, size: 0x4 }' >> %t-unit.map
+# RUN: echo '...' >> %t-unit.map
+
+# RUN: dsymutil --linker classic -y %t-unit.map -f -o %t-unit-classic.out
+# RUN: llvm-dwarfdump -a %t-unit-classic.out | FileCheck %s --check-prefix=UNIT
+# RUN: llvm-dwarfdump --verify %t-unit-classic.out | FileCheck %s --check-prefix=VERIFY
+
+# RUN: dsymutil --linker parallel -y %t-unit.map -f -o %t-unit-parallel.out
+# RUN: llvm-dwarfdump -a %t-unit-parallel.out | FileCheck %s --check-prefix=UNIT
+# RUN: llvm-dwarfdump --verify %t-unit-parallel.out | FileCheck %s --check-prefix=VERIFY
+
+# Same again with DW_AT_high_pc as an address rather than a length.
+
+# RUN: llvm-mc -triple arm64-apple-darwin -filetype=obj \
+# RUN:   %p/Inputs/subprogram-high-pc-past-symbol-dwarf2.s -o %t.o
+# RUN: dsymutil --linker classic -y %t.map -f -o %t-classic2.out
+# RUN: llvm-dwarfdump -a %t-classic2.out | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t-classic2.out | FileCheck %s --check-prefix=VERIFY
+
+# RUN: dsymutil --linker parallel -y %t.map -f -o %t-parallel2.out
+# RUN: llvm-dwarfdump -a %t-parallel2.out | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t-parallel2.out | FileCheck %s --check-prefix=VERIFY
+
+# CHECK:      DW_TAG_subprogram
+# CHECK:        DW_AT_name{{.*}}"a"
+# CHECK-NEXT:   DW_AT_low_pc{{.*}}(0x0000000000001000)
+# CHECK-NEXT:   DW_AT_high_pc{{.*}}(0x0000000000001004)
+# CHECK:        DW_TAG_lexical_block
+# CHECK-NEXT:     DW_AT_low_pc{{.*}}(0x0000000000001000)
+# CHECK-NEXT:     DW_AT_high_pc{{.*}}(0x0000000000001004)
+# CHECK:      DW_TAG_subprogram
+# CHECK:        DW_AT_name{{.*}}"b"
+# CHECK-NEXT:   DW_AT_low_pc{{.*}}(0x0000000000001004)
+# CHECK-NEXT:   DW_AT_high_pc{{.*}}(0x0000000000001008)
+
+# UNIT:      DW_TAG_compile_unit
+# UNIT:        DW_AT_low_pc{{.*}}(0x0000000000000004)
+# UNIT-NEXT:   DW_AT_high_pc{{.*}}(0x000000000000000c)
+# UNIT:      DW_TAG_subprogram
+# UNIT:        DW_AT_name{{.*}}"a"
+# UNIT-NEXT:   DW_AT_low_pc{{.*}}(0x0000000000000004)
+# UNIT-NEXT:   DW_AT_high_pc{{.*}}(0x0000000000000008)
+# UNIT:      DW_TAG_subprogram
+# UNIT:        DW_AT_name{{.*}}"b"
+# UNIT-NEXT:   DW_AT_low_pc{{.*}}(0x0000000000000008)
+# UNIT-NEXT:   DW_AT_high_pc{{.*}}(0x000000000000000c)
+
+# VERIFY: No errors.

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -126,6 +126,9 @@ private:
     /// Address ranges for symbols with sizes (used for assembly file support).
     RangesTy AddressRanges;
 
+    /// Sorted linked start addresses of the symbols with a known size.
+    std::vector<uint64_t> LinkedSymbolStarts;
+
     /// Returns list of valid relocations from \p Relocs,
     /// between \p StartOffset and \p NextOffset.
     ///
@@ -170,15 +173,21 @@ private:
       } else {
         findValidRelocsInDebugSections(Obj, DMO);
       }
-      // Populate address ranges from debug map symbols that have sizes.
-      // This is used for assembly files where labels may not have high_pc.
+      // Only a sized symbol has a known extent. The ranges stand in for the
+      // high_pc that assembly files lack.
       for (const auto &Entry : DMO.symbols()) {
         const auto &Mapping = Entry.getValue();
-        if (Mapping.Size && Mapping.ObjectAddress)
+        if (!Mapping.Size)
+          continue;
+        LinkedSymbolStarts.push_back(Mapping.BinaryAddress);
+        if (Mapping.ObjectAddress)
           AddressRanges.insert(
               {*Mapping.ObjectAddress, *Mapping.ObjectAddress + Mapping.Size},
               int64_t(Mapping.BinaryAddress) - *Mapping.ObjectAddress);
       }
+      llvm::sort(LinkedSymbolStarts);
+      LinkedSymbolStarts.erase(llvm::unique(LinkedSymbolStarts),
+                               LinkedSymbolStarts.end());
     }
     ~AddressManager() override { clear(); }
 
@@ -239,13 +248,22 @@ private:
       ValidDebugInfoRelocs.clear();
       ValidDebugAddrRelocs.clear();
       AddressRanges.clear();
+      LinkedSymbolStarts.clear();
     }
 
-    std::optional<AssemblyRange>
-    getAssemblyRangeForAddress(uint64_t Addr) override {
+    std::optional<SymbolRange>
+    getSymbolRangeForAddress(uint64_t Addr) override {
       if (auto Range = AddressRanges.getRangeThatContains(Addr))
-        return AssemblyRange(Range->Range.start(), Range->Range.end());
+        return SymbolRange(Range->Range.start(), Range->Range.end());
       return std::nullopt;
+    }
+
+    std::optional<uint64_t>
+    getNextLinkedSymbolStart(uint64_t LinkedAddr) override {
+      auto It = llvm::lower_bound(LinkedSymbolStarts, LinkedAddr);
+      if (It == LinkedSymbolStarts.end())
+        return std::nullopt;
+      return *It;
     }
   };
 


### PR DESCRIPTION
Mach-O objects built with .subsections_via_symbols make every symbol an independently placeable atom, and the linker packs atoms without preserving the spacing they had in the object file.

I have an example where the compiler describes such a subprogram as extending past its own atom. While it's debatable whether that's a good idea, it's not invalid in the object file. However, once linked, it is invalid.

We can make dsymutil resilient against this by looking at the size of the symbol in the debug map and adjusting the end_pc. I'm doing so conservatively so that only a collision is repaired. Already overlapping/invalid ranges remain untouched.

rdar://184768778
(cherry picked from commit 8a6a59a0b4b06e43e508b7ff4c19cbfa3719f777)