### PR TITLE
[cherry-pick next][lldb][test] Un-skip variables/actor in embedded Swift

### DIFF
--- a/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
+++ b/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
@@ -9,7 +9,8 @@ import os
 
 
 class TestSwiftActorTypes(TestBase):
-    @skipEmbeddedSwift  # rdar://183960945 (Fix async tests running in embedded mode)
+    @skipEmbeddedSwiftOnWindows
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     def test_swift_class_types(self):
         """Test swift Actor types"""


### PR DESCRIPTION
This is fixed by https://github.com/swiftlang/swift/pull/91365

(cherry picked from commit 0075adbe24adc2cd68a5faa4e627345dc1ac7942)
