### PR TITLE
[Cherry-pick into next] [LLDB] Make the resilience test Makefile rebuild-safe

### DIFF
--- a/lldb/test/API/lang/swift/resilience/Makefile
+++ b/lldb/test/API/lang/swift/resilience/Makefile
@@ -3,8 +3,17 @@ all: libmod.a.dylib libmod.b.dylib main.a main.b
 
 include Makefile.rules
 
+# Both recipes below build into flavor-independent names (libmod.dylib,
+# mod.swiftinterface, main, ...) and rename the results per flavor afterwards,
+# so they are only correct when the directory does not already contain the
+# results of an earlier build or test run: `mv` descends into an existing
+# destination directory rather than replacing it, and writing to a leftover
+# symlink follows it instead of overwriting it. Clear both before building.
+
 libmod.%.dylib: mod.%.swift \
                 $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
+	$(call RM_RF,$@.dSYM libmod.dylib libmod.dylib.dSYM \
+	             mod.swiftinterface mod.$*.swiftinterface mod.swiftmodule)
 	$(call LN_SF,$<,mod.swift)
 	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -###
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
@@ -19,6 +28,7 @@ libmod.%.dylib: mod.%.swift \
 	$(call RM,mod.swift)
 
 main.%: main.swift
+	$(call RM_RF,main.$*.dSYM main main.dSYM)
 	$(call LN_SF,libmod.$*.dylib,libmod.dylib)
 	$(call LN_SF,libmod.$*.dylib.dSYM,libmod.dylib.dSYM)
 	$(call LN_SF,mod.$*.swiftdoc,mod.swiftdoc)

--- a/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
@@ -66,10 +66,10 @@ class TestSwiftResilience(TestBase):
         execute_command("cp " + self.getBuildArtifact("main." + exe_flavor) + " " + self.getBuildArtifact("main"))
         execute_command("ln -sf " + self.getBuildArtifact("main." + exe_flavor + ".dSYM") + " " + self.getBuildArtifact("main.dSYM"))
 
-        execute_command("cp " + self.getBuildArtifact("libmod." + exe_flavor + ".dylib") + " " + self.getBuildArtifact("libmod.dylib"))
-        execute_command("ln -sf " + self.getBuildArtifact("libmod." + exe_flavor + ".dylib.dSYM") + " " + self.getBuildArtifact("libmod.dylib.dSYM"))
+        execute_command("cp " + self.getBuildArtifact("libmod." + mod_flavor + ".dylib") + " " + self.getBuildArtifact("libmod.dylib"))
+        execute_command("ln -sf " + self.getBuildArtifact("libmod." + mod_flavor + ".dylib.dSYM") + " " + self.getBuildArtifact("libmod.dylib.dSYM"))
 
-        execute_command("ln -sf " + self.getBuildArtifact("mod." + exe_flavor + ".swiftinterface") + " " + self.getBuildArtifact("mod.swiftinterface"))
+        execute_command("ln -sf " + self.getBuildArtifact("mod." + mod_flavor + ".swiftinterface") + " " + self.getBuildArtifact("mod.swiftinterface"))
 
     def cleanupSymlinks(self):
         execute_command(

--- a/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
@@ -68,7 +68,6 @@ class TestSwiftResilience(TestBase):
 
         execute_command("cp " + self.getBuildArtifact("libmod." + exe_flavor + ".dylib") + " " + self.getBuildArtifact("libmod.dylib"))
         execute_command("ln -sf " + self.getBuildArtifact("libmod." + exe_flavor + ".dylib.dSYM") + " " + self.getBuildArtifact("libmod.dylib.dSYM"))
-        execute_command("ln -sf " + self.getBuildArtifact("mod." + exe_flavor + ".o") + " " + self.getBuildArtifact("mod.o"))
 
         execute_command("ln -sf " + self.getBuildArtifact("mod." + exe_flavor + ".swiftinterface") + " " + self.getBuildArtifact("mod.swiftinterface"))
 


### PR DESCRIPTION
```
commit a7f6c75526dfdfd651b18d424742917e7fcb3ce4
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Aug 17 14:57:58 2026 -0700

    [LLDB] Make the resilience test Makefile rebuild-safe
    
    Both recipes build into flavor-independent names (libmod.dylib,
    mod.swiftinterface, main) and rename the results per flavor afterwards,
    which is only correct in a pristine directory. On a rebuild, mv descends
    into an existing destination directory instead of replacing it, so each
    new dSYM ended up nested inside the previous one, leaving a stale dSYM
    behind. A leftover mod.swiftinterface symlink from the test's own
    createSymlinks was also written through and then renamed, cross-linking
    one flavor's .swiftinterface to the other's.
    
    With a stale dSYM the dylib's fileprivate globals become unfindable:
    
      error: can't find global variable 'g_b'
    
    This was unreachable until a7f47a109b35 added a dependency on the
    compiler, which correctly makes these rules re-run whenever the
    toolchain is rebuilt. Clear the destinations and the shared
    intermediates up front rather than dropping that dependency.
    
    Assisted-by: Claude

commit 5c59003868bdb469d2f7a18997a948a750ea9521
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Aug 17 15:01:11 2026 -0700

    [LLDB] Drop a dangling symlink from the resilience test (NFC)
    
    99bacde7b481 moved Swift compilation onto the driver, which renamed the
    object file from mod.o to mod.swift.o; the Makefile was updated to
    rename it to mod.$*.swift.o but createSymlinks still pointed mod.o at
    mod.$*.o. That file has not existed since, so the symlink has been
    dangling for every run and cleanupSymlinks never removed it either.
    
    Nothing reads it: all four tests require dsym debug info, and a dSYM
    carries its own DWARF rather than referring back to the object file.
    Remove the line instead of repointing it at mod.$*.swift.o, which would
    only reintroduce a name the build writes through on a rebuild.
    
    Assisted-by: Claude

commit 6c537cf648fae8912674dfdeba1f049127587bfb
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Aug 17 15:01:32 2026 -0700

    [LLDB] Actually vary the module flavor in the resilience test
    
    createSymlinks takes an exe_flavor and a mod_flavor, but selected every
    artifact with exe_flavor, so mod_flavor was dead. The a_b and b_a cases
    paired each executable with its own library, duplicating a_a and b_b:
    the test claimed to cover four combinations of library and executable
    and covered two.
    
    Select the dylib, its dSYM and its .swiftinterface with mod_flavor, and
    keep exe_flavor for the executable. Both executables link against
    @executable_path/libmod.dylib and both dylibs carry that install name,
    so copying the chosen flavor over libmod.dylib decides which module is
    loaded. The cross combinations pass, which is the point: a resilient API
    is meant to work for any pairing.
    
    Assisted-by: Claude
```
