### PR TITLE
[clang] Fix BoundsSafety test

### DIFF
--- a/clang/test/BoundsSafety/AST/auto-type-attribute-only-mode.c
+++ b/clang/test/BoundsSafety/AST/auto-type-attribute-only-mode.c
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c -ast-dump %s 2>&1 | FileCheck --check-prefix=C %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c++ -ast-dump %s 2>&1 | FileCheck --check-prefixes=C,CXX %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c -ast-dump %s 2>&1 | FileCheck --check-prefix=C %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c++ -ast-dump %s 2>&1 | FileCheck --check-prefixes=C,CXX %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c -ast-dump %s | FileCheck --check-prefix=C %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c++ -ast-dump %s | FileCheck --check-prefixes=C,CXX %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c -ast-dump %s | FileCheck --check-prefix=C %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c++ -ast-dump %s | FileCheck --check-prefixes=C,CXX %s
 
 #include <ptrcheck.h>
 


### PR DESCRIPTION
These clang commands emit a bunch of warnings to stderr which are left unchecked. I've found in some cases that the stderr output can interfere with the CHECK lines, causing the test to fail. Remove the `2>&1` to ignore stderr.