### PR TITLE
[lldb][embedded] Enable and reclassify tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
@@ -107,7 +107,7 @@ class PlaygroundREPLTest(TestBase):
         error = self.get_stream_data(result)
         print("Crash Error: {}".format(error))
 
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # the playground REPL has no embedded Swift counterpart
     @swiftTest
     @skipIfRemote
     def test_playgrounds(self):

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 
 
 class TestCase(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128860 (Embedded Swift: a breakpoint on a property-accessor name resolves zero locations)
     @swiftTest
     def test(self):
         """Test that a breakpoint on a property accessor can be set by name."""

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -17,7 +17,7 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # only fails on CI
     @swiftTest
     @skipIf(oslist=["windows"])
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -7,7 +7,7 @@ class TestSwiftWerror(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128839 (Embedded Swift: a test whose breakpoint is in a linked dylib runs to exit without stopping)
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIfLinux

--- a/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
+++ b/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
@@ -20,7 +20,7 @@ import os
 import os.path
 
 class TestSwiftCrossModuleExtension(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128839 (Embedded Swift: a test whose breakpoint is in a linked dylib runs to exit without stopping)
     @skipUnlessDarwin
     @swiftTest
     def test_cross_module_extension(self):

--- a/lldb/test/API/lang/swift/cross_module_extension_self/TestSwiftCrossModuleExtensionSelf.py
+++ b/lldb/test/API/lang/swift/cross_module_extension_self/TestSwiftCrossModuleExtensionSelf.py
@@ -12,7 +12,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftCrossModuleExtensionSelf(TestBase):
-    @skipEmbeddedSwift # 6.4.x only
+    @requireNotEmbeddedSwift # library evolution cannot be enabled with embedded Swift
     @swiftTest
     def test_unusable_self_does_not_break_frame(self):
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftForwardInteropCxxLangOpt(TestBase):
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128839 (Embedded Swift: a test whose breakpoint is in a linked dylib runs to exit without stopping)
     @swiftTest
     def test_class(self):
         """

--- a/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
+++ b/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
@@ -1,4 +1,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
+# rdar://185128962 (Embedded Swift: po falls back to p, so object-description output is unavailable)
 lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
+++ b/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
@@ -40,7 +40,7 @@ class TestSwiftDifferentClangFlags(TestBase):
     @skipIf(
         debug_info=decorators.no_match("dsym"),
         bugnumber="This test requires a stripped binary and a dSYM")
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128839 (Embedded Swift: a test whose breakpoint is in a linked dylib runs to exit without stopping)
     def test_swift_different_clang_flags(self):
         """Test that we use the right compiler flags when debugging"""
         self.build()

--- a/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
+++ b/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test indirect enums"""

--- a/lldb/test/API/lang/swift/enums/single_case_indirect/TestSwiftSingleCaseIndirectEnum.py
+++ b/lldb/test/API/lang/swift/enums/single_case_indirect/TestSwiftSingleCaseIndirectEnum.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftSingleCaseIndirectEnum(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Test single-case indirect enum projection"""

--- a/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExpressionErrorMissingType(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://184841378 (Embedded Swift: module-from-interface builds are missing IS_EMBEDDED_SWIFT_MODULE, breaking import + LLDB expr eval)
     @swiftTest
     def test(self):
         """Test an extra hint inserted by LLDB for missing module imports"""

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestDefiningOverloadedFunctions(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128821 (Embedded Swift: an overloaded function defined in one expression is not callable from a later expression)
     @swiftTest
     def test_simple_overload_expressions(self):
         """Test defining overloaded functions"""

--- a/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
@@ -31,7 +31,7 @@ class TestSwiftExprInProtocolExtension(TestBase):
         self.continue_to_bkpt(self.process, bkpt)
         self.target.BreakpointDelete(bkpt.GetID())
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://184869028 (Embedded Swift: self is unavailable in a static protocol extension frame after mandatory specialization)
     @swiftTest
     def test_protocol_extension(self):
         """Tests that swift expressions in protocol extension functions behave correctly"""

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftExpressionsInClassFunctions(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://184869028 (Embedded Swift: self is unavailable in a static protocol extension frame after mandatory specialization)
     @swiftTest
     def test_expressions_in_class_functions(self):
         """Test expressions in class func contexts"""

--- a/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
+++ b/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
@@ -17,7 +17,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftGenericExtension(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185129012 (Embedded Swift: expr --bind-generic-types false cannot be honoured in a monomorphized frame)
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/inner_generic_params/TestSwiftInnerGenericParams.py
+++ b/lldb/test/API/lang/swift/inner_generic_params/TestSwiftInnerGenericParams.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftInnerGenericParams(TestBase):
-    @skipEmbeddedSwift # 6.4.x. only
+    @skipEmbeddedSwift # rdar://185129012 (Embedded Swift: expr --bind-generic-types false cannot be honoured in a monomorphized frame)
     @swiftTest
     def test_outermost_params(self):
         """Sanity check: a non-generic method works."""
@@ -15,7 +15,7 @@ class TestSwiftInnerGenericParams(TestBase):
         )
         self.expect("expression --bind-generic-types false -- value", substrs=["42"])
 
-    @skipEmbeddedSwift # 6.4.x. only
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test_inner_params_are_declined(self):
         """A generic method in a generic context is not supported."""

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -10,7 +10,7 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://184839637 (Type lookup searches the frame's module, not the type's owning module)
     @swiftTest
     @requireMacOS
     # FIXME: Without the ClangImporter, transitive module dependencies can't be

--- a/lldb/test/API/lang/swift/noncopyable_field_reflection/TestSwiftNoncopyableFieldReflection.py
+++ b/lldb/test/API/lang/swift/noncopyable_field_reflection/TestSwiftNoncopyableFieldReflection.py
@@ -10,7 +10,7 @@ class TestSwiftNoncopyableFieldReflection(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @requireDarwin
-    @skipEmbeddedSwift
+    @requireNotEmbeddedSwift # library evolution cannot be enabled with embedded Swift
     @swiftTest
     def test(self):
         """Test that LLDB surfaces an error when a resilient class

--- a/lldb/test/API/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
+++ b/lldb/test/API/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
@@ -12,4 +12,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
+# rdar://185128962 (Embedded Swift: po falls back to p, so object-description output is unavailable)
 lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipEmbeddedSwift, swiftTest])

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -20,7 +20,7 @@ import os
 
 
 class TestSwiftTypeLookup(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128964 (Embedded Swift: type lookup emits no doc comments)
     @swiftTest
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""

--- a/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/TestSwiftRuntimeInstrumentationRecognizer.py
+++ b/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/TestSwiftRuntimeInstrumentationRecognizer.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftRuntimeInstrumentationRecognizer(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185129217 (Embedded Swift: the Swift runtime instrumentation frame recognizer never fires)
     @swiftTest
     @expectedFailureWindows
     def test(self):

--- a/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
+++ b/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
@@ -21,7 +21,7 @@ import os.path
 import time
 
 class TestSwiftVersion(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185129232 (Embedded Swift: calling an initializer in an expression across -swift-version modules yields no value)
     @skipUnlessDarwin
     @swiftTest
     def test_cross_module_extension(self):

--- a/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
+++ b/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
@@ -15,7 +15,8 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftErrorType(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     def test(self):
         """Test handling of Swift Error types"""

--- a/lldb/test/API/lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py
+++ b/lldb/test/API/lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py
@@ -52,7 +52,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         )
         self.assertEqual(breakpoint.GetNumLocations(), 1, breakpoint)
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128968 (Embedded Swift: stepping through yield_once coroutine accessors lands on the wrong line and loses self)
     @swiftTest
     @skipIf(oslist=["linux"], archs=no_match("x86_64")) # rdar://170532470
     def test_step_over_starting_inside_coroutine(self):
@@ -69,7 +69,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         thread.StepOver()
         self.hit_correct_line(thread, "last main line")
 
-    @skipEmbeddedSwift
+    @skipEmbeddedSwift # rdar://185128968 (Embedded Swift: stepping through yield_once coroutine accessors lands on the wrong line and loses self)
     @swiftTest
     @skipIfWindows # rdar://173245044
     def test_step_in_and_out_callsite(self):


### PR DESCRIPTION
- Enable tests that are already passing, probably from a fix that landed
  in the last 2 weeks.
- Reclassify more tests that geninuely can't run in embedded with @requireNotEmbeddedSwift
- Annotate tests that are not relevant to corefile debugging with the
  radar number tracking them.

Assisted-by: Claude
