### PR TITLE
[lldb] Test debug locations for variables holding a global's address

### DIFF
--- a/lldb/test/API/lang/swift/sugared_type_substitution/TestSwiftSugaredTypeSubstitution.py
+++ b/lldb/test/API/lang/swift/sugared_type_substitution/TestSwiftSugaredTypeSubstitution.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import ValueCheck
 
 class TestCase(lldbtest.TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     def test(self):
         """Canonicalizing a sugared type must yield a canonical mangled name"""

--- a/lldb/test/API/lang/swift/sugared_type_substitution/main.swift
+++ b/lldb/test/API/lang/swift/sugared_type_substitution/main.swift
@@ -8,7 +8,8 @@ func f() -> [Int] {
   }
   let kp = \S.values
   let s = S()
-  print(s[keyPath: kp]) // break here
+  // Array has no CustomStringConvertible conformance in embedded Swift.
+  print(s[keyPath: kp][0][0]) // break here
   return [0]
 }
 

--- a/lldb/test/API/lang/swift/variables/global_address_location/Makefile
+++ b/lldb/test/API/lang/swift/variables/global_address_location/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/global_address_location/TestSwiftGlobalAddressLocation.py
+++ b/lldb/test/API/lang/swift/variables/global_address_location/TestSwiftGlobalAddressLocation.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestCase(lldbtest.TestBase):
+    @skipEmbeddedSwiftOnWindows
+    @swiftTest
+    def test(self):
+        """A variable holding a global's address must have a debug location"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        # A dbg_value naming a global has no DWARF location at -Onone, so a
+        # variable whose storage is a global's address is only readable if it
+        # gets a stack slot.
+        self.expect_var_path("cfn", type="(Int) -> Int")
+        self.expect_var_path("thinfn", type="(Int) -> Int")

--- a/lldb/test/API/lang/swift/variables/global_address_location/main.swift
+++ b/lldb/test/API/lang/swift/variables/global_address_location/main.swift
@@ -1,0 +1,13 @@
+// A function reference is a value whose storage is the address of a global
+// rather than the result of an instruction.
+
+func target(_ x: Int) -> Int { return x + 1 }
+
+func f() {
+  let cfn: @convention(c) (Int) -> Int = target
+  let thinfn: @convention(thin) (Int) -> Int = target
+  print(cfn(1)) // break here
+  print(thinfn(2))
+}
+
+f()


### PR DESCRIPTION
Add a test for a thin and a C function reference, whose values are the
address of a global function. Both used to read back as optimized out,
because IRGen described them with a dbg_value naming the global and LLVM
emits no location for that at -O0.

Also enable the sugared type substitution test under embedded Swift. It
was skipped for the same missing location on its key path variable, which
is a constant global there. Its assertions are unchanged; only the print
had to be adjusted, since embedded Swift cannot print an Array.

Assisted-by: claude
