### PR TITLE
[clang][include-tree] Add test coverage for repeated includes

### DIFF
--- a/clang/test/ClangScanDeps/include-tree-module-map-file-without-modules.c
+++ b/clang/test/ClangScanDeps/include-tree-module-map-file-without-modules.c
@@ -45,5 +45,6 @@ module Foo {
 void foo(void);
 
 //--- tu.c
-#include "foo.h"
+#import "foo.h"
+#import "foo.h"
 void tu(void) { foo(); }


### PR DESCRIPTION
This adds coverage for a fix of rdar://184549117 implemented here: https://github.com/llvm/llvm-project/pull/216704 

Repeated includes of modular headers in a textual compilation resolved to import directives, which the include-tree attempted and failed to resolve with `fatal error: module 'X' is needed but has not been provided, and implicit use of module files is disabled`.