### PR TITLE
[cherry-pick next][lldb] Un-skip constrained_existential under embedded Swift

### DIFF
--- a/lldb/test/API/lang/swift/constrained_existential/TestSwiftConstrainedExistential.py
+++ b/lldb/test/API/lang/swift/constrained_existential/TestSwiftConstrainedExistential.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftConstrainedExistential(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test constrained existential types"""


### PR DESCRIPTION
This is enabled by commit 6398cb3 on the swift side.

Assisted-by: claude

(cherry picked from commit b340128552c01e30162834a9120ff865afce4694)
