### PR TITLE
[BoundsSafety] Add __single AttributedType sugar

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3937,6 +3937,9 @@ QualType ASTContext::getBoundsSafetyPointerType(QualType PointerTy,
   const auto *PTy = PointerTy->getAs<PointerType>();
   if (!PTy || PointerTy->isBoundsAttributedType())
     return PointerTy;
+  if (const auto *AT = dyn_cast<AttributedType>(PointerTy.getTypePtr()))
+    if (AT->getAttrKind() == attr::PtrSingle)
+      return PointerTy;
   if (PTy->getPointerAttributes() == Attr) {
     if (Attr.isSingle())
       return getAttributedType(attr::PtrSingle, PointerTy, PointerTy);

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3937,8 +3937,8 @@ QualType ASTContext::getBoundsSafetyPointerType(QualType PointerTy,
   const auto *PTy = PointerTy->getAs<PointerType>();
   if (!PTy || PointerTy->isBoundsAttributedType())
     return PointerTy;
-  if (const auto *AT = dyn_cast<AttributedType>(PointerTy.getTypePtr()))
-    if (AT->getAttrKind() == attr::PtrSingle)
+  if (const auto *AT = PointerTy.getTypePtr()->getAs<AttributedType>())
+    if (AT->getAttrKind() == attr::PtrSingle && Attr.isSingle())
       return PointerTy;
   if (PTy->getPointerAttributes() == Attr) {
     if (Attr.isSingle())

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3935,9 +3935,13 @@ QualType ASTContext::getValueTerminatedType(QualType T,
 QualType ASTContext::getBoundsSafetyPointerType(QualType PointerTy,
                                              BoundsSafetyPointerAttributes Attr) {
   const auto *PTy = PointerTy->getAs<PointerType>();
-  if (!PTy || PTy->getPointerAttributes() == Attr ||
-      PointerTy->isBoundsAttributedType())
+  if (!PTy || PointerTy->isBoundsAttributedType())
     return PointerTy;
+  if (PTy->getPointerAttributes() == Attr) {
+    if (Attr.isSingle())
+      return getAttributedType(attr::PtrSingle, PointerTy, PointerTy);
+    return PointerTy;
+  }
 
   std::function<QualType(QualType)>
   getBoundsSafetyPointerTypeRecurse = [&](QualType Ty) -> QualType {
@@ -3962,6 +3966,8 @@ QualType ASTContext::getBoundsSafetyPointerType(QualType PointerTy,
     assert(PointerTy->isPointerType());
     auto QualsOnT = PointerTy.getQualifiers();
     Ty = getPointerType(PointerTy->getPointeeType(), Attr);
+    if (Attr.isSingle())
+      Ty = getAttributedType(attr::PtrSingle, Ty, Ty);
     if (!QualsOnT.empty()) {
       QualifierCollector QC(QualsOnT);
       Ty = QC.apply(*this, Ty);
@@ -6401,7 +6407,7 @@ QualType ASTContext::getAttributedType(attr::Kind attrKind,
   assert(!attr || attr->getKind() == attrKind);
 
   QualType canon = getCanonicalType(equivalentType);
-	type = new (*this, alignof(AttributedType))
+  type = new (*this, alignof(AttributedType))
       AttributedType(canon, attrKind, attr, modifiedType, equivalentType);
 
   Types.push_back(type);

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2115,7 +2115,8 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
     return;
 
   if (T->getAttrKind() == attr::PtrSingle) {
-    OS << "__single";
+    if (!T->getModifiedType()->isSinglePointerType())
+      OS << "__single";
     return;
   }
   if (T->getAttrKind() == attr::PtrUnsafeIndexable) {

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1007,6 +1007,7 @@ Sema::ImpCastExprToType(Expr *E, QualType Ty, CastKind Kind, ExprValueKind VK,
           Ty = PreservingAttributes(Ty, [=](QualType QT) {
             QualType PT = Context.getPointerType(
                 QT->getPointeeType(), BoundsSafetyPointerAttributes::single());
+            PT = Context.getAttributedType(attr::PtrSingle, PT, PT);
             return Context.getValueTerminatedType(PT, VTT->getTerminatorExpr());
           });
           break;
@@ -1032,7 +1033,8 @@ Sema::ImpCastExprToType(Expr *E, QualType Ty, CastKind Kind, ExprValueKind VK,
         BoundsSafetyPointerAttributes FA;
         FA.setSingle();
         auto PT = Ty->getAs<PointerType>();
-        return Context.getPointerType(PT->getPointeeType(), FA);
+        QualType NewTy = Context.getPointerType(PT->getPointeeType(), FA);
+        return Context.getAttributedType(attr::PtrSingle, NewTy, NewTy);
       });
       break;
     }

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -515,6 +515,7 @@ Sema::deduceCastPointerAttributes(QualType ResultType, QualType SrcType) {
         // DstTy is __terminated_by(), update only the pointee.
         QualType Ty = Context.getPointerType(
             MergePointeeTy, BoundsSafetyPointerAttributes::single());
+        Ty = Context.getAttributedType(attr::PtrSingle, Ty, Ty);
         return Context.getValueTerminatedType(Ty, DVTT->getTerminatorExpr());
       }
 
@@ -526,6 +527,7 @@ Sema::deduceCastPointerAttributes(QualType ResultType, QualType SrcType) {
         assert(!DVTT && SPTy->isSingle());
         QualType Ty = Context.getPointerType(
             MergePointeeTy, BoundsSafetyPointerAttributes::single());
+        Ty = Context.getAttributedType(attr::PtrSingle, Ty, Ty);
         return Context.getValueTerminatedType(Ty, SVTT->getTerminatorExpr());
       }
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -10690,6 +10690,9 @@ checkConditionalObjectPointersCompatibility(Sema &S, ExprResult &LHS,
 
   if (lFPAttr != destFPAttr) {
     QualType destType = S.Context.getPointerType(lhptee, destFPAttr);
+    if (destFPAttr.isSingle())
+      destType =
+          S.Context.getAttributedType(attr::PtrSingle, destType, destType);
     SplitQualType Split = LHSTy.getSplitUnqualifiedType();
     destType = S.Context.getQualifiedType(destType, Split.Quals);
 
@@ -26377,9 +26380,11 @@ ExprResult Sema::ActOnForgeSingle(SourceLocation KWLoc, Expr *Addr,
   if (getLangOpts().isBoundsSafetyAttributeOnlyMode()) {
     ResultType = Context.getAttributedType(attr::PtrSingle, Context.VoidPtrTy,
                                            Context.VoidPtrTy);
-  } else
-    ResultType = Context.getPointerType(Context.VoidTy,
-                                        BoundsSafetyPointerAttributes::single());
+  } else {
+    QualType SingleTy = Context.getPointerType(
+        Context.VoidTy, BoundsSafetyPointerAttributes::single());
+    ResultType = Context.getAttributedType(attr::PtrSingle, SingleTy, SingleTy);
+  }
   return BuildForgePtrExpr(KWLoc, RParenLoc, ResultType, Addr);
 }
 

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -4462,6 +4462,7 @@ static bool AdjustFunctionParmAndArgTypesForDeduction(
     } else if (ArgType->isFunctionType()) {
       ArgType = S.Context.getPointerType(ArgType,
                                          BoundsSafetyPointerAttributes::single());
+      ArgType = S.Context.getAttributedType(attr::PtrSingle, ArgType, ArgType);
     } else {
       ArgType = ArgType.getUnqualifiedType();
     }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6276,7 +6276,14 @@ namespace {
         Sema::GetTypeFromParser(DS.getRepAsType(), &TInfo);
         assert(TInfo);
         // TO_UPSTREAM(BoundsSafety): initializeFullCopy -> copy
-        TL.getValueLoc().copy(TInfo->getTypeLoc());
+        TypeLoc ValueLoc = TL.getValueLoc();
+        TypeLoc ParsedLoc = TInfo->getTypeLoc();
+        while (ValueLoc.getTypeLocClass() != ParsedLoc.getTypeLocClass()) {
+          AttributedTypeLoc ATL = ValueLoc.castAs<AttributedTypeLoc>();
+          fillAttributedTypeLoc(ATL, State);
+          ValueLoc = ATL.getModifiedLoc();
+        }
+        ValueLoc.copy(ParsedLoc);
       } else {
         TL.setKWLoc(DS.getAtomicSpecLoc());
         // No parens, to indicate this was spelled as an _Atomic qualifier.
@@ -9331,7 +9338,14 @@ public:
       return AttrOnlyModeType;
     }
 
-    return Ctx.getPointerType(PTy->getPointeeType(), FAttr);
+    QualType NewPtrTy = Ctx.getPointerType(PTy->getPointeeType(), FAttr);
+
+    if (Kind == ParsedAttr::AT_PtrSingle) {
+      const Attr *A = createSimpleAttr<PtrSingleAttr>(Ctx, PAttr);
+      return state.getAttributedType(A, NewPtrTy, NewPtrTy);
+    }
+
+    return NewPtrTy;
   }
 
   QualType GetTypeWithAttrForAttributeOnlyMode(QualType T) const {


### PR DESCRIPTION
Step 2 of splitting up #13651, per @hnrklssn’s feedback.

Adds AttributedType(PtrSingle, ...) sugar wherever a __single pointer type is constructed, while retaining the underlying BoundsSafetyPointerAttributes ptrattr for existing consumers and semantic checks. The sugar is transparently handled by the existing isSinglePointerType()/getAs<PointerType>() call sites, so this is intended to be NFC for existing test output.

Also fixes a crash in TypeSpecLocFiller::VisitAtomicTypeLoc (TST_atomic). For declarations such as _Atomic(int *) __single p;, the __single attribute introduces an additional AttributedTypeLoc layer that was not present in the parsed TypeSourceInfo, causing a TypeLoc::copy assertion. The fix handles the additional AttributedTypeLoc layer(s) via fillAttributedTypeLoc() before copying.

TypePrinter.cpp also needed a small fix to avoid duplicate printing of __single once the sugar is present. This is minimal and only preserves NFC output; full AST printer support for the sugar node is intended as a separate follow-up per the split.

### Scope

Sugar is added at the relevant __single construction sites in:

* ASTContext.cpp (getBoundsSafetyPointerType)
* Sema.cpp (ImpCastExprToType)
* SemaExpr.cpp (checkConditionalObjectPointersCompatibility, ActOnForgeSingle)
* SemaCast.cpp (deduceCastPointerAttributes)
* SemaType.cpp (AT_PtrSingle parsing, plus the VisitAtomicTypeLoc fix)
* SemaTemplateDeduction.cpp (function-type decay during template argument deduction)
* TypePrinter.cpp (minimal duplicate-print guard)

SemaTemplateDeduction.cpp was identified while auditing the __single construction sites and is included to ensure the sugar is applied consistently.

Existing semantic-check migrations and unrelated pointer-sugar paths remain unchanged; those are covered by the other steps of the split.

Testing
All BoundsSafety tests passed. 11 expected failures.

Part of #13065.        