### PR TITLE
[lldb] Add synthetic formatters for more basic types

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -188,6 +188,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
+      "Swift.Int128", ConstString("Swift.Int128"), basic_synth_flags);
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
       "Swift.Int64", ConstString("Swift.Int64"), basic_synth_flags);
   AddCXXSynthetic(
       swift_category_sp,
@@ -206,6 +210,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
       "Swift.Int", ConstString("Swift.Int"), basic_synth_flags);
 
+  AddFormat(swift_category_sp, lldb::eFormatDecimal,
+            ConstString("Swift.Int128"), format_flags, false);
   AddFormat(swift_category_sp, lldb::eFormatDecimal, ConstString("Swift.Int64"),
             format_flags, false);
   AddFormat(swift_category_sp, lldb::eFormatDecimal, ConstString("Swift.Int32"),
@@ -217,6 +223,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddFormat(swift_category_sp, lldb::eFormatDecimal, ConstString("Swift.Int"),
             format_flags, false);
 
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
+      "Swift.UInt128", ConstString("Swift.UInt128"), basic_synth_flags);
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
@@ -239,6 +249,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "Swift.UInt", ConstString("Swift.UInt"), basic_synth_flags);
 
   AddFormat(swift_category_sp, lldb::eFormatUnsigned,
+            ConstString("Swift.UInt128"), format_flags, false);
+  AddFormat(swift_category_sp, lldb::eFormatUnsigned,
             ConstString("Swift.UInt64"), format_flags, false);
   AddFormat(swift_category_sp, lldb::eFormatUnsigned,
             ConstString("Swift.UInt32"), format_flags, false);
@@ -249,6 +261,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddFormat(swift_category_sp, lldb::eFormatUnsigned, ConstString("Swift.UInt"),
             format_flags, false);
 
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
+      "Swift.Float16", ConstString("Swift.Float16"), basic_synth_flags);
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,

--- a/lldb/test/API/lang/swift/variables/float16/Makefile
+++ b/lldb/test/API/lang/swift/variables/float16/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/float16/TestSwiftFloat16.py
+++ b/lldb/test/API/lang/swift/variables/float16/TestSwiftFloat16.py
@@ -1,0 +1,31 @@
+"""
+Test that Float16 reports a scalar value.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftFloat16(TestBase):
+    @swiftTest
+    @skipEmbeddedSwiftOnWindows
+    # Float16 is unavailable in the stdlib on x86_64 macOS.
+    @skipIf(oslist=["macosx"], archs=["x86_64"])
+    def test(self):
+        """Test that Float16 has a value, like Float and Double do."""
+        self.build()
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        # The controls: both report a value rather than only a _value child.
+        lldbutil.check_variable(self, frame.FindVariable("f32"), False, value="2.5")
+        lldbutil.check_variable(self, frame.FindVariable("f64"), False, value="3.5")
+
+        lldbutil.check_variable(self, frame.FindVariable("f16"), False, value="1.5")

--- a/lldb/test/API/lang/swift/variables/float16/main.swift
+++ b/lldb/test/API/lang/swift/variables/float16/main.swift
@@ -1,0 +1,10 @@
+func f() {
+    let f16: Float16 = 1.5
+    let f32: Float = 2.5
+    let f64: Double = 3.5
+
+    print("break here")
+    _ = (f16, f32, f64)
+}
+
+f()

--- a/lldb/test/API/lang/swift/variables/int128/Makefile
+++ b/lldb/test/API/lang/swift/variables/int128/Makefile
@@ -1,0 +1,6 @@
+SWIFT_SOURCES := main.swift
+# Int128 carries a stdlib availability annotation newer than the deployment
+# target the test suite compiles against.
+SWIFTFLAGS_EXTRAS := -Xfrontend -disable-availability-checking
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/int128/TestSwiftInt128.py
+++ b/lldb/test/API/lang/swift/variables/int128/TestSwiftInt128.py
@@ -1,0 +1,44 @@
+"""
+Test that Int128 is printed signed, across the whole range.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftInt128(TestBase):
+    @swiftTest
+    @skipEmbeddedSwiftOnWindows
+    def test(self):
+        """Test that Int128 values are printed as signed decimal."""
+        self.build()
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        lldbutil.check_variable(
+            self, frame.FindVariable("negative"), False, value="-42"
+        )
+        lldbutil.check_variable(
+            self, frame.FindVariable("positive"), False, value="42"
+        )
+
+        # The ends of the range, where the sign bit alone decides the value.
+        lldbutil.check_variable(
+            self,
+            frame.FindVariable("mostNegative"),
+            False,
+            value="-170141183460469231731687303715884105728",
+        )
+        lldbutil.check_variable(
+            self,
+            frame.FindVariable("mostPositive"),
+            False,
+            value="170141183460469231731687303715884105727",
+        )

--- a/lldb/test/API/lang/swift/variables/int128/main.swift
+++ b/lldb/test/API/lang/swift/variables/int128/main.swift
@@ -1,0 +1,11 @@
+func f() {
+    let mostNegative = Int128.min
+    let mostPositive = Int128.max
+    let negative: Int128 = -42
+    let positive: Int128 = 42
+
+    print("break here")
+    _ = (mostNegative, mostPositive, negative, positive)
+}
+
+f()

--- a/lldb/test/API/lang/swift/variables/uint128/Makefile
+++ b/lldb/test/API/lang/swift/variables/uint128/Makefile
@@ -1,0 +1,6 @@
+SWIFT_SOURCES := main.swift
+# Int128 and UInt128 carry a stdlib availability annotation newer than the
+# deployment target the test suite compiles against.
+SWIFTFLAGS_EXTRAS := -Xfrontend -disable-availability-checking
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/uint128/TestSwiftUInt128.py
+++ b/lldb/test/API/lang/swift/variables/uint128/TestSwiftUInt128.py
@@ -1,0 +1,34 @@
+"""
+Test that UInt128 is printed unsigned.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftUInt128(TestBase):
+    @swiftTest
+    @skipEmbeddedSwiftOnWindows
+    def test(self):
+        """Test that a UInt128 with its high bit set is not printed signed."""
+        self.build()
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        # The controls: a UInt128 with the high bit clear, and a real Int128.
+        lldbutil.check_variable(self, frame.FindVariable("small"), False, value="42")
+        lldbutil.check_variable(self, frame.FindVariable("signed"), False, value="-42")
+
+        lldbutil.check_variable(
+            self,
+            frame.FindVariable("big"),
+            False,
+            value="320500633375363362511929115231785247216",
+        )

--- a/lldb/test/API/lang/swift/variables/uint128/main.swift
+++ b/lldb/test/API/lang/swift/variables/uint128/main.swift
@@ -1,0 +1,14 @@
+// `big` has its high bit set, so it only renders correctly if the formatter
+// treats a UInt128 as unsigned. The controls are a UInt128 with the high bit
+// clear, and an Int128, which really is signed.
+
+func f() {
+    let big: UInt128 = 0xF11E_2D3C_4B5A_6978_8796_A5B4_C3D2_E1F0
+    let small: UInt128 = 42
+    let signed: Int128 = -42
+
+    print("break here")
+    _ = (big, small, signed)
+}
+
+f()


### PR DESCRIPTION
Int128, UInt128, Float16, were missing data formatters. In effect, they
were shown with "_value = 42", which is ok, but doesn't match how we
format our other basic types.

Assisted-by: claude
rdar://185258743
