### PR TITLE
Don't ask trampoline handler plans to step past line 0. (#216770)

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlanShouldStopHere.h
+++ b/lldb/include/lldb/Target/ThreadPlanShouldStopHere.h
@@ -60,7 +60,9 @@ public:
     eAvoidInlines = (1 << 0),
     eStepInAvoidNoDebug = (1 << 1),
     eStepOutAvoidNoDebug = (1 << 2),
-    eStepOutPastThunks = (1 << 3)
+    eStepOutPastThunks = (1 << 3),
+    eStepPastLine0 = (1 << 4) // Only source level plans should handle
+                              // step past line 0 - not trampoline handlers.
   };
 
   // Constructors and Destructors

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
@@ -274,6 +274,12 @@ AppleThreadPlanStepThroughDirectDispatch ::
   // We only care about step in.  Our parent plan will figure out what to
   // do when we've stepped out again.
   GetFlags().Clear(ThreadPlanShouldStopHere::eStepOutAvoidNoDebug);
+
+  // Don't try to do the step past line 0 from here.  That gets confused with
+  // our need to get past any intermediate ObjC message calls which might lie
+  // in the path of getting to the actual target, and if we need to do this,
+  // then one of the plans that is using us will make that happen.
+  GetFlags().Clear(ThreadPlanShouldStopHere::eStepPastLine0);
 }
 
 AppleThreadPlanStepThroughDirectDispatch::
@@ -379,11 +385,13 @@ bool AppleThreadPlanStepThroughDirectDispatch::ShouldStop(Event *event_ptr) {
     if (!m_objc_step_through_sp->PlanSucceeded()) {
       LLDB_LOGF(log, "ObjC Step through plan failed.  Stepping out.");
     }
+
     Status error;
     if (InvokeShouldStopHereCallback(eFrameCompareYounger, error)) {
       SetPlanComplete(true);
       return true;
     }
+
     // If we didn't want to stop at this msgSend, there might be another so
     // we should just continue on with the step out and see if our breakpoint
     // triggers again.

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -114,6 +114,7 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
 
   // If we're in a trampoline, don't stop by default.
   if (Target::GetGlobalProperties().GetEnableTrampolineSupport()) {
+    sc = frame->GetSymbolContext(lldb::eSymbolContextFunction);    
     if (sc.function && sc.function->IsGenericTrampoline())
       should_stop_here = false;
   }

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -98,7 +98,9 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
       }
     }
   }
-  // Always avoid code with line number 0.
+  // Source line stepping plans should always avoid code with line number 0.
+  // But trampoline plans should not; it's easier to reason about if they
+  // leave that up to the source line plan that's driving them.
   // FIXME: At present the ShouldStop and the StepFromHere calculate this
   // independently.  If this ever
   // becomes expensive (this one isn't) we can try to have this set a state
@@ -106,12 +108,12 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
   SymbolContext sc;
   sc = frame->GetSymbolContext(eSymbolContextLineEntry);
 
-  if (sc.line_entry.line == 0)
+  if (flags.Test(ThreadPlanShouldStopHere::eStepPastLine0)
+      && sc.line_entry.line == 0)
     should_stop_here = false;
 
   // If we're in a trampoline, don't stop by default.
   if (Target::GetGlobalProperties().GetEnableTrampolineSupport()) {
-    sc = frame->GetSymbolContext(lldb::eSymbolContextFunction);
     if (sc.function && sc.function->IsGenericTrampoline())
       should_stop_here = false;
   }

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -30,7 +30,8 @@ using namespace lldb_private;
 
 uint32_t ThreadPlanStepInRange::s_default_flag_values =
     ThreadPlanShouldStopHere::eStepInAvoidNoDebug |
-    ThreadPlanShouldStopHere::eStepOutPastThunks;
+    ThreadPlanShouldStopHere::eStepOutPastThunks |
+    ThreadPlanShouldStopHere::eStepPastLine0;
 
 // ThreadPlanStepInRange: Step through a stack range, either stepping over or
 // into based on the value of \a type.

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -36,7 +36,8 @@
 using namespace lldb;
 using namespace lldb_private;
 
-uint32_t ThreadPlanStepOut::s_default_flag_values = 0;
+uint32_t ThreadPlanStepOut::s_default_flag_values =
+    ThreadPlanShouldStopHere::eStepPastLine0;
 
 /// Computes the target frame this plan should step out to.
 static StackFrameSP

--- a/lldb/source/Target/ThreadPlanStepOverRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverRange.cpp
@@ -26,7 +26,8 @@
 using namespace lldb_private;
 using namespace lldb;
 
-uint32_t ThreadPlanStepOverRange::s_default_flag_values = 0;
+uint32_t ThreadPlanStepOverRange::s_default_flag_values =
+    ThreadPlanShouldStopHere::eStepPastLine0;
 
 // ThreadPlanStepOverRange: Step through a stack range, either stepping over or
 // into based on the value of \a type.


### PR DESCRIPTION
That isbetter done by the source line stepping plans. This fixes a test suite failure on the swift fork, but I don't know how to really write a test for it since it depends on getting to a function whose first instruction is attributed to line 0 by an ObjC direct dispatch. Turns out swift does this in its present incarnation.

But this division of labor really is the right way to work the machine, since that makes the trampoline plans easier to reason about, and if stepping past line 0 is desired, there's always going to be a source line stepping plan controlling the step that will do the job.

(cherry picked from commit 27ffa745f3a7eaafe5f3491ace03d345e3a80129)