### PR TITLE
[LLDB] Fix enum payload expression paths

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1863,8 +1863,13 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
     assert(false);
     return llvm::createStringError("enum with unexpected offset");
   }
-  return valobj.GetSyntheticChildAtOffset(0, projected_type, /*can_create=*/true,
-                                          ConstString(field_info.Name));
+  ValueObjectSP projected_sp = valobj.GetSyntheticChildAtOffset(
+      0, projected_type, /*can_create=*/true, ConstString(field_info.Name));
+  // Children inherit this flag, and it makes GetExpressionPath() emit a raw
+  // address instead of a path.
+  if (projected_sp)
+    projected_sp->SetSyntheticChildrenGenerated(false);
+  return projected_sp;
 }
 
 std::pair<SwiftLanguageRuntime::LookupResult, std::optional<size_t>>


### PR DESCRIPTION
ProjectEnum builds the payload with GetSyntheticChildAtOffset, which marks the result synthetic-children-generated since upstream b6a56c466593 (#198859).

6e37e1c6c63f already worked around this for Optional in the SwiftOptional frontend. Clear the flag where the payload is created instead, so plain payload enums are covered too.

Assisted-by: Claude