### PR TITLE
[lldb] Let go of CAS object stores when a session ends

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -1178,10 +1178,15 @@ protected:
 
   // BEGIN CAS
 
-  /// All CAS configurations (+instances) associated with this
-  /// module. An empty optional means uninitialized, an empty vector
-  /// means that this module has no CAS associated with it.
-  std::optional<std::vector<ModuleList::CAS>> m_cas;
+  /// All CAS configurations associated with this module. An empty optional
+  /// means uninitialized, an empty vector means that this module has no CAS
+  /// associated with it.
+  ///
+  /// Only the configurations are kept, not the instances, so that a CAS
+  /// instance can be reopened from its configuration when needed. ModuleList
+  /// keeps a cache of the instances opened for each CASConfiguration, which is
+  /// used to look up an already opened instance.
+  std::optional<std::vector<llvm::cas::CASConfiguration>> m_cas;
   mutable std::mutex m_cas_init_mutex;
 
   // END CAS

--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -574,11 +574,10 @@ public:
     std::shared_ptr<llvm::cas::ObjectStore> object_store;
     std::shared_ptr<llvm::cas::ActionCache> action_cache;
   };
-  /// Find an initialize every CAS associated with \c module_sp.
-  static void ConfigureCASStorage(const lldb::ModuleSP &module_sp);
-
-  /// Return a list of all CAS associated with \c module_sp.
-  static llvm::ArrayRef<CAS> GetCASStorage(const lldb::ModuleSP &module_sp);
+  /// Return a list of all CAS associated with \c module_sp, opening them if
+  /// they are not currently open. The returned instances keep the stores alive
+  /// for as long as the caller holds them, and no longer.
+  static std::vector<CAS> GetCASStorage(const lldb::ModuleSP &module_sp);
 
   /// Return the first CAS associated with \c module_sp whose
   /// ObjectStore resolves \c cas_id. Returns an error if no CAS
@@ -612,6 +611,16 @@ public:
   static lldb::ModuleSP FindSharedModule(const UUID &uuid);
 
   static size_t RemoveOrphanSharedModules(bool mandatory);
