### PR TITLE
[cherry-pick stable/23.x][lldb][test] Un-skip variables/swift in embedded Swift on x86_64

### DIFF
--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -20,8 +20,8 @@ import platform
 
 
 class TestSwiftTypes(TestBase):
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
-    @skipEmbeddedSwift # printing the x86_64-only Float80 crashes LLDB in embedded Swift.
     def test_swift_types(self):
         """Test that we can inspect basic Swift types"""
         self.build()


### PR DESCRIPTION
This was crashing in x86_64 because of bad debug info for a Float80 type.

Assisted-by: claude

(cherry picked from commit 470cf39a6861674741e944db428e620bb487d0cd)
