### PR TITLE
Fix passing negative value as count to function returning counted_by

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -26515,7 +26515,6 @@ ExprResult Sema::ActOnBoundsSafetyCall(ExprResult Call) {
     Expr *CountE = ReturnCount.get();
     if (auto *OVE = dyn_cast<OpaqueValueExpr>(CountE))
       CountE = OVE->getSourceExpr();
-    CountE = CountE->IgnoreParenCasts();
     if (CountE && !CountE->isValueDependent()) {
       Expr::EvalResult EvalRes;
       if (CountE->EvaluateAsInt(EvalRes, Context)) {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -26511,6 +26511,26 @@ ExprResult Sema::ActOnBoundsSafetyCall(ExprResult Call) {
     ReturnCount = DefaultLvalueConversion(ReturnCount.get());
     if (!ReturnCount.get())
       return ExprError();
+
+    Expr *CountE = ReturnCount.get();
+    if (auto *OVE = dyn_cast<OpaqueValueExpr>(CountE))
+      CountE = OVE->getSourceExpr();
+    CountE = CountE->IgnoreParenCasts();
+    if (CountE && !CountE->isValueDependent()) {
+      Expr::EvalResult EvalRes;
+      if (CountE->EvaluateAsInt(EvalRes, Context)) {
+        const llvm::APSInt &CountVal = EvalRes.Val.getInt();
+        if (CountVal < 0 && !DCPT->isOrNull()) {
+          Diag(CallE->getBeginLoc(),
+               diag::err_bounds_safety_dynamic_count_negative)
+             << ResultTy << DCPT->isCountInBytes() << CountVal.getSExtValue()
+             << false << ""
+             << CountE->getSourceRange();
+          return ExprError();
+        }
+      }
+    }
+
     auto *PtrOVE = OpaqueValueExpr::EnsureWrapped(
         Context, ResultExpr, OVEs);
     auto *CountOVE = OpaqueValueExpr::EnsureWrapped(

--- a/clang/test/BoundsSafety-legacy-checks/CodeGen/counted_by_to_counted_by-O2.c
+++ b/clang/test/BoundsSafety-legacy-checks/CodeGen/counted_by_to_counted_by-O2.c
@@ -71,7 +71,8 @@ void TestUCountNegFail(void) {
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestCountNegRetFail(void) {
-  int *local_p = my_alloc_int(-1); //rdar://80808704
+  int x = -1;
+  int *local_p = my_alloc_int(x);
   (void)*local_p;
 }
 

--- a/clang/test/BoundsSafety/CodeGen/counted_by_to_counted_by-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/counted_by_to_counted_by-O2.c
@@ -71,7 +71,8 @@ void TestUCountNegFail(void) {
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
 //
 void TestCountNegRetFail(void) {
-  int *local_p = my_alloc_int(-1); //rdar://80808704
+  int x = -1;
+  int *local_p = my_alloc_int(x);
   (void)*local_p;
 }
 

--- a/clang/test/BoundsSafety/Sema/arithmetic-ops-in-counted-by-calls.c
+++ b/clang/test/BoundsSafety/Sema/arithmetic-ops-in-counted-by-calls.c
@@ -71,6 +71,6 @@ void call_param_with_shared_size(void) {
 void *__sized_by(count * size) return_with_count_size(int count, int size);
 
 void call_return_with_count_size(void) {
-  // FIXME: rdar://103368466
+  // expected-error@+1{{negative size value of -1 for 'void *__single __sized_by(count * size)' (aka 'void *__single')}}
   void *buf = return_with_count_size(-1, 1);
 }

--- a/clang/test/BoundsSafety/Sema/count-attr-casts.c
+++ b/clang/test/BoundsSafety/Sema/count-attr-casts.c
@@ -1,0 +1,26 @@
+
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+#include <limits.h>
+#include <ptrcheck.h>
+
+int *__counted_by(len * count) foo(int len, short count);
+int *__counted_by(len * count) baz(unsigned int len, long long count);
+
+int *__counted_by((int)(len * count)) mul(unsigned len, unsigned count);
+int *__counted_by((int)((len) * (count))) mul_paren(unsigned len, unsigned count);
+
+void Test(void) {
+  // expected-error@+1{{negative count value of -1 for 'int *__single __counted_by(len * count)'}}
+  foo(1, -1);
+
+  // expected-error@+1{{negative count value of -4294967295 for 'int *__single __counted_by(len * count)'}}
+  baz(UINT_MAX, -1LL);
+
+  // expected-error@+1{{negative count value of -1 for 'int *__single __counted_by((int)(len * count))'}}
+  mul(0xFFFFFFFFu, 1u); // Should error. 
+
+  // expected-error@+1{{negative count value of -1 for 'int *__single __counted_by((int)(len * count))' (aka 'int *__single')}}
+  mul(0xFFFFFFFFu, 1u); // Should error.
+}

--- a/clang/test/BoundsSafety/Sema/negative-count.c
+++ b/clang/test/BoundsSafety/Sema/negative-count.c
@@ -69,6 +69,7 @@ void ret_values() {
     int len = -1;
     nullable_ret(-1);
     nullable_ret(len);
+    // expected-error@+1{{negative count value of -1 for 'int *__single __counted_by(len)' (aka 'int *__single')}}
     nonnullable_ret(-1);
     nonnullable_ret(len);
     len = 0;

--- a/clang/test/BoundsSafety/Sema/negative-size.c
+++ b/clang/test/BoundsSafety/Sema/negative-size.c
@@ -69,6 +69,7 @@ void ret_values() {
     int size = -1;
     nullable_ret(-1);
     nullable_ret(size);
+    // expected-error@+1{{negative size value of -1 for 'int *__single __sized_by(size)' (aka 'int *__single')}}
     nonnullable_ret(-1);
     nonnullable_ret(size);
     size = 0;


### PR DESCRIPTION
Added check for value of return type's count expression such that no negative values are passed as arguments to
functions returning `counted_by`.

Changed tests to correspond with correct program behavior and removed rdar://80808704 and rdar://103368466 comments from the tests which errored.

Fixes: #13550