### PR TITLE
[Cherry-pick into stable/23.x] [lldb][RPC] Do not treat int8_t/uint8_t as strings (#216850)

### DIFF
--- a/lldb/tools/lldb-rpc-gen/RPCCommon.cpp
+++ b/lldb/tools/lldb-rpc-gen/RPCCommon.cpp
@@ -263,9 +263,7 @@ bool lldb_rpc_gen::TypeIsConstCharPtr(QualType T) {
   // platforms, but Linux platforms expect that the underlying type is an
   // unsigned integer.
   return UnderlyingType->isSpecificBuiltinType(BuiltinType::Char_S) ||
-         UnderlyingType->isSpecificBuiltinType(BuiltinType::SChar) ||
-         UnderlyingType->isSpecificBuiltinType(BuiltinType::Char_U) ||
-         UnderlyingType->isSpecificBuiltinType(BuiltinType::UChar);
+         UnderlyingType->isSpecificBuiltinType(BuiltinType::Char_U);
 }
 
 bool lldb_rpc_gen::TypeIsConstCharPtrPtr(QualType T) {


### PR DESCRIPTION
```
commit fa4c6a65dc6a6825e0397eaf09f638ae53cf2c03
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Aug 17 16:08:17 2026 -0700

    [lldb][RPC] Do not treat int8_t/uint8_t as strings (#216850)
    
    `Char_S` and `Char_U` both denote a plain `char`; which of the two is
    used depends on whether `char` is signed on the target. `SChar` and
    `UChar` instead denote an explicitly signed or unsigned `char`, which is
    how `int8_t`/`uint8_t` spell a byte buffer rather than a string.
    Accepting those in TypeIsConstCharPtr truncates data at the first NUL
    and produces a `const char *` where the API wants a `const uint8_t *`.
```
