### PR TITLE
[clang][lex] Cache stat failures in `-Wshadow-header` (#215962)

### DIFF
--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -907,7 +907,7 @@ void HeaderSearch::diagnoseHeaderShadowing(
       const auto &IncluderAndDir = Includers[i];
       SmallString<1024> TmpDir = IncluderAndDir.second.getName();
       llvm::sys::path::append(TmpDir, Filename);
-      if (auto File = getFileMgr().getOptionalFileRef(TmpDir, false, false)) {
+      if (auto File = getFileMgr().getOptionalFileRef(TmpDir)) {
         if (&File->getFileEntry() == *FE)
           continue;
         Diags.Report(IncludeLoc, diag::warn_header_shadowing)
@@ -932,7 +932,7 @@ void HeaderSearch::diagnoseHeaderShadowing(
       continue;
     SmallString<1024> TmpPath = It->getName();
     llvm::sys::path::append(TmpPath, Filename);
-    if (auto File = getFileMgr().getOptionalFileRef(TmpPath, false, false)) {
+    if (auto File = getFileMgr().getOptionalFileRef(TmpPath)) {
       if (&File->getFileEntry() == *FE)
         continue;
       Diags.Report(IncludeLoc, diag::warn_header_shadowing)

--- a/clang/test/Preprocessor/header-shadowing-stats.c
+++ b/clang/test/Preprocessor/header-shadowing-stats.c
@@ -1,0 +1,22 @@
+// This test checks that -Wshadow-header doesn't repeatedly perform the same IO.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+//--- tu1.c
+#include "header.h"
+//--- tu2.c
+#include "header.h"
+// The following line should not trigger more IO:
+#include "header.h"
+//--- include1/header.h
+//--- include2/keep.h
+
+// RUN: %clang_cc1 -Eonly %t/tu1.c -I %t/include1 -I %t/include2 -Wshadow-header -print-stats 2>%t/tu1.stats
+// RUN: %clang_cc1 -Eonly %t/tu2.c -I %t/include1 -I %t/include2 -Wshadow-header -print-stats 2>%t/tu2.stats
+
+// RUN: cat %t/tu1.stats %t/tu2.stats | FileCheck %s
+// CHECK:      *** Virtual File System Stats:
+// CHECK-NEXT: [[STATUS_COUNT:[0-9]+]] status() calls
+// CHECK:      *** Virtual File System Stats:
+// CHECK-NEXT: [[STATUS_COUNT]] status() calls


### PR DESCRIPTION
The `-Wshadow-header` warning introduced in
https://github.com/llvm/llvm-project/pull/162491 gets enabled by `-Weverything` and causes `O(H*I*S)` extra `status()` syscalls (where H is the number of included headers, I is the average number of inclusions per header, S is the number of search paths). This is caused by proactively probing search paths even after finding a suitable header, and calling `FileManager` with `CacheFailure = false`.

There's no reason to not cache the non-existence of header files during these probes. This PR starts caching these, bringing down the complexity to `O(H*S)` and adds a regression test.

(cherry picked from commit 5fa5caa0f2f768af54087a3df749990c41c18a04)