+
+  // BEGIN CAS
+  /// Let go of every CAS ObjectStore the shared cache is keeping open, so the
+  /// on-disk databases stop being locked against pruning. A module that needs
+  /// one again will reopen it.
+  ///
+  /// \returns the number of stores that something else still references, and
+  /// which therefore stay open. Non-zero means a leak; each is logged by path.
+  static size_t ReleaseCASObjectStores();
+  // END CAS
 
   static bool RemoveSharedModuleIfOrphaned(const lldb::ModuleWP module_ptr);
 

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1000,6 +1000,12 @@ void Debugger::Destroy(DebuggerSP &debugger_sp) {
 
   debugger_sp->Clear();
 
+  // BEGIN CAS
+  // The targets are gone, so let go of the CAS databases this session opened
+  // and stop holding their on-disk storage locked against pruning.
+  ModuleList::ReleaseCASObjectStores();
+  // END CAS
+
   std::lock_guard<std::mutex> guard(GetDebuggerListMutex());
   if (g_debugger_list_ptr) {
     DebuggerList::iterator pos, end = g_debugger_list_ptr->end();

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1318,16 +1318,24 @@ private:
   // BEGIN CAS
 public:
   struct CAS {
-    std::weak_ptr<llvm::cas::ObjectStore> object_store;
-    std::weak_ptr<llvm::cas::ActionCache> action_cache;
+    std::shared_ptr<llvm::cas::ObjectStore> object_store;
+    std::shared_ptr<llvm::cas::ActionCache> action_cache;
     CAS(std::shared_ptr<llvm::cas::ObjectStore> os,
         std::shared_ptr<llvm::cas::ActionCache> ac)
         : object_store(std::move(os)), action_cache(std::move(ac)) {}
   };
 
-  /// Holds all currently loaded CAS for each configuration. If the
-  /// weak_ptr is null, the CAS was previously created, but has been
-  /// garbage collected.
+  /// Holds every CAS that has been opened, keyed by its configuration, so a
+  /// second module with the same configuration reuses it rather than opening
+  /// the database again. A disengaged optional records a configuration that
+  /// failed to open, so it is not retried.
+  ///
+  /// These are strong references, and an open CAS holds a lock against the
+  /// on-disk database being pruned, so something has to let them go:
+  /// \c ModuleList::ReleaseCASObjectStores().
+  ///
+  /// Reading or writing this requires holding
+  /// \c SharedModuleListInfo::shared_lock.
   llvm::DenseMap<llvm::cas::CASConfiguration, std::optional<CAS>> m_cas_cache;
 
 private:
@@ -1402,6 +1410,41 @@ lldb::ModuleSP ModuleList::FindSharedModule(const UUID &uuid) {
 size_t ModuleList::RemoveOrphanSharedModules(bool mandatory) {
   return GetSharedModuleList().RemoveOrphans(mandatory);
 }
+
+// BEGIN CAS
+size_t ModuleList::ReleaseCASObjectStores() {
+  SharedModuleListInfo &shared_module_list_info = GetSharedModuleListInfo();
+  std::scoped_lock<std::mutex> lock(shared_module_list_info.shared_lock);
+  auto &cas_cache = shared_module_list_info.module_list.m_cas_cache;
+
+  Log *log = GetLog(LLDBLog::Modules);
+  size_t released = 0;
+  size_t still_referenced = 0;
+  for (auto &entry : cas_cache) {
+    if (!entry.second)
+      continue;
+    // Anything referenced elsewhere stays open, and its database stays locked,
+    // so report it rather than assume the release worked. The cache's own
+    // reference is the one being dropped, hence the comparison against 1.
+    if (entry.second->object_store.use_count() > 1 ||
+        entry.second->action_cache.use_count() > 1) {
+      ++still_referenced;
+      LLDB_LOG(log, "CAS still referenced: {0}", entry.first.CASPath);
+      continue;
+    }
+    ++released;
+  }
+
+  // Drop the entries outright rather than marking them, so a module that needs
+  // one of these again opens it again instead of treating the configuration as
+  // one that failed.
+  cas_cache.clear();
+
+  LLDB_LOG(log, "Released {0} CAS object store(s), {1} still referenced",
+           released, still_referenced);
+  return still_referenced;
+}
+// END CAS
 
 Status
 ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
@@ -1693,15 +1736,15 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
 llvm::Expected<ModuleSpec> ModuleList::LoadModuleFromCAS(
     llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
     const ModuleSP &nearby, const UUID &uuid, const ArchSpec &arch) {
-  ConfigureCASStorage(nearby);
   if (!nearby) {
     LLDB_LOG(GetLog(LLDBLog::Modules),
              "Failed to load module '{0}' at '{1}' from CAS: no module",
              name_for_diagnostics, cas_id);
     return ModuleSpec();
   }
-  assert(nearby->m_cas && "ConfigureCASStorage should have populated m_cas");
-  if (nearby->m_cas->empty()) {
+  // Holds the stores alive for the duration of the loop.
+  std::vector<CAS> all_cas = GetCASStorage(nearby);
+  if (all_cas.empty()) {
     LLDB_LOG(GetLog(LLDBLog::Modules),
              "Failed to load module '{0}' at '{1}' from CAS: no CAS "
              "associated with module",
@@ -1711,7 +1754,7 @@ llvm::Expected<ModuleSpec> ModuleList::LoadModuleFromCAS(
 
   // Try each CAS in turn; return on the first successful resolve.
   llvm::Error errors = llvm::Error::success();
-  for (const auto &entry : *nearby->m_cas) {
+  for (const auto &entry : all_cas) {
     const auto &cas = entry.object_store;
     if (!cas)
       continue;
@@ -1728,8 +1771,16 @@ llvm::Expected<ModuleSpec> ModuleList::LoadModuleFromCAS(
       errors = joinErrors(std::move(errors), module_proxy.takeError());
       continue;
     }
-    auto file_buffer =
-        std::make_shared<DataBufferLLVM>(module_proxy->getMemoryBuffer());
+    // Ask for a buffer that does not reference the CAS, so the store can be
+    // released at the end of the session while this module stays usable.
+    //
+    // Object files are read as a sized range, not as a C string, so they do
+    // not need a nul terminator; FileSystem::CreateDataBuffer() does not ask
+    // for one either. Requiring it would force a copy of exactly the objects
+    // big enough to be worth not copying.
+    auto file_buffer = std::make_shared<DataBufferLLVM>(
+        module_proxy->getStandaloneMemoryBuffer(
+            cas_id, /*RequiresNullTerminator=*/false));
     FileSpec cas_spec;
     cas_spec.SetDirectory(ConstString(entry.configuration.CASPath));
     cas_spec.SetFilename(ConstString(cas_id));
@@ -1886,80 +1937,66 @@ FindCASConfigurations(const ModuleSP &module_sp) {
   return {};
 }
 
-/// Look up cas_config in the shared CAS cache, or instantiate it and
-/// insert. Returns a CAS triple with null instances if instantiation
-/// failed.
-///
-/// \pre Caller must hold \c shared_module_list.shared_lock — the
-///      function mutates \c shared_module_list.module_list.m_cas_cache.
-static ModuleList::CAS
-FindOrCreateInSharedCache(const llvm::cas::CASConfiguration &cas_config,
-                          SharedModuleListInfo &shared_module_list) {
-  auto &cas_cache = shared_module_list.module_list.m_cas_cache;
-  auto weak_cached = cas_cache.find(cas_config);
-  if (weak_cached != cas_cache.end()) {
-    if (weak_cached->second) {
-      auto os = weak_cached->second->object_store.lock();
-      auto ac = weak_cached->second->action_cache.lock();
-      if (os && ac)
-        return {cas_config, std::move(os), std::move(ac)};
-      cas_cache.erase(cas_config);
-      LLDB_LOG(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
-               "CAS at {0} was garbage-collected", cas_config.CASPath);
-    } else {
-      return {cas_config, nullptr, nullptr};
-    }
-  }
-  auto created = cas_config.createDatabases();
-  if (!created) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
-                   created.takeError(), "Failed to initialize CAS at {1}: {0}",
-                   cas_config.CASPath);
-    cas_cache.insert({cas_config, {}});
-    return {cas_config, nullptr, nullptr};
-  }
-  LLDB_LOG(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
-           "Initialized CAS at {0}", cas_config.CASPath);
-  cas_cache.insert(
-      {cas_config, SharedModuleList::CAS(created->first, created->second)});
-  return {cas_config, created->first, created->second};
-}
-
-void ModuleList::ConfigureCASStorage(const ModuleSP &module_sp) {
-  if (!module_sp)
-    return;
-  std::lock_guard<std::mutex> module_lock(module_sp->m_cas_init_mutex);
-  std::optional<std::vector<ModuleList::CAS>> &module_cas = module_sp->m_cas;
-  if (module_cas)
-    return; // Already initialized.
-  std::vector<llvm::cas::CASConfiguration> found =
-      FindCASConfigurations(module_sp);
-  auto &entries = module_cas.emplace();
-  if (found.empty())
-    return;
-  auto &shared_module_list = GetSharedModuleListInfo();
-  std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
-  entries.reserve(found.size());
-  for (auto &cfg : found)
-    entries.push_back(FindOrCreateInSharedCache(cfg, shared_module_list));
-}
-
-llvm::ArrayRef<ModuleList::CAS>
+std::vector<ModuleList::CAS>
 ModuleList::GetCASStorage(const ModuleSP &module_sp) {
-  ConfigureCASStorage(module_sp);
   if (!module_sp)
     return {};
-  assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
-  return *module_sp->m_cas;
+
+  // Which CAS a module uses does not change, so the search for its
+  // configurations runs once.
+  std::vector<llvm::cas::CASConfiguration> configurations;
+  {
+    std::lock_guard<std::mutex> module_lock(module_sp->m_cas_init_mutex);
+    if (!module_sp->m_cas)
+      module_sp->m_cas = FindCASConfigurations(module_sp);
+    configurations = *module_sp->m_cas;
+  }
+  if (configurations.empty())
+    return {};
+
+  auto &shared_module_list_info = GetSharedModuleListInfo();
+  auto &cas_cache = shared_module_list_info.module_list.m_cas_cache;
+  std::scoped_lock<std::mutex> lock(shared_module_list_info.shared_lock);
+
+  std::vector<CAS> entries;
+  entries.reserve(configurations.size());
+  for (const llvm::cas::CASConfiguration &cas_config : configurations) {
+    auto cached = cas_cache.find(cas_config);
+    if (cached != cas_cache.end()) {
+      // A disengaged entry records a configuration that failed to open, so it
+      // is not retried.
+      if (cached->second)
+        entries.push_back({cas_config, cached->second->object_store,
+                           cached->second->action_cache});
+      else
+        entries.push_back({cas_config, nullptr, nullptr});
+      continue;
+    }
+
+    auto created = cas_config.createDatabases();
+    if (!created) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
+                     created.takeError(),
+                     "Failed to initialize CAS at {1}: {0}",
+                     cas_config.CASPath);
+      cas_cache[cas_config] = std::nullopt;
+      entries.push_back({cas_config, nullptr, nullptr});
+      continue;
+    }
+    LLDB_LOG(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
+             "Initialized CAS at {0}", cas_config.CASPath);
+    cas_cache[cas_config] =
+        SharedModuleList::CAS(created->first, created->second);
+    entries.push_back({cas_config, created->first, created->second});
+  }
+  return entries;
 }
 
 bool ModuleList::IsCASID(const ModuleSP &module_sp,
                          llvm::StringRef id) {
-  ConfigureCASStorage(module_sp);
   if (!module_sp)
     return false;
-  assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
-  for (const auto &entry : *module_sp->m_cas) {
+  for (const auto &entry : GetCASStorage(module_sp)) {
     if (!entry.object_store)
       continue;
     auto ref = entry.object_store->parseID(id);
@@ -1972,14 +2009,13 @@ bool ModuleList::IsCASID(const ModuleSP &module_sp,
 
 llvm::Expected<ModuleList::CAS>
 ModuleList::GetCASForID(const ModuleSP &module_sp, llvm::StringRef cas_id) {
-  ConfigureCASStorage(module_sp);
   if (!module_sp)
     return llvm::createStringError("no lldb::Module available");
-  assert(module_sp->m_cas && "ConfigureCASStorage should have populated m_cas");
-  if (module_sp->m_cas->empty())
+  std::vector<CAS> all_cas = GetCASStorage(module_sp);
+  if (all_cas.empty())
     return llvm::createStringError("no CAS associated with module");
   llvm::Error errors = llvm::Error::success();
-  for (const auto &entry : *module_sp->m_cas) {
+  for (const auto &entry : all_cas) {
     if (!entry.object_store)
       continue;
     auto id = entry.object_store->parseID(cas_id);
@@ -2020,9 +2056,16 @@ llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
   auto status = GetSharedModule(module_spec, module_sp, nullptr, nullptr,
                                 /*always_create=*/false);
   if (status.Success()) {
-    if (module_sp) {
+    if (module_sp && module_sp != nearby) {
+      // The loaded module resolves its CASIDs against the same configurations
+      // as the module that referenced it.
+      std::optional<std::vector<llvm::cas::CASConfiguration>> configurations;
+      {
+        std::lock_guard<std::mutex> src_lock(nearby->m_cas_init_mutex);
+        configurations = nearby->m_cas;
+      }
       std::lock_guard<std::mutex> dest_lock(module_sp->m_cas_init_mutex);
-      module_sp->m_cas = nearby->m_cas;
+      module_sp->m_cas = std::move(configurations);
     }
     return true;
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -936,8 +936,7 @@ static std::string GetClangModulesCacheProperty() {
 }
 
 void SwiftASTContext::ConfigureDefaultCASStorage(const ModuleSP &module_sp) {
-  llvm::ArrayRef<ModuleList::CAS> all_cas =
-      ModuleList::GetCASStorage(module_sp);
+  std::vector<ModuleList::CAS> all_cas = ModuleList::GetCASStorage(module_sp);
   if (all_cas.empty()) {
     HEALTH_LOG_PRINTF("Did not create CAS: no CAS associated with module");
     return;
@@ -9984,7 +9983,9 @@ loadPCHFromCAS(llvm::cas::ObjectStore &m_cas, llvm::cas::ActionCache &m_cache,
   }
   if (!*proxy)
     return nullptr;
-  return (*proxy)->getMemoryBuffer();
+  // The PCH is handed to a filesystem that the ASTContext keeps, so it has to
+  // stay readable after the CAS is released.
+  return (*proxy)->getStandaloneMemoryBuffer(maybe_id);
 }
 
 void SwiftASTContext::ConfigureBridgingHeader(const SymbolContext &sc) {

--- a/lldb/test/API/functionalities/cas/gmodules/Makefile
+++ b/lldb/test/API/functionalities/cas/gmodules/Makefile
@@ -1,0 +1,65 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS = -g -I$(SRCDIR)
+LD_EXTRAS = $(BUILDDIR)/cached/libcached.dylib $(BUILDDIR)/uncached/libuncached.dylib
+
+all: a.out
+
+include Makefile.rules
+
+# Two dylibs built from the same headers. The cached one is compiled through
+# the explicit-module driver with a CAS, so its DWARF refers to the .pcm by
+# CASID; the uncached one is built the ordinary way, so its DWARF refers to the
+# .pcm by path. Both get a .cas-config next to them pointing at a CAS of their
+# own, so both resolve to a CAS -- but only the cached one loads a module out of
+# one.
+#
+# Built with explicit rules rather than DYLIB_C_SOURCES because the cached
+# dylib needs a bespoke compile step and neither may be run through dsymutil:
+# that would resolve the -gmodules references and there would be no module
+# left to load out of the CAS.
+#
+# The build directory is not erased between test runs, so each rule spells out
+# everything it is built from, the tools included: a rebuilt clang has to
+# rebuild the dylibs, or the module lldb reads out of the CAS would be one the
+# previous clang wrote.
+
+CAS_DIR = $(BUILDDIR)/cached
+NOCAS_DIR = $(BUILDDIR)/uncached
+MODULE_FLAGS = -fmodules -gmodules -I$(SRCDIR)
+COMPILE_FLAGS = -g $(SYSROOT_FLAGS) $(ARCH_CFLAGS)
+EXPLICIT_MODULE_BUILD = $(LLDB_BASE_DIR)/scripts/clang-explicit-module-build.py
+CLANG_SCAN_DEPS = $(dir $(firstword $(CC)))clang-scan-deps
+
+a.out: $(CAS_DIR)/libcached.dylib $(NOCAS_DIR)/libuncached.dylib
+
+# The explicit-module build shells out to clang-scan-deps next to $(CC), so that
+# is a tool this rule uses too.
+$(CAS_DIR)/libcached.dylib: $(SRCDIR)/cached.c $(SRCDIR)/cached.h \
+                            $(SRCDIR)/module.modulemap \
+                            $(EXPLICIT_MODULE_BUILD) \
+                            $(call tool_prereq,$(CC)) \
+                            $(call tool_prereq,$(CLANG_SCAN_DEPS)) \
+                            | $(CAS_DIR)/.cas-config
+	python3 $(EXPLICIT_MODULE_BUILD) -cas-path $(CAS_DIR)/cas -- \
+	  $(CC) -c $(COMPILE_FLAGS) $(MODULE_FLAGS) \
+	  -fmodules-cache-path=$(CAS_DIR)/module-cache \
+	  -o $(CAS_DIR)/cached.o $(SRCDIR)/cached.c
+	$(CC) -dynamiclib $(COMPILE_FLAGS) $(CAS_DIR)/cached.o -o $@
+
+$(NOCAS_DIR)/libuncached.dylib: $(SRCDIR)/uncached.c $(SRCDIR)/uncached.h \
+                                $(SRCDIR)/module.modulemap \
+                                $(call tool_prereq,$(CC)) \
+                                | $(NOCAS_DIR)/.cas-config
+	$(CC) -c $(COMPILE_FLAGS) $(MODULE_FLAGS) \
+	  -fmodules-cache-path=$(NOCAS_DIR)/module-cache \
+	  -o $(NOCAS_DIR)/uncached.o $(SRCDIR)/uncached.c
+	$(CC) -dynamiclib $(COMPILE_FLAGS) $(NOCAS_DIR)/uncached.o -o $@
+
+# One rule per config file rather than an echo in the recipes above, so that a
+# config that is missing from an existing build directory comes back without
+# the dylib next to it having to be rebuilt. An order-only prerequisite above:
+# what a dylib is built from does not depend on this file's contents, only on
+# the directory existing.
+$(CAS_DIR)/.cas-config $(NOCAS_DIR)/.cas-config:
+	$(call MKDIR_P,$(@D))
+	echo '{"CASPath": "$(@D)/cas"}' > $@

--- a/lldb/test/API/functionalities/cas/gmodules/TestCASReleaseObjectStore.py
+++ b/lldb/test/API/functionalities/cas/gmodules/TestCASReleaseObjectStore.py
@@ -1,0 +1,85 @@
+"""
+Test that lldb stops holding a CAS ObjectStore open once a session ends.
+
+The modules that were loaded out of the CAS stay in the shared module list and
+stay usable, because the buffers backing them no longer reference the store.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCASReleaseObjectStore(TestBase):
+    def load_both_modules(self, target):
+        """Stop in each dylib and evaluate an expression there, so that both
+        SymbolFiles import their clang module -- one out of the CAS, one from a
+        .pcm on disk."""
+        for source, pattern in [
+            ("cached.c", "BREAK CACHED"),
+            ("uncached.c", "BREAK UNCACHED"),
+        ]:
+            bkpt = target.BreakpointCreateBySourceRegex(
+                pattern, lldb.SBFileSpec(source)
+            )
+            self.assertEqual(bkpt.GetNumLocations(), 1, source)
+
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertState(process.GetState(), lldb.eStateStopped)
+
+        for variable, expected in [("c", "x = 41"), ("u", "y = 17")]:
+            frame = process.GetSelectedThread().GetFrameAtIndex(0)
+            value = frame.EvaluateExpression(variable)
+            self.assertSuccess(value.GetError(), "evaluating '%s'" % variable)
+            self.assertIn(expected, str(value))
+            process.Continue()
+
+    def debug_in_a_fresh_debugger(self, executable, log_path):
+        """Debug `executable` in a debugger of our own -- the test's primary
+        debugger would keep its targets, and so the CAS, alive -- capturing the
+        module log, then destroy that debugger. Returns the log contents."""
+        debugger = lldb.SBDebugger.Create()
+        try:
+            debugger.SetAsync(False)
+            result = lldb.SBCommandReturnObject()
+            debugger.GetCommandInterpreter().HandleCommand(
+                'log enable lldb module -f "%s"' % log_path, result
+            )
+            self.assertTrue(result.Succeeded(), result.GetError())
+
+            target = debugger.CreateTarget(executable)
+            self.assertTrue(target.IsValid())
+            self.load_both_modules(target)
+        finally:
+            lldb.SBDebugger.Destroy(debugger)
+
+        with open(log_path, "r") as f:
+            return f.read()
+
+    @skipUnlessDarwin
+    @skipIf(compiler=no_match("clang"))
+    def test_cas_released_on_debugger_destroy(self):
+        self.build()
+        executable = self.getBuildArtifact("a.out")
+
+        log = self.debug_in_a_fresh_debugger(
+            executable, self.getBuildArtifact("first_session.log")
+        )
+
+        # The point of the test: something really was read out of a CAS, so
+        # what follows is not vacuous.
+        self.assertIn("loading module using CASID", log)
+
+        # And by the time the debugger is gone, no store is still held.
+        # Something was released, and nothing outlived the release.
+        self.assertRegex(log, r"Released [1-9]\d* CAS object store\(s\), 0 still referenced")
+
+        # The modules stay in the shared module list and stay usable, so
+        # debugging the same binary again evaluates the same expressions out of
+        # buffers whose CAS has been released -- without reopening it.
+        second = self.debug_in_a_fresh_debugger(
+            executable, self.getBuildArtifact("second_session.log")
+        )
+        self.assertNotIn("Initialized CAS at", second)
+        self.assertIn("0 still referenced", second)

--- a/lldb/test/API/functionalities/cas/gmodules/cached.c
+++ b/lldb/test/API/functionalities/cas/gmodules/cached.c
@@ -1,0 +1,7 @@
+#include "cached.h"
+
+int cached_fn(void) {
+  struct Cached c;
+  c.x = 41;
+  return c.x; // BREAK CACHED
+}

--- a/lldb/test/API/functionalities/cas/gmodules/cached.h
+++ b/lldb/test/API/functionalities/cas/gmodules/cached.h
@@ -1,0 +1,2 @@
+#pragma once
+struct Cached { int x; };

--- a/lldb/test/API/functionalities/cas/gmodules/main.c
+++ b/lldb/test/API/functionalities/cas/gmodules/main.c
@@ -1,0 +1,4 @@
+int cached_fn(void);
+int uncached_fn(void);
+
+int main(void) { return cached_fn() + uncached_fn() - 58; }

--- a/lldb/test/API/functionalities/cas/gmodules/module.modulemap
+++ b/lldb/test/API/functionalities/cas/gmodules/module.modulemap
@@ -1,0 +1,2 @@
+module Cached { header "cached.h" export * }
+module Uncached { header "uncached.h" export * }

--- a/lldb/test/API/functionalities/cas/gmodules/uncached.c
+++ b/lldb/test/API/functionalities/cas/gmodules/uncached.c
@@ -1,0 +1,7 @@
+#include "uncached.h"
+
+int uncached_fn(void) {
+  struct Uncached u;
+  u.y = 17;
+  return u.y; // BREAK UNCACHED
+}

--- a/lldb/test/API/functionalities/cas/gmodules/uncached.h
+++ b/lldb/test/API/functionalities/cas/gmodules/uncached.h
@@ -1,0 +1,2 @@
+#pragma once
+struct Uncached { int y; };

--- a/lldb/test/API/functionalities/cas/swift/Makefile
+++ b/lldb/test/API/functionalities/cas/swift/Makefile
@@ -1,0 +1,13 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_COMPILE_CACHE := YES
+# Without a .swiftmodule next to the binary, the SwiftASTContext has to load
+# the module out of the CAS, which is the reference we want released.
+HIDE_SWIFTMODULE := YES
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR)
+
+all: a.out cas-config
+
+include Makefile.rules
+
+cas-config:
+	echo "{\"CASPath\": \"$(BUILDDIR)/cas\"}" > .cas-config

--- a/lldb/test/API/functionalities/cas/swift/TestSwiftCASReleaseObjectStore.py
+++ b/lldb/test/API/functionalities/cas/swift/TestSwiftCASReleaseObjectStore.py
@@ -1,0 +1,79 @@
+"""
+Test that a Swift debug session stops holding its CAS ObjectStore open once the
+debugger is destroyed, without giving up the modules it loaded.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftCASReleaseObjectStore(TestBase):
+    def debug_in_a_fresh_debugger(self, executable, log_path):
+        """Debug `executable` in a debugger of our own -- the test's primary
+        debugger would keep its targets, and so the CAS, alive -- evaluate an
+        expression that needs the CAS-backed Swift module, then destroy that
+        debugger. Returns the log contents."""
+        debugger = lldb.SBDebugger.Create()
+        try:
+            debugger.SetAsync(False)
+            result = lldb.SBCommandReturnObject()
+            debugger.GetCommandInterpreter().HandleCommand(
+                'log enable lldb module -f "%s"' % log_path, result
+            )
+            self.assertTrue(result.Succeeded(), result.GetError())
+
+            target = debugger.CreateTarget(executable)
+            self.assertTrue(target.IsValid())
+
+            breakpoint = target.BreakpointCreateBySourceRegex(
+                "break here", lldb.SBFileSpec("main.swift")
+            )
+            self.assertEqual(breakpoint.GetNumLocations(), 1)
+
+            process = target.LaunchSimple(
+                None, None, self.get_process_working_directory()
+            )
+            self.assertState(process.GetState(), lldb.eStateStopped)
+
+            frame = process.GetSelectedThread().GetFrameAtIndex(0)
+            value = frame.EvaluateExpression("obj")
+            self.assertSuccess(value.GetError(), "evaluating 'obj'")
+            self.assertIn("x = 0", str(value))
+
+            # The Swift module was hidden from the filesystem, so the context
+            # that just answered this can only have loaded it out of the CAS.
+            self.assertTrue(
+                frame.GetLanguageSpecificData()
+                .GetValueForKey("SwiftHasCAS")
+                .GetBooleanValue()
+            )
+        finally:
+            lldb.SBDebugger.Destroy(debugger)
+
+        with open(log_path, "r") as f:
+            return f.read()
+
+    # Embedded Swift does not stand up a SwiftASTContext, so there is no
+    # CAS-backed module load to release here.
+    @requireNotEmbeddedSwift
+    @skipUnlessDarwin
+    @swiftTest
+    def test_cas_released_on_debugger_destroy(self):
+        self.build()
+        executable = self.getBuildArtifact("a.out")
+
+        log = self.debug_in_a_fresh_debugger(
+            executable, self.getBuildArtifact("first_session.log")
+        )
+        # Something was released, and nothing outlived the release.
+        self.assertRegex(log, r"Released [1-9]\d* CAS object store\(s\), 0 still referenced")
+
+        # Debugging the same binary again still works, out of modules whose CAS
+        # has been released, and nothing is left holding one at the end of that
+        # session either.
+        second = self.debug_in_a_fresh_debugger(
+            executable, self.getBuildArtifact("second_session.log")
+        )
+        self.assertIn("0 still referenced", second)

--- a/lldb/test/API/functionalities/cas/swift/a.h
+++ b/lldb/test/API/functionalities/cas/swift/a.h
@@ -1,0 +1,3 @@
+struct A {
+  int x;
+};

--- a/lldb/test/API/functionalities/cas/swift/main.swift
+++ b/lldb/test/API/functionalities/cas/swift/main.swift
@@ -1,0 +1,4 @@
+import ClangA
+
+let obj = A()
+print("break here \(obj)")

--- a/lldb/test/API/functionalities/cas/swift/module.modulemap
+++ b/lldb/test/API/functionalities/cas/swift/module.modulemap
@@ -1,0 +1,3 @@
+module ClangA {
+  header "a.h"
+}

--- a/lldb/test/Shell/SymbolFile/cas-gmodule.test
+++ b/lldb/test/Shell/SymbolFile/cas-gmodule.test
@@ -31,9 +31,11 @@
 # CHECK: Initialized CAS at [[CAS:.*]]
 # CHECK: Loading module 'Top' from CAS at
 # CHECK: top = (x = 1)
-# CHECK: CAS at [[CAS]] was garbage-collected
-# CHECK: Initialized CAS at [[CAS]]
-# CHECK: Loading module 'Top' from CAS at
+# One CAS is opened for the session and released at the end of it, with
+# nothing left holding it. Loading a second module out of the same CAS reuses
+# the open one rather than opening it again.
+# CHECK-NOT: Initialized CAS at
+# CHECK: Released 1 CAS object store(s), 0 still referenced
 
 # NONCAS-NOT: is not valid CASID
 # NONCAS: unable to locate module needed for external types


### PR DESCRIPTION
lldb-rpc-server held a CAS ObjectStore alive for the lifetime of the process, keeping the on-disk database mapped and its lock held, which prevents CAS pruning. A CAS is created lazily per session, so a server serving many sessions accumulated one per session and never let go.

Nothing dropped them because the state keeping them alive outlives the debugger. Modules live in the global shared module list by design, and a module read out of a CAS pointed straight into the store's memory mapping, so the store could not be released without evicting the module.

Ask the CAS for buffers that do not reference it. ObjectStore's getStandaloneMemoryBuffer() re-reads the object's file where it has one and copies otherwise, so the bytes stay valid once the store is gone. The two places in lldb that keep CAS data past the end of a session use it: the object file of a module loaded from a CAS, and a bridging PCH handed to a SwiftASTContext's filesystem.

Module::m_cas held instances too, on every module that ever asked for a CAS rather than only those that read from one. It is a lookup cache, so it now holds only the configurations, and the instances come from the shared cache keyed by configuration.

With that, the shared cache is the one owner, and
ModuleList::ReleaseCASObjectStores() at the end of Debugger::Destroy() is all that has to let go. Nothing is evicted, and nothing has to be rebuilt in a later session; a module that needs a released CAS again reopens it. The disk space behind an object lldb still has mapped is not reclaimed until it unmaps it, which happens when the module goes away.

Whatever is still referenced when the release runs stays open, and is reported by path, so "the CAS should be gone by now" is checkable rather than assumed.

Two API tests, functionalities/cas/gmodules and functionalities/cas/swift, drive a debugger of their own -- the test's primary debugger would keep its targets, and so the CAS, alive -- check that a module really was read out of a CAS, that nothing still holds one once the debugger is gone, and that debugging the same binary again works without reopening the CAS at all. Both fail if a reference is leaked past the release.

rdar://183455561