### PR TITLE
[lldb] Report the Swift toolchain mismatch at AST context initialization

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1403,12 +1403,6 @@ public:
   ///     pre-computed.
   void PrintWarningOptimization(const SymbolContext &sc);
 
-#ifdef LLDB_ENABLE_SWIFT
-  /// Print a user-visible warning about Swift CUs compiled with a
-  /// different Swift compiler than the one embedded in LLDB.
-  void PrintWarningToolchainMismatch(const SymbolContext &sc);
-#endif
-
   /// Print a user-visible warning about a function written in a
   /// language that this version of LLDB doesn't support.
   ///

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3158,6 +3158,27 @@ void SwiftASTContext::DiscoverImplicitlyTrackedModules(
   }
 }
 
+/// Warn if \p comp_unit was built by a Swift compiler that doesn't match the
+/// one integrated into LLDB.
+static void ReportToolchainMismatch(Module &module, CompileUnit &comp_unit,
+                                    Target &target) {
+  // The debugger driving a scripted process is unrelated to the toolchain that
+  // built the target, so a mismatch is expected and not actionable.
+  if (target.GetProcessLaunchInfo().IsScriptedProcess())
+    return;
+
+  // Before there is a process, the setting only exists in the global
+  // properties.
+  ProcessSP process_sp = target.GetProcessSP();
+  const ProcessProperties &process_properties =
+      process_sp ? *process_sp : Process::GetGlobalProperties();
+  if (!process_properties.GetWarningsToolchainMismatch())
+    return;
+
+  module.ReportWarningToolchainMismatch(comp_unit,
+                                        target.GetDebugger().GetID());
+}
+
 lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     const SymbolContext &sc, TypeSystemSwiftTypeRef &typeref_typesystem,
     bool repl, bool playground, const char *extra_options) {
@@ -3198,6 +3219,13 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   // -              SwiftASTContext: target=null,     module=non-null.
   ModuleSP module_sp = sc.module_sp;
   TargetSP target_sp = typeref_typesystem.GetTargetWP().lock();
+
+  // Only an expression type system carries a target, so a per-module context
+  // takes it from the symbol context. Without a target there is no debugger to
+  // address, and reporting would consume the module's one-shot flag.
+  Target *warning_target = target_sp ? target_sp.get() : sc.target_sp.get();
+  if (module_sp && swift_context && warning_target)
+    ReportToolchainMismatch(*module_sp, *cu, *warning_target);
 
   // Make an AST but don't set the triple yet. We need to
   // try and detect if we have a iOS simulator.

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -6623,27 +6623,6 @@ void Process::PrintWarningOptimization(const SymbolContext &sc) {
   sc.module_sp->ReportWarningOptimization(GetTarget().GetDebugger().GetID());
 }
 
-#ifdef LLDB_ENABLE_SWIFT
-void Process::PrintWarningToolchainMismatch(const SymbolContext &sc) {
-  if (GetTarget().GetProcessLaunchInfo().IsScriptedProcess())
-    // It's very likely that the debugger used to launch the ScriptedProcess
-    // will not match the compiler version used to build the target, and we
-    // shouldn't need Swift's serialized AST to symbolicate the frame where we
-    // stopped. However, because this is called from a generic place
-    // (Thread::FrameSelectedCallback), it's safe to silence the warning for
-    // Scripted Processes.
-    return;
-  if (!GetWarningsToolchainMismatch())
-    return;
-  if (!sc.module_sp || !sc.comp_unit)
-    return;
-  if (sc.GetLanguage() != eLanguageTypeSwift)
-    return;
-  sc.module_sp->ReportWarningToolchainMismatch(
-      *sc.comp_unit, GetTarget().GetDebugger().GetID());
-}
-#endif
-
 void Process::PrintWarningUnsupportedLanguage(const SymbolContext &sc) {
   if (!GetWarningsUnsupportedLanguage())
     return;

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -349,9 +349,12 @@ let Definition = "process" in {
   def WarningUnsupportedLanguage: Property<"unsupported-language-warnings", "Boolean">,
     DefaultTrue,
     Desc<"If true, warn when stopped in code that is written in a source language that LLDB does not support.">;
-  def WarningToolchainMismatch: Property<"toolchain-mismatch-warnings", "Boolean">,
-    DefaultTrue,
-    Desc<"If true, warn when stopped in code that was compiled by a Swift compiler different from the one embedded in LLDB.">;
+  def WarningToolchainMismatch
+      : Property<"toolchain-mismatch-warnings", "Boolean">,
+        DefaultTrue,
+        Desc<"If true, warn when a Swift AST context is initialized for code "
+             "that was compiled by a Swift compiler different from the one "
+             "embedded in LLDB.">;
   def StopOnExec: Property<"stop-on-exec", "Boolean">,
     Global,
     DefaultTrue,

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -353,18 +353,11 @@ void Thread::FrameSelectedCallback(StackFrame *frame) {
 
   if (frame->HasDebugInformation() &&
       (GetProcess()->GetWarningsOptimization() ||
-       GetProcess()->GetWarningsUnsupportedLanguage()
-#ifdef LLDB_ENABLE_SWIFT
-       || GetProcess()->GetWarningsToolchainMismatch()
-#endif
-           )) {
+       GetProcess()->GetWarningsUnsupportedLanguage())) {
     SymbolContext sc =
         frame->GetSymbolContext(eSymbolContextFunction | eSymbolContextModule);
     GetProcess()->PrintWarningOptimization(sc);
     GetProcess()->PrintWarningUnsupportedLanguage(sc);
-#ifdef LLDB_ENABLE_SWIFT
-    GetProcess()->PrintWarningToolchainMismatch(sc);
-#endif
   }
 }
 

--- a/lldb/test/Shell/Swift/ToolchainMismatch.test
+++ b/lldb/test/Shell/Swift/ToolchainMismatch.test
@@ -1,7 +1,7 @@
 # REQUIRES: swift
 
-# Tests that a warning is printed when stopped in a Swift frame
-# compiled by a different Swift compiler than the one embedded in LLDB.
+# Tests that a warning is printed when a Swift AST context is initialized for
+# code compiled by a different Swift compiler than the one embedded in LLDB.
 
 # RUN: rm -rf %t && mkdir %t && cd %t
 # RUN: %target-swiftc -g \
@@ -29,6 +29,7 @@
 
 b main
 run
+expression 1
 quit
 
 # The {{ }} avoids accidentally matching the input script!


### PR DESCRIPTION
The warning about a module built by a different Swift compiler was emitted
whenever a Swift frame was selected, even for sessions that never evaluate an
expression. Only expression evaluation needs a compiler matching the debugger,
so report it when a Swift AST context is created instead.

Assisted-by: claude
rdar://185242442
