### PR TITLE
[clang][lex] Do not translate repeated include into import

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -840,6 +840,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 - Clang now defines the GCC-compatible predefined macro `__SIG_ATOMIC_TYPE__`. (#GH213895)
 - Fix a crash in addUnsizedArray due assert not verifying we have a Base before doing checks on it. (#GH44212)
 - Fixed an assertion that could occur when rebuilding parenthesized list initialization expressions during template instantiation or AST transformation.
+- Fixed a bug where repeated #imports of modular headers in non-modular compilation were translated to #pragma clang module import. (#GH216924)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2755,7 +2755,8 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
     if (UsableHeaderUnit && !getLangOpts().CompilingPCH)
       Action = TrackGMFState.inGMF() ? Import : Skip;
     else
-      Action = (ModuleToImport && !getLangOpts().CompilingPCH) ? Import : Skip;
+      Action = (UsableClangHeaderModule && !getLangOpts().CompilingPCH) ? Import
+                                                                        : Skip;
   }
 
   // Check for circular inclusion of the main file.

--- a/clang/test/ClangScanDeps/include-tree-module-map-file-without-modules.c
+++ b/clang/test/ClangScanDeps/include-tree-module-map-file-without-modules.c
@@ -45,5 +45,6 @@ module Foo {
 void foo(void);
 
 //--- tu.c
-#include "foo.h"
+#import "foo.h"
+#import "foo.h"
 void tu(void) { foo(); }

--- a/clang/test/Modules/non-modular-with-module-file.c
+++ b/clang/test/Modules/non-modular-with-module-file.c
@@ -1,0 +1,31 @@
+// Check that repeated inclusion of a modular header doesn't get translated
+// into an import in textual compilation.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -E %t/tu.c -o %t/tu.ii -I %t -fmodule-map-file=%t/module.modulemap
+
+// RUN: FileCheck --input-file=%t/tu.ii %s -DPREFIX=%t
+
+// CHECK:      # 1 "[[PREFIX]]{{/|\\}}tu.c"
+// CHECK-NEXT: # 1 "<built-in>" 1
+// CHECK-NEXT: # 1 "<built-in>" 3
+// CHECK-NEXT: # {{[0-9]+}} "<built-in>" 3
+// CHECK-NEXT: # 1 "<command line>" 1
+// CHECK-NEXT: # 1 "<built-in>" 2
+// CHECK-NEXT: # 1 "[[PREFIX]]{{/|\\}}tu.c" 2
+// CHECK-NEXT: # 1 "[[PREFIX]]{{/|\\}}Mod.h" 1
+// CHECK-NEXT: #pragma clang module begin Mod
+// CHECK-NEXT: # 2 "[[PREFIX]]{{/|\\}}tu.c" 2
+// CHECK-NEXT: # 1 "[[PREFIX]]{{/|\\}}tu.c"
+// CHECK-NEXT: #pragma clang module end /*Mod*/
+// CHECK-NOT:  #pragma clang module import
+
+//--- module.modulemap
+module Mod { header "Mod.h" }
+//--- Mod.h
+#pragma once
+//--- tu.c
+#include "Mod.h"
+#include "Mod.h"


### PR DESCRIPTION
Using `ModuleToImport` when deciding whether to turn a repeated include
into an import, or whether to skip it, isn't right. We have
`ModuleToImport=true` even without `-fmodules` in textual compilations.
This PR starts checking `UsableClangHeaderModule`, matching what we do
for the first inclusion of that header.

rdar://184549117