### PR TITLE
[LoopTrapAnalysis] Enhanced loop trap analysis

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/LoopTrapAnalysis.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopTrapAnalysis.h
@@ -9,13 +9,33 @@
 #ifndef LLVM_TRANSFORMS_SCALAR_LoopTrapAnalysis_H
 #define LLVM_TRANSFORMS_SCALAR_LoopTrapAnalysis_H
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/IR/PassManager.h"
+#include <string>
 
 namespace llvm {
 
 struct LoopTrapAnalysisPass : public PassInfoMixin<LoopTrapAnalysisPass> {
+  // Tag appended to remark Names so the pass can run at more than one pipeline
+  // point with distinguishable output. Empty (default) keeps the bare Names.
+  std::string Tag;
+
+  // Per-Function run() counter, emitted as InvocationSeq (gated by
+  // -loop-trap-analysis-explain) so consumers can dedup repeated invocations
+  // by max(seq) per (function, src_bb, trap_bb). mutable: bookkeeping side
+  // channel, not analysis state; single-threaded per FunctionAnalysisManager.
+  mutable DenseMap<const Function *, unsigned> InvocationCount;
+
+  LoopTrapAnalysisPass(StringRef Tag = "") : Tag(Tag.str()) {}
+
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+
+  static bool isRequired() { return true; }
+
+  void printPipeline(raw_ostream &OS,
+                     function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 } // end namespace llvm

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -962,6 +962,12 @@ Expected<bool> parseEarlyCSEPassOptions(StringRef Params) {
   return PassBuilder::parseSinglePassOption(Params, "memssa", "EarlyCSE");
 }
 
+// TO_UPSTREAM(BoundsSafety)
+Expected<StringRef> parseLoopTrapAnalysisPassOptions(StringRef Params) {
+  Params.consume_front("tag=");
+  return Params;
+}
+
 Expected<bool> parseEntryExitInstrumenterPassOptions(StringRef Params) {
   return PassBuilder::parseSinglePassOption(Params, "post-inline",
                                             "EntryExitInstrumenter");

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -480,8 +480,6 @@ FUNCTION_PASS("loop-fusion", LoopFusePass())
 FUNCTION_PASS("loop-load-elim", LoopLoadEliminationPass())
 FUNCTION_PASS("loop-simplify", LoopSimplifyPass())
 FUNCTION_PASS("loop-sink", LoopSinkPass())
-// TO_UPSTREAM(BoundsSafety)
-FUNCTION_PASS("loop-trap-analysis", LoopTrapAnalysisPass())
 FUNCTION_PASS("loop-versioning", LoopVersioningPass())
 FUNCTION_PASS("lower-atomic", LowerAtomicPass())
 FUNCTION_PASS("lower-constant-intrinsics", LowerConstantIntrinsicsPass())
@@ -588,6 +586,11 @@ FUNCTION_PASS_WITH_PARAMS(
     "early-cse", "EarlyCSEPass",
     [](bool UseMemorySSA) { return EarlyCSEPass(UseMemorySSA); },
     parseEarlyCSEPassOptions, "memssa")
+// TO_UPSTREAM(BoundsSafety)
+FUNCTION_PASS_WITH_PARAMS(
+    "loop-trap-analysis", "LoopTrapAnalysisPass",
+    [](StringRef Tag) { return LoopTrapAnalysisPass(Tag); },
+    parseLoopTrapAnalysisPassOptions, "tag=N")
 FUNCTION_PASS_WITH_PARAMS(
     "drop-unnecessary-assumes", "DropUnnecessaryAssumesPass",
     [](bool DropDereferenceable) { return DropUnnecessaryAssumesPass(DropDereferenceable); },

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -673,23 +673,30 @@ static StringRef computeTrapClass(
                     Shape == TrapPredicateShape::AndBoundsCheckVarBound;
   const bool TwoAR = Shape == TrapPredicateShape::OrTwoAddRecICmp ||
                      Shape == TrapPredicateShape::AndTwoAddRecICmp;
+  // The leading token is the index-shape axis -- how well the compiler can
+  // model the trapping index: `Invariant-` = not inside any loop (one-shot /
+  // hoistable check); `Affine-` = the index is an affine AddRec over the loop
+  // IV (understood; eliminability turns on trip count / no-wrap); `Opaque-` =
+  // the index depends on an in-loop load / phi / call / opaque value SCEV can't
+  // model. `InLoop-NonExit` carries no index-shape axis. The rest of each name
+  // is unchanged.
   // Out-of-loop: classify by structural redundancy / predicate shape.
   if (!InLoop) {
     if (IsEntryProx)
-      return "OutsideLoop-EntryProximate";
+      return "Invariant-OutsideLoop-EntryProximate";
     if (DomByEquiv)
-      return "OutsideLoop-RedundantWithDominatingCheck";
+      return "Invariant-OutsideLoop-RedundantWithDominatingCheck";
     if (ConstK)
-      return "OutsideLoop-MultiComparison-ConstBound";
+      return "Invariant-OutsideLoop-MultiComparison-ConstBound";
     if (VarK)
-      return "OutsideLoop-MultiComparison-VarBound";
+      return "Invariant-OutsideLoop-MultiComparison-VarBound";
     if (Shape == TrapPredicateShape::SingleICmp)
-      return "OutsideLoop-SingleComparison";
+      return "Invariant-OutsideLoop-SingleComparison";
     if (Shape == TrapPredicateShape::OtherMulti)
-      return "OutsideLoop-MultiComparison-Other";
+      return "Invariant-OutsideLoop-MultiComparison-Other";
     if (TwoAR)
-      return "OutsideLoop-MultiComparison-Other";
-    return "OutsideLoop-Unclassifiable";
+      return "Invariant-OutsideLoop-MultiComparison-Other";
+    return "Invariant-OutsideLoop-Unclassifiable";
   }
   // In-loop, not a loop exit.
   if (!IsLoopExit)
@@ -703,31 +710,32 @@ static StringRef computeTrapClass(
   const bool HasBlocker = StoreReload || MemIReload || CallReload ||
                           InLoopPhi || UnaliasLoad || OtherUnk || OpaqueNoUnk;
   if (EdgeBTCComputable && (!LTAEmitExplain || !HasBlocker))
-    return LoopOtherUnk ? "InLoopExit-TripCountKnown-LoopBlockedElsewhere"
-                        : "InLoopExit-TripCountKnown";
+    return LoopOtherUnk
+               ? "Affine-InLoopExit-TripCountKnown-LoopBlockedElsewhere"
+               : "Affine-InLoopExit-TripCountKnown";
   const bool S = StoreReload || MemIReload;
   if (S && CallReload)
-    return "InLoopExit-TripCountUnknown-StoreAndCallReload";
+    return "Opaque-InLoopExit-TripCountUnknown-StoreAndCallReload";
   if (S)
-    return "InLoopExit-TripCountUnknown-StoreReload";
+    return "Opaque-InLoopExit-TripCountUnknown-StoreReload";
   if (CallReload)
-    return "InLoopExit-TripCountUnknown-CallReload";
+    return "Opaque-InLoopExit-TripCountUnknown-CallReload";
   if (InLoopPhi)
-    return "InLoopExit-TripCountUnknown-InLoopPhiOperand";
+    return "Opaque-InLoopExit-TripCountUnknown-InLoopPhiOperand";
   if (UnaliasLoad)
-    return "InLoopExit-TripCountUnknown-InLoopLoadOperand";
+    return "Opaque-InLoopExit-TripCountUnknown-InLoopLoadOperand";
   // The opaque-operand class split by opacity shape (freeze / select / other
   // in-loop unknown). InLoopFreeze / InLoopSelect are subsets of OtherUnk, so
   // test them first.
   if (OtherUnk) {
     if (InLoopFreeze)
-      return "InLoopExit-TripCountUnknown-OpaqueOperand-Freeze";
+      return "Opaque-InLoopExit-TripCountUnknown-OpaqueOperand-Freeze";
     if (InLoopSelect)
-      return "InLoopExit-TripCountUnknown-OpaqueOperand-Select";
-    return "InLoopExit-TripCountUnknown-OpaqueOperand-Other";
+      return "Opaque-InLoopExit-TripCountUnknown-OpaqueOperand-Select";
+    return "Opaque-InLoopExit-TripCountUnknown-OpaqueOperand-Other";
   }
   if (OpaqueNoUnk)
-    return "InLoopExit-TripCountUnknown-OpaqueOperand-NoInLoopUnknown";
+    return "Opaque-InLoopExit-TripCountUnknown-OpaqueOperand-NoInLoopUnknown";
   // The multi-comparison suffix is driven by the predicate SHAPE (one source of
   // truth), so the multi-comparison class can't disagree with the emitted
   // PredicateShape. Legacy (flag off) keeps the NumLeafOps>=4 gate for
@@ -737,17 +745,17 @@ static StringRef computeTrapClass(
                                    : (NumLeafOps >= 4);
   if (MultiShape) {
     if (ConstK)
-      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-MultiComparison-"
-             "ConstBound";
+      return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+             "MultiComparison-ConstBound";
     if (VarK)
-      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-MultiComparison-"
-             "VarBound";
+      return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+             "MultiComparison-VarBound";
     if (TwoAR)
-      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-MultiComparison-"
-             "TwoAddRec";
+      return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+             "MultiComparison-TwoAddRec";
     if (Shape == TrapPredicateShape::OtherMulti)
-      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-MultiComparison-"
-             "Other";
+      return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+             "MultiComparison-Other";
   }
   // Surface stride-fragility (the Has*StrideForLAddRec flags previously never
   // influenced the class) instead of lumping it into the bare weak-no-wrap
@@ -755,16 +763,19 @@ static StringRef computeTrapClass(
   // (byte-identical).
   if (LTAEmitExplain) {
     if (NonConstStride)
-      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-NonConstantStride";
+      return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+             "NonConstantStride";
     if (NonUnitStride)
-      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-NonUnitStride";
+      return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+             "NonUnitStride";
     if (NegStride)
-      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-NegativeStride";
+      return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+             "NegativeStride";
     if (NotProvenMonotonicOnly)
-      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+      return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-"
              "NotProvenMonotonicOnly";
   }
-  return "InLoopExit-TripCountUnknown-NotProvenMonotonic";
+  return "Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic";
 }
 
 /// Match the bounded-iterator OR / AND shape:

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -711,7 +711,7 @@ static StringRef computeTrapClass(
                           InLoopPhi || UnaliasLoad || OtherUnk || OpaqueNoUnk;
   if (EdgeBTCComputable && (!LTAEmitExplain || !HasBlocker))
     return LoopOtherUnk
-               ? "Affine-InLoopExit-TripCountKnown-LoopBlockedElsewhere"
+               ? "Affine-InLoopExit-TripCountKnown-LoopBlockedOtherTrapExit"
                : "Affine-InLoopExit-TripCountKnown";
   const bool S = StoreReload || MemIReload;
   if (S && CallReload)

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -442,7 +442,11 @@ static bool hasHoistedInPreheader(Loop *L,
 
 /// Build a remark Name suffixed with the optional Tag (so the same pass can
 /// be invoked multiple times in a pipeline with distinguishable output).
-static std::string taggedName(StringRef Base, StringRef Tag) { return ""; }
+static std::string taggedName(StringRef Base, StringRef Tag) {
+  if (Tag.empty())
+    return Base.str();
+  return (Base + Tag).str();
+}
 
 /// Print a stable, non-empty label for \p BB, so remark args that identify
 /// BasicBlocks stay useful when the BB has no source-level name (numeric IR,
@@ -451,7 +455,16 @@ static std::string taggedName(StringRef Base, StringRef Tag) { return ""; }
 /// Preferred: `BB->getName()`. Fallback: `printAsOperand` slot-tracker form
 /// (`%5` etc.), which is parseable and unique within the function. Never
 /// returns empty.
-static std::string bbLabel(const BasicBlock *BB) { return ""; }
+static std::string bbLabel(const BasicBlock *BB) {
+  if (!BB)
+    return "<null>";
+  if (BB->hasName())
+    return BB->getName().str();
+  std::string S;
+  raw_string_ostream OS(S);
+  BB->printAsOperand(OS, /*PrintType=*/false);
+  return S.empty() ? std::string("<unnamed>") : S;
+}
 
 /// Recursively unfold a boolean expression chain (select-OR, select-AND,
 /// or/and) into the leaf comparison operands. Used to surface every
@@ -969,27 +982,600 @@ static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
                                 AAResults &AA, DominatorTree &DT,
                                 OptimizationRemarkEmitter &ORE, StringRef Tag,
                                 unsigned InvocationSeq) {
-  // Call-wiring: exercise every per-edge helper so none is unused.
-  BasicBlock *BB = &F.getEntryBlock();
-  Loop *L = LI.getLoopFor(BB);
-  (void)taggedName("LoopTrapEdge", Tag);
-  (void)isTrapBlock(BB, BoundsSafetyTrapsOnly, LegacyTrapMatch::TrapIntrinsic);
-  SmallVector<Value *, 8> Operands;
-  SmallPtrSet<Value *, 16> Visited;
-  collectBoolLeafOperands(nullptr, Operands, Visited);
-  (void)classifyTrapPredicateShape(nullptr, SE, L);
-  (void)trapPredicateShapeName(TrapPredicateShape::Unknown);
-  (void)computeTrapClass(false, TrapPredicateShape::Unknown, false, false,
-                         false, false, false, false, false, false, false,
-                         false, false, false, false, false, 0u, false, false,
-                         false, false);
-  (void)isEntryProximate(F, BB, DT, LI);
-  (void)isDominatedByEquivalentCheck(BB, nullptr, DT);
-  (void)computeIVUpdateDominatesLatch(nullptr, L, DT);
-  (void)bbLabel(BB);
-  (void)InvocationSeq;
-  (void)ORE;
-  (void)AA;
+  std::string Name = taggedName("LoopTrapEdge", Tag);
+  // Same trap-block predicate as the rest of the pass: require `call
+  // @llvm.trap()` immediately before `unreachable`. Bare `unreachable` (after a
+  // noreturn call, or `__builtin_unreachable`) is NOT a trap.
+  auto IsTrapBlock = [](BasicBlock *BB) {
+    return isTrapBlock(BB, BoundsSafetyTrapsOnly,
+                       LegacyTrapMatch::TrapIntrinsic);
+  };
+
+  // Pre-pass: per innermost loop, count how many of its trap-exits have
+  // SCEVCouldNotCompute exit-counts. Used downstream to classify the
+  // "edge is computable but loop's other traps aren't" case.
+  DenseMap<Loop *, unsigned> UncomputableTrapExits;
+  for (Loop *L : LI.getLoopsInPreorder()) {
+    SmallVector<BasicBlock *, 4> Exiting;
+    L->getExitingBlocks(Exiting);
+    unsigned N = 0;
+    for (BasicBlock *EB : Exiting) {
+      auto *BI = dyn_cast<CondBrInst>(EB->getTerminator());
+      if (!BI)
+        continue;
+      BasicBlock *TrapSucc = nullptr;
+      for (BasicBlock *Succ : BI->successors())
+        if (!L->contains(Succ) && IsTrapBlock(Succ)) {
+          TrapSucc = Succ;
+          break;
+        }
+      if (!TrapSucc)
+        continue;
+      const SCEV *EC = SE.getExitCount(L, EB);
+      if (isa<SCEVCouldNotCompute>(EC))
+        ++N;
+    }
+    UncomputableTrapExits[L] = N;
+  }
+
+  // Per-loop cache of "do any in-loop instructions may-alias this load?",
+  // populated lazily. Key: (Loop*, LoadInst*). Returns (StoreAlias,
+  // MemIntrinsicAlias, CallAlias) tracked SEPARATELY so the consumer can bucket
+  // scalar-store vs struct-copy (mem-intrinsic) aliasing (different levers).
+  DenseMap<std::pair<Loop *, LoadInst *>, std::tuple<bool, bool, bool>>
+      ReloadCache;
+  auto LoadAliasFlags = [&](LoadInst *Load,
+                            Loop *L) -> std::tuple<bool, bool, bool> {
+    auto Key = std::make_pair(L, Load);
+    auto It = ReloadCache.find(Key);
+    if (It != ReloadCache.end())
+      return It->second;
+    bool Store = false, MemI = false, Call = false;
+    MemoryLocation LoadLoc = MemoryLocation::get(Load);
+    for (BasicBlock *BB : L->blocks()) {
+      for (Instruction &I : *BB) {
+        if (&I == Load)
+          continue;
+        if (auto *SI = dyn_cast<StoreInst>(&I)) {
+          if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
+                             : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
+            Store = true;
+        } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
+          if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
+            MemI = true;
+        } else if (auto *CB = dyn_cast<CallBase>(&I)) {
+          if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
+            continue;
+          if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
+            Call = true;
+        }
+        if (Store && MemI && Call)
+          break;
+      }
+      if (Store && MemI && Call)
+        break;
+    }
+    auto Out = std::make_tuple(Store, MemI, Call);
+    ReloadCache[Key] = Out;
+    return Out;
+  };
+
+  // For a load flagged store-may-cause-reload, return the FIRST in-loop
+  // store / mem-intrinsic that may-alias it (per AA, which already folds in
+  // TBAA). Lets the consumer point at the specific writer that blocks LICM.
+  auto FirstAliasingStore = [&](LoadInst *Load, Loop *L) -> Instruction * {
+    MemoryLocation LoadLoc = MemoryLocation::get(Load);
+    for (BasicBlock *BB : L->blocks())
+      for (Instruction &I : *BB) {
+        if (&I == Load)
+          continue;
+        if (auto *SI = dyn_cast<StoreInst>(&I)) {
+          if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
+                             : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
+            return &I;
+        } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
+          if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
+            return &I;
+        }
+      }
+    return nullptr;
+  };
+
+  // Extract a human-readable TBAA access-type name from an instruction's TBAA
+  // metadata (struct-path tag: operand 1 is the access-type descriptor; scalar
+  // tag: operand 0 is the type-name string). A memcpy / struct copy carries
+  // !tbaa.struct instead — report "struct-copy". Empty if no TBAA.
+  auto TBAATypeName = [](const Instruction *I) -> StringRef {
+    AAMDNodes AAMD = I->getAAMetadata();
+    if (const MDNode *TBAA = AAMD.TBAA) {
+      const MDNode *AccessType = TBAA;
+      if (TBAA->getNumOperands() >= 2)
+        if (auto *AT = dyn_cast<MDNode>(TBAA->getOperand(1)))
+          AccessType = AT;
+      if (AccessType->getNumOperands() >= 1)
+        if (auto *Name = dyn_cast<MDString>(AccessType->getOperand(0)))
+          return Name->getString();
+    }
+    if (AAMD.TBAAStruct)
+      return "struct-copy";
+    return "";
+  };
+
+  // Short kind tag for a reload-blocking writer.
+  auto WriterKind = [](const Instruction *I) -> StringRef {
+    if (isa<MemCpyInst>(I))
+      return "memcpy";
+    if (isa<MemMoveInst>(I))
+      return "memmove";
+    if (isa<MemSetInst>(I))
+      return "memset";
+    if (isa<MemIntrinsic>(I))
+      return "mem-intrinsic";
+    if (isa<StoreInst>(I))
+      return "store";
+    if (isa<CallBase>(I))
+      return "call";
+    return "writer";
+  };
+
+  // Like FirstAliasingStore but also considers side-effecting calls — used
+  // by the flag-gated per-load alias annotation (LoopLoadAlias).
+  auto FirstAliasingWriter = [&](LoadInst *Load, Loop *L) -> Instruction * {
+    MemoryLocation LoadLoc = MemoryLocation::get(Load);
+    for (BasicBlock *BB : L->blocks())
+      for (Instruction &I : *BB) {
+        if (&I == Load)
+          continue;
+        if (auto *SI = dyn_cast<StoreInst>(&I)) {
+          if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
+                             : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
+            return &I;
+        } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
+          if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
+            return &I;
+        } else if (auto *CB = dyn_cast<CallBase>(&I)) {
+          if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
+            continue;
+          if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
+            return &I;
+        }
+      }
+    return nullptr;
+  };
+
+  for (BasicBlock &BB : F) {
+    auto *BI = dyn_cast<CondBrInst>(BB.getTerminator());
+    if (!BI)
+      continue;
+    BasicBlock *TrapSucc = nullptr;
+    for (BasicBlock *Succ : BI->successors())
+      if (IsTrapBlock(Succ)) {
+        TrapSucc = Succ;
+        break;
+      }
+    if (!TrapSucc)
+      continue;
+
+    // Compute the chain of containing loops for the source BB.
+    Loop *Innermost = LI.getLoopFor(&BB);
+    SmallVector<Loop *, 4> ContainingLoops;
+    for (Loop *L = Innermost; L; L = L->getParentLoop())
+      ContainingLoops.push_back(L);
+
+    bool IsLoopExit = Innermost && !Innermost->contains(TrapSucc);
+
+    // Unfold the predicate into leaf operands.
+    SmallVector<Value *, 8> LeafOperands;
+    SmallPtrSet<Value *, 16> Visited;
+    collectBoolLeafOperands(BI->getCondition(), LeafOperands, Visited);
+
+    bool AllComputed = true;
+    bool LoopInvariantInInnermost = true; // trivially true if no loop
+    bool HasAddRec = false;
+    bool HasInLoopUnknown = false;
+    bool HasStoreReload = false;
+    bool HasMemIntrinsicReload = false;
+    bool HasCallReload = false;
+    // Trip-count-unknown sub-flavor flags (set when the operand SCEV is
+    // computable but non-AddRec / non-invariant for L AND the AA reload check
+    // didn't fire). Split the opaque-operand cases by what makes the operand
+    // opaque:
+    //   HasUnaliasedLoadOperand  — LoadInst in L with no may-aliased writer
+    //                              (data-dependent/indirect load).
+    //   HasInLoopPhiOperand      — non-IV PHINode in L (loop-carried
+    //                              state / conditional increments). IV phis
+    //                              fold to AddRecs and don't appear here.
+    //   HasOtherInLoopUnknownOperand — some other in-loop def: select / freeze
+    //                              / intrinsic-call result / etc.
+    //   HasOpaqueOperandNoInLoopUnknown — non-AddRec/non-invariant for L but no
+    //                              in-loop SCEVUnknown leaf (outer-loop
+    //                              AddRec, or non-unit modular stride).
+    bool HasUnaliasedLoadOperand = false;
+    bool HasInLoopPhiOperand = false;
+    bool HasInLoopFreezeOperand = false;
+    bool HasInLoopSelectOperand = false;
+    bool HasOtherInLoopUnknownOperand = false;
+    // The in-loop store / mem-intrinsic that blocks a reload, and the load it
+    // clobbers; null unless HasStoreReload fires.
+    Instruction *ReloadStore = nullptr;
+    LoadInst *ReloadLoad = nullptr;
+    bool HasOpaqueOperandNoInLoopUnknown = false;
+    // True when any operand SCEV contains an AddRec on a loop that is NOT the
+    // innermost. Splits the opaque / no-in-loop-unknown class into "via
+    // outer-loop AddRec" (attackable by teaching SCEV that an outer-loop AddRec
+    // is innermost-invariant) vs "via something else" (modular stride, etc.).
+    bool HasOuterLoopAddRecOperand = false;
+    // Weak-no-wrap-class sub-classifier flags. The weak-no-wrap class is
+    // "operands clean for L but getExitCount still CouldNotCompute"; these
+    // break it down:
+    //   HasNonUnitStrideForLAddRec  — an L-AddRec operand with |step| > 1.
+    //                                 SCEV's exit-count machinery has limited
+    //                                 non-unit-stride support (needs a
+    //                                 divisibility proof against the bound).
+    //   HasOnlyNotProvenMonotonicForLAddRec — an L-AddRec with FlagNW but
+    //   neither NUW
+    //                                 nor NSW; howMany{Less,Greater}Thans
+    //                                 typically need the stronger flag.
+    //   HasNegativeStrideForLAddRec — an L-AddRec with a negative step (hits
+    //                                 the independently fragile
+    //                                 howManyGreaterThans path).
+    // Note: no HasMultipleLeafOperands field — NumLeafOperands already exposes
+    // it; the Python aggregator treats NumLeafOperands>1 as the multi-leaf
+    // OR/AND-of-icmps case (the dominant weak-no-wrap-class shape).
+    bool HasNonUnitStrideForLAddRec = false;
+    bool HasOnlyNotProvenMonotonicForLAddRec = false;
+    bool HasNegativeStrideForLAddRec = false;
+    // True when some L-AddRec has a NON-CONSTANT (runtime) step. Distinct from
+    // constant-but-non-unit: closed-form trip count is essentially never
+    // computable for a non-constant step. Surfaced separately so consumers can
+    // split "stride!=±1 (gcd alignment maybe works)" from "stride is runtime".
+    bool HasNonConstantStrideForLAddRec = false;
+    unsigned NumLeafOps = 0;
+
+    for (Value *V : LeafOperands) {
+      ++NumLeafOps;
+      if (!V || isa<Constant>(V))
+        continue;
+      if (!SE.isSCEVable(V->getType())) {
+        AllComputed = false;
+        continue;
+      }
+      const SCEV *SC = SE.getSCEV(V);
+      if (isa<SCEVCouldNotCompute>(SC)) {
+        AllComputed = false;
+        continue;
+      }
+      // Walk the SCEV tree.
+      SCEVNodeCollector Coll;
+      SCEVTraversal<SCEVNodeCollector>(Coll).visitAll(SC);
+      if (!Coll.AddRecs.empty())
+        HasAddRec = true;
+      // Weak-no-wrap-class sub-classifier: for each AddRec on the innermost
+      // loop, inspect step
+      // constness, magnitude, and nowrap flags.
+      if (Innermost) {
+        for (const SCEVAddRecExpr *AR : Coll.AddRecs) {
+          if (AR->getLoop() != Innermost)
+            continue;
+          if (!AR->isAffine())
+            continue;
+          // FlagNW only (no NUW / NSW) — typical for AddRecs from
+          // `add invariant, mul(IV, const)` where the outer add lacks IR-level
+          // nowrap.
+          if (!AR->hasNoUnsignedWrap() && !AR->hasNoSignedWrap())
+            HasOnlyNotProvenMonotonicForLAddRec = true;
+          if (auto *StepC = dyn_cast<SCEVConstant>(AR->getStepRecurrence(SE))) {
+            const APInt &Step = StepC->getAPInt();
+            if (Step.isNegative())
+              HasNegativeStrideForLAddRec = true;
+            // |step| > 1 — non-unit stride, fragile for getExitCount.
+            APInt AbsStep = Step.isNegative() ? -Step : Step;
+            if (AbsStep.ugt(1))
+              HasNonUnitStrideForLAddRec = true;
+          } else {
+            // Non-constant (runtime) step: closed-form trip count essentially
+            // never computable. Tag both the umbrella non-unit flag and the
+            // specific non-constant-stride flag.
+            HasNonUnitStrideForLAddRec = true;
+            HasNonConstantStrideForLAddRec = true;
+          }
+        }
+      }
+      // Per-loop invariance: standard SE.isLoopInvariant against the
+      // *innermost* containing loop only (single canonical bool; caller can
+      // re-query outer loops via SE).
+      if (Innermost && !SE.isLoopInvariant(SC, Innermost))
+        LoopInvariantInInnermost = false;
+
+      // Is this operand "opaque w.r.t. L" — the kind that pushes the edge into
+      // a trip-count-unknown bucket because its SCEV isn't pinned to L's IV and
+      // isn't loop-invariant?
+      bool OpIsOpaqueForL = false;
+      if (Innermost) {
+        OpIsOpaqueForL = !SE.isLoopInvariant(SC, Innermost);
+        if (auto *AR = dyn_cast<SCEVAddRecExpr>(SC))
+          if (AR->getLoop() == Innermost)
+            OpIsOpaqueForL = false;
+      }
+      // Did we find any in-loop SCEVUnknown for THIS operand? Fires the
+      // opaque-operand / no-in-loop-unknown flavor when the SCEV is
+      // opaque-for-L but its leaves are all outside L.
+      bool OpHasInLoopUnknown = false;
+
+      // SCEVUnknowns defined in any containing loop — diagnostic for the "load
+      // lives in an outer containing loop" case (invariant in the innermost,
+      // but a load in some outer loop changes per-outer-iteration).
+      for (const SCEVUnknown *U : Coll.Unknowns) {
+        Value *UV = U->getValue();
+        auto *I = dyn_cast_or_null<Instruction>(UV);
+        if (!I)
+          continue;
+        Loop *DefLoop = LI.getLoopFor(I->getParent());
+        for (Loop *DL = DefLoop; DL; DL = DL->getParentLoop()) {
+          for (Loop *CL : ContainingLoops)
+            if (DL == CL) {
+              HasInLoopUnknown = true;
+              break;
+            }
+          if (HasInLoopUnknown)
+            break;
+        }
+        // AA-based reload classification and operand-flavor bucketing: only
+        // meaningful when the SCEVUnknown's Inst is in the *innermost* loop
+        // (the one SCEV reasons about and partial-BTC predication would
+        // target).
+        if (Innermost && Innermost->contains(I->getParent())) {
+          OpHasInLoopUnknown = true;
+          if (auto *Load = dyn_cast<LoadInst>(I)) {
+            auto [SAlias, MAlias, CAlias] = LoadAliasFlags(Load, Innermost);
+            if (SAlias)
+              HasStoreReload = true;
+            if (MAlias)
+              HasMemIntrinsicReload = true;
+            if (CAlias)
+              HasCallReload = true;
+            // Point at the specific aliasing writer (first store / mem-
+            // intrinsic wins) so the consumer sees WHERE the reload comes from.
+            if ((SAlias || MAlias) && !ReloadStore) {
+              ReloadStore = FirstAliasingStore(Load, Innermost);
+              ReloadLoad = Load;
+            }
+            // Load with no AA-detected writer (indirect / data-dependent;
+            // classifier today buckets under the generic trip-count-unknown
+            // opaque-operand case).
+            if (!SAlias && !MAlias && !CAlias)
+              HasUnaliasedLoadOperand = true;
+          } else if (isa<PHINode>(I)) {
+            // In-loop phi operand — phi SCEV couldn't recognize as an IV (IVs
+            // fold into an AddRec instead of appearing here as a SCEVUnknown).
+            HasInLoopPhiOperand = true;
+          } else {
+            // Any other in-loop def (freeze / select / intrinsic / call /
+            // ...). HasOtherInLoopUnknownOperand is the umbrella flag (superset
+            // for existing consumers); the specific opacity shape is also
+            // recorded so newer consumers can split freeze vs select vs other.
+            // freeze is often a redundant freeze on a value proven non-poison
+            // by a dominating guard; select is a control-flow-merge choice.
+            HasOtherInLoopUnknownOperand = true;
+            if (isa<FreezeInst>(I))
+              HasInLoopFreezeOperand = true;
+            else if (isa<SelectInst>(I))
+              HasInLoopSelectOperand = true;
+          }
+        }
+      }
+
+      // Detect AddRecs on a loop OTHER than the innermost. If the opaque /
+      // no-in-loop-unknown class fires for this operand AND such an AddRec is
+      // present, the opacity is only because SCEV doesn't fold outer-loop
+      // AddRecs into innermost-invariance — a SCEV-teaching opportunity, not a
+      // fundamental "modular stride" wall.
+      if (Innermost) {
+        for (const SCEVAddRecExpr *AR : Coll.AddRecs) {
+          if (AR->getLoop() != Innermost) {
+            HasOuterLoopAddRecOperand = true;
+            break;
+          }
+        }
+      }
+
+      // Opaque-operand / no-in-loop-unknown class — operand SCEV is non-AddRec
+      // / non-invariant for L but none of its SCEVUnknown leaves is defined
+      // inside L. Captures outer-loop AddRecs and other constructs blocking
+      // partial-BTC predication for reasons unrelated to in-loop memory.
+      if (OpIsOpaqueForL && !OpHasInLoopUnknown)
+        HasOpaqueOperandNoInLoopUnknown = true;
+    }
+
+    // Per-edge exit count + per-loop "other-uncomputable" flag.
+    // EdgeBTCComputable reflects the per-edge SCEV exit count for THIS exiting
+    // block (SE.getExitCount for &BB), not the loop's overall
+    // latch/backedge-taken count.
+    bool EdgeBTCComputable = false;
+    bool EdgeBTCSymbolic = false;
+    bool LoopHasOtherUnknownBTCTrap = false;
+    if (Innermost && IsLoopExit) {
+      const SCEV *EC = SE.getExitCount(Innermost, &BB);
+      EdgeBTCComputable = !isa<SCEVCouldNotCompute>(EC);
+      if (!EdgeBTCComputable) {
+        // Not exactly-known; check the SymbolicMaximum bucket so edge-level
+        // attribution matches the per-loop SCEV bucket.
+        const SCEV *SymEC =
+            SE.getExitCount(Innermost, &BB, ScalarEvolution::SymbolicMaximum);
+        EdgeBTCSymbolic = !isa<SCEVCouldNotCompute>(SymEC);
+      }
+      unsigned NUnc = UncomputableTrapExits.lookup(Innermost);
+      LoopHasOtherUnknownBTCTrap = EdgeBTCComputable ? (NUnc > 0) : (NUnc > 1);
+    }
+
+    // Predicate-tree shape (in-loop and out-of-loop edges alike). Sizes the
+    // reach of shape-specific levers: NUW propagation on a bounds-check OR
+    // targets OrBoundsCheckConstBound; the AND-form lever targets
+    // AndBoundsCheckConstBound; the variable-bound extension targets the
+    // *BoundsCheckVarBound shapes; a generic SCEV exit-count extension targets
+    // {Or,And}TwoAddRecICmp.
+    TrapPredicateShape PredShape =
+        classifyTrapPredicateShape(BI->getCondition(), SE, Innermost);
+
+    // Out-of-loop / structural-redundancy fields. Also computed for in-loop
+    // edges (cheap, and an in-loop trap dominated by an equivalent earlier
+    // check is still a CVP / dominator-fold candidate).
+    bool IsEntryProx = isEntryProximate(F, &BB, DT, LI);
+    bool DomByEquiv = isDominatedByEquivalentCheck(&BB, BI->getCondition(), DT);
+
+    // Q1 (dominance): does the trap branch's BB dominate the latch? If yes the
+    // cond fires every iteration; if no it's in a conditional arm and LICM
+    // can't hoist here. Q2 (IV update): for any IV operand, does its update
+    // dominate the latch? If no, the IV is conditionally updated and SCEV
+    // refuses an AddRec → trap not eliminable via trip-count.
+    bool DominatesLatch = false;
+    bool IVUpdateDominatesLatch = true;
+    if (LTAEmitExplain) {
+      BasicBlock *Latch = Innermost ? Innermost->getLoopLatch() : nullptr;
+      DominatesLatch = Latch && DT.dominates(&BB, Latch);
+      IVUpdateDominatesLatch =
+          computeIVUpdateDominatesLatch(BI->getCondition(), Innermost, DT);
+    }
+
+    // Resolve the reload-blocking writer: source line, kind (store / memcpy /
+    // …), TBAA type; plus WHICH load is reloaded (pointer name + source line)
+    // and its TBAA type. Empty when no store-reload.
+    unsigned ReloadStoreLine = 0, ReloadLoadLine = 0;
+    StringRef ReloadStoreTBAA, ReloadStoreKind, ReloadLoadTBAA, ReloadLoadName;
+    if (ReloadStore) {
+      if (const DebugLoc &DL = ReloadStore->getDebugLoc())
+        ReloadStoreLine = DL.getLine();
+      ReloadStoreTBAA = TBAATypeName(ReloadStore);
+      ReloadStoreKind = WriterKind(ReloadStore);
+    }
+    if (ReloadLoad) {
+      ReloadLoadTBAA = TBAATypeName(ReloadLoad);
+      if (const DebugLoc &DL = ReloadLoad->getDebugLoc())
+        ReloadLoadLine = DL.getLine();
+      if (Value *Ptr = ReloadLoad->getPointerOperand())
+        ReloadLoadName = Ptr->getName();
+    }
+
+    // Count-ordered trap-class code, computed once here (single source of
+    // truth; consumers read `TrapClass` instead of re-deriving it).
+    StringRef TrapClass = computeTrapClass(
+        /*InLoop=*/Innermost != nullptr, PredShape, IsEntryProx, DomByEquiv,
+        IsLoopExit, EdgeBTCComputable, LoopHasOtherUnknownBTCTrap,
+        HasStoreReload, HasMemIntrinsicReload, HasCallReload,
+        HasInLoopPhiOperand, HasUnaliasedLoadOperand,
+        HasOtherInLoopUnknownOperand, HasOpaqueOperandNoInLoopUnknown,
+        HasInLoopFreezeOperand, HasInLoopSelectOperand, NumLeafOps,
+        HasNonUnitStrideForLAddRec, HasNegativeStrideForLAddRec,
+        HasNonConstantStrideForLAddRec, HasOnlyNotProvenMonotonicForLAddRec);
+
+    OptimizationRemarkAnalysis Rem(REMARK_PASS, Name, BI);
+    Rem << "Function " << NV("Function", F.getName())
+        << " src_bb=" << NV("SourceBB", bbLabel(&BB))
+        << " trap_bb=" << NV("TrapBB", bbLabel(TrapSucc)) << " loop_depth="
+        << NV("LoopDepth", Innermost ? Innermost->getLoopDepth() : 0u)
+        << " loop_header="
+        << NV("LoopHeader",
+              Innermost ? bbLabel(Innermost->getHeader()) : std::string(""))
+        << " is_innermost="
+        << NV("IsInnermost", (bool)(Innermost && Innermost->isInnermost()))
+        << " is_loop_exit=" << NV("IsLoopExit", IsLoopExit)
+        << " trap_class=" << NV("TrapClass", TrapClass)
+        << " num_leaf_operands=" << NV("NumLeafOperands", NumLeafOps)
+        << " scev_computed=" << NV("SCEVComputed", AllComputed)
+        << " scev_loop_invariant="
+        << NV("SCEVLoopInvariant", LoopInvariantInInnermost)
+        << " has_addrec=" << NV("HasAddRec", HasAddRec)
+        << " has_in_loop_unknown=" << NV("HasInLoopUnknown", HasInLoopUnknown)
+        << " has_store_reload=" << NV("HasStoreReload", HasStoreReload)
+        << " has_mem_intrinsic_reload="
+        << NV("HasMemIntrinsicReload", HasMemIntrinsicReload)
+        << " reload_store_line=" << NV("ReloadStoreLine", ReloadStoreLine)
+        << " reload_store_kind=" << NV("ReloadStoreKind", ReloadStoreKind)
+        << " reload_store_tbaa=" << NV("ReloadStoreTBAA", ReloadStoreTBAA)
+        << " reload_load_tbaa=" << NV("ReloadLoadTBAA", ReloadLoadTBAA)
+        << " reload_load_name=" << NV("ReloadLoadName", ReloadLoadName)
+        << " reload_load_line=" << NV("ReloadLoadLine", ReloadLoadLine)
+        << " has_call_reload=" << NV("HasCallReload", HasCallReload)
+        << " has_unaliased_load_operand="
+        << NV("HasUnaliasedLoadOperand", HasUnaliasedLoadOperand)
+        << " has_in_loop_phi_operand="
+        << NV("HasInLoopPhiOperand", HasInLoopPhiOperand)
+        << " has_in_loop_freeze_operand="
+        << NV("HasInLoopFreezeOperand", HasInLoopFreezeOperand)
+        << " has_in_loop_select_operand="
+        << NV("HasInLoopSelectOperand", HasInLoopSelectOperand)
+        << " has_other_in_loop_unknown_operand="
+        << NV("HasOtherInLoopUnknownOperand", HasOtherInLoopUnknownOperand)
+        << " has_opaque_operand_no_in_loop_unknown="
+        << NV("HasOpaqueOperandNoInLoopUnknown",
+              HasOpaqueOperandNoInLoopUnknown)
+        << " has_outer_loop_addrec_operand="
+        << NV("HasOuterLoopAddRecOperand", HasOuterLoopAddRecOperand)
+        << " has_non_unit_stride_for_l_addrec="
+        << NV("HasNonUnitStrideForLAddRec", HasNonUnitStrideForLAddRec)
+        << " has_non_constant_stride_for_l_addrec="
+        << NV("HasNonConstantStrideForLAddRec", HasNonConstantStrideForLAddRec)
+        << " has_only_weak_no_wrap_for_l_addrec="
+        << NV("HasOnlyNotProvenMonotonicForLAddRec",
+              HasOnlyNotProvenMonotonicForLAddRec)
+        << " has_negative_stride_for_l_addrec="
+        << NV("HasNegativeStrideForLAddRec", HasNegativeStrideForLAddRec)
+        << " edge_btc_computable=" << NV("EdgeBTCComputable", EdgeBTCComputable)
+        << " edge_btc_symbolic=" << NV("EdgeBTCSymbolic", EdgeBTCSymbolic)
+        << " loop_has_other_unknown_btc_trap="
+        << NV("LoopHasOtherUnknownBTCTrap", LoopHasOtherUnknownBTCTrap)
+        << " predicate_shape="
+        << NV("PredicateShape", trapPredicateShapeName(PredShape).str())
+        << " is_entry_proximate=" << NV("IsEntryProximate", IsEntryProx)
+        << " dominated_by_equivalent_check="
+        << NV("DominatedByEquivalentCheck", DomByEquiv);
+    if (LTAEmitExplain) {
+      Rem << " dominates_latch=" << NV("DominatesLatch", DominatesLatch)
+          << " iv_update_dominates_latch="
+          << NV("IVUpdateDominatesLatch", IVUpdateDominatesLatch)
+          << " invocation_seq=" << NV("InvocationSeq", InvocationSeq);
+    }
+    ORE.emit(Rem);
+  }
+
+  // Flag-gated per-load alias annotation: for each load in an INNERMOST loop
+  // may-clobbered by an in-loop writer (store / memcpy / call), emit a
+  // LoopLoadAlias record naming the first such writer. Clobbered loads only
+  // (hoistable loads omitted).
+  if (LTAEmitLoadAlias) {
+    std::string LName = taggedName("LoopLoadAlias", Tag);
+    for (Loop *L : LI.getLoopsInPreorder()) {
+      if (!L->isInnermost())
+        continue;
+      for (BasicBlock *BB : L->blocks())
+        for (Instruction &I : *BB) {
+          auto *Load = dyn_cast<LoadInst>(&I);
+          if (!Load)
+            continue;
+          Instruction *W = FirstAliasingWriter(Load, L);
+          if (!W)
+            continue; // hoistable — no in-loop writer may-aliases it
+          unsigned LoadLine = 0, WLine = 0;
+          if (const DebugLoc &DL = Load->getDebugLoc())
+            LoadLine = DL.getLine();
+          if (const DebugLoc &DL = W->getDebugLoc())
+            WLine = DL.getLine();
+          StringRef LoadName;
+          if (Value *P = Load->getPointerOperand())
+            LoadName = P->getName();
+          OptimizationRemarkAnalysis Rem(REMARK_PASS, LName, Load);
+          Rem << "Function " << NV("Function", F.getName())
+              << " load_name=" << NV("LoadName", LoadName)
+              << " load_line=" << NV("LoadLine", LoadLine)
+              << " load_tbaa=" << NV("LoadTBAA", TBAATypeName(Load))
+              << " loop_header=" << NV("LoopHeader", bbLabel(L->getHeader()))
+              << " writer_kind=" << NV("WriterKind", WriterKind(W))
+              << " writer_line=" << NV("WriterLine", WLine)
+              << " writer_tbaa=" << NV("WriterTBAA", TBAATypeName(W));
+          ORE.emit(Rem);
+        }
+    }
+  }
 }
 
 /// Emit one machine-readable LoopPrimitives remark per loop in F, plus a

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -431,7 +431,81 @@ static TrapCondShape classifyCondTrapEdges(Loop *L, ScalarEvolution &SE,
 // may-not-return}. Optional ": <callee>" disambiguates calls. Splitting by
 // class (vs the prior two opaque buckets) shows which lever -- TBAA,
 // function-attr annotations, per-intrinsic AA -- would unblock a given loop.
-static std::string getSideEffectReasons(const Instruction &I) { return ""; }
+static std::string getSideEffectReasons(const Instruction &I) {
+  std::string Buf;
+  raw_string_ostream OS(Buf);
+
+  // CallInst class: distinguish intrinsics from user calls, split by memory
+  // effect. AA models memcpy/memset ModRefInfo well; opaque user calls not.
+  if (const auto *CI = dyn_cast<CallInst>(&I)) {
+    StringRef CalleeName;
+    if (const Function *Callee = CI->getCalledFunction())
+      CalleeName = Callee->getName();
+    bool IsIntrinsic = CI->getIntrinsicID() != Intrinsic::not_intrinsic;
+    StringRef CategoryPrefix = IsIntrinsic ? "MemIntrinsic" : "Call";
+
+    // argmemonly memintrinsics (memcpy/memset/memmove) only touch their
+    // pointer arguments, which AA already models precisely, so a generic
+    // memory-effect tag would mis-suggest they are blockers. Skip the
+    // may-{write,read}-memory tags for them; throw / no-return still emit
+    // (orthogonal to memory).
+    bool SkipMemoryTags =
+        IsIntrinsic && CI->getMemoryEffects().onlyAccessesArgPointees();
+
+    if (CI->isVolatile())
+      OS << "VolatileCall.may-access-memory\n";
+    if (!SkipMemoryTags) {
+      if (I.mayWriteToMemory()) {
+        OS << CategoryPrefix << ".may-write-to-memory";
+        if (!CalleeName.empty())
+          OS << ": " << CalleeName;
+        OS << "\n";
+      } else if (I.mayReadFromMemory()) {
+        OS << CategoryPrefix << ".may-read-from-memory";
+        if (!CalleeName.empty())
+          OS << ": " << CalleeName;
+        OS << "\n";
+      }
+    }
+    if (I.mayThrow())
+      OS << CategoryPrefix << ".may-throw\n";
+    if (!I.willReturn())
+      OS << CategoryPrefix << ".may-not-return\n";
+    return Buf;
+  }
+
+  // Non-call instructions: split by opcode so the metric distinguishes
+  // a real store from atomic RMW / cmpxchg / fence / volatile load.
+  if (auto *SI = dyn_cast<StoreInst>(&I)) {
+    if (SI->isVolatile())
+      OS << "VolatileStore.may-write-to-memory\n";
+    else if (SI->isAtomic())
+      OS << "AtomicStore.may-write-to-memory\n";
+    else
+      OS << "Store.may-write-to-memory\n";
+  } else if (auto *LI = dyn_cast<LoadInst>(&I)) {
+    if (LI->isVolatile())
+      OS << "VolatileLoad.may-write-to-memory\n";
+    else if (LI->isAtomic())
+      OS << "AtomicLoad.may-write-to-memory\n";
+    // Plain load: mayWriteToMemory() is false — nothing to emit.
+  } else if (isa<AtomicRMWInst>(&I)) {
+    OS << "AtomicRMW.may-write-to-memory\n";
+  } else if (isa<AtomicCmpXchgInst>(&I)) {
+    OS << "AtomicCmpXchg.may-write-to-memory\n";
+  } else if (isa<FenceInst>(&I)) {
+    OS << "Fence.may-write-to-memory\n";
+  } else if (I.mayWriteToMemory()) {
+    // Catch-all for any other non-call write (rare).
+    OS << "Other.may-write-to-memory\n";
+  }
+
+  if (I.mayThrow())
+    OS << "Instruction.may-throw\n";
+  if (!I.willReturn())
+    OS << "Instruction.may-not-return\n";
+  return Buf;
+}
 
 /// Check if the loop preheader has ".hoisted" instructions, indicating
 /// successful hoisting of trap checks out of the loop.
@@ -902,6 +976,60 @@ static bool isDominatedByEquivalentCheck(BasicBlock *BB, Value *MyCond,
   return false;
 }
 
+/// For each conditional branch whose target is a trap block, emit one
+/// `LoopTrapEdge<Tag>` remark with per-edge classification fields.
+///
+/// SCEV / AA blockers (in-loop trap edges):
+///   SCEVComputed       — every leaf-operand has a non-CouldNotCompute SCEV
+///   SCEVLoopInvariant  — every leaf-operand SCEV is loop-invariant in the
+///                        *innermost* containing loop (standard
+///                        `SE.isLoopInvariant(SCEV, L)`; trivially true when
+///                        the source BB is outside any loop).
+///   HasAddRec          — at least one operand SCEV contains a SCEVAddRecExpr
+///   HasInLoopUnknown   — at least one operand SCEV contains a SCEVUnknown
+///                        whose Instruction is defined inside any containing
+///                        loop (true even when SCEVLoopInvariant w.r.t.
+///                        innermost holds — i.e. the load lives in an outer
+///                        loop).
+///   HasStoreReload     — at least one operand SCEV references a SCEVUnknown
+///                        that is a LoadInst in the innermost loop,
+///                        AA-may-aliased by some StoreInst / mem-intrinsic in
+///                        that loop.
+///   HasCallReload      — as HasStoreReload but for a may-modifying CallBase.
+///                        (Not exclusive: an edge can have both; downstream
+///                        treats that as a "both" bucket.)
+///   IsLoopExit         — the trap successor is outside the innermost loop
+///                        (loop-exit, not loop-internal). Required for the BTC
+///                        fields to be meaningful.
+///   EdgeBTCComputable  — the per-edge SCEV exit count for THIS trap edge's
+///                        source BB is known: `SE.getExitCount(Innermost,
+///                        sourceBB) != SCEVCouldNotCompute` (false if
+///                        !IsLoopExit). This is the exit count for this
+///                        specific exiting block, NOT the loop's overall
+///                        latch/backedge-taken count.
+///   LoopHasOtherUnknownBTCTrap — the innermost loop has another trap-exit
+///                        (excluding this edge) with SCEVCouldNotCompute exit
+///                        count ("this edge computable but loop's others
+///                        aren't, so we can't hoist any").
+///
+/// Predicate-tree shape (all trap edges):
+///   PredicateShape     — TrapPredicateShape enum name for the trap branch's
+///                        i1 predicate. Sizes the reach of shape-specific
+///                        levers (NUW propagation on bounds-check OR/AND forms,
+///                        their variable-bound extensions, and generic
+///                        OR-of-AddRec exit recognition).
+///
+/// Out-of-loop / structural-redundancy fields:
+///   IsEntryProximate   — source BB within `EntryProximityDepth` dominator
+///                        steps of the entry block OR a loop preheader; genuine
+///                        validation trap, NOT an elimination candidate.
+///   DominatedByEquivalentCheck — some dominator of source BB ends in a
+///                        cond-branch with the same predicate; already proven
+///                        earlier — a dominator-aware InstCombine / CVP fold
+///                        candidate.
+///
+/// Plus loop-context fields (LoopHeader / Depth / IsInnermost) so downstream
+/// tooling can join against `LoopPrimitives<Tag>` records.
 /// Walk the def chain of \p Cond (bounded to instructions inside \p L) and
 /// answer Q2 of the trap-explanation tree: for every IV-shaped operand reached,
 /// does its update dominate the loop latch?
@@ -2079,11 +2207,76 @@ static CheckLoopHoistType processLoops(Loop *L, ScalarEvolution &SE,
                                        LoopInfo &LI,
                                        OptimizationRemarkEmitter &ORE,
                                        StringRef Tag) {
-  // Call-wiring: exercise the per-loop hoist helpers so none is unused.
-  (void)hasUnreachableInst(L);
-  for (auto *BB : L->blocks())
-    (void)getSideEffectReasons(*BB->getTerminator());
-  return CheckLoopHoistType::SKIP;
+  CheckLoopHoistType HoistType;
+  bool SymbolicMaxBackEdgeComputable =
+      !isa<SCEVCouldNotCompute>(SE.getSymbolicMaxBackedgeTakenCount(L));
+  bool HasSideEffects = false;
+  if (!hasUnreachableInst(L))
+    return CheckLoopHoistType::SKIP;
+
+  unsigned TrapCount = countTrapExits(L, LI);
+
+  SmallVector<std::string, 4> InstructionsWithSideEffects;
+  SmallVector<std::string, 4> SideEffectReasons;
+  for (auto *BB : L->blocks()) {
+    if (any_of(*BB, [&InstructionsWithSideEffects,
+                     &SideEffectReasons](const Instruction &I) {
+          bool InstHasSideEffects = false;
+          // If a call instruction reads or writes to memory we don't know if
+          // the access is non-volatile so we asssume that the call instruction
+          // has side effects.
+          if (isa<CallInst>(I))
+            InstHasSideEffects =
+                I.mayHaveSideEffects() || I.mayReadFromMemory();
+          else if (LTAEmitExplain)
+            InstHasSideEffects = !I.willReturn() || I.mayThrow();
+          else
+            InstHasSideEffects = I.mayHaveSideEffects();
+          if (InstHasSideEffects) {
+            std::string Buf;
+            raw_string_ostream OS(Buf);
+            I.print(OS);
+            InstructionsWithSideEffects.push_back(Buf);
+            SideEffectReasons.push_back(getSideEffectReasons(I));
+          }
+          return InstHasSideEffects;
+        })) {
+
+      HasSideEffects = true;
+      break;
+    }
+  }
+
+  HoistType = !HasSideEffects && SymbolicMaxBackEdgeComputable
+                  ? CheckLoopHoistType::MAYBE_CAN_HOIST
+                  : CheckLoopHoistType::CANNOT_HOIST;
+  // Emit a remark for the loop.
+  // NB: `OptimizationRemarkAnalysis` stores its `RemarkName` as a `StringRef`.
+  // Passing `taggedName(...)` inline would create a temporary `std::string`
+  // destroyed at the end of the full expression, leaving the stored `StringRef`
+  // dangling and producing garbled `Name:` fields in YAML. Hold the name in a
+  // local that outlives the remark.
+  std::string TrapRemarkName = taggedName("LoopTrap", Tag);
+  auto ORA = OptimizationRemarkAnalysis(REMARK_PASS, TrapRemarkName,
+                                        &L->getHeader()->front());
+  ORA << "Loop: " << L->getName() << " "
+      << "TrapExits: " << NV("TrapExitCount", TrapCount) << " ";
+  if (HoistType == CheckLoopHoistType::CANNOT_HOIST) {
+    ORA << "cannot be hoisted: \n";
+    if (HasSideEffects) {
+      ORA << "\nThe following instructions have side effects:\n";
+      for (unsigned Idx = 0; Idx < InstructionsWithSideEffects.size(); Idx++) {
+        ORA << "\t" << InstructionsWithSideEffects[Idx] << "\n";
+        ORA << "Reason:\n";
+        ORA << SideEffectReasons[Idx];
+      }
+    }
+    if (!SymbolicMaxBackEdgeComputable)
+      ORA << "Backedge is not computable.\n";
+  } else
+    ORA << "can be hoisted\n";
+  ORE.emit(ORA);
+  return HoistType;
 }
 
 /// Collect info for hoistable loop checks for \p F and report remarks for
@@ -2091,13 +2284,46 @@ static CheckLoopHoistType processLoops(Loop *L, ScalarEvolution &SE,
 static void emitRemarks(Function &F, LoopInfo &LI,
                         OptimizationRemarkEmitter &ORE, ScalarEvolution &SE,
                         StringRef Tag) {
-  // Call-wiring: exercise processLoops and hasHoistedInPreheader so neither is
-  // unused.
+  unsigned TotalCanHoistLoops = 0;
+  unsigned TotalUnHoistableLoops = 0;
+  unsigned TotalHoistedLoops = 0;
   for (auto *L : LI.getLoopsInPreorder()) {
-    SmallVector<std::string, 4> Hoisted;
-    (void)hasHoistedInPreheader(L, Hoisted);
-    (void)processLoops(L, SE, LI, ORE, Tag);
+    // Check for .hoisted instructions in preheader (successfully hoisted)
+    SmallVector<std::string, 4> PreheaderHoisted;
+    if (hasHoistedInPreheader(L, PreheaderHoisted)) {
+      TotalHoistedLoops++;
+      // RemarkName must outlive the remark — see comment at the
+      // earlier LoopTrap remark for context.
+      std::string HoistRemarkName = taggedName("LoopTrapHoisted", Tag);
+      OptimizationRemarkAnalysis HoistRem(REMARK_PASS, HoistRemarkName,
+                                          &L->getHeader()->front());
+      HoistRem << "Loop: " << L->getName()
+               << " has trap check hoisted to preheader\n";
+      for (const auto &Inst : PreheaderHoisted)
+        HoistRem << "\t" << Inst << "\n";
+      ORE.emit(HoistRem);
+    }
+
+    CheckLoopHoistType Type = processLoops(L, SE, LI, ORE, Tag);
+    if (Type == CheckLoopHoistType::MAYBE_CAN_HOIST)
+      TotalCanHoistLoops++;
+    else if (Type == CheckLoopHoistType::CANNOT_HOIST)
+      TotalUnHoistableLoops++;
   }
+
+  // RemarkName must outlive the remark — see earlier comment.
+  std::string SummaryRemarkName = taggedName("LoopTrapSummary", Tag);
+  OptimizationRemarkAnalysis Rem(REMARK_PASS, SummaryRemarkName, &F);
+  Rem << "Trap checks results:\n";
+  Rem << "Total count of loops with traps "
+      << NV("TotalCount", TotalCanHoistLoops + TotalUnHoistableLoops) << "\n";
+  Rem << "Loops that maybe can be hoisted: "
+      << NV("CountHoist", TotalCanHoistLoops) << "\n";
+  Rem << "Loops that cannot be hoisted: "
+      << NV("CountCannotHoist", TotalUnHoistableLoops) << "\n";
+  Rem << "Loops with trap check hoisted to preheader: "
+      << NV("CountHoisted", TotalHoistedLoops) << "\n";
+  ORE.emit(Rem);
 }
 
 PreservedAnalyses LoopTrapAnalysisPass::run(Function &F,

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -90,15 +90,95 @@ enum class LegacyTrapMatch {
 /// change.
 static bool isTrapBlock(BasicBlock *BB, bool BoundsSafetyOnly,
                         LegacyTrapMatch Legacy) {
+  if (!BB || BB->empty())
+    return false;
+  Instruction *Term = BB->getTerminator();
+  if (!isa<UnreachableInst>(Term))
+    return false;
+  if (LTAEmitExplain) {
+    // Unified: bounds-safety filter + a trap-like terminating call, identified
+    // by its semantic property rather than an intrinsic allowlist: a
+    // `noreturn` call touching only inaccessible memory (the shared property of
+    // @llvm.trap / @llvm.ubsantrap / @llvm.looptrap and any future trap
+    // intrinsic).
+    if (BoundsSafetyOnly && !isBoundsSafetyAnnotated(Term))
+      return false;
+    if (Term == &BB->front())
+      return false;
+    if (auto *CI = dyn_cast<CallInst>(Term->getPrevNode()))
+      return CI->doesNotReturn() && CI->onlyAccessesInaccessibleMemory();
+    return false;
+  }
+  // Legacy: reproduce each caller's original predicate byte-for-byte.
+  switch (Legacy) {
+  case LegacyTrapMatch::AnyUnreachableBoundsSafety:
+    return !BoundsSafetyOnly || isBoundsSafetyAnnotated(Term);
+  case LegacyTrapMatch::AnyUnreachable:
+    return true;
+  case LegacyTrapMatch::TrapIntrinsic:
+    if (Term == &BB->front())
+      return false;
+    if (auto *CI = dyn_cast<CallInst>(Term->getPrevNode()))
+      if (Function *Callee = CI->getCalledFunction())
+        return Callee->getIntrinsicID() == Intrinsic::trap;
+    return false;
+  }
   return false;
 }
 
 /// Check for an unreachable instruction that has an edge to any of \p L basic
 /// blocks. if `--use-bounds-safety-traps-only` is used make sure that the trap and
 /// branch instructions have -fbounds-safety annotation.
-static bool hasUnreachableInst(Loop *L) { return false; }
+static bool hasUnreachableInst(Loop *L) {
+  SmallVector<BasicBlock *, 4> LoopExitBlocks;
+  L->getExitBlocks(LoopExitBlocks);
+  for (auto *BB : LoopExitBlocks) {
+    // Trap exit block (shared predicate, honoring
+    // --use-bounds-safety-traps-only).
+    if (!isTrapBlock(BB, BoundsSafetyTrapsOnly,
+                     LegacyTrapMatch::AnyUnreachableBoundsSafety))
+      continue;
+    if (any_of(predecessors(BB), [L](BasicBlock *PredB) {
+          auto *TerminatorInst = PredB->getTerminator();
+          return L->contains(PredB) &&
+                 (isa<CondBrInst>(TerminatorInst) ||
+                  isa<UncondBrInst>(TerminatorInst) ||
+                  isa<SwitchInst>(TerminatorInst)) &&
+                 (!BoundsSafetyTrapsOnly ||
+                  isBoundsSafetyAnnotated(TerminatorInst));
+        }))
+      return true;
+  }
+  return false;
+}
 
-static unsigned countTrapExits(Loop *L, LoopInfo &LI) { return 0u; }
+static unsigned countTrapExits(Loop *L, LoopInfo &LI) {
+  unsigned Count = 0;
+  SmallVector<BasicBlock *, 4> LoopExitBlocks;
+  L->getExitBlocks(LoopExitBlocks);
+  for (auto *BB : LoopExitBlocks) {
+    if (!isTrapBlock(BB, BoundsSafetyTrapsOnly,
+                     LegacyTrapMatch::AnyUnreachableBoundsSafety))
+      continue;
+    // Strict attribution: count this trap exit only if it has a predecessor
+    // whose immediate containing loop is L (not a nested sub-loop). Otherwise
+    // an inner trap's unreachable target -- in every enclosing loop's exit set
+    // -- would be counted at every nest level.
+    if (any_of(predecessors(BB), [L, &LI](BasicBlock *PredB) {
+          if (LI.getLoopFor(PredB) != L)
+            return false;
+          auto *TerminatorInst = PredB->getTerminator();
+          return L->contains(PredB) &&
+                 (isa<CondBrInst>(TerminatorInst) ||
+                  isa<UncondBrInst>(TerminatorInst) ||
+                  isa<SwitchInst>(TerminatorInst)) &&
+                 (!BoundsSafetyTrapsOnly ||
+                  isBoundsSafetyAnnotated(TerminatorInst));
+        }))
+      ++Count;
+  }
+  return Count;
+}
 
 /// Count conditional branches inside the loop body whose target is a trap
 /// block (BB ending in `unreachable`, optionally preceded by
@@ -108,12 +188,68 @@ static unsigned countTrapExits(Loop *L, LoopInfo &LI) { return 0u; }
 /// any sub-loop). Since `L->blocks()` transitively includes sub-loop blocks,
 /// without this filter an inner-loop trap would be double-counted by every
 /// enclosing loop's record.
-static unsigned countCondTrapEdges(Loop *L, LoopInfo &LI) { return 0u; }
+static unsigned countCondTrapEdges(Loop *L, LoopInfo &LI) {
+  unsigned Count = 0;
+  // Trap block: an unreachable BB whose only side effect is llvm.trap (or bare
+  // unreachable).
+  auto IsTrapBlock = [](BasicBlock *BB) {
+    return isTrapBlock(BB, BoundsSafetyTrapsOnly,
+                       LegacyTrapMatch::AnyUnreachableBoundsSafety);
+  };
+  for (auto *BB : L->blocks()) {
+    // Strict attribution: only edges whose source BB's immediate containing
+    // loop is L. Edges in nested sub-loops belong to those inner loops.
+    if (LI.getLoopFor(BB) != L)
+      continue;
+    auto *Term = BB->getTerminator();
+    auto *BI = dyn_cast<CondBrInst>(Term);
+    if (!BI)
+      continue;
+    for (BasicBlock *Succ : BI->successors()) {
+      if (L->contains(Succ))
+        continue;
+      if (IsTrapBlock(Succ)) {
+        if (BoundsSafetyTrapsOnly && !isBoundsSafetyAnnotated(Term))
+          continue;
+        ++Count;
+      }
+    }
+  }
+  return Count;
+}
 
 /// Count cond-trap edges whose condition is loop-invariant — i.e. LICM could
 /// hoist them out but hasn't. Estimates the residual hoisting opportunity.
 static unsigned countHoistableCondTrapEdges(Loop *L, LoopInfo &LI) {
-  return 0u;
+  unsigned Count = 0;
+  auto IsTrapBlock = [](BasicBlock *BB) {
+    return isTrapBlock(BB, BoundsSafetyTrapsOnly,
+                       LegacyTrapMatch::AnyUnreachable);
+  };
+  for (auto *BB : L->blocks()) {
+    // Strict attribution: only edges originating in L's own body. Same rule
+    // as countCondTrapEdges.
+    if (LI.getLoopFor(BB) != L)
+      continue;
+    auto *Term = BB->getTerminator();
+    auto *BI = dyn_cast<CondBrInst>(Term);
+    if (!BI)
+      continue;
+    bool HasTrapSucc = false;
+    for (BasicBlock *Succ : BI->successors()) {
+      if (L->contains(Succ))
+        continue;
+      if (IsTrapBlock(Succ)) {
+        HasTrapSucc = true;
+        break;
+      }
+    }
+    if (!HasTrapSucc)
+      continue;
+    if (L->isLoopInvariant(BI->getCondition()))
+      ++Count;
+  }
+  return Count;
 }
 
 /// Classify cond-trap edges by the shape of their controlling condition.

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -297,7 +297,126 @@ struct TrapCondShape {
 };
 static TrapCondShape classifyCondTrapEdges(Loop *L, ScalarEvolution &SE,
                                            const DominatorTree &DT) {
-  return TrapCondShape();
+  TrapCondShape S;
+  BasicBlock *Latch = L->getLoopLatch();
+  auto IsTrapBlock = [](BasicBlock *BB) {
+    return isTrapBlock(BB, BoundsSafetyTrapsOnly,
+                       LegacyTrapMatch::AnyUnreachable);
+  };
+  for (auto *BB : L->blocks()) {
+    auto *Term = BB->getTerminator();
+    auto *BI = dyn_cast<CondBrInst>(Term);
+    if (!BI)
+      continue;
+    bool HasTrapSucc = false;
+    for (BasicBlock *Succ : BI->successors()) {
+      if (L->contains(Succ))
+        continue;
+      if (IsTrapBlock(Succ)) {
+        HasTrapSucc = true;
+        break;
+      }
+    }
+    if (!HasTrapSucc)
+      continue;
+
+    // Dominance dimension: if the trap branch's parent BB dominates the latch,
+    // the cond evaluates every iteration; otherwise it's in a conditional arm
+    // and SCEV cannot compute trip counts past it.
+    bool DominatesLatch = Latch && DT.dominates(BB, Latch);
+    if (DominatesLatch)
+      ++S.DominatesLatch;
+    else
+      ++S.NotDominatingLatch;
+
+    Value *Cond = BI->getCondition();
+    if (L->isLoopInvariant(Cond)) {
+      ++S.Invariant;
+      if (DominatesLatch)
+        ++S.DLInvariant;
+      else
+        ++S.NDLInvariant;
+      continue;
+    }
+    auto *Cmp = dyn_cast<ICmpInst>(Cond);
+    bool FoundAddRec = false;
+    auto Inspect = [&](Value *V) {
+      if (L->isLoopInvariant(V))
+        return;
+      if (!SE.isSCEVable(V->getType()))
+        return;
+      const SCEV *SC = SE.getSCEV(V);
+      if (auto *AR = dyn_cast<SCEVAddRecExpr>(SC))
+        if (AR->getLoop() == L)
+          FoundAddRec = true;
+    };
+    if (Cmp) {
+      Inspect(Cmp->getOperand(0));
+      Inspect(Cmp->getOperand(1));
+    } else {
+      Inspect(Cond);
+    }
+    if (FoundAddRec) {
+      ++S.IVDerived;
+      if (DominatesLatch)
+        ++S.DLIVDerived;
+      else
+        ++S.NDLIVDerived;
+    } else {
+      ++S.NonIV;
+      if (DominatesLatch)
+        ++S.DLNonIV;
+      else
+        ++S.NDLNonIV;
+
+      // Sub-classify NonIV: walk the cond's operand chain (in-loop,
+      // depth-bounded) and tag which operand classes appear. Flags are
+      // non-exclusive. The walk is shallow (no header-phi recurrence) so it
+      // stays O(loop body) without chain explosion.
+      SmallPtrSet<const Value *, 32> Seen;
+      SmallVector<const Value *, 16> Stack;
+      auto Push = [&](Value *V) { Stack.push_back(V); };
+      if (Cmp) {
+        Push(Cmp->getOperand(0));
+        Push(Cmp->getOperand(1));
+      } else {
+        Push(Cond);
+      }
+      bool HasLoad = false, HasPhi = false, HasSelect = false, HasCall = false;
+      unsigned Steps = 0;
+      const unsigned StepLimit = 64;
+      while (!Stack.empty() && Steps++ < StepLimit) {
+        const Value *V = Stack.pop_back_val();
+        if (!Seen.insert(V).second)
+          continue;
+        const auto *I = dyn_cast<Instruction>(V);
+        if (!I || !L->contains(I->getParent()))
+          continue;
+        if (isa<LoadInst>(I))
+          HasLoad = true;
+        else if (isa<PHINode>(I))
+          HasPhi = true;
+        else if (isa<SelectInst>(I) || isa<FreezeInst>(I))
+          HasSelect = true;
+        else if (isa<CallInst>(I))
+          HasCall = true;
+        // Don't recurse through phi operands (avoids cycle chain explosion);
+        // 'phi' is already tagged. Recurse through anything else.
+        if (!isa<PHINode>(I))
+          for (const Use &U : I->operands())
+            Stack.push_back(U.get());
+      }
+      if (HasLoad)
+        ++S.NonIVLoadOp;
+      if (HasPhi)
+        ++S.NonIVPhiOp;
+      if (HasSelect)
+        ++S.NonIVSelectOp;
+      if (HasCall)
+        ++S.NonIVCallOp;
+    }
+  }
+  return S;
 }
 
 // Emit one or more side-effect tags identifying the *class* of instruction
@@ -340,7 +459,42 @@ static std::string bbLabel(const BasicBlock *BB) { return ""; }
 static void collectBoolLeafOperands(Value *V,
                                     SmallVectorImpl<Value *> &Operands,
                                     SmallPtrSetImpl<Value *> &Visited,
-                                    int Depth = 0) {}
+                                    int Depth = 0) {
+  if (!V || !Visited.insert(V).second || Depth > 8)
+    return;
+  if (auto *SI = dyn_cast<SelectInst>(V)) {
+    Value *T = SI->getTrueValue(), *FV = SI->getFalseValue();
+    if (auto *TC = dyn_cast<ConstantInt>(T))
+      if (TC->isOne()) {
+        collectBoolLeafOperands(SI->getCondition(), Operands, Visited,
+                                Depth + 1);
+        collectBoolLeafOperands(FV, Operands, Visited, Depth + 1);
+        return;
+      }
+    if (auto *FC = dyn_cast<ConstantInt>(FV))
+      if (FC->isZero()) {
+        collectBoolLeafOperands(SI->getCondition(), Operands, Visited,
+                                Depth + 1);
+        collectBoolLeafOperands(T, Operands, Visited, Depth + 1);
+        return;
+      }
+  }
+  if (auto *BO = dyn_cast<BinaryOperator>(V)) {
+    if (BO->getOpcode() == Instruction::Or ||
+        BO->getOpcode() == Instruction::And) {
+      collectBoolLeafOperands(BO->getOperand(0), Operands, Visited, Depth + 1);
+      collectBoolLeafOperands(BO->getOperand(1), Operands, Visited, Depth + 1);
+      return;
+    }
+  }
+  if (auto *Cmp = dyn_cast<CmpInst>(V)) {
+    Operands.push_back(Cmp->getOperand(0));
+    Operands.push_back(Cmp->getOperand(1));
+    return;
+  }
+  // Opaque — record as itself.
+  Operands.push_back(V);
+}
 
 /// SCEV traversal helper: collects every SCEVUnknown and SCEVAddRecExpr
 /// node reachable from a SCEV expression. We use the canonical
@@ -378,7 +532,29 @@ enum class TrapPredicateShape {
 };
 } // anonymous namespace
 
-static StringRef trapPredicateShapeName(TrapPredicateShape S) { return ""; }
+static StringRef trapPredicateShapeName(TrapPredicateShape S) {
+  switch (S) {
+  case TrapPredicateShape::Unknown:
+    return "Unknown";
+  case TrapPredicateShape::SingleICmp:
+    return "SingleICmp";
+  case TrapPredicateShape::OrBoundsCheckConstBound:
+    return "OrBoundsCheck-ConstBound";
+  case TrapPredicateShape::AndBoundsCheckConstBound:
+    return "AndBoundsCheck-ConstBound";
+  case TrapPredicateShape::OrBoundsCheckVarBound:
+    return "OrBoundsCheck-VarBound";
+  case TrapPredicateShape::AndBoundsCheckVarBound:
+    return "AndBoundsCheck-VarBound";
+  case TrapPredicateShape::OrTwoAddRecICmp:
+    return "OrTwoAddRecICmp";
+  case TrapPredicateShape::AndTwoAddRecICmp:
+    return "AndTwoAddRecICmp";
+  case TrapPredicateShape::OtherMulti:
+    return "OtherMulti";
+  }
+  llvm_unreachable("unhandled TrapPredicateShape");
+}
 
 /// Compute the count-ordered, descriptive trap-class name for one trap edge
 /// from its per-edge fields. Single source of truth for a classification
@@ -410,6 +586,41 @@ static bool matchBoundsCheckArmsImpl(Value *Arm1, Value *Arm2,
                                      ICmpInst::Predicate ArmAPred,
                                      ICmpInst::Predicate ArmBPred, bool VarK,
                                      ScalarEvolution &SE, Loop *L) {
+  using namespace PatternMatch;
+  for (int Try = 0; Try < 2; ++Try) {
+    Value *A = Try == 0 ? Arm1 : Arm2;
+    Value *B = Try == 0 ? Arm2 : Arm1;
+    auto *CmpA = dyn_cast<ICmpInst>(A);
+    auto *CmpB = dyn_cast<ICmpInst>(B);
+    if (!CmpA || !CmpB)
+      continue;
+    if (CmpA->getPredicate() != ArmAPred)
+      continue;
+    if (CmpB->getPredicate() != ArmBPred)
+      continue;
+    Value *X = CmpA->getOperand(0);
+    Value *Bound = CmpA->getOperand(1);
+    Value *SubV = CmpB->getOperand(0);
+    Value *K = CmpB->getOperand(1);
+    Value *BoundOfSub = nullptr, *XOfSub = nullptr;
+    if (!match(SubV, m_Sub(m_Value(BoundOfSub), m_Value(XOfSub))))
+      continue;
+    if (Bound != BoundOfSub || X != XOfSub)
+      continue;
+    if (VarK) {
+      if (!L)
+        continue;
+      if (!SE.isSCEVable(K->getType()))
+        continue;
+      const SCEV *KS = SE.getSCEV(K);
+      if (auto *AR = dyn_cast<SCEVAddRecExpr>(KS))
+        if (AR->getLoop() == L && AR->isAffine())
+          return true;
+      continue;
+    }
+    if (isa<ConstantInt>(K))
+      return true;
+  }
   return false;
 }
 
@@ -420,7 +631,23 @@ static bool matchBoundsCheckArmsImpl(Value *Arm1, Value *Arm2,
 /// operands).
 static bool matchTwoAddRecICmpImpl(Value *Arm1, Value *Arm2,
                                    ScalarEvolution &SE, Loop *L) {
-  return false;
+  if (!L)
+    return false;
+  auto HasLAddRec = [&](Value *V) -> bool {
+    auto *Cmp = dyn_cast<ICmpInst>(V);
+    if (!Cmp)
+      return false;
+    for (Value *Op : {Cmp->getOperand(0), Cmp->getOperand(1)}) {
+      if (!SE.isSCEVable(Op->getType()))
+        continue;
+      const SCEV *S = SE.getSCEV(Op);
+      if (auto *AR = dyn_cast<SCEVAddRecExpr>(S))
+        if (AR->getLoop() == L)
+          return true;
+    }
+    return false;
+  };
+  return HasLAddRec(Arm1) && HasLAddRec(Arm2);
 }
 
 /// Classify a trap branch's i1 predicate by structural shape.
@@ -436,15 +663,40 @@ static bool matchTwoAddRecICmpImpl(Value *Arm1, Value *Arm2,
 /// pipeline iterations.
 static TrapPredicateShape
 classifyTrapPredicateShape(Value *Cond, ScalarEvolution &SE, Loop *L) {
-  // Call-wiring: exercise the shape-matcher helpers so none is unused.
-  (void)matchBoundsCheckArmsImpl(Cond, Cond, ICmpInst::ICMP_UGE,
-                                 ICmpInst::ICMP_ULT, /*VarK=*/false, SE, L);
-  (void)matchTwoAddRecICmpImpl(Cond, Cond, SE, L);
-  (void)trapPredicateShapeName(TrapPredicateShape::Unknown);
-  SmallVector<Value *, 8> Operands;
-  SmallPtrSet<Value *, 16> Visited;
-  collectBoolLeafOperands(Cond, Operands, Visited);
-  return TrapPredicateShape::Unknown;
+  using namespace PatternMatch;
+  if (!Cond)
+    return TrapPredicateShape::Unknown;
+
+  if (isa<ICmpInst>(Cond))
+    return TrapPredicateShape::SingleICmp;
+
+  Value *L1 = nullptr, *L2 = nullptr;
+
+  if (match(Cond, m_LogicalOr(m_Value(L1), m_Value(L2)))) {
+    if (matchBoundsCheckArmsImpl(L1, L2, ICmpInst::ICMP_UGE, ICmpInst::ICMP_ULT,
+                                 /*VarK=*/false, SE, L))
+      return TrapPredicateShape::OrBoundsCheckConstBound;
+    if (matchBoundsCheckArmsImpl(L1, L2, ICmpInst::ICMP_UGE, ICmpInst::ICMP_ULT,
+                                 /*VarK=*/true, SE, L))
+      return TrapPredicateShape::OrBoundsCheckVarBound;
+    if (matchTwoAddRecICmpImpl(L1, L2, SE, L))
+      return TrapPredicateShape::OrTwoAddRecICmp;
+    return TrapPredicateShape::OtherMulti;
+  }
+
+  if (match(Cond, m_LogicalAnd(m_Value(L1), m_Value(L2)))) {
+    if (matchBoundsCheckArmsImpl(L1, L2, ICmpInst::ICMP_ULT, ICmpInst::ICMP_UGE,
+                                 /*VarK=*/false, SE, L))
+      return TrapPredicateShape::AndBoundsCheckConstBound;
+    if (matchBoundsCheckArmsImpl(L1, L2, ICmpInst::ICMP_ULT, ICmpInst::ICMP_UGE,
+                                 /*VarK=*/true, SE, L))
+      return TrapPredicateShape::AndBoundsCheckVarBound;
+    if (matchTwoAddRecICmpImpl(L1, L2, SE, L))
+      return TrapPredicateShape::AndTwoAddRecICmp;
+    return TrapPredicateShape::OtherMulti;
+  }
+
+  return TrapPredicateShape::OtherMulti;
 }
 
 /// HEURISTIC that estimates which trap checks are likely necessary validation
@@ -499,6 +751,7 @@ static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
   SmallPtrSet<Value *, 16> Visited;
   collectBoolLeafOperands(nullptr, Operands, Visited);
   (void)classifyTrapPredicateShape(nullptr, SE, L);
+  (void)trapPredicateShapeName(TrapPredicateShape::Unknown);
   (void)computeTrapClass(false, TrapPredicateShape::Unknown, false, false,
                          false, false, false, false, false, false, false,
                          false, false, false, false, false, 0u, false, false,

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -437,7 +437,18 @@ static std::string getSideEffectReasons(const Instruction &I) { return ""; }
 /// successful hoisting of trap checks out of the loop.
 static bool hasHoistedInPreheader(Loop *L,
                                   SmallVectorImpl<std::string> &HoistedInsts) {
-  return false;
+  BasicBlock *Preheader = L->getLoopPreheader();
+  if (!Preheader)
+    return false;
+  for (auto &I : *Preheader) {
+    if (I.hasName() && I.getName().contains(".hoisted")) {
+      std::string Buf;
+      raw_string_ostream OS(Buf);
+      I.print(OS);
+      HoistedInsts.push_back(Buf);
+    }
+  }
+  return !HoistedInsts.empty();
 }
 
 /// Build a remark Name suffixed with the optional Tag (so the same pass can
@@ -1587,21 +1598,479 @@ static void emitLoopPrimitives(Function &F, LoopInfo &LI,
                                ScalarEvolution &SE, AAResults &AA,
                                DominatorTree &DT, StringRef Tag,
                                unsigned InvocationSeq) {
-  // Call-wiring: exercise every per-loop helper so none is unused.
-  BasicBlock *BB = &F.getEntryBlock();
-  Loop *L = LI.getLoopFor(BB);
-  (void)countTrapExits(L, LI);
-  (void)countCondTrapEdges(L, LI);
-  (void)countHoistableCondTrapEdges(L, LI);
-  (void)hasUnreachableInst(L);
-  SmallVector<std::string, 4> Hoisted;
-  (void)hasHoistedInPreheader(L, Hoisted);
-  (void)getSideEffectReasons(*BB->getTerminator());
-  (void)classifyCondTrapEdges(L, SE, DT);
-  (void)Tag;
-  (void)InvocationSeq;
-  (void)ORE;
-  (void)AA;
+  unsigned TotalLoops = 0;
+  unsigned Innermost = 0;
+  unsigned LoopsWithTraps = 0;
+  unsigned LoopsWithTrapsUnknownBTC = 0;
+  unsigned MaxDepth = 0;
+  unsigned Depth1 = 0, Depth2 = 0, Depth3Plus = 0;
+  // Trap-condition shape histogram (sum across all loops in this function).
+  unsigned ShapeInvariant = 0, ShapeIVDerived = 0, ShapeNonIV = 0;
+  unsigned ShapeDominatesLatch = 0, ShapeNotDominatingLatch = 0;
+
+  std::string PrimName = taggedName("LoopPrimitives", Tag);
+  std::string SumName = taggedName("LoopPrimitivesSummary", Tag);
+
+  for (auto *L : LI.getLoopsInPreorder()) {
+    ++TotalLoops;
+    bool IsInnermost = L->isInnermost();
+    if (IsInnermost)
+      ++Innermost;
+    unsigned Depth = L->getLoopDepth();
+    if (Depth > MaxDepth)
+      MaxDepth = Depth;
+    if (Depth == 1)
+      ++Depth1;
+    else if (Depth == 2)
+      ++Depth2;
+    else if (Depth >= 3)
+      ++Depth3Plus;
+
+    unsigned TrapExits = countTrapExits(L, LI);
+    unsigned CondTrapEdges = countCondTrapEdges(L, LI);
+    unsigned HoistableCondTrapEdges = countHoistableCondTrapEdges(L, LI);
+    TrapCondShape Shape = classifyCondTrapEdges(L, SE, DT);
+    ShapeInvariant += Shape.Invariant;
+    ShapeIVDerived += Shape.IVDerived;
+    ShapeNonIV += Shape.NonIV;
+    ShapeDominatesLatch += Shape.DominatesLatch;
+    ShapeNotDominatingLatch += Shape.NotDominatingLatch;
+    bool BTCKnown = !isa<SCEVCouldNotCompute>(SE.getBackedgeTakenCount(L));
+    if (TrapExits > 0 || CondTrapEdges > 0) {
+      ++LoopsWithTraps;
+      if (!BTCKnown)
+        ++LoopsWithTrapsUnknownBTC;
+    }
+
+    // Per-exit SCEV-computability counts. IndVars partial-BTC needs every
+    // exiting block's exit count SCEV-computable; counting unknowns split by
+    // trap-vs-early shows what blocks eligibility.
+    //   trap_exits_unknown_btc      — conditional exits targeting a trap block
+    //                                  whose SE.getExitCount(L, BB) is
+    //                                  SCEVCouldNotCompute
+    //   non_trap_exits_unknown_btc  — same, for exits NOT targeting a trap
+    //
+    // Unknown-BTC exits further split by blocker reason:
+    //   *_due_to_reload  — a cmp operand's SCEV (after select-OR/AND unfold)
+    //                      refers to an in-loop SCEVUnknown: the predicate
+    //                      reloads a value per iteration, so SCEV gives up.
+    //   *_other_reason   — SCEV gave up otherwise (operand not AddRec for L,
+    //                      not invariant, not an in-loop SCEVUnknown — rare;
+    //                      AddRec for a different loop, modular non-unit
+    //                      stride).
+    //
+    // Reload-blocked additionally subdivided by what blocked hoisting the load:
+    //   *_store_reload   — a StoreInst / mem-intrinsic in L may-aliases the
+    //                      load (AA). Common: char* / unsigned-char* writes AA
+    //                      can't disambiguate from the bound-param storage.
+    //   *_call_reload    — a side-effecting CallBase in L may-modifies the
+    //                      load's location (AA), no aliasing store found. E.g.
+    //                      C++ methods on `this` reachable through the same
+    //                      allocation.
+    //   *_other_blocker  — not a clean store/call match: non-load SCEVUnknown
+    //                      (PHI/select/etc.), or a load with no aliasing
+    //                      writer.
+    // Sums: store_reload + call_reload + other_blocker = trap_exits_unknown_btc
+    //       (same for non-trap).
+    unsigned TrapExitsUnknownBTC = 0;
+    unsigned NonTrapExitsUnknownBTC = 0;
+    unsigned TrapExitsUnknownBTCDueToReload = 0;
+    unsigned TrapExitsUnknownBTCOtherReason = 0;
+    unsigned NonTrapExitsUnknownBTCDueToReload = 0;
+    unsigned NonTrapExitsUnknownBTCOtherReason = 0;
+    unsigned TrapExitsUnknownBTCStoreReload = 0;
+    unsigned TrapExitsUnknownBTCCallReload = 0;
+    unsigned TrapExitsUnknownBTCOtherBlocker = 0;
+    unsigned NonTrapExitsUnknownBTCStoreReload = 0;
+    unsigned NonTrapExitsUnknownBTCCallReload = 0;
+    unsigned NonTrapExitsUnknownBTCOtherBlocker = 0;
+    // SCEV-computable counterparts: cond-trap edges whose per-exit BTC is
+    // computable. These are the edges IndVars *could* fold via predication if
+    // the other gates hold — they bound the achievable reduction from
+    // compiler-side trap-edge work.
+    //
+    // Three-way SCEV bucket per exit, increasing strength:
+    //   *Unknown*    — both Exact and SymbolicMax are CouldNotCompute.
+    //   *Symbolic*   — Exact CouldNotCompute but SymbolicMax known (upper
+    //                  bound). Folding the trap "never taken" needs comparing
+    //                  the trap-exit's count to this bound.
+    //   *Computable* — Exact known; cleanest case for predication.
+    unsigned TrapExitsComputableBTC = 0;
+    unsigned NonTrapExitsComputableBTC = 0;
+    unsigned TrapExitsSymbolicBTC = 0;
+    unsigned NonTrapExitsSymbolicBTC = 0;
+    {
+      auto IsTrapBB = [](BasicBlock *BB) {
+        return isTrapBlock(BB, BoundsSafetyTrapsOnly,
+                           LegacyTrapMatch::TrapIntrinsic);
+      };
+
+      // 3-way reason for an unknown-BTC exit. Priority StoreReload > CallReload
+      // > Other so buckets are exclusive and total to the unknown-BTC count.
+      enum class Reason { StoreReload, CallReload, Other };
+
+      // Cache per-load AA result: several leaf cmp operands (within and across
+      // exits in L) can fan in from the same load; don't re-walk L each time.
+      DenseMap<LoadInst *, Reason> LoadCache;
+
+      auto LoadReloadCause = [&](LoadInst *Load) -> Reason {
+        auto It = LoadCache.find(Load);
+        if (It != LoadCache.end())
+          return It->second;
+        MemoryLocation LoadLoc = MemoryLocation::get(Load);
+        bool SawCallMod = false;
+        Reason Result = Reason::Other;
+        for (BasicBlock *BB : L->blocks()) {
+          for (Instruction &I : *BB) {
+            if (&I == Load)
+              continue;
+            if (auto *SI = dyn_cast<StoreInst>(&I)) {
+              if (LTAEmitExplain
+                      ? isModSet(AA.getModRefInfo(SI, LoadLoc))
+                      : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc)) {
+                Result = Reason::StoreReload;
+                goto done;
+              }
+              continue;
+            }
+            if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
+              if (isModSet(AA.getModRefInfo(MI, LoadLoc))) {
+                Result = Reason::StoreReload;
+                goto done;
+              }
+              continue;
+            }
+            if (auto *CB = dyn_cast<CallBase>(&I)) {
+              if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
+                continue;
+              if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
+                SawCallMod = true;
+            }
+          }
+        }
+        if (SawCallMod)
+          Result = Reason::CallReload;
+      done:
+        LoadCache[Load] = Result;
+        return Result;
+      };
+
+      // Walk a branch's leaf cmp operands. For each whose SCEV references an
+      // in-loop SCEVUnknown, classify the blocker; the exit-level reason is the
+      // strongest cause across operands.
+      auto ClassifyExit = [&](CondBrInst *BI) -> Reason {
+        SmallVector<Value *, 8> Operands;
+        SmallPtrSet<Value *, 16> Visited;
+        collectBoolLeafOperands(BI->getCondition(), Operands, Visited);
+        Reason Best = Reason::Other;
+        for (Value *V : Operands) {
+          if (!V || isa<Constant>(V))
+            continue;
+          if (!SE.isSCEVable(V->getType()))
+            continue;
+          const SCEV *SC = SE.getSCEV(V);
+          if (isa<SCEVCouldNotCompute>(SC))
+            continue;
+          if (SE.isLoopInvariant(SC, L))
+            continue;
+          if (auto *AR = dyn_cast<SCEVAddRecExpr>(SC))
+            if (AR->getLoop() == L)
+              continue;
+          SCEVNodeCollector Coll;
+          SCEVTraversal<SCEVNodeCollector>(Coll).visitAll(SC);
+          for (const SCEVUnknown *U : Coll.Unknowns) {
+            auto *I = dyn_cast_or_null<Instruction>(U->getValue());
+            if (!I || !L->contains(I->getParent()))
+              continue;
+            if (auto *Load = dyn_cast<LoadInst>(I)) {
+              Reason R = LoadReloadCause(Load);
+              if (R == Reason::StoreReload)
+                return R;
+              if (R == Reason::CallReload && Best != Reason::CallReload)
+                Best = R;
+            }
+            // Non-load in-loop SCEVUnknown → genuine varying. Stays Other
+            // unless another operand promotes us.
+          }
+        }
+        return Best;
+      };
+
+      // Legacy bool: did *any* leaf operand reference an in-loop SCEVUnknown?
+      // (Superset of the reason buckets.) Kept for backwards-compat with
+      // classify_unknown_btc.py and existing dashboards.
+      auto IsBlockedByReload = [&](CondBrInst *BI) -> bool {
+        SmallVector<Value *, 8> Operands;
+        SmallPtrSet<Value *, 16> Visited;
+        collectBoolLeafOperands(BI->getCondition(), Operands, Visited);
+        for (Value *V : Operands) {
+          if (!V || isa<Constant>(V))
+            continue;
+          if (!SE.isSCEVable(V->getType()))
+            continue;
+          const SCEV *SC = SE.getSCEV(V);
+          if (isa<SCEVCouldNotCompute>(SC))
+            continue;
+          if (SE.isLoopInvariant(SC, L))
+            continue;
+          if (auto *AR = dyn_cast<SCEVAddRecExpr>(SC))
+            if (AR->getLoop() == L)
+              continue;
+          SCEVNodeCollector Coll;
+          SCEVTraversal<SCEVNodeCollector>(Coll).visitAll(SC);
+          for (const SCEVUnknown *U : Coll.Unknowns) {
+            if (auto *I = dyn_cast_or_null<Instruction>(U->getValue()))
+              if (L->contains(I->getParent()))
+                return true;
+          }
+        }
+        return false;
+      };
+
+      SmallVector<BasicBlock *, 4> ExitingBlocks;
+      L->getExitingBlocks(ExitingBlocks);
+      for (BasicBlock *EB : ExitingBlocks) {
+        // Strict attribution: only count this exit if its source-BB's
+        // immediate containing loop is L. Otherwise an inner-loop trap-exit --
+        // whose unreachable successor exits every enclosing loop -- would be
+        // counted at every nesting level's SCEV-bucket counters.
+        if (LI.getLoopFor(EB) != L)
+          continue;
+        auto *BI = dyn_cast<CondBrInst>(EB->getTerminator());
+        if (!BI)
+          continue;
+        BasicBlock *ExitSucc = nullptr;
+        for (BasicBlock *Succ : BI->successors())
+          if (!L->contains(Succ)) {
+            ExitSucc = Succ;
+            break;
+          }
+        if (!ExitSucc)
+          continue;
+        const SCEV *EC = SE.getExitCount(L, EB);
+        bool IsTrap = IsTrapBB(ExitSucc);
+        if (!isa<SCEVCouldNotCompute>(EC)) {
+          if (IsTrap)
+            ++TrapExitsComputableBTC;
+          else
+            ++NonTrapExitsComputableBTC;
+          continue;
+        }
+        // Exact unknown; check the symbolic-max bucket before fully-unknown
+        // attribution.
+        const SCEV *SymEC =
+            SE.getExitCount(L, EB, ScalarEvolution::SymbolicMaximum);
+        if (!isa<SCEVCouldNotCompute>(SymEC)) {
+          if (IsTrap)
+            ++TrapExitsSymbolicBTC;
+          else
+            ++NonTrapExitsSymbolicBTC;
+          continue;
+        }
+        bool ByReload = IsBlockedByReload(BI);
+        Reason R = ClassifyExit(BI);
+        if (IsTrap) {
+          ++TrapExitsUnknownBTC;
+          if (ByReload)
+            ++TrapExitsUnknownBTCDueToReload;
+          else
+            ++TrapExitsUnknownBTCOtherReason;
+          if (R == Reason::StoreReload)
+            ++TrapExitsUnknownBTCStoreReload;
+          else if (R == Reason::CallReload)
+            ++TrapExitsUnknownBTCCallReload;
+          else
+            ++TrapExitsUnknownBTCOtherBlocker;
+        } else {
+          ++NonTrapExitsUnknownBTC;
+          if (ByReload)
+            ++NonTrapExitsUnknownBTCDueToReload;
+          else
+            ++NonTrapExitsUnknownBTCOtherReason;
+          if (R == Reason::StoreReload)
+            ++NonTrapExitsUnknownBTCStoreReload;
+          else if (R == Reason::CallReload)
+            ++NonTrapExitsUnknownBTCCallReload;
+          else
+            ++NonTrapExitsUnknownBTCOtherBlocker;
+        }
+      }
+    }
+
+    std::string ParentHeader = "-";
+    if (Loop *Parent = L->getParentLoop())
+      ParentHeader = bbLabel(Parent->getHeader());
+
+    OptimizationRemarkAnalysis Rem(REMARK_PASS, PrimName,
+                                   &L->getHeader()->front());
+    Rem << "Loop " << NV("LoopHeader", bbLabel(L->getHeader()))
+        << " depth=" << NV("Depth", Depth)
+        << " parent=" << NV("ParentHeader", ParentHeader)
+        << " innermost=" << NV("IsInnermost", IsInnermost)
+        << " blocks=" << NV("BlockCount", (unsigned)L->getNumBlocks())
+        << " trap_exits=" << NV("TrapExitCount", TrapExits)
+        << " cond_trap_edges=" << NV("CondTrapEdgeCount", CondTrapEdges)
+        << " hoistable_cond_trap_edges="
+        << NV("HoistableCondTrapEdges", HoistableCondTrapEdges)
+        << " trap_cond_invariant=" << NV("TrapCondInvariant", Shape.Invariant)
+        << " trap_cond_iv_derived=" << NV("TrapCondIVDerived", Shape.IVDerived)
+        << " trap_cond_non_iv=" << NV("TrapCondNonIV", Shape.NonIV);
+    if (LTAEmitExplain) {
+      Rem << " trap_cond_dominates_latch="
+          << NV("TrapCondDominatesLatch", Shape.DominatesLatch)
+          << " trap_cond_not_dominating_latch="
+          << NV("TrapCondNotDominatingLatch", Shape.NotDominatingLatch)
+          << " trap_cond_dl_invariant="
+          << NV("TrapCondDLInvariant", Shape.DLInvariant)
+          << " trap_cond_dl_iv_derived="
+          << NV("TrapCondDLIVDerived", Shape.DLIVDerived)
+          << " trap_cond_dl_non_iv=" << NV("TrapCondDLNonIV", Shape.DLNonIV)
+          << " trap_cond_ndl_invariant="
+          << NV("TrapCondNDLInvariant", Shape.NDLInvariant)
+          << " trap_cond_ndl_iv_derived="
+          << NV("TrapCondNDLIVDerived", Shape.NDLIVDerived)
+          << " trap_cond_ndl_non_iv=" << NV("TrapCondNDLNonIV", Shape.NDLNonIV)
+          << " trap_cond_non_iv_load_op="
+          << NV("TrapCondNonIVLoadOp", Shape.NonIVLoadOp)
+          << " trap_cond_non_iv_phi_op="
+          << NV("TrapCondNonIVPhiOp", Shape.NonIVPhiOp)
+          << " trap_cond_non_iv_select_op="
+          << NV("TrapCondNonIVSelectOp", Shape.NonIVSelectOp)
+          << " trap_cond_non_iv_call_op="
+          << NV("TrapCondNonIVCallOp", Shape.NonIVCallOp);
+    }
+    Rem << " btc_known=" << NV("BTCKnown", BTCKnown)
+        << " trap_exits_unknown_btc="
+        << NV("TrapExitsUnknownBTC", TrapExitsUnknownBTC)
+        << " trap_exits_unknown_btc_reload="
+        << NV("TrapExitsUnknownBTCDueToReload", TrapExitsUnknownBTCDueToReload)
+        << " trap_exits_unknown_btc_other="
+        << NV("TrapExitsUnknownBTCOtherReason", TrapExitsUnknownBTCOtherReason)
+        << " trap_exits_unknown_btc_store_reload="
+        << NV("TrapExitsUnknownBTCStoreReload", TrapExitsUnknownBTCStoreReload)
+        << " trap_exits_unknown_btc_call_reload="
+        << NV("TrapExitsUnknownBTCCallReload", TrapExitsUnknownBTCCallReload)
+        << " trap_exits_unknown_btc_other_blocker="
+        << NV("TrapExitsUnknownBTCOtherBlocker",
+              TrapExitsUnknownBTCOtherBlocker)
+        << " non_trap_exits_unknown_btc="
+        << NV("NonTrapExitsUnknownBTC", NonTrapExitsUnknownBTC)
+        << " non_trap_exits_unknown_btc_reload="
+        << NV("NonTrapExitsUnknownBTCDueToReload",
+              NonTrapExitsUnknownBTCDueToReload)
+        << " non_trap_exits_unknown_btc_other="
+        << NV("NonTrapExitsUnknownBTCOtherReason",
+              NonTrapExitsUnknownBTCOtherReason)
+        << " non_trap_exits_unknown_btc_store_reload="
+        << NV("NonTrapExitsUnknownBTCStoreReload",
+              NonTrapExitsUnknownBTCStoreReload)
+        << " non_trap_exits_unknown_btc_call_reload="
+        << NV("NonTrapExitsUnknownBTCCallReload",
+              NonTrapExitsUnknownBTCCallReload)
+        << " non_trap_exits_unknown_btc_other_blocker="
+        << NV("NonTrapExitsUnknownBTCOtherBlocker",
+              NonTrapExitsUnknownBTCOtherBlocker)
+        << " trap_exits_computable_btc="
+        << NV("TrapExitsComputableBTC", TrapExitsComputableBTC)
+        << " non_trap_exits_computable_btc="
+        << NV("NonTrapExitsComputableBTC", NonTrapExitsComputableBTC)
+        << " trap_exits_symbolic_btc="
+        << NV("TrapExitsSymbolicBTC", TrapExitsSymbolicBTC)
+        << " non_trap_exits_symbolic_btc="
+        << NV("NonTrapExitsSymbolicBTC", NonTrapExitsSymbolicBTC);
+    if (LTAEmitExplain)
+      Rem << " invocation_seq=" << NV("InvocationSeq", InvocationSeq);
+    ORE.emit(Rem);
+  }
+
+  OptimizationRemarkAnalysis Sum(REMARK_PASS, SumName, &F);
+  // Per-function unique trap-block accounting: each trap BB counted once.
+  // UniqueTrapBlocksInLoop = subset with at least one predecessor inside any
+  // loop body (each loop-incident trap attributed once, independent of nesting
+  // depth or incoming-edge count).
+  auto IsTrapBlock = [](BasicBlock *BB) {
+    return isTrapBlock(BB, BoundsSafetyTrapsOnly,
+                       LegacyTrapMatch::TrapIntrinsic);
+  };
+  SmallPtrSet<BasicBlock *, 32> LoopBlocks;
+  for (Loop *L : LI.getLoopsInPreorder())
+    for (BasicBlock *BB : L->blocks())
+      LoopBlocks.insert(BB);
+  unsigned UniqueTrapBlocksTotal = 0;
+  unsigned UniqueTrapBlocksReachableFromLoop = 0;
+  // Edge-level counts: each cond-branch in any loop body that targets a
+  // trap block counted once (no nesting overcount). Hoistable subset =
+  // condition is loop-invariant for the innermost enclosing loop.
+  unsigned InLoopTrapEdges = 0;
+  unsigned InLoopHoistableTrapEdges = 0;
+  // Symmetric counter for cond-branches OUTSIDE any loop body that target a
+  // trap.
+  unsigned OutOfLoopTrapEdges = 0;
+  for (BasicBlock &BB : F) {
+    if (!IsTrapBlock(&BB))
+      continue;
+    ++UniqueTrapBlocksTotal;
+    for (BasicBlock *Pred : predecessors(&BB)) {
+      if (LoopBlocks.count(Pred)) {
+        ++UniqueTrapBlocksReachableFromLoop;
+        break;
+      }
+    }
+  }
+  // Walk all BBs once; classify cond-branch-to-trap as in-loop or out-of-loop.
+  for (BasicBlock &BB : F) {
+    auto *BI = dyn_cast<CondBrInst>(BB.getTerminator());
+    if (!BI)
+      continue;
+    bool BBInLoop = LoopBlocks.count(&BB) != 0;
+    Loop *Inner = BBInLoop ? LI.getLoopFor(&BB) : nullptr;
+    for (BasicBlock *Succ : BI->successors()) {
+      if (BBInLoop && LoopBlocks.count(Succ))
+        continue; // skip loop-internal succs
+      if (!IsTrapBlock(Succ))
+        continue;
+      if (BBInLoop) {
+        ++InLoopTrapEdges;
+        if (Inner && Inner->isLoopInvariant(BI->getCondition()))
+          ++InLoopHoistableTrapEdges;
+      } else {
+        ++OutOfLoopTrapEdges;
+      }
+    }
+  }
+
+  Sum << "Function " << NV("Function", F.getName())
+      << " total_loops=" << NV("TotalLoops", TotalLoops)
+      << " innermost=" << NV("Innermost", Innermost)
+      << " loops_with_traps=" << NV("LoopsWithTraps", LoopsWithTraps)
+      << " loops_with_traps_unknown_btc="
+      << NV("LoopsWithTrapsUnknownBTC", LoopsWithTrapsUnknownBTC)
+      << " max_depth=" << NV("MaxDepth", MaxDepth)
+      << " depth1=" << NV("Depth1", Depth1)
+      << " depth2=" << NV("Depth2", Depth2)
+      << " depth3+=" << NV("Depth3Plus", Depth3Plus)
+      << " unique_trap_blocks=" << NV("UniqueTrapBlocks", UniqueTrapBlocksTotal)
+      << " unique_trap_blocks_reachable_from_loop="
+      << NV("UniqueTrapBlocksReachableFromLoop",
+            UniqueTrapBlocksReachableFromLoop)
+      << " in_loop_trap_edges=" << NV("InLoopTrapEdges", InLoopTrapEdges)
+      << " in_loop_hoistable_trap_edges="
+      << NV("InLoopHoistableTrapEdges", InLoopHoistableTrapEdges)
+      << " out_of_loop_trap_edges="
+      << NV("OutOfLoopTrapEdges", OutOfLoopTrapEdges)
+      << " trap_cond_invariant_total="
+      << NV("TrapCondInvariantTotal", ShapeInvariant)
+      << " trap_cond_iv_derived_total="
+      << NV("TrapCondIVDerivedTotal", ShapeIVDerived)
+      << " trap_cond_non_iv_total=" << NV("TrapCondNonIVTotal", ShapeNonIV);
+  if (LTAEmitExplain) {
+    Sum << " trap_cond_dominates_latch_total="
+        << NV("TrapCondDominatesLatchTotal", ShapeDominatesLatch)
+        << " trap_cond_not_dominating_latch_total="
+        << NV("TrapCondNotDominatingLatchTotal", ShapeNotDominatingLatch)
+        << " invocation_seq=" << NV("InvocationSeq", InvocationSeq);
+  }
+  ORE.emit(Sum);
 }
 
 /// Check if \p L can be hoisted or not and emit a detailed remark about why
@@ -1610,6 +2079,10 @@ static CheckLoopHoistType processLoops(Loop *L, ScalarEvolution &SE,
                                        LoopInfo &LI,
                                        OptimizationRemarkEmitter &ORE,
                                        StringRef Tag) {
+  // Call-wiring: exercise the per-loop hoist helpers so none is unused.
+  (void)hasUnreachableInst(L);
+  for (auto *BB : L->blocks())
+    (void)getSideEffectReasons(*BB->getTerminator());
   return CheckLoopHoistType::SKIP;
 }
 
@@ -1618,9 +2091,13 @@ static CheckLoopHoistType processLoops(Loop *L, ScalarEvolution &SE,
 static void emitRemarks(Function &F, LoopInfo &LI,
                         OptimizationRemarkEmitter &ORE, ScalarEvolution &SE,
                         StringRef Tag) {
-  // Call-wiring: exercise processLoops so it is not unused.
-  for (auto *L : LI.getLoopsInPreorder())
+  // Call-wiring: exercise processLoops and hasHoistedInPreheader so neither is
+  // unused.
+  for (auto *L : LI.getLoopsInPreorder()) {
+    SmallVector<std::string, 4> Hoisted;
+    (void)hasHoistedInPreheader(L, Hoisted);
     (void)processLoops(L, SE, LI, ORE, Tag);
+  }
 }
 
 PreservedAnalyses LoopTrapAnalysisPass::run(Function &F,

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -7,164 +7,418 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Scalar/LoopTrapAnalysis.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/MemoryLocation.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/Analysis/ScalarEvolutionExpressions.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/PatternMatch.h"
 #include "llvm/Remarks/BoundsSafetyOptRemarks.h"
 #include "llvm/Support/CommandLine.h"
-
 using namespace llvm;
 using namespace llvm::ore;
 #define DEBUG_TYPE "loop-trap-analysis"
 #define REMARK_PASS DEBUG_TYPE
 
 enum class CheckLoopHoistType { MAYBE_CAN_HOIST, CANNOT_HOIST, SKIP };
-static cl::opt<bool> NewTrapSemantics(
-    "use-new-trap-semantics", cl::init(false),
-    cl::desc("Assume that traps are using the new trap semantics "
-             "logic."));
 static cl::opt<bool> BoundsSafetyTrapsOnly(
     "use-bounds-safety-traps-only", cl::init(false),
     cl::desc(
         "We only check for -fbounds-safety traps if the flag is false we can check "
         "for any hoistable traps."));
 
-/// Check for an unreachable instruction that has an edge to any of \p L basic
-/// blocks. if `--use-bounds-safety-traps-only` is used make sure that the trap and
-/// branch instructions have -fbounds-safety annotation.
-static bool hasUnreachableInst(Loop *L) {
-  SmallVector<BasicBlock *, 4> LoopExitBlocks;
-  L->getExitBlocks(LoopExitBlocks);
-  for (auto *BB : LoopExitBlocks) {
-    auto *I = BB->getTerminator();
-    // check for trap instructions. If `BoundsSafetyTrapsOnly` is false then we
-    // ignore if the trap has a -fbounds-safety annotation.
-    if (!isa<UnreachableInst>(I))
-      continue;
-    if (BoundsSafetyTrapsOnly && !isBoundsSafetyAnnotated(I))
-      continue;
-    if (any_of(predecessors(BB), [L](BasicBlock *PredB) {
-          auto *TerminatorInst = PredB->getTerminator();
-          return L->contains(PredB) &&
-                 (isa<CondBrInst>(TerminatorInst) ||
-                  isa<UncondBrInst>(TerminatorInst) ||
-                  isa<SwitchInst>(TerminatorInst)) &&
-                 (!BoundsSafetyTrapsOnly ||
-                  isBoundsSafetyAnnotated(TerminatorInst));
-        }))
-      return true;
-  }
+/// Max dominator depth from the entry block at which a trap-edge source BB is
+/// still "entry-proximate" (plausible parameter validation). Populates the
+/// `IsEntryProximate` field on each LoopTrapEdge record.
+static cl::opt<unsigned> EntryProximityDepth(
+    "loop-trap-entry-proximity-depth", cl::init(3),
+    cl::desc("Maximum dominator depth from function entry at which a "
+             "trap edge is classified IsEntryProximate (default 3)."));
+
+/// Gate the explanatory trap analysis. When false (default), the pass emits
+/// bit-identical YAML to a pre-framework snapshot. When true, it emits the
+/// full explanation: the refined TrapClass classification (recognizes all
+/// trap-like calls, splits stride variants, does not mask blocked edges) plus
+/// the extra per-loop and per-edge fields (DominatesLatch / IV-update /
+/// operand-class). Lets the framework be A/B compared and reverted via one
+/// flag.
+static cl::opt<bool> LTAEmitExplain(
+    "loop-trap-analysis-explain", cl::init(false),
+    cl::desc("Emit the explanatory trap analysis: the refined TrapClass "
+             "classification plus per-loop and per-edge explanatory fields "
+             "(DominatesLatch / IV-update / operand-class). When false "
+             "(default), only the pre-explanation fields and compact TrapClass "
+             "are emitted, so the framework can be A/B compared and reverted "
+             "by toggling this flag alone."));
+
+static cl::opt<bool> LTAEmitLoadAlias(
+    "loop-load-alias", cl::init(false),
+    cl::desc("Opt-in: for each load in an INNERMOST loop that is may-clobbered "
+             "by an in-loop writer (store / memcpy / call), emit a "
+             "LoopLoadAlias record naming the first such writer. Clobbered "
+             "loads only (hoistable loads are omitted). Off by default; "
+             "enable selectively as it emits one record per clobbered load."));
+
+/// Legacy (pre-unification) trap-block predicate variants, reproduced
+/// byte-for-byte when `-loop-trap-analysis-explain` is off so existing output /
+/// lit tests are unchanged:
+///   AnyUnreachableBoundsSafety - any `unreachable`, filtered by the
+///       -fbounds-safety annotation when BoundsSafetyOnly.
+///   AnyUnreachable - any `unreachable`, no annotation filter.
+///   TrapIntrinsic  - `unreachable` preceded by `call @llvm.trap()` only.
+enum class LegacyTrapMatch {
+  AnyUnreachableBoundsSafety,
+  AnyUnreachable,
+  TrapIntrinsic
+};
+
+/// Single source of truth for "is BB a trap block". With
+/// `-loop-trap-analysis-explain` (opt-in), all callers agree: BB ends in
+/// `unreachable` immediately preceded by `@llvm.trap()` or `@llvm.ubsantrap()`
+/// (Swift -fbounds-safety lowers to ubsantrap), with a consistent bounds-safety
+/// annotation filter. When the flag is off (default), each caller's original
+/// predicate (\p Legacy) is reproduced exactly, so emitted records do not
+/// change.
+static bool isTrapBlock(BasicBlock *BB, bool BoundsSafetyOnly,
+                        LegacyTrapMatch Legacy) {
   return false;
 }
 
-static std::string getSideEffectReasons(const Instruction &I) {
-  std::string Buf;
-  raw_string_ostream OS(Buf);
-  if (isa<CallInst>(I) && I.mayReadOrWriteMemory())
-    OS << "Instruction might have a volatile memory access";
-  else {
-    if (I.mayWriteToMemory())
-      OS << "Instruction may write to memory\n";
-    if (I.mayThrow())
-      OS << "Instruction may throw an exception\n";
-    if (!I.willReturn())
-      OS << "Instruction may not return\n";
+/// Check for an unreachable instruction that has an edge to any of \p L basic
+/// blocks. if `--use-bounds-safety-traps-only` is used make sure that the trap and
+/// branch instructions have -fbounds-safety annotation.
+static bool hasUnreachableInst(Loop *L) { return false; }
+
+static unsigned countTrapExits(Loop *L, LoopInfo &LI) { return 0u; }
+
+/// Count conditional branches inside the loop body whose target is a trap
+/// block (BB ending in `unreachable`, optionally preceded by
+/// `tail call @llvm.trap()`). Captures per-iteration trap-direction branches.
+///
+/// Strict attribution: only edges originating in this loop's own body (not in
+/// any sub-loop). Since `L->blocks()` transitively includes sub-loop blocks,
+/// without this filter an inner-loop trap would be double-counted by every
+/// enclosing loop's record.
+static unsigned countCondTrapEdges(Loop *L, LoopInfo &LI) { return 0u; }
+
+/// Count cond-trap edges whose condition is loop-invariant — i.e. LICM could
+/// hoist them out but hasn't. Estimates the residual hoisting opportunity.
+static unsigned countHoistableCondTrapEdges(Loop *L, LoopInfo &LI) {
+  return 0u;
+}
+
+/// Classify cond-trap edges by the shape of their controlling condition.
+/// Returns (invariant, iv_derived, non_iv) counts:
+///   invariant:  whole condition is loop-invariant (LICM/Unswitch territory).
+///   iv_derived: at least one icmp operand has an AddRec SCEV on this loop
+///               (IndVars PredicatedExit / partial-BTC could help).
+///   non_iv:     condition varies per-iter but no operand is an AddRec on L —
+///               can't hoist (varies), can't predicate (no recurrence).
+struct TrapCondShape {
+  unsigned Invariant = 0;
+  unsigned IVDerived = 0;
+  unsigned NonIV = 0;
+  // Cross-product of {DominatesLatch, NotDominatingLatch} ×
+  // {Invariant, IVDerived, NonIV}, partitioning all cond-trap edges:
+  //   NotDominatingLatch_*      : cond is in a conditional arm that doesn't
+  //                               post-dominate the body; SCEV can't compute
+  //                               trip count downstream, can't hoist here.
+  //   DominatesLatch_Invariant  : fires every iteration and is invariant. LICM.
+  //   DominatesLatch_IVDerived  : every iteration, has an L-AddRec operand.
+  //                               SCEV / IndVars attackable.
+  //   DominatesLatch_NonIV      : every iteration but no invariant/affine
+  //                               operand. Varying yet uncomputable -- needs
+  //                               AA/TBAA refinement or source change.
+  unsigned DominatesLatch = 0;
+  unsigned NotDominatingLatch = 0;
+  unsigned DLInvariant = 0, DLIVDerived = 0, DLNonIV = 0;
+  unsigned NDLInvariant = 0, NDLIVDerived = 0, NDLNonIV = 0;
+
+  // Sub-classification of NonIV -- *why* the operands aren't affine. Flags are
+  // non-exclusive and bounded by NonIV. Explains SCEV trap-elimination failure
+  // (SCEV needs every operand invariant or affine).
+  //   NonIVLoadOp   : operand chain reaches an in-loop LoadInst. Lever: TBAA /
+  //                   AA refinement so LICM can hoist the load.
+  //   NonIVPhiOp    : operand chain reaches a non-AddRec in-loop PHI (header
+  //                   phi with conditional update, or merge phi). Lever:
+  //                   source restructure.
+  //   NonIVSelectOp : operand chain reaches an in-loop SelectInst / FreezeInst
+  //                   (often from control-flow flattening). Same lever as Phi.
+  //   NonIVCallOp   : an operand is a call result. SCEV treats as Unknown.
+  unsigned NonIVLoadOp = 0;
+  unsigned NonIVPhiOp = 0;
+  unsigned NonIVSelectOp = 0;
+  unsigned NonIVCallOp = 0;
+};
+static TrapCondShape classifyCondTrapEdges(Loop *L, ScalarEvolution &SE,
+                                           const DominatorTree &DT) {
+  return TrapCondShape();
+}
+
+// Emit one or more side-effect tags identifying the *class* of instruction
+// that blocks LICM. Tags use the structured format
+//
+//   <Category>.<cause>[: <callee>]
+//
+// where <Category> is the instruction class (Store / AtomicStore /
+// VolatileStore / AtomicLoad / VolatileLoad / AtomicRMW / AtomicCmpXchg /
+// Fence / Other / Call / MemIntrinsic / VolatileCall) and <cause> is one of
+// {may-write-to-memory, may-read-from-memory, may-access-memory, may-throw,
+// may-not-return}. Optional ": <callee>" disambiguates calls. Splitting by
+// class (vs the prior two opaque buckets) shows which lever -- TBAA,
+// function-attr annotations, per-intrinsic AA -- would unblock a given loop.
+static std::string getSideEffectReasons(const Instruction &I) { return ""; }
+
+/// Check if the loop preheader has ".hoisted" instructions, indicating
+/// successful hoisting of trap checks out of the loop.
+static bool hasHoistedInPreheader(Loop *L,
+                                  SmallVectorImpl<std::string> &HoistedInsts) {
+  return false;
+}
+
+/// Build a remark Name suffixed with the optional Tag (so the same pass can
+/// be invoked multiple times in a pipeline with distinguishable output).
+static std::string taggedName(StringRef Base, StringRef Tag) { return ""; }
+
+/// Print a stable, non-empty label for \p BB, so remark args that identify
+/// BasicBlocks stay useful when the BB has no source-level name (numeric IR,
+/// stripped names, or non-C frontends such as swiftc's IRGen).
+///
+/// Preferred: `BB->getName()`. Fallback: `printAsOperand` slot-tracker form
+/// (`%5` etc.), which is parseable and unique within the function. Never
+/// returns empty.
+static std::string bbLabel(const BasicBlock *BB) { return ""; }
+
+/// Recursively unfold a boolean expression chain (select-OR, select-AND,
+/// or/and) into the leaf comparison operands. Used to surface every
+/// concrete operand of a trap predicate so we can classify each one.
+static void collectBoolLeafOperands(Value *V,
+                                    SmallVectorImpl<Value *> &Operands,
+                                    SmallPtrSetImpl<Value *> &Visited,
+                                    int Depth = 0) {}
+
+/// SCEV traversal helper: collects every SCEVUnknown and SCEVAddRecExpr
+/// node reachable from a SCEV expression. We use the canonical
+/// `SCEVTraversal<>` machinery — no string parsing, no regex.
+namespace {
+struct SCEVNodeCollector {
+  SmallPtrSet<const SCEVUnknown *, 8> Unknowns;
+  SmallPtrSet<const SCEVAddRecExpr *, 4> AddRecs;
+  bool follow(const SCEV *S) {
+    if (auto *U = dyn_cast<SCEVUnknown>(S))
+      Unknowns.insert(U);
+    if (auto *AR = dyn_cast<SCEVAddRecExpr>(S))
+      AddRecs.insert(AR);
+    return true; // keep walking
   }
-  return Buf;
+  bool isDone() const { return false; }
+};
+} // anonymous namespace
+
+/// Structural shape of a trap branch's i1 predicate. Sizes the reach of
+/// compiler-side fix opportunities (bounds-check OR/AND forms with a constant
+/// or variable bound, and the generic OR-of-AddRec exit recognition).
+/// Independent of whether the source BB sits inside a loop.
+namespace {
+enum class TrapPredicateShape {
+  Unknown,                  ///< Could not classify (null cond, etc.).
+  SingleICmp,               ///< Single icmp (NumLeafOps <= 2).
+  OrBoundsCheckConstBound,  ///< or(uge(X, B), ult(sub(B, X), K_const))
+  AndBoundsCheckConstBound, ///< and(ult(X, B), uge(sub(B, X), K_const))
+  OrBoundsCheckVarBound,    ///< or(uge(X, B), ult(sub(B, X), K_addrec))
+  AndBoundsCheckVarBound,   ///< and(ult(X, B), uge(sub(B, X), K_addrec))
+  OrTwoAddRecICmp,          ///< or(icmp(AR_a), icmp(AR_b)) — no sub-arith
+  AndTwoAddRecICmp,         ///< and(icmp(AR_a), icmp(AR_b)) — no sub-arith
+  OtherMulti,               ///< NumLeafOps >= 4, no recognized structure
+};
+} // anonymous namespace
+
+static StringRef trapPredicateShapeName(TrapPredicateShape S) { return ""; }
+
+/// Compute the count-ordered, descriptive trap-class name for one trap edge
+/// from its per-edge fields. Single source of truth for a classification
+/// consumers previously re-derived in Python (gen_ir_view.priority_class);
+/// emitted as the `TrapClass` field, and its precedence must stay in lock-step
+/// with that fallback. Returned strings are static literals (safe as
+/// StringRef).
+static StringRef computeTrapClass(
+    bool InLoop, TrapPredicateShape Shape, bool IsEntryProx, bool DomByEquiv,
+    bool IsLoopExit, bool EdgeBTCComputable, bool LoopOtherUnk,
+    bool StoreReload, bool MemIReload, bool CallReload, bool InLoopPhi,
+    bool UnaliasLoad, bool OtherUnk, bool OpaqueNoUnk, bool InLoopFreeze,
+    bool InLoopSelect, unsigned NumLeafOps, bool NonUnitStride, bool NegStride,
+    bool NonConstStride, bool NotProvenMonotonicOnly) {
+  return "";
+}
+
+/// Match the bounded-iterator OR / AND shape:
+///   OR  form: or (uge X, B)  (ult (sub B, X), K)
+///   AND form: and(ult X, B)  (uge (sub B, X), K)
+/// Returns true iff one arm ordering matches the requested (predicate-pair,
+/// K-kind) tuple. K-kind is constant for the *ConstK shapes and an L-affine
+/// SCEVAddRecExpr for the *VarK shapes.
+///
+/// icmp operand-swap is not attempted: clang's post-SROA/SimplifyCFG lowering
+/// produces canonical (X, B) and (sub, K) orderings. Swapped forms fall through
+/// to OtherMulti, the correct conservative classification.
+static bool matchBoundsCheckArmsImpl(Value *Arm1, Value *Arm2,
+                                     ICmpInst::Predicate ArmAPred,
+                                     ICmpInst::Predicate ArmBPred, bool VarK,
+                                     ScalarEvolution &SE, Loop *L) {
+  return false;
+}
+
+/// Match `or/and(icmp(X), icmp(Y))` where each arm has an operand whose SCEV is
+/// an L-AddRec -- the "two unrelated AddRec exits combined by one OR/AND" shape
+/// that SCEV's `computeExitLimit` does not fold to `min(BTC_a, BTC_b)`.
+/// Returns false when L is null (out-of-loop edges can't have L-AddRec
+/// operands).
+static bool matchTwoAddRecICmpImpl(Value *Arm1, Value *Arm2,
+                                   ScalarEvolution &SE, Loop *L) {
+  return false;
+}
+
+/// Classify a trap branch's i1 predicate by structural shape.
+/// Trial order matters: the more-specific bounds-check sub-arithmetic OR/AND
+/// shapes (incl. var-K) are attempted before the generic two-AddRec shape, so a
+/// sub-arithmetic OR is never reported as `OrTwoAddRecICmp`.
+///
+/// Uses `m_LogicalOr` / `m_LogicalAnd` to catch both the explicit `or/and i1`
+/// form and clang's `select i1` lowering.
+///
+/// 3+-arm cascades (`or(or(a, b), c)`) report as `OtherMulti`; the
+/// simplification fixpoint peels inner forms into recognized shapes on later
+/// pipeline iterations.
+static TrapPredicateShape
+classifyTrapPredicateShape(Value *Cond, ScalarEvolution &SE, Loop *L) {
+  // Call-wiring: exercise the shape-matcher helpers so none is unused.
+  (void)matchBoundsCheckArmsImpl(Cond, Cond, ICmpInst::ICMP_UGE,
+                                 ICmpInst::ICMP_ULT, /*VarK=*/false, SE, L);
+  (void)matchTwoAddRecICmpImpl(Cond, Cond, SE, L);
+  (void)trapPredicateShapeName(TrapPredicateShape::Unknown);
+  SmallVector<Value *, 8> Operands;
+  SmallPtrSet<Value *, 16> Visited;
+  collectBoolLeafOperands(Cond, Operands, Visited);
+  return TrapPredicateShape::Unknown;
+}
+
+/// HEURISTIC that estimates which trap checks are likely necessary validation
+/// traps for incoming (function-argument) values, as opposed to in-loop
+/// elimination candidates. Returns true iff \p BB sits within
+/// `EntryProximityDepth` dominator steps of the function's entry block OR any
+/// loop preheader. A trap at/above a preheader is structurally like
+/// entry-level parameter validation -- on the pre-loop boundary, never paid for
+/// by the loop body.
+static bool isEntryProximate(const Function &F, BasicBlock *BB,
+                             const DominatorTree &DT, const LoopInfo &LI) {
+  return false;
+}
+
+/// Decide whether an equivalent check on a dominating path already guarantees
+/// this trap cannot fire. Returns true iff some dominator of \p BB ends in a
+/// conditional branch whose condition is the same as \p MyCond -- either the
+/// identical SSA value, or a structurally equivalent icmp (same predicate and
+/// operand pointers) -- so the trap predicate has already been decided before
+/// control reaches \p BB.
+static bool isDominatedByEquivalentCheck(BasicBlock *BB, Value *MyCond,
+                                         const DominatorTree &DT) {
+  return false;
+}
+
+/// Walk the def chain of \p Cond (bounded to instructions inside \p L) and
+/// answer Q2 of the trap-explanation tree: for every IV-shaped operand reached,
+/// does its update dominate the loop latch?
+///
+/// For each header phi reached, walk its loop-carried recurrence (the
+/// latch-incoming value, through non-header phis) and check every visited
+/// Instruction's parent BB. If any does not dominate the latch, the IV's update
+/// is control-dependent (e.g. `m = c ? m + 1 : m` puts `m+1` in a
+/// non-dominating arm) and SCEV refuses an AddRec -> returns false.
+///
+/// Returns true vacuously when no header-phi is reached.
+static bool computeIVUpdateDominatesLatch(Value *Cond, Loop *L,
+                                          const DominatorTree &DT) {
+  return true;
+}
+
+static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
+                                AAResults &AA, DominatorTree &DT,
+                                OptimizationRemarkEmitter &ORE, StringRef Tag,
+                                unsigned InvocationSeq) {
+  // Call-wiring: exercise every per-edge helper so none is unused.
+  BasicBlock *BB = &F.getEntryBlock();
+  Loop *L = LI.getLoopFor(BB);
+  (void)taggedName("LoopTrapEdge", Tag);
+  (void)isTrapBlock(BB, BoundsSafetyTrapsOnly, LegacyTrapMatch::TrapIntrinsic);
+  SmallVector<Value *, 8> Operands;
+  SmallPtrSet<Value *, 16> Visited;
+  collectBoolLeafOperands(nullptr, Operands, Visited);
+  (void)classifyTrapPredicateShape(nullptr, SE, L);
+  (void)computeTrapClass(false, TrapPredicateShape::Unknown, false, false,
+                         false, false, false, false, false, false, false,
+                         false, false, false, false, false, 0u, false, false,
+                         false, false);
+  (void)isEntryProximate(F, BB, DT, LI);
+  (void)isDominatedByEquivalentCheck(BB, nullptr, DT);
+  (void)computeIVUpdateDominatesLatch(nullptr, L, DT);
+  (void)bbLabel(BB);
+  (void)InvocationSeq;
+  (void)ORE;
+  (void)AA;
+}
+
+/// Emit one machine-readable LoopPrimitives remark per loop in F, plus a
+/// per-function LoopPrimitivesSummary. Always emits (does not gate on
+/// hasUnreachableInst) so every loop is captured, including trap-free ones —
+/// lets the early/late diff find loops that disappear between pipeline points.
+static void emitLoopPrimitives(Function &F, LoopInfo &LI,
+                               OptimizationRemarkEmitter &ORE,
+                               ScalarEvolution &SE, AAResults &AA,
+                               DominatorTree &DT, StringRef Tag,
+                               unsigned InvocationSeq) {
+  // Call-wiring: exercise every per-loop helper so none is unused.
+  BasicBlock *BB = &F.getEntryBlock();
+  Loop *L = LI.getLoopFor(BB);
+  (void)countTrapExits(L, LI);
+  (void)countCondTrapEdges(L, LI);
+  (void)countHoistableCondTrapEdges(L, LI);
+  (void)hasUnreachableInst(L);
+  SmallVector<std::string, 4> Hoisted;
+  (void)hasHoistedInPreheader(L, Hoisted);
+  (void)getSideEffectReasons(*BB->getTerminator());
+  (void)classifyCondTrapEdges(L, SE, DT);
+  (void)Tag;
+  (void)InvocationSeq;
+  (void)ORE;
+  (void)AA;
 }
 
 /// Check if \p L can be hoisted or not and emit a detailed remark about why
 /// it can't be hoisted.
 static CheckLoopHoistType processLoops(Loop *L, ScalarEvolution &SE,
-                                       OptimizationRemarkEmitter &ORE) {
-  CheckLoopHoistType HoistType;
-  bool SymbolicMaxBackEdgeComputable =
-      !isa<SCEVCouldNotCompute>(SE.getSymbolicMaxBackedgeTakenCount(L));
-  bool HasSideEffects = false;
-  if (!hasUnreachableInst(L))
-    return CheckLoopHoistType::SKIP;
-
-  SmallVector<std::string, 4> InstructionsWithSideEffects;
-  SmallVector<std::string, 4> SideEffectReasons;
-  for (auto *BB : L->blocks()) {
-    if (any_of(*BB, [&InstructionsWithSideEffects,
-                     &SideEffectReasons](const Instruction &I) {
-          bool InstHasSideEffects = false;
-          // If a call instruction reads or writes to memory we don't know if
-          // the access is non-volatile so we asssume that the call instruction
-          // has side effects.
-          if (isa<CallInst>(I))
-            InstHasSideEffects =
-                I.mayHaveSideEffects() || I.mayReadFromMemory();
-          else if (NewTrapSemantics)
-            InstHasSideEffects = !I.willReturn() || I.mayThrow();
-          else
-            InstHasSideEffects = I.mayHaveSideEffects();
-          if (InstHasSideEffects) {
-            std::string Buf;
-            raw_string_ostream OS(Buf);
-            I.print(OS);
-            InstructionsWithSideEffects.push_back(Buf);
-            SideEffectReasons.push_back(getSideEffectReasons(I));
-          }
-          return InstHasSideEffects;
-        })) {
-
-      HasSideEffects = true;
-      break;
-    }
-  }
-
-  HoistType = !HasSideEffects && SymbolicMaxBackEdgeComputable
-                  ? CheckLoopHoistType::MAYBE_CAN_HOIST
-                  : CheckLoopHoistType::CANNOT_HOIST;
-  // Emit a remark for the loop
-  auto ORA = OptimizationRemarkAnalysis(REMARK_PASS, "LoopTrap",
-                                        &L->getHeader()->front());
-  ORA << "Loop: " << L->getName() << " ";
-  if (HoistType == CheckLoopHoistType::CANNOT_HOIST) {
-    ORA << "cannot be hoisted: \n";
-    if (HasSideEffects) {
-      ORA << "\nThe following instructions have side effects:\n";
-      for (unsigned Idx = 0; Idx < InstructionsWithSideEffects.size(); Idx++) {
-        ORA << "\t" << InstructionsWithSideEffects[Idx] << "\n";
-        ORA << "Reason:\n";
-        ORA << SideEffectReasons[Idx];
-      }
-    }
-    if (!SymbolicMaxBackEdgeComputable)
-      ORA << "Backedge is not computable.\n";
-  } else
-    ORA << "can be hoisted\n";
-  ORE.emit(ORA);
-  return HoistType;
+                                       LoopInfo &LI,
+                                       OptimizationRemarkEmitter &ORE,
+                                       StringRef Tag) {
+  return CheckLoopHoistType::SKIP;
 }
 
 /// Collect info for hoistable loop checks for \p F and report remarks for
 /// individual loops and report a summary for hoistable checks for the function.
 static void emitRemarks(Function &F, LoopInfo &LI,
-                        OptimizationRemarkEmitter &ORE, ScalarEvolution &SE) {
-  unsigned TotalCanHoistLoops = 0;
-  unsigned TotalUnHoistableLoops = 0;
-  for (auto *L : LI.getLoopsInPreorder()) {
-    CheckLoopHoistType Type = processLoops(L, SE, ORE);
-    if (Type == CheckLoopHoistType::MAYBE_CAN_HOIST)
-      TotalCanHoistLoops++;
-    else if (Type == CheckLoopHoistType::CANNOT_HOIST)
-      TotalUnHoistableLoops++;
-  }
-
-  OptimizationRemarkAnalysis Rem(REMARK_PASS, "LoopTrapSummary", &F);
-  Rem << "Trap checks results:\n";
-  Rem << "Total count of loops with traps "
-      << NV("TotalCount", TotalCanHoistLoops + TotalUnHoistableLoops) << "\n";
-  Rem << "Loops that maybe can be hoisted: "
-      << NV("CountHoist", TotalCanHoistLoops) << "\n";
-  Rem << "Loops that cannot be hoisted: "
-      << NV("CountCannotHoist", TotalUnHoistableLoops) << "\n";
-  ORE.emit(Rem);
+                        OptimizationRemarkEmitter &ORE, ScalarEvolution &SE,
+                        StringRef Tag) {
+  // Call-wiring: exercise processLoops so it is not unused.
+  for (auto *L : LI.getLoopsInPreorder())
+    (void)processLoops(L, SE, LI, ORE, Tag);
 }
 
 PreservedAnalyses LoopTrapAnalysisPass::run(Function &F,
@@ -172,6 +426,21 @@ PreservedAnalyses LoopTrapAnalysisPass::run(Function &F,
   auto &LI = AM.getResult<LoopAnalysis>(F);
   auto &SE = AM.getResult<ScalarEvolutionAnalysis>(F);
   auto &ORE = AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
-  emitRemarks(F, LI, ORE, SE);
+  auto &AA = AM.getResult<AAManager>(F);
+  auto &DT = AM.getResult<DominatorTreeAnalysis>(F);
+  // Per-function run() counter, emitted as InvocationSeq (gated by
+  // -loop-trap-analysis-explain) so repeated invocations can be deduped by
+  // max(seq) per (function, src_bb, trap_bb); stays 1 for a single run.
+  unsigned Seq = ++InvocationCount[&F];
+  emitLoopPrimitives(F, LI, ORE, SE, AA, DT, Tag, Seq);
+  emitRemarks(F, LI, ORE, SE, Tag);
+  emitPerTrapEdgeSCEV(F, LI, SE, AA, DT, ORE, Tag, Seq);
   return PreservedAnalyses::all();
+}
+
+void LoopTrapAnalysisPass::printPipeline(
+    raw_ostream &OS, function_ref<StringRef(StringRef)> MapClassName2PassName) {
+  OS << "loop-trap-analysis";
+  if (!Tag.empty())
+    OS << "<tag=" << Tag << ">";
 }

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -569,7 +569,104 @@ static StringRef computeTrapClass(
     bool UnaliasLoad, bool OtherUnk, bool OpaqueNoUnk, bool InLoopFreeze,
     bool InLoopSelect, unsigned NumLeafOps, bool NonUnitStride, bool NegStride,
     bool NonConstStride, bool NotProvenMonotonicOnly) {
-  return "";
+  const bool ConstK = Shape == TrapPredicateShape::OrBoundsCheckConstBound ||
+                      Shape == TrapPredicateShape::AndBoundsCheckConstBound;
+  const bool VarK = Shape == TrapPredicateShape::OrBoundsCheckVarBound ||
+                    Shape == TrapPredicateShape::AndBoundsCheckVarBound;
+  const bool TwoAR = Shape == TrapPredicateShape::OrTwoAddRecICmp ||
+                     Shape == TrapPredicateShape::AndTwoAddRecICmp;
+  // Out-of-loop: classify by structural redundancy / predicate shape.
+  if (!InLoop) {
+    if (IsEntryProx)
+      return "OutsideLoop-EntryProximate";
+    if (DomByEquiv)
+      return "OutsideLoop-RedundantWithDominatingCheck";
+    if (ConstK)
+      return "OutsideLoop-MultiComparison-ConstBound";
+    if (VarK)
+      return "OutsideLoop-MultiComparison-VarBound";
+    if (Shape == TrapPredicateShape::SingleICmp)
+      return "OutsideLoop-SingleComparison";
+    if (Shape == TrapPredicateShape::OtherMulti)
+      return "OutsideLoop-MultiComparison-Other";
+    if (TwoAR)
+      return "OutsideLoop-MultiComparison-Other";
+    return "OutsideLoop-Unclassifiable";
+  }
+  // In-loop, not a loop exit.
+  if (!IsLoopExit)
+    return "InLoop-NonExit";
+  // In-loop loop-exit.
+  // A BTC-computable edge whose predicate also has a reload/opaque blocker
+  // isn't cleanly eliminable via trip count, so under LTAEmitExplain it is NOT
+  // masked as a trip-count-known class -- it falls through to the blocker
+  // classes below. Legacy (flag off) keeps the trip-count-known classes for any
+  // BTC-computable edge (byte-identical).
+  const bool HasBlocker = StoreReload || MemIReload || CallReload ||
+                          InLoopPhi || UnaliasLoad || OtherUnk || OpaqueNoUnk;
+  if (EdgeBTCComputable && (!LTAEmitExplain || !HasBlocker))
+    return LoopOtherUnk ? "InLoopExit-TripCountKnown-LoopBlockedElsewhere"
+                        : "InLoopExit-TripCountKnown";
+  const bool S = StoreReload || MemIReload;
+  if (S && CallReload)
+    return "InLoopExit-TripCountUnknown-StoreAndCallReload";
+  if (S)
+    return "InLoopExit-TripCountUnknown-StoreReload";
+  if (CallReload)
+    return "InLoopExit-TripCountUnknown-CallReload";
+  if (InLoopPhi)
+    return "InLoopExit-TripCountUnknown-InLoopPhiOperand";
+  if (UnaliasLoad)
+    return "InLoopExit-TripCountUnknown-InLoopLoadOperand";
+  // The opaque-operand class split by opacity shape (freeze / select / other
+  // in-loop unknown). InLoopFreeze / InLoopSelect are subsets of OtherUnk, so
+  // test them first.
+  if (OtherUnk) {
+    if (InLoopFreeze)
+      return "InLoopExit-TripCountUnknown-OpaqueOperand-Freeze";
+    if (InLoopSelect)
+      return "InLoopExit-TripCountUnknown-OpaqueOperand-Select";
+    return "InLoopExit-TripCountUnknown-OpaqueOperand-Other";
+  }
+  if (OpaqueNoUnk)
+    return "InLoopExit-TripCountUnknown-OpaqueOperand-NoInLoopUnknown";
+  // The multi-comparison suffix is driven by the predicate SHAPE (one source of
+  // truth), so the multi-comparison class can't disagree with the emitted
+  // PredicateShape. Legacy (flag off) keeps the NumLeafOps>=4 gate for
+  // byte-identical output.
+  bool MultiShape = LTAEmitExplain ? (ConstK || VarK || TwoAR ||
+                                      Shape == TrapPredicateShape::OtherMulti)
+                                   : (NumLeafOps >= 4);
+  if (MultiShape) {
+    if (ConstK)
+      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-MultiComparison-"
+             "ConstBound";
+    if (VarK)
+      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-MultiComparison-"
+             "VarBound";
+    if (TwoAR)
+      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-MultiComparison-"
+             "TwoAddRec";
+    if (Shape == TrapPredicateShape::OtherMulti)
+      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-MultiComparison-"
+             "Other";
+  }
+  // Surface stride-fragility (the Has*StrideForLAddRec flags previously never
+  // influenced the class) instead of lumping it into the bare weak-no-wrap
+  // class. Legacy (flag off) returns the bare weak-no-wrap class
+  // (byte-identical).
+  if (LTAEmitExplain) {
+    if (NonConstStride)
+      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-NonConstantStride";
+    if (NonUnitStride)
+      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-NonUnitStride";
+    if (NegStride)
+      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-NegativeStride";
+    if (NotProvenMonotonicOnly)
+      return "InLoopExit-TripCountUnknown-NotProvenMonotonic-"
+             "NotProvenMonotonicOnly";
+  }
+  return "InLoopExit-TripCountUnknown-NotProvenMonotonic";
 }
 
 /// Match the bounded-iterator OR / AND shape:
@@ -708,6 +805,29 @@ classifyTrapPredicateShape(Value *Cond, ScalarEvolution &SE, Loop *L) {
 /// by the loop body.
 static bool isEntryProximate(const Function &F, BasicBlock *BB,
                              const DominatorTree &DT, const LoopInfo &LI) {
+  if (!BB)
+    return false;
+  auto *N = DT.getNode(BB);
+  if (!N)
+    return false;
+  unsigned Depth = 0;
+  for (auto *Cur = N; Cur; Cur = Cur->getIDom()) {
+    BasicBlock *CurBB = Cur->getBlock();
+    // Function entry: classical entry-proximity boundary.
+    if (CurBB == &F.getEntryBlock())
+      return true;
+    // Loop preheader: also a validation boundary. It sits outside the loop,
+    // and trap edges at/above it run once per outer entry to the nest,
+    // regardless of inner-loop iteration counts.
+    if (BasicBlock *Succ = CurBB->getSingleSuccessor()) {
+      if (Loop *SuccL = LI.getLoopFor(Succ))
+        if (SuccL->getHeader() == Succ && SuccL->getLoopPreheader() == CurBB)
+          return true;
+    }
+    if (Depth >= EntryProximityDepth.getValue())
+      return false;
+    ++Depth;
+  }
   return false;
 }
 
@@ -719,6 +839,42 @@ static bool isEntryProximate(const Function &F, BasicBlock *BB,
 /// control reaches \p BB.
 static bool isDominatedByEquivalentCheck(BasicBlock *BB, Value *MyCond,
                                          const DominatorTree &DT) {
+  if (!BB || !MyCond)
+    return false;
+  auto *MyCmp = dyn_cast<ICmpInst>(MyCond);
+  auto *N = DT.getNode(BB);
+  if (!N)
+    return false;
+  // Walk strict dominators (skip BB itself), bounding cost on functions with
+  // very deep dominator chains.
+  const unsigned MaxDomChains = 16;
+  unsigned Steps = 0;
+  for (auto *Cur = N->getIDom(); Cur && Steps < MaxDomChains;
+       Cur = Cur->getIDom(), ++Steps) {
+    BasicBlock *Dom = Cur->getBlock();
+    auto *DomBI = dyn_cast<CondBrInst>(Dom->getTerminator());
+    if (!DomBI)
+      continue;
+    Value *DomCond = DomBI->getCondition();
+    bool Equivalent = (DomCond == MyCond);
+    if (!Equivalent && MyCmp)
+      if (auto *DomCmp = dyn_cast<ICmpInst>(DomCond))
+        Equivalent = DomCmp->getPredicate() == MyCmp->getPredicate() &&
+                     DomCmp->getOperand(0) == MyCmp->getOperand(0) &&
+                     DomCmp->getOperand(1) == MyCmp->getOperand(1);
+    if (!Equivalent)
+      continue;
+    if (!LTAEmitExplain)
+      return true;
+    // Require the dominating branch to actually DETERMINE the condition on the
+    // path to BB (one of its edges dominates BB). A same-condition dominator
+    // whose neither edge dominates BB proves nothing, so calling the trap
+    // "redundant" would be unsound.
+    BasicBlockEdge TrueEdge(Dom, DomBI->getSuccessor(0));
+    BasicBlockEdge FalseEdge(Dom, DomBI->getSuccessor(1));
+    if (DT.dominates(TrueEdge, BB) || DT.dominates(FalseEdge, BB))
+      return true;
+  }
   return false;
 }
 
@@ -735,6 +891,77 @@ static bool isDominatedByEquivalentCheck(BasicBlock *BB, Value *MyCond,
 /// Returns true vacuously when no header-phi is reached.
 static bool computeIVUpdateDominatesLatch(Value *Cond, Loop *L,
                                           const DominatorTree &DT) {
+  if (!L)
+    return true;
+  BasicBlock *Header = L->getHeader();
+  BasicBlock *Latch = L->getLoopLatch();
+  if (!Latch)
+    return true;
+  // Walk the recurrence chain reachable from a header phi's loop-carried
+  // incoming value, returning false if any reached in-loop Instruction sits in
+  // a BB that doesn't dominate the latch. Follows operands transitively through
+  // non-header (merge) phis and arithmetic, so the chain reaches the underlying
+  // add/sub even behind an inserted merge phi.
+  auto AllUpdatesDominate = [&](Value *Start) -> bool {
+    SmallPtrSet<const Value *, 32> Seen;
+    SmallVector<const Value *, 16> Stack;
+    Stack.push_back(Start);
+    unsigned Steps = 0;
+    const unsigned StepLimit = 64;
+    while (!Stack.empty() && Steps++ < StepLimit) {
+      const Value *V = Stack.pop_back_val();
+      if (!Seen.insert(V).second)
+        continue;
+      const auto *I = dyn_cast<Instruction>(V);
+      if (!I)
+        continue;
+      if (!L->contains(I->getParent()))
+        continue;
+      // The header phi's parent IS the header, which dominates the latch;
+      // don't recurse through it (recurrence already inspected at the call
+      // site).
+      if (isa<PHINode>(I) && I->getParent() == Header)
+        continue;
+      // Any other chain instruction must live in a BB dominating the latch;
+      // otherwise the update is control-dependent.
+      if (!DT.dominates(I->getParent(), Latch))
+        return false;
+      // Walk operands. For non-header (merge) phis this recurses into both
+      // arms — catching the `m += cond ? 1 : 0` shape where one arm's add sits
+      // in a non-dominating BB.
+      for (const Use &U : I->operands())
+        Stack.push_back(U.get());
+    }
+    return true;
+  };
+
+  SmallPtrSet<const Value *, 32> Seen;
+  SmallVector<const Value *, 16> Stack;
+  Stack.push_back(Cond);
+  unsigned Steps = 0;
+  const unsigned StepLimit = 64;
+  while (!Stack.empty() && Steps++ < StepLimit) {
+    const Value *V = Stack.pop_back_val();
+    if (!Seen.insert(V).second)
+      continue;
+    const auto *I = dyn_cast<Instruction>(V);
+    if (!I)
+      continue;
+    if (!L->contains(I->getParent()))
+      continue;
+    if (const auto *Phi = dyn_cast<PHINode>(I)) {
+      if (Phi->getParent() == Header) {
+        if (Value *In = Phi->getIncomingValueForBlock(Latch))
+          if (!AllUpdatesDominate(In))
+            return false;
+        // Don't recurse through phi operands — recurrence just inspected via
+        // the latch incoming.
+        continue;
+      }
+    }
+    for (const Use &U : I->operands())
+      Stack.push_back(U.get());
+  }
   return true;
 }
 

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -831,6 +831,22 @@ static bool matchBoundsCheckArmsImpl(Value *Arm1, Value *Arm2,
   return false;
 }
 
+/// True when \p V is an icmp with an operand whose SCEV is an AddRec for \p L.
+static bool hasLAddRec(Value *V, ScalarEvolution &SE, Loop *L) {
+  auto *Cmp = dyn_cast<ICmpInst>(V);
+  if (!Cmp)
+    return false;
+  for (Value *Op : {Cmp->getOperand(0), Cmp->getOperand(1)}) {
+    if (!SE.isSCEVable(Op->getType()))
+      continue;
+    const SCEV *S = SE.getSCEV(Op);
+    if (auto *AR = dyn_cast<SCEVAddRecExpr>(S))
+      if (AR->getLoop() == L)
+        return true;
+  }
+  return false;
+}
+
 /// Match `or/and(icmp(X), icmp(Y))` where each arm has an operand whose SCEV is
 /// an L-AddRec -- the "two unrelated AddRec exits combined by one OR/AND" shape
 /// that SCEV's `computeExitLimit` does not fold to `min(BTC_a, BTC_b)`.
@@ -840,21 +856,7 @@ static bool matchTwoAddRecICmpImpl(Value *Arm1, Value *Arm2,
                                    ScalarEvolution &SE, Loop *L) {
   if (!L)
     return false;
-  auto HasLAddRec = [&](Value *V) -> bool {
-    auto *Cmp = dyn_cast<ICmpInst>(V);
-    if (!Cmp)
-      return false;
-    for (Value *Op : {Cmp->getOperand(0), Cmp->getOperand(1)}) {
-      if (!SE.isSCEVable(Op->getType()))
-        continue;
-      const SCEV *S = SE.getSCEV(Op);
-      if (auto *AR = dyn_cast<SCEVAddRecExpr>(S))
-        if (AR->getLoop() == L)
-          return true;
-    }
-    return false;
-  };
-  return HasLAddRec(Arm1) && HasLAddRec(Arm2);
+  return hasLAddRec(Arm1, SE, L) && hasLAddRec(Arm2, SE, L);
 }
 
 /// Classify a trap branch's i1 predicate by structural shape.
@@ -1042,6 +1044,45 @@ static bool isDominatedByEquivalentCheck(BasicBlock *BB, Value *MyCond,
 ///
 /// Plus loop-context fields (LoopHeader / Depth / IsInnermost) so downstream
 /// tooling can join against `LoopPrimitives<Tag>` records.
+/// Walk the recurrence chain reachable from a header phi's loop-carried
+/// incoming value, returning false if any reached in-loop Instruction sits in
+/// a BB that doesn't dominate the latch. Follows operands transitively through
+/// non-header (merge) phis and arithmetic, so the chain reaches the underlying
+/// add/sub even behind an inserted merge phi.
+static bool allUpdatesDominate(Value *Start, Loop *L, BasicBlock *Header,
+                               BasicBlock *Latch, const DominatorTree &DT) {
+  SmallPtrSet<const Value *, 32> Seen;
+  SmallVector<const Value *, 16> Stack;
+  Stack.push_back(Start);
+  unsigned Steps = 0;
+  const unsigned StepLimit = 64;
+  while (!Stack.empty() && Steps++ < StepLimit) {
+    const Value *V = Stack.pop_back_val();
+    if (!Seen.insert(V).second)
+      continue;
+    const auto *I = dyn_cast<Instruction>(V);
+    if (!I)
+      continue;
+    if (!L->contains(I->getParent()))
+      continue;
+    // The header phi's parent IS the header, which dominates the latch;
+    // don't recurse through it (recurrence already inspected at the call
+    // site).
+    if (isa<PHINode>(I) && I->getParent() == Header)
+      continue;
+    // Any other chain instruction must live in a BB dominating the latch;
+    // otherwise the update is control-dependent.
+    if (!DT.dominates(I->getParent(), Latch))
+      return false;
+    // Walk operands. For non-header (merge) phis this recurses into both
+    // arms — catching the `m += cond ? 1 : 0` shape where one arm's add sits
+    // in a non-dominating BB.
+    for (const Use &U : I->operands())
+      Stack.push_back(U.get());
+  }
+  return true;
+}
+
 /// Walk the def chain of \p Cond (bounded to instructions inside \p L) and
 /// answer Q2 of the trap-explanation tree: for every IV-shaped operand reached,
 /// does its update dominate the loop latch?
@@ -1061,44 +1102,6 @@ static bool computeIVUpdateDominatesLatch(Value *Cond, Loop *L,
   BasicBlock *Latch = L->getLoopLatch();
   if (!Latch)
     return true;
-  // Walk the recurrence chain reachable from a header phi's loop-carried
-  // incoming value, returning false if any reached in-loop Instruction sits in
-  // a BB that doesn't dominate the latch. Follows operands transitively through
-  // non-header (merge) phis and arithmetic, so the chain reaches the underlying
-  // add/sub even behind an inserted merge phi.
-  auto AllUpdatesDominate = [&](Value *Start) -> bool {
-    SmallPtrSet<const Value *, 32> Seen;
-    SmallVector<const Value *, 16> Stack;
-    Stack.push_back(Start);
-    unsigned Steps = 0;
-    const unsigned StepLimit = 64;
-    while (!Stack.empty() && Steps++ < StepLimit) {
-      const Value *V = Stack.pop_back_val();
-      if (!Seen.insert(V).second)
-        continue;
-      const auto *I = dyn_cast<Instruction>(V);
-      if (!I)
-        continue;
-      if (!L->contains(I->getParent()))
-        continue;
-      // The header phi's parent IS the header, which dominates the latch;
-      // don't recurse through it (recurrence already inspected at the call
-      // site).
-      if (isa<PHINode>(I) && I->getParent() == Header)
-        continue;
-      // Any other chain instruction must live in a BB dominating the latch;
-      // otherwise the update is control-dependent.
-      if (!DT.dominates(I->getParent(), Latch))
-        return false;
-      // Walk operands. For non-header (merge) phis this recurses into both
-      // arms — catching the `m += cond ? 1 : 0` shape where one arm's add sits
-      // in a non-dominating BB.
-      for (const Use &U : I->operands())
-        Stack.push_back(U.get());
-    }
-    return true;
-  };
-
   SmallPtrSet<const Value *, 32> Seen;
   SmallVector<const Value *, 16> Stack;
   Stack.push_back(Cond);
@@ -1116,7 +1119,7 @@ static bool computeIVUpdateDominatesLatch(Value *Cond, Loop *L,
     if (const auto *Phi = dyn_cast<PHINode>(I)) {
       if (Phi->getParent() == Header) {
         if (Value *In = Phi->getIncomingValueForBlock(Latch))
-          if (!AllUpdatesDominate(In))
+          if (!allUpdatesDominate(In, L, Header, Latch, DT))
             return false;
         // Don't recurse through phi operands — recurrence just inspected via
         // the latch incoming.
@@ -1127,6 +1130,132 @@ static bool computeIVUpdateDominatesLatch(Value *Cond, Loop *L,
       Stack.push_back(U.get());
   }
   return true;
+}
+
+// Per-load "do any in-loop instructions may-alias this load?" query, cached in
+// \p ReloadCache. Key: (Loop*, LoadInst*). Returns (StoreAlias,
+// MemIntrinsicAlias, CallAlias) tracked SEPARATELY so the consumer can bucket
+// scalar-store vs struct-copy (mem-intrinsic) aliasing (different levers).
+static std::tuple<bool, bool, bool> loadAliasFlags(
+    LoadInst *Load, Loop *L, AAResults &AA,
+    DenseMap<std::pair<Loop *, LoadInst *>, std::tuple<bool, bool, bool>>
+        &ReloadCache) {
+  auto Key = std::make_pair(L, Load);
+  auto It = ReloadCache.find(Key);
+  if (It != ReloadCache.end())
+    return It->second;
+  bool Store = false, MemI = false, Call = false;
+  MemoryLocation LoadLoc = MemoryLocation::get(Load);
+  for (BasicBlock *BB : L->blocks()) {
+    for (Instruction &I : *BB) {
+      if (&I == Load)
+        continue;
+      if (auto *SI = dyn_cast<StoreInst>(&I)) {
+        if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
+                           : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
+          Store = true;
+      } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
+        if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
+          MemI = true;
+      } else if (auto *CB = dyn_cast<CallBase>(&I)) {
+        if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
+          continue;
+        if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
+          Call = true;
+      }
+      if (Store && MemI && Call)
+        break;
+    }
+    if (Store && MemI && Call)
+      break;
+  }
+  auto Out = std::make_tuple(Store, MemI, Call);
+  ReloadCache[Key] = Out;
+  return Out;
+}
+
+// For a load flagged store-may-cause-reload, return the FIRST in-loop
+// store / mem-intrinsic that may-alias it (per AA, which already folds in
+// TBAA). Lets the consumer point at the specific writer that blocks LICM.
+static Instruction *firstAliasingStore(LoadInst *Load, Loop *L, AAResults &AA) {
+  MemoryLocation LoadLoc = MemoryLocation::get(Load);
+  for (BasicBlock *BB : L->blocks())
+    for (Instruction &I : *BB) {
+      if (&I == Load)
+        continue;
+      if (auto *SI = dyn_cast<StoreInst>(&I)) {
+        if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
+                           : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
+          return &I;
+      } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
+        if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
+          return &I;
+      }
+    }
+  return nullptr;
+}
+
+// Extract a human-readable TBAA access-type name from an instruction's TBAA
+// metadata (struct-path tag: operand 1 is the access-type descriptor; scalar
+// tag: operand 0 is the type-name string). A memcpy / struct copy carries
+// !tbaa.struct instead — report "struct-copy". Empty if no TBAA.
+static StringRef tbaaTypeName(const Instruction *I) {
+  AAMDNodes AAMD = I->getAAMetadata();
+  if (const MDNode *TBAA = AAMD.TBAA) {
+    const MDNode *AccessType = TBAA;
+    if (TBAA->getNumOperands() >= 2)
+      if (auto *AT = dyn_cast<MDNode>(TBAA->getOperand(1)))
+        AccessType = AT;
+    if (AccessType->getNumOperands() >= 1)
+      if (auto *Name = dyn_cast<MDString>(AccessType->getOperand(0)))
+        return Name->getString();
+  }
+  if (AAMD.TBAAStruct)
+    return "struct-copy";
+  return "";
+}
+
+// Short kind tag for a reload-blocking writer.
+static StringRef writerKind(const Instruction *I) {
+  if (isa<MemCpyInst>(I))
+    return "memcpy";
+  if (isa<MemMoveInst>(I))
+    return "memmove";
+  if (isa<MemSetInst>(I))
+    return "memset";
+  if (isa<MemIntrinsic>(I))
+    return "mem-intrinsic";
+  if (isa<StoreInst>(I))
+    return "store";
+  if (isa<CallBase>(I))
+    return "call";
+  return "writer";
+}
+
+// Like firstAliasingStore but also considers side-effecting calls — used
+// by the flag-gated per-load alias annotation (LoopLoadAlias).
+static Instruction *firstAliasingWriter(LoadInst *Load, Loop *L,
+                                        AAResults &AA) {
+  MemoryLocation LoadLoc = MemoryLocation::get(Load);
+  for (BasicBlock *BB : L->blocks())
+    for (Instruction &I : *BB) {
+      if (&I == Load)
+        continue;
+      if (auto *SI = dyn_cast<StoreInst>(&I)) {
+        if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
+                           : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
+          return &I;
+      } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
+        if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
+          return &I;
+      } else if (auto *CB = dyn_cast<CallBase>(&I)) {
+        if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
+          continue;
+        if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
+          return &I;
+      }
+    }
+  return nullptr;
 }
 
 static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
@@ -1175,124 +1304,6 @@ static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
   // scalar-store vs struct-copy (mem-intrinsic) aliasing (different levers).
   DenseMap<std::pair<Loop *, LoadInst *>, std::tuple<bool, bool, bool>>
       ReloadCache;
-  auto LoadAliasFlags = [&](LoadInst *Load,
-                            Loop *L) -> std::tuple<bool, bool, bool> {
-    auto Key = std::make_pair(L, Load);
-    auto It = ReloadCache.find(Key);
-    if (It != ReloadCache.end())
-      return It->second;
-    bool Store = false, MemI = false, Call = false;
-    MemoryLocation LoadLoc = MemoryLocation::get(Load);
-    for (BasicBlock *BB : L->blocks()) {
-      for (Instruction &I : *BB) {
-        if (&I == Load)
-          continue;
-        if (auto *SI = dyn_cast<StoreInst>(&I)) {
-          if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
-                             : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
-            Store = true;
-        } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
-          if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
-            MemI = true;
-        } else if (auto *CB = dyn_cast<CallBase>(&I)) {
-          if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
-            continue;
-          if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
-            Call = true;
-        }
-        if (Store && MemI && Call)
-          break;
-      }
-      if (Store && MemI && Call)
-        break;
-    }
-    auto Out = std::make_tuple(Store, MemI, Call);
-    ReloadCache[Key] = Out;
-    return Out;
-  };
-
-  // For a load flagged store-may-cause-reload, return the FIRST in-loop
-  // store / mem-intrinsic that may-alias it (per AA, which already folds in
-  // TBAA). Lets the consumer point at the specific writer that blocks LICM.
-  auto FirstAliasingStore = [&](LoadInst *Load, Loop *L) -> Instruction * {
-    MemoryLocation LoadLoc = MemoryLocation::get(Load);
-    for (BasicBlock *BB : L->blocks())
-      for (Instruction &I : *BB) {
-        if (&I == Load)
-          continue;
-        if (auto *SI = dyn_cast<StoreInst>(&I)) {
-          if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
-                             : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
-            return &I;
-        } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
-          if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
-            return &I;
-        }
-      }
-    return nullptr;
-  };
-
-  // Extract a human-readable TBAA access-type name from an instruction's TBAA
-  // metadata (struct-path tag: operand 1 is the access-type descriptor; scalar
-  // tag: operand 0 is the type-name string). A memcpy / struct copy carries
-  // !tbaa.struct instead — report "struct-copy". Empty if no TBAA.
-  auto TBAATypeName = [](const Instruction *I) -> StringRef {
-    AAMDNodes AAMD = I->getAAMetadata();
-    if (const MDNode *TBAA = AAMD.TBAA) {
-      const MDNode *AccessType = TBAA;
-      if (TBAA->getNumOperands() >= 2)
-        if (auto *AT = dyn_cast<MDNode>(TBAA->getOperand(1)))
-          AccessType = AT;
-      if (AccessType->getNumOperands() >= 1)
-        if (auto *Name = dyn_cast<MDString>(AccessType->getOperand(0)))
-          return Name->getString();
-    }
-    if (AAMD.TBAAStruct)
-      return "struct-copy";
-    return "";
-  };
-
-  // Short kind tag for a reload-blocking writer.
-  auto WriterKind = [](const Instruction *I) -> StringRef {
-    if (isa<MemCpyInst>(I))
-      return "memcpy";
-    if (isa<MemMoveInst>(I))
-      return "memmove";
-    if (isa<MemSetInst>(I))
-      return "memset";
-    if (isa<MemIntrinsic>(I))
-      return "mem-intrinsic";
-    if (isa<StoreInst>(I))
-      return "store";
-    if (isa<CallBase>(I))
-      return "call";
-    return "writer";
-  };
-
-  // Like FirstAliasingStore but also considers side-effecting calls — used
-  // by the flag-gated per-load alias annotation (LoopLoadAlias).
-  auto FirstAliasingWriter = [&](LoadInst *Load, Loop *L) -> Instruction * {
-    MemoryLocation LoadLoc = MemoryLocation::get(Load);
-    for (BasicBlock *BB : L->blocks())
-      for (Instruction &I : *BB) {
-        if (&I == Load)
-          continue;
-        if (auto *SI = dyn_cast<StoreInst>(&I)) {
-          if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
-                             : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc))
-            return &I;
-        } else if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
-          if (isModSet(AA.getModRefInfo(MI, LoadLoc)))
-            return &I;
-        } else if (auto *CB = dyn_cast<CallBase>(&I)) {
-          if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
-            continue;
-          if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
-            return &I;
-        }
-      }
-    return nullptr;
-  };
 
   for (BasicBlock &BB : F) {
     auto *BI = dyn_cast<CondBrInst>(BB.getTerminator());
@@ -1478,7 +1489,8 @@ static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
         if (Innermost && Innermost->contains(I->getParent())) {
           OpHasInLoopUnknown = true;
           if (auto *Load = dyn_cast<LoadInst>(I)) {
-            auto [SAlias, MAlias, CAlias] = LoadAliasFlags(Load, Innermost);
+            auto [SAlias, MAlias, CAlias] =
+                loadAliasFlags(Load, Innermost, AA, ReloadCache);
             if (SAlias)
               HasStoreReload = true;
             if (MAlias)
@@ -1488,7 +1500,7 @@ static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
             // Point at the specific aliasing writer (first store / mem-
             // intrinsic wins) so the consumer sees WHERE the reload comes from.
             if ((SAlias || MAlias) && !ReloadStore) {
-              ReloadStore = FirstAliasingStore(Load, Innermost);
+              ReloadStore = firstAliasingStore(Load, Innermost, AA);
               ReloadLoad = Load;
             }
             // Load with no AA-detected writer (indirect / data-dependent;
@@ -1596,11 +1608,11 @@ static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
     if (ReloadStore) {
       if (const DebugLoc &DL = ReloadStore->getDebugLoc())
         ReloadStoreLine = DL.getLine();
-      ReloadStoreTBAA = TBAATypeName(ReloadStore);
-      ReloadStoreKind = WriterKind(ReloadStore);
+      ReloadStoreTBAA = tbaaTypeName(ReloadStore);
+      ReloadStoreKind = writerKind(ReloadStore);
     }
     if (ReloadLoad) {
-      ReloadLoadTBAA = TBAATypeName(ReloadLoad);
+      ReloadLoadTBAA = tbaaTypeName(ReloadLoad);
       if (const DebugLoc &DL = ReloadLoad->getDebugLoc())
         ReloadLoadLine = DL.getLine();
       if (Value *Ptr = ReloadLoad->getPointerOperand())
@@ -1703,7 +1715,7 @@ static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
           auto *Load = dyn_cast<LoadInst>(&I);
           if (!Load)
             continue;
-          Instruction *W = FirstAliasingWriter(Load, L);
+          Instruction *W = firstAliasingWriter(Load, L, AA);
           if (!W)
             continue; // hoistable — no in-loop writer may-aliases it
           unsigned LoadLine = 0, WLine = 0;
@@ -1718,15 +1730,139 @@ static void emitPerTrapEdgeSCEV(Function &F, LoopInfo &LI, ScalarEvolution &SE,
           Rem << "Function " << NV("Function", F.getName())
               << " load_name=" << NV("LoadName", LoadName)
               << " load_line=" << NV("LoadLine", LoadLine)
-              << " load_tbaa=" << NV("LoadTBAA", TBAATypeName(Load))
+              << " load_tbaa=" << NV("LoadTBAA", tbaaTypeName(Load))
               << " loop_header=" << NV("LoopHeader", bbLabel(L->getHeader()))
-              << " writer_kind=" << NV("WriterKind", WriterKind(W))
+              << " writer_kind=" << NV("WriterKind", writerKind(W))
               << " writer_line=" << NV("WriterLine", WLine)
-              << " writer_tbaa=" << NV("WriterTBAA", TBAATypeName(W));
+              << " writer_tbaa=" << NV("WriterTBAA", tbaaTypeName(W));
           ORE.emit(Rem);
         }
     }
   }
+}
+
+// 3-way reason for an unknown-BTC exit. Priority StoreReload > CallReload
+// > Other so buckets are exclusive and total to the unknown-BTC count.
+enum class ReloadReason { StoreReload, CallReload, Other };
+
+// Classify why an in-loop load blocks SCEV, caching the result per-load in
+// \p LoadCache: several leaf cmp operands (within and across exits in L) can
+// fan in from the same load; don't re-walk L each time.
+static ReloadReason
+loadReloadCause(LoadInst *Load, Loop *L, AAResults &AA,
+                DenseMap<LoadInst *, ReloadReason> &LoadCache) {
+  auto It = LoadCache.find(Load);
+  if (It != LoadCache.end())
+    return It->second;
+  MemoryLocation LoadLoc = MemoryLocation::get(Load);
+  bool SawCallMod = false;
+  ReloadReason Result = ReloadReason::Other;
+  for (BasicBlock *BB : L->blocks()) {
+    for (Instruction &I : *BB) {
+      if (&I == Load)
+        continue;
+      if (auto *SI = dyn_cast<StoreInst>(&I)) {
+        if (LTAEmitExplain ? isModSet(AA.getModRefInfo(SI, LoadLoc))
+                           : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc)) {
+          Result = ReloadReason::StoreReload;
+          goto done;
+        }
+        continue;
+      }
+      if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
+        if (isModSet(AA.getModRefInfo(MI, LoadLoc))) {
+          Result = ReloadReason::StoreReload;
+          goto done;
+        }
+        continue;
+      }
+      if (auto *CB = dyn_cast<CallBase>(&I)) {
+        if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
+          continue;
+        if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
+          SawCallMod = true;
+      }
+    }
+  }
+  if (SawCallMod)
+    Result = ReloadReason::CallReload;
+done:
+  LoadCache[Load] = Result;
+  return Result;
+}
+
+// Walk a branch's leaf cmp operands. For each whose SCEV references an
+// in-loop SCEVUnknown, classify the blocker; the exit-level reason is the
+// strongest cause across operands.
+static ReloadReason
+classifyExit(CondBrInst *BI, Loop *L, ScalarEvolution &SE, AAResults &AA,
+             DenseMap<LoadInst *, ReloadReason> &LoadCache) {
+  SmallVector<Value *, 8> Operands;
+  SmallPtrSet<Value *, 16> Visited;
+  collectBoolLeafOperands(BI->getCondition(), Operands, Visited);
+  ReloadReason Best = ReloadReason::Other;
+  for (Value *V : Operands) {
+    if (!V || isa<Constant>(V))
+      continue;
+    if (!SE.isSCEVable(V->getType()))
+      continue;
+    const SCEV *SC = SE.getSCEV(V);
+    if (isa<SCEVCouldNotCompute>(SC))
+      continue;
+    if (SE.isLoopInvariant(SC, L))
+      continue;
+    if (auto *AR = dyn_cast<SCEVAddRecExpr>(SC))
+      if (AR->getLoop() == L)
+        continue;
+    SCEVNodeCollector Coll;
+    SCEVTraversal<SCEVNodeCollector>(Coll).visitAll(SC);
+    for (const SCEVUnknown *U : Coll.Unknowns) {
+      auto *I = dyn_cast_or_null<Instruction>(U->getValue());
+      if (!I || !L->contains(I->getParent()))
+        continue;
+      if (auto *Load = dyn_cast<LoadInst>(I)) {
+        ReloadReason R = loadReloadCause(Load, L, AA, LoadCache);
+        if (R == ReloadReason::StoreReload)
+          return R;
+        if (R == ReloadReason::CallReload && Best != ReloadReason::CallReload)
+          Best = R;
+      }
+      // Non-load in-loop SCEVUnknown → genuine varying. Stays Other
+      // unless another operand promotes us.
+    }
+  }
+  return Best;
+}
+
+// Legacy bool: did *any* leaf operand reference an in-loop SCEVUnknown?
+// (Superset of the reason buckets.) Kept for backwards-compat with
+// classify_unknown_btc.py and existing dashboards.
+static bool isBlockedByReload(CondBrInst *BI, Loop *L, ScalarEvolution &SE) {
+  SmallVector<Value *, 8> Operands;
+  SmallPtrSet<Value *, 16> Visited;
+  collectBoolLeafOperands(BI->getCondition(), Operands, Visited);
+  for (Value *V : Operands) {
+    if (!V || isa<Constant>(V))
+      continue;
+    if (!SE.isSCEVable(V->getType()))
+      continue;
+    const SCEV *SC = SE.getSCEV(V);
+    if (isa<SCEVCouldNotCompute>(SC))
+      continue;
+    if (SE.isLoopInvariant(SC, L))
+      continue;
+    if (auto *AR = dyn_cast<SCEVAddRecExpr>(SC))
+      if (AR->getLoop() == L)
+        continue;
+    SCEVNodeCollector Coll;
+    SCEVTraversal<SCEVNodeCollector>(Coll).visitAll(SC);
+    for (const SCEVUnknown *U : Coll.Unknowns) {
+      if (auto *I = dyn_cast_or_null<Instruction>(U->getValue()))
+        if (L->contains(I->getParent()))
+          return true;
+    }
+  }
+  return false;
 }
 
 /// Emit one machine-readable LoopPrimitives remark per loop in F, plus a
@@ -1863,127 +1999,9 @@ static void emitLoopPrimitives(Function &F, LoopInfo &LI,
                            LegacyTrapMatch::TrapIntrinsic);
       };
 
-      // 3-way reason for an unknown-BTC exit. Priority StoreReload > CallReload
-      // > Other so buckets are exclusive and total to the unknown-BTC count.
-      enum class Reason { StoreReload, CallReload, Other };
-
       // Cache per-load AA result: several leaf cmp operands (within and across
       // exits in L) can fan in from the same load; don't re-walk L each time.
-      DenseMap<LoadInst *, Reason> LoadCache;
-
-      auto LoadReloadCause = [&](LoadInst *Load) -> Reason {
-        auto It = LoadCache.find(Load);
-        if (It != LoadCache.end())
-          return It->second;
-        MemoryLocation LoadLoc = MemoryLocation::get(Load);
-        bool SawCallMod = false;
-        Reason Result = Reason::Other;
-        for (BasicBlock *BB : L->blocks()) {
-          for (Instruction &I : *BB) {
-            if (&I == Load)
-              continue;
-            if (auto *SI = dyn_cast<StoreInst>(&I)) {
-              if (LTAEmitExplain
-                      ? isModSet(AA.getModRefInfo(SI, LoadLoc))
-                      : !AA.isNoAlias(MemoryLocation::get(SI), LoadLoc)) {
-                Result = Reason::StoreReload;
-                goto done;
-              }
-              continue;
-            }
-            if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
-              if (isModSet(AA.getModRefInfo(MI, LoadLoc))) {
-                Result = Reason::StoreReload;
-                goto done;
-              }
-              continue;
-            }
-            if (auto *CB = dyn_cast<CallBase>(&I)) {
-              if (CB->onlyReadsMemory() || CB->doesNotAccessMemory())
-                continue;
-              if (isModSet(AA.getModRefInfo(CB, LoadLoc)))
-                SawCallMod = true;
-            }
-          }
-        }
-        if (SawCallMod)
-          Result = Reason::CallReload;
-      done:
-        LoadCache[Load] = Result;
-        return Result;
-      };
-
-      // Walk a branch's leaf cmp operands. For each whose SCEV references an
-      // in-loop SCEVUnknown, classify the blocker; the exit-level reason is the
-      // strongest cause across operands.
-      auto ClassifyExit = [&](CondBrInst *BI) -> Reason {
-        SmallVector<Value *, 8> Operands;
-        SmallPtrSet<Value *, 16> Visited;
-        collectBoolLeafOperands(BI->getCondition(), Operands, Visited);
-        Reason Best = Reason::Other;
-        for (Value *V : Operands) {
-          if (!V || isa<Constant>(V))
-            continue;
-          if (!SE.isSCEVable(V->getType()))
-            continue;
-          const SCEV *SC = SE.getSCEV(V);
-          if (isa<SCEVCouldNotCompute>(SC))
-            continue;
-          if (SE.isLoopInvariant(SC, L))
-            continue;
-          if (auto *AR = dyn_cast<SCEVAddRecExpr>(SC))
-            if (AR->getLoop() == L)
-              continue;
-          SCEVNodeCollector Coll;
-          SCEVTraversal<SCEVNodeCollector>(Coll).visitAll(SC);
-          for (const SCEVUnknown *U : Coll.Unknowns) {
-            auto *I = dyn_cast_or_null<Instruction>(U->getValue());
-            if (!I || !L->contains(I->getParent()))
-              continue;
-            if (auto *Load = dyn_cast<LoadInst>(I)) {
-              Reason R = LoadReloadCause(Load);
-              if (R == Reason::StoreReload)
-                return R;
-              if (R == Reason::CallReload && Best != Reason::CallReload)
-                Best = R;
-            }
-            // Non-load in-loop SCEVUnknown → genuine varying. Stays Other
-            // unless another operand promotes us.
-          }
-        }
-        return Best;
-      };
-
-      // Legacy bool: did *any* leaf operand reference an in-loop SCEVUnknown?
-      // (Superset of the reason buckets.) Kept for backwards-compat with
-      // classify_unknown_btc.py and existing dashboards.
-      auto IsBlockedByReload = [&](CondBrInst *BI) -> bool {
-        SmallVector<Value *, 8> Operands;
-        SmallPtrSet<Value *, 16> Visited;
-        collectBoolLeafOperands(BI->getCondition(), Operands, Visited);
-        for (Value *V : Operands) {
-          if (!V || isa<Constant>(V))
-            continue;
-          if (!SE.isSCEVable(V->getType()))
-            continue;
-          const SCEV *SC = SE.getSCEV(V);
-          if (isa<SCEVCouldNotCompute>(SC))
-            continue;
-          if (SE.isLoopInvariant(SC, L))
-            continue;
-          if (auto *AR = dyn_cast<SCEVAddRecExpr>(SC))
-            if (AR->getLoop() == L)
-              continue;
-          SCEVNodeCollector Coll;
-          SCEVTraversal<SCEVNodeCollector>(Coll).visitAll(SC);
-          for (const SCEVUnknown *U : Coll.Unknowns) {
-            if (auto *I = dyn_cast_or_null<Instruction>(U->getValue()))
-              if (L->contains(I->getParent()))
-                return true;
-          }
-        }
-        return false;
-      };
+      DenseMap<LoadInst *, ReloadReason> LoadCache;
 
       SmallVector<BasicBlock *, 4> ExitingBlocks;
       L->getExitingBlocks(ExitingBlocks);
@@ -2025,24 +2043,24 @@ static void emitLoopPrimitives(Function &F, LoopInfo &LI,
             ++NonTrapExitsSymbolicBTC;
           continue;
         }
-        bool ByReload = IsBlockedByReload(BI);
-        Reason R = ClassifyExit(BI);
+        bool ByReload = isBlockedByReload(BI, L, SE);
+        ReloadReason R = classifyExit(BI, L, SE, AA, LoadCache);
         if (IsTrap) {
           ++UnknownBTC["TrapExitsUnknownBTC"];
           ++UnknownBTC[ByReload ? "TrapExitsUnknownBTCDueToReload"
                                 : "TrapExitsUnknownBTCOtherReason"];
-          ++UnknownBTC[R == Reason::StoreReload
+          ++UnknownBTC[R == ReloadReason::StoreReload
                            ? "TrapExitsUnknownBTCStoreReload"
-                       : R == Reason::CallReload
+                       : R == ReloadReason::CallReload
                            ? "TrapExitsUnknownBTCCallReload"
                            : "TrapExitsUnknownBTCOtherBlocker"];
         } else {
           ++UnknownBTC["NonTrapExitsUnknownBTC"];
           ++UnknownBTC[ByReload ? "NonTrapExitsUnknownBTCDueToReload"
                                 : "NonTrapExitsUnknownBTCOtherReason"];
-          ++UnknownBTC[R == Reason::StoreReload
+          ++UnknownBTC[R == ReloadReason::StoreReload
                            ? "NonTrapExitsUnknownBTCStoreReload"
-                       : R == Reason::CallReload
+                       : R == ReloadReason::CallReload
                            ? "NonTrapExitsUnknownBTCCallReload"
                            : "NonTrapExitsUnknownBTCOtherBlocker"];
         }

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Scalar/LoopTrapAnalysis.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Analysis/AliasAnalysis.h"
@@ -1811,18 +1812,36 @@ static void emitLoopPrimitives(Function &F, LoopInfo &LI,
     //                      writer.
     // Sums: store_reload + call_reload + other_blocker = trap_exits_unknown_btc
     //       (same for non-trap).
-    unsigned TrapExitsUnknownBTC = 0;
-    unsigned NonTrapExitsUnknownBTC = 0;
-    unsigned TrapExitsUnknownBTCDueToReload = 0;
-    unsigned TrapExitsUnknownBTCOtherReason = 0;
-    unsigned NonTrapExitsUnknownBTCDueToReload = 0;
-    unsigned NonTrapExitsUnknownBTCOtherReason = 0;
-    unsigned TrapExitsUnknownBTCStoreReload = 0;
-    unsigned TrapExitsUnknownBTCCallReload = 0;
-    unsigned TrapExitsUnknownBTCOtherBlocker = 0;
-    unsigned NonTrapExitsUnknownBTCStoreReload = 0;
-    unsigned NonTrapExitsUnknownBTCCallReload = 0;
-    unsigned NonTrapExitsUnknownBTCOtherBlocker = 0;
+    // One ordered, tag-keyed table drives the unknown-BTC breakdown so the set
+    // generalizes: add a counter with a row here, not a local plus an NV line.
+    // Field is the remark tag consumers read; Label is the full inline text
+    // (leading space, trailing '='); the map is seeded in table order so
+    // emission stays deterministic.
+    static const std::pair<StringRef, StringRef> UnknownBTCCounters[] = {
+        {"TrapExitsUnknownBTC", " trap_exits_unknown_btc="},
+        {"TrapExitsUnknownBTCDueToReload", " trap_exits_unknown_btc_reload="},
+        {"TrapExitsUnknownBTCOtherReason", " trap_exits_unknown_btc_other="},
+        {"TrapExitsUnknownBTCStoreReload",
+         " trap_exits_unknown_btc_store_reload="},
+        {"TrapExitsUnknownBTCCallReload",
+         " trap_exits_unknown_btc_call_reload="},
+        {"TrapExitsUnknownBTCOtherBlocker",
+         " trap_exits_unknown_btc_other_blocker="},
+        {"NonTrapExitsUnknownBTC", " non_trap_exits_unknown_btc="},
+        {"NonTrapExitsUnknownBTCDueToReload",
+         " non_trap_exits_unknown_btc_reload="},
+        {"NonTrapExitsUnknownBTCOtherReason",
+         " non_trap_exits_unknown_btc_other="},
+        {"NonTrapExitsUnknownBTCStoreReload",
+         " non_trap_exits_unknown_btc_store_reload="},
+        {"NonTrapExitsUnknownBTCCallReload",
+         " non_trap_exits_unknown_btc_call_reload="},
+        {"NonTrapExitsUnknownBTCOtherBlocker",
+         " non_trap_exits_unknown_btc_other_blocker="},
+    };
+    MapVector<StringRef, unsigned> UnknownBTC;
+    for (const auto &KV : UnknownBTCCounters)
+      UnknownBTC[KV.first] = 0;
     // SCEV-computable counterparts: cond-trap edges whose per-exit BTC is
     // computable. These are the edges IndVars *could* fold via predication if
     // the other gates hold — they bound the achievable reduction from
@@ -2009,29 +2028,23 @@ static void emitLoopPrimitives(Function &F, LoopInfo &LI,
         bool ByReload = IsBlockedByReload(BI);
         Reason R = ClassifyExit(BI);
         if (IsTrap) {
-          ++TrapExitsUnknownBTC;
-          if (ByReload)
-            ++TrapExitsUnknownBTCDueToReload;
-          else
-            ++TrapExitsUnknownBTCOtherReason;
-          if (R == Reason::StoreReload)
-            ++TrapExitsUnknownBTCStoreReload;
-          else if (R == Reason::CallReload)
-            ++TrapExitsUnknownBTCCallReload;
-          else
-            ++TrapExitsUnknownBTCOtherBlocker;
+          ++UnknownBTC["TrapExitsUnknownBTC"];
+          ++UnknownBTC[ByReload ? "TrapExitsUnknownBTCDueToReload"
+                                : "TrapExitsUnknownBTCOtherReason"];
+          ++UnknownBTC[R == Reason::StoreReload
+                           ? "TrapExitsUnknownBTCStoreReload"
+                       : R == Reason::CallReload
+                           ? "TrapExitsUnknownBTCCallReload"
+                           : "TrapExitsUnknownBTCOtherBlocker"];
         } else {
-          ++NonTrapExitsUnknownBTC;
-          if (ByReload)
-            ++NonTrapExitsUnknownBTCDueToReload;
-          else
-            ++NonTrapExitsUnknownBTCOtherReason;
-          if (R == Reason::StoreReload)
-            ++NonTrapExitsUnknownBTCStoreReload;
-          else if (R == Reason::CallReload)
-            ++NonTrapExitsUnknownBTCCallReload;
-          else
-            ++NonTrapExitsUnknownBTCOtherBlocker;
+          ++UnknownBTC["NonTrapExitsUnknownBTC"];
+          ++UnknownBTC[ByReload ? "NonTrapExitsUnknownBTCDueToReload"
+                                : "NonTrapExitsUnknownBTCOtherReason"];
+          ++UnknownBTC[R == Reason::StoreReload
+                           ? "NonTrapExitsUnknownBTCStoreReload"
+                       : R == Reason::CallReload
+                           ? "NonTrapExitsUnknownBTCCallReload"
+                           : "NonTrapExitsUnknownBTCOtherBlocker"];
         }
       }
     }
@@ -2078,38 +2091,10 @@ static void emitLoopPrimitives(Function &F, LoopInfo &LI,
           << " trap_cond_non_iv_call_op="
           << NV("TrapCondNonIVCallOp", Shape.NonIVCallOp);
     }
-    Rem << " btc_known=" << NV("BTCKnown", BTCKnown)
-        << " trap_exits_unknown_btc="
-        << NV("TrapExitsUnknownBTC", TrapExitsUnknownBTC)
-        << " trap_exits_unknown_btc_reload="
-        << NV("TrapExitsUnknownBTCDueToReload", TrapExitsUnknownBTCDueToReload)
-        << " trap_exits_unknown_btc_other="
-        << NV("TrapExitsUnknownBTCOtherReason", TrapExitsUnknownBTCOtherReason)
-        << " trap_exits_unknown_btc_store_reload="
-        << NV("TrapExitsUnknownBTCStoreReload", TrapExitsUnknownBTCStoreReload)
-        << " trap_exits_unknown_btc_call_reload="
-        << NV("TrapExitsUnknownBTCCallReload", TrapExitsUnknownBTCCallReload)
-        << " trap_exits_unknown_btc_other_blocker="
-        << NV("TrapExitsUnknownBTCOtherBlocker",
-              TrapExitsUnknownBTCOtherBlocker)
-        << " non_trap_exits_unknown_btc="
-        << NV("NonTrapExitsUnknownBTC", NonTrapExitsUnknownBTC)
-        << " non_trap_exits_unknown_btc_reload="
-        << NV("NonTrapExitsUnknownBTCDueToReload",
-              NonTrapExitsUnknownBTCDueToReload)
-        << " non_trap_exits_unknown_btc_other="
-        << NV("NonTrapExitsUnknownBTCOtherReason",
-              NonTrapExitsUnknownBTCOtherReason)
-        << " non_trap_exits_unknown_btc_store_reload="
-        << NV("NonTrapExitsUnknownBTCStoreReload",
-              NonTrapExitsUnknownBTCStoreReload)
-        << " non_trap_exits_unknown_btc_call_reload="
-        << NV("NonTrapExitsUnknownBTCCallReload",
-              NonTrapExitsUnknownBTCCallReload)
-        << " non_trap_exits_unknown_btc_other_blocker="
-        << NV("NonTrapExitsUnknownBTCOtherBlocker",
-              NonTrapExitsUnknownBTCOtherBlocker)
-        << " trap_exits_computable_btc="
+    Rem << " btc_known=" << NV("BTCKnown", BTCKnown);
+    for (const auto &[Field, Label] : UnknownBTCCounters)
+      Rem << Label << NV(Field, UnknownBTC[Field]);
+    Rem << " trap_exits_computable_btc="
         << NV("TrapExitsComputableBTC", TrapExitsComputableBTC)
         << " non_trap_exits_computable_btc="
         << NV("NonTrapExitsComputableBTC", NonTrapExitsComputableBTC)

--- a/llvm/test/Transforms/Util/TrapAnalysis/bounds-safety-loop-trap-remarks.ll
+++ b/llvm/test/Transforms/Util/TrapAnalysis/bounds-safety-loop-trap-remarks.ll
@@ -3,11 +3,116 @@
 
 ; OPT-REM: --- !Analysis
 ; OPT-REM-NEXT: Pass:            loop-trap-analysis
+; OPT-REM-NEXT: Name:            LoopPrimitives
+; OPT-REM-NEXT: Function:        write_checks
+; OPT-REM-NEXT: Args:
+; OPT-REM-NEXT:   - String:          'Loop '
+; OPT-REM-NEXT:   - LoopHeader:      for.body
+; OPT-REM-NEXT:   - String:          ' depth='
+; OPT-REM-NEXT:   - Depth:           '1'
+; OPT-REM-NEXT:   - String:          ' parent='
+; OPT-REM-NEXT:   - ParentHeader:    '-'
+; OPT-REM-NEXT:   - String:          ' innermost='
+; OPT-REM-NEXT:   - IsInnermost:     'true'
+; OPT-REM-NEXT:   - String:          ' blocks='
+; OPT-REM-NEXT:   - BlockCount:      '2'
+; OPT-REM-NEXT:   - String:          ' trap_exits='
+; OPT-REM-NEXT:   - TrapExitCount:   '1'
+; OPT-REM-NEXT:   - String:          ' cond_trap_edges='
+; OPT-REM-NEXT:   - CondTrapEdgeCount: '1'
+; OPT-REM-NEXT:   - String:          ' hoistable_cond_trap_edges='
+; OPT-REM-NEXT:   - HoistableCondTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_invariant='
+; OPT-REM-NEXT:   - TrapCondInvariant: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_iv_derived='
+; OPT-REM-NEXT:   - TrapCondIVDerived: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_non_iv='
+; OPT-REM-NEXT:   - TrapCondNonIV:   '1'
+; OPT-REM-NEXT:   - String:          ' btc_known='
+; OPT-REM-NEXT:   - BTCKnown:        'false'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTC: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCDueToReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_other='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCOtherReason: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_store_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCStoreReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_call_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCCallReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_other_blocker='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCOtherBlocker: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTC: '1'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCDueToReload: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_other='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCOtherReason: '1'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_store_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCStoreReload: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_call_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCCallReload: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_other_blocker='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCOtherBlocker: '1'
+; OPT-REM-NEXT:   - String:          ' trap_exits_computable_btc='
+; OPT-REM-NEXT:   - TrapExitsComputableBTC: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_computable_btc='
+; OPT-REM-NEXT:   - NonTrapExitsComputableBTC: '1'
+; OPT-REM-NEXT:   - String:          ' trap_exits_symbolic_btc='
+; OPT-REM-NEXT:   - TrapExitsSymbolicBTC: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_symbolic_btc='
+; OPT-REM-NEXT:   - NonTrapExitsSymbolicBTC: '0'
+; OPT-REM-NEXT: ...
+; OPT-REM-NEXT: --- !Analysis
+; OPT-REM-NEXT: Pass:            loop-trap-analysis
+; OPT-REM-NEXT: Name:            LoopPrimitivesSummary
+; OPT-REM-NEXT: Function:        write_checks
+; OPT-REM-NEXT: Args:
+; OPT-REM-NEXT:   - String:          'Function '
+; OPT-REM-NEXT:   - Function:        write_checks
+; OPT-REM-NEXT:   - String:          ' total_loops='
+; OPT-REM-NEXT:   - TotalLoops:      '1'
+; OPT-REM-NEXT:   - String:          ' innermost='
+; OPT-REM-NEXT:   - Innermost:       '1'
+; OPT-REM-NEXT:   - String:          ' loops_with_traps='
+; OPT-REM-NEXT:   - LoopsWithTraps:  '1'
+; OPT-REM-NEXT:   - String:          ' loops_with_traps_unknown_btc='
+; OPT-REM-NEXT:   - LoopsWithTrapsUnknownBTC: '1'
+; OPT-REM-NEXT:   - String:          ' max_depth='
+; OPT-REM-NEXT:   - MaxDepth:        '1'
+; OPT-REM-NEXT:   - String:          ' depth1='
+; OPT-REM-NEXT:   - Depth1:          '1'
+; OPT-REM-NEXT:   - String:          ' depth2='
+; OPT-REM-NEXT:   - Depth2:          '0'
+; OPT-REM-NEXT:   - String:          ' depth3+='
+; OPT-REM-NEXT:   - Depth3Plus:      '0'
+; OPT-REM-NEXT:   - String:          ' unique_trap_blocks='
+; OPT-REM-NEXT:   - UniqueTrapBlocks: '0'
+; OPT-REM-NEXT:   - String:          ' unique_trap_blocks_reachable_from_loop='
+; OPT-REM-NEXT:   - UniqueTrapBlocksReachableFromLoop: '0'
+; OPT-REM-NEXT:   - String:          ' in_loop_trap_edges='
+; OPT-REM-NEXT:   - InLoopTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' in_loop_hoistable_trap_edges='
+; OPT-REM-NEXT:   - InLoopHoistableTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' out_of_loop_trap_edges='
+; OPT-REM-NEXT:   - OutOfLoopTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_invariant_total='
+; OPT-REM-NEXT:   - TrapCondInvariantTotal: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_iv_derived_total='
+; OPT-REM-NEXT:   - TrapCondIVDerivedTotal: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_non_iv_total='
+; OPT-REM-NEXT:   - TrapCondNonIVTotal: '1'
+; OPT-REM-NEXT: ...
+; OPT-REM-NEXT: --- !Analysis
+; OPT-REM-NEXT: Pass:            loop-trap-analysis
 ; OPT-REM-NEXT: Name:            LoopTrap
 ; OPT-REM-NEXT: Function:        write_checks
 ; OPT-REM-NEXT: Args:
 ; OPT-REM-NEXT:   - String:          'Loop: '
 ; OPT-REM-NEXT:   - String:          for.body
+; OPT-REM-NEXT:   - String:          ' '
+; OPT-REM-NEXT:   - String:          'TrapExits: '
+; OPT-REM-NEXT:   - TrapExitCount:   '1'
 ; OPT-REM-NEXT:   - String:          ' '
 ; OPT-REM-NEXT:   - String:          "cannot be hoisted: \n"
 ; OPT-REM-NEXT:   - String:           |
@@ -17,7 +122,7 @@
 ; OPT-REM-NEXT:   - String:          '  store i32 1, ptr %ptr.ind, align 4'
 ; OPT-REM-NEXT:   - String:          "\n"
 ; OPT-REM-NEXT:   - String:          "Reason:\n"
-; OPT-REM-NEXT:   - String:          "Instruction may write to memory\n"
+; OPT-REM-NEXT:   - String:          "Store.may-write-to-memory\n"
 ; OPT-REM-NEXT: ...
 ; OPT-REM-NEXT: --- !Analysis
 ; OPT-REM-NEXT: Pass:            loop-trap-analysis
@@ -34,6 +139,10 @@
 ; OPT-REM-NEXT:   - String:          'Loops that cannot be hoisted: '
 ; OPT-REM-NEXT:   - CountCannotHoist: '1'
 ; OPT-REM-NEXT:   - String:          "\n"
+; OPT-REM-NEXT:   - String:          'Loops with trap check hoisted to preheader: '
+; OPT-REM-NEXT:   - CountHoisted:    '0'
+; OPT-REM-NEXT:   - String:          "\n"
+; OPT-REM-NEXT: ...
 define void @write_checks(ptr %base, i32 %N) {
 entry:
   %ptr.lb = getelementptr i32, ptr %base, i32 0
@@ -68,11 +177,116 @@ cont6:                                            ; preds = %for.body
 
 ; OPT-REM: --- !Analysis
 ; OPT-REM-NEXT: Pass:            loop-trap-analysis
+; OPT-REM-NEXT: Name:            LoopPrimitives
+; OPT-REM-NEXT: Function:        accumulate_checks
+; OPT-REM-NEXT: Args:
+; OPT-REM-NEXT:   - String:          'Loop '
+; OPT-REM-NEXT:   - LoopHeader:      for.body
+; OPT-REM-NEXT:   - String:          ' depth='
+; OPT-REM-NEXT:   - Depth:           '1'
+; OPT-REM-NEXT:   - String:          ' parent='
+; OPT-REM-NEXT:   - ParentHeader:    '-'
+; OPT-REM-NEXT:   - String:          ' innermost='
+; OPT-REM-NEXT:   - IsInnermost:     'true'
+; OPT-REM-NEXT:   - String:          ' blocks='
+; OPT-REM-NEXT:   - BlockCount:      '2'
+; OPT-REM-NEXT:   - String:          ' trap_exits='
+; OPT-REM-NEXT:   - TrapExitCount:   '1'
+; OPT-REM-NEXT:   - String:          ' cond_trap_edges='
+; OPT-REM-NEXT:   - CondTrapEdgeCount: '1'
+; OPT-REM-NEXT:   - String:          ' hoistable_cond_trap_edges='
+; OPT-REM-NEXT:   - HoistableCondTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_invariant='
+; OPT-REM-NEXT:   - TrapCondInvariant: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_iv_derived='
+; OPT-REM-NEXT:   - TrapCondIVDerived: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_non_iv='
+; OPT-REM-NEXT:   - TrapCondNonIV:   '1'
+; OPT-REM-NEXT:   - String:          ' btc_known='
+; OPT-REM-NEXT:   - BTCKnown:        'false'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTC: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCDueToReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_other='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCOtherReason: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_store_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCStoreReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_call_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCCallReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_other_blocker='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCOtherBlocker: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTC: '1'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCDueToReload: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_other='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCOtherReason: '1'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_store_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCStoreReload: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_call_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCCallReload: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_other_blocker='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCOtherBlocker: '1'
+; OPT-REM-NEXT:   - String:          ' trap_exits_computable_btc='
+; OPT-REM-NEXT:   - TrapExitsComputableBTC: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_computable_btc='
+; OPT-REM-NEXT:   - NonTrapExitsComputableBTC: '1'
+; OPT-REM-NEXT:   - String:          ' trap_exits_symbolic_btc='
+; OPT-REM-NEXT:   - TrapExitsSymbolicBTC: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_symbolic_btc='
+; OPT-REM-NEXT:   - NonTrapExitsSymbolicBTC: '0'
+; OPT-REM-NEXT: ...
+; OPT-REM-NEXT: --- !Analysis
+; OPT-REM-NEXT: Pass:            loop-trap-analysis
+; OPT-REM-NEXT: Name:            LoopPrimitivesSummary
+; OPT-REM-NEXT: Function:        accumulate_checks
+; OPT-REM-NEXT: Args:
+; OPT-REM-NEXT:   - String:          'Function '
+; OPT-REM-NEXT:   - Function:        accumulate_checks
+; OPT-REM-NEXT:   - String:          ' total_loops='
+; OPT-REM-NEXT:   - TotalLoops:      '1'
+; OPT-REM-NEXT:   - String:          ' innermost='
+; OPT-REM-NEXT:   - Innermost:       '1'
+; OPT-REM-NEXT:   - String:          ' loops_with_traps='
+; OPT-REM-NEXT:   - LoopsWithTraps:  '1'
+; OPT-REM-NEXT:   - String:          ' loops_with_traps_unknown_btc='
+; OPT-REM-NEXT:   - LoopsWithTrapsUnknownBTC: '1'
+; OPT-REM-NEXT:   - String:          ' max_depth='
+; OPT-REM-NEXT:   - MaxDepth:        '1'
+; OPT-REM-NEXT:   - String:          ' depth1='
+; OPT-REM-NEXT:   - Depth1:          '1'
+; OPT-REM-NEXT:   - String:          ' depth2='
+; OPT-REM-NEXT:   - Depth2:          '0'
+; OPT-REM-NEXT:   - String:          ' depth3+='
+; OPT-REM-NEXT:   - Depth3Plus:      '0'
+; OPT-REM-NEXT:   - String:          ' unique_trap_blocks='
+; OPT-REM-NEXT:   - UniqueTrapBlocks: '0'
+; OPT-REM-NEXT:   - String:          ' unique_trap_blocks_reachable_from_loop='
+; OPT-REM-NEXT:   - UniqueTrapBlocksReachableFromLoop: '0'
+; OPT-REM-NEXT:   - String:          ' in_loop_trap_edges='
+; OPT-REM-NEXT:   - InLoopTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' in_loop_hoistable_trap_edges='
+; OPT-REM-NEXT:   - InLoopHoistableTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' out_of_loop_trap_edges='
+; OPT-REM-NEXT:   - OutOfLoopTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_invariant_total='
+; OPT-REM-NEXT:   - TrapCondInvariantTotal: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_iv_derived_total='
+; OPT-REM-NEXT:   - TrapCondIVDerivedTotal: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_non_iv_total='
+; OPT-REM-NEXT:   - TrapCondNonIVTotal: '1'
+; OPT-REM-NEXT: ...
+; OPT-REM-NEXT: --- !Analysis
+; OPT-REM-NEXT: Pass:            loop-trap-analysis
 ; OPT-REM-NEXT: Name:            LoopTrap
 ; OPT-REM-NEXT: Function:        accumulate_checks
 ; OPT-REM-NEXT: Args:
 ; OPT-REM-NEXT:   - String:          'Loop: '
 ; OPT-REM-NEXT:   - String:          for.body
+; OPT-REM-NEXT:   - String:          ' '
+; OPT-REM-NEXT:   - String:          'TrapExits: '
+; OPT-REM-NEXT:   - TrapExitCount:   '1'
 ; OPT-REM-NEXT:   - String:          ' '
 ; OPT-REM-NEXT:   - String:          "can be hoisted\n"
 ; OPT-REM-NEXT: ...
@@ -90,6 +304,9 @@ cont6:                                            ; preds = %for.body
 ; OPT-REM-NEXT:   - String:          "\n"
 ; OPT-REM-NEXT:   - String:          'Loops that cannot be hoisted: '
 ; OPT-REM-NEXT:   - CountCannotHoist: '0'
+; OPT-REM-NEXT:   - String:          "\n"
+; OPT-REM-NEXT:   - String:          'Loops with trap check hoisted to preheader: '
+; OPT-REM-NEXT:   - CountHoisted:    '0'
 ; OPT-REM-NEXT:   - String:          "\n"
 ; OPT-REM-NEXT: ...
 define void @accumulate_checks(ptr %base, i32 %N) {
@@ -125,11 +342,116 @@ trap:                                             ; preds = %for.body
 
 ; OPT-REM: --- !Analysis
 ; OPT-REM-NEXT: Pass:            loop-trap-analysis
+; OPT-REM-NEXT: Name:            LoopPrimitives
+; OPT-REM-NEXT: Function:        trip_count_unknown
+; OPT-REM-NEXT: Args:
+; OPT-REM-NEXT:   - String:          'Loop '
+; OPT-REM-NEXT:   - LoopHeader:      loop
+; OPT-REM-NEXT:   - String:          ' depth='
+; OPT-REM-NEXT:   - Depth:           '1'
+; OPT-REM-NEXT:   - String:          ' parent='
+; OPT-REM-NEXT:   - ParentHeader:    '-'
+; OPT-REM-NEXT:   - String:          ' innermost='
+; OPT-REM-NEXT:   - IsInnermost:     'true'
+; OPT-REM-NEXT:   - String:          ' blocks='
+; OPT-REM-NEXT:   - BlockCount:      '3'
+; OPT-REM-NEXT:   - String:          ' trap_exits='
+; OPT-REM-NEXT:   - TrapExitCount:   '1'
+; OPT-REM-NEXT:   - String:          ' cond_trap_edges='
+; OPT-REM-NEXT:   - CondTrapEdgeCount: '1'
+; OPT-REM-NEXT:   - String:          ' hoistable_cond_trap_edges='
+; OPT-REM-NEXT:   - HoistableCondTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_invariant='
+; OPT-REM-NEXT:   - TrapCondInvariant: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_iv_derived='
+; OPT-REM-NEXT:   - TrapCondIVDerived: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_non_iv='
+; OPT-REM-NEXT:   - TrapCondNonIV:   '1'
+; OPT-REM-NEXT:   - String:          ' btc_known='
+; OPT-REM-NEXT:   - BTCKnown:        'false'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTC: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCDueToReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_other='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCOtherReason: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_store_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCStoreReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_call_reload='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCCallReload: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_unknown_btc_other_blocker='
+; OPT-REM-NEXT:   - TrapExitsUnknownBTCOtherBlocker: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTC: '3'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCDueToReload: '2'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_other='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCOtherReason: '1'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_store_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCStoreReload: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_call_reload='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCCallReload: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_unknown_btc_other_blocker='
+; OPT-REM-NEXT:   - NonTrapExitsUnknownBTCOtherBlocker: '3'
+; OPT-REM-NEXT:   - String:          ' trap_exits_computable_btc='
+; OPT-REM-NEXT:   - TrapExitsComputableBTC: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_computable_btc='
+; OPT-REM-NEXT:   - NonTrapExitsComputableBTC: '0'
+; OPT-REM-NEXT:   - String:          ' trap_exits_symbolic_btc='
+; OPT-REM-NEXT:   - TrapExitsSymbolicBTC: '0'
+; OPT-REM-NEXT:   - String:          ' non_trap_exits_symbolic_btc='
+; OPT-REM-NEXT:   - NonTrapExitsSymbolicBTC: '0'
+; OPT-REM-NEXT: ...
+; OPT-REM-NEXT: --- !Analysis
+; OPT-REM-NEXT: Pass:            loop-trap-analysis
+; OPT-REM-NEXT: Name:            LoopPrimitivesSummary
+; OPT-REM-NEXT: Function:        trip_count_unknown
+; OPT-REM-NEXT: Args:
+; OPT-REM-NEXT:   - String:          'Function '
+; OPT-REM-NEXT:   - Function:        trip_count_unknown
+; OPT-REM-NEXT:   - String:          ' total_loops='
+; OPT-REM-NEXT:   - TotalLoops:      '1'
+; OPT-REM-NEXT:   - String:          ' innermost='
+; OPT-REM-NEXT:   - Innermost:       '1'
+; OPT-REM-NEXT:   - String:          ' loops_with_traps='
+; OPT-REM-NEXT:   - LoopsWithTraps:  '1'
+; OPT-REM-NEXT:   - String:          ' loops_with_traps_unknown_btc='
+; OPT-REM-NEXT:   - LoopsWithTrapsUnknownBTC: '1'
+; OPT-REM-NEXT:   - String:          ' max_depth='
+; OPT-REM-NEXT:   - MaxDepth:        '1'
+; OPT-REM-NEXT:   - String:          ' depth1='
+; OPT-REM-NEXT:   - Depth1:          '1'
+; OPT-REM-NEXT:   - String:          ' depth2='
+; OPT-REM-NEXT:   - Depth2:          '0'
+; OPT-REM-NEXT:   - String:          ' depth3+='
+; OPT-REM-NEXT:   - Depth3Plus:      '0'
+; OPT-REM-NEXT:   - String:          ' unique_trap_blocks='
+; OPT-REM-NEXT:   - UniqueTrapBlocks: '0'
+; OPT-REM-NEXT:   - String:          ' unique_trap_blocks_reachable_from_loop='
+; OPT-REM-NEXT:   - UniqueTrapBlocksReachableFromLoop: '0'
+; OPT-REM-NEXT:   - String:          ' in_loop_trap_edges='
+; OPT-REM-NEXT:   - InLoopTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' in_loop_hoistable_trap_edges='
+; OPT-REM-NEXT:   - InLoopHoistableTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' out_of_loop_trap_edges='
+; OPT-REM-NEXT:   - OutOfLoopTrapEdges: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_invariant_total='
+; OPT-REM-NEXT:   - TrapCondInvariantTotal: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_iv_derived_total='
+; OPT-REM-NEXT:   - TrapCondIVDerivedTotal: '0'
+; OPT-REM-NEXT:   - String:          ' trap_cond_non_iv_total='
+; OPT-REM-NEXT:   - TrapCondNonIVTotal: '1'
+; OPT-REM-NEXT: ...
+; OPT-REM-NEXT: --- !Analysis
+; OPT-REM-NEXT: Pass:            loop-trap-analysis
 ; OPT-REM-NEXT: Name:            LoopTrap
 ; OPT-REM-NEXT: Function:        trip_count_unknown
 ; OPT-REM-NEXT: Args:
 ; OPT-REM-NEXT:   - String:          'Loop: '
 ; OPT-REM-NEXT:   - String:          loop
+; OPT-REM-NEXT:   - String:          ' '
+; OPT-REM-NEXT:   - String:          'TrapExits: '
+; OPT-REM-NEXT:   - TrapExitCount:   '1'
 ; OPT-REM-NEXT:   - String:          ' '
 ; OPT-REM-NEXT:   - String:          "cannot be hoisted: \n"
 ; OPT-REM-NEXT:   - String:          "Backedge is not computable.\n"
@@ -148,6 +470,9 @@ trap:                                             ; preds = %for.body
 ; OPT-REM-NEXT:   - String:          "\n"
 ; OPT-REM-NEXT:   - String:          'Loops that cannot be hoisted: '
 ; OPT-REM-NEXT:   - CountCannotHoist: '1'
+; OPT-REM-NEXT:   - String:          "\n"
+; OPT-REM-NEXT:   - String:          'Loops with trap check hoisted to preheader: '
+; OPT-REM-NEXT:   - CountHoisted:    '0'
 ; OPT-REM-NEXT:   - String:          "\n"
 ; OPT-REM-NEXT: ...
 define void @trip_count_unknown(ptr %A, ptr %B, i32 %N, i32 %M) {

--- a/llvm/test/Transforms/Util/TrapAnalysis/loop-structures-semantics.ll
+++ b/llvm/test/Transforms/Util/TrapAnalysis/loop-structures-semantics.ll
@@ -1,0 +1,136 @@
+; RUN: opt -passes='loop-trap-analysis' --loop-trap-analysis-explain -disable-output \
+; RUN:   -pass-remarks-output=%t.yaml %s
+; RUN: FileCheck --input-file=%t.yaml %s
+
+declare void @llvm.trap()
+
+; Single innermost loop with one trap exit (depth 1).
+define void @single_loop(ptr %base, i32 %n) {
+entry:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %cmp = icmp ult i32 %iv, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %p = getelementptr i32, ptr %base, i32 %iv
+  store i32 0, ptr %p
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}single_loop
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+
+; Nested loops with the trap exit only in the INNER loop: exactly one edge,
+; attributed at depth 2 (the outer loop is not double-counted).
+define void @nested_inner_trap(i32 %n, i32 %m) {
+entry:
+  br label %outer
+outer:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %outer.latch ]
+  br label %inner
+inner:
+  %j = phi i32 [ 0, %outer ], [ %j.next, %inner.latch ]
+  %cmp = icmp ult i32 %j, %m
+  br i1 %cmp, label %inner.latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+inner.latch:
+  %j.next = add i32 %j, 1
+  %ej = icmp eq i32 %j.next, %m
+  br i1 %ej, label %outer.latch, label %inner
+outer.latch:
+  %i.next = add i32 %i, 1
+  %ei = icmp eq i32 %i.next, %n
+  br i1 %ei, label %exit, label %outer
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}nested_inner_trap
+; CHECK: LoopDepth:{{ +}}'2'
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+
+; Loop with multiple exits: one trap exit plus one normal (non-trap) exit.
+define void @multi_exit(ptr %p, i32 %n) {
+entry:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %cmp = icmp ult i32 %iv, %n
+  br i1 %cmp, label %chk, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+chk:
+  %v = load i32, ptr %p
+  %z = icmp eq i32 %v, 0
+  br i1 %z, label %exit, label %latch
+latch:
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}multi_exit
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+
+; Nested loops with the trap exit in the OUTER loop: attributed at depth 1.
+define void @nested_outer_trap(i32 %n, i32 %m) {
+entry:
+  br label %outer
+outer:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %outer.latch ]
+  %co = icmp ult i32 %i, %n
+  br i1 %co, label %inner, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+inner:
+  %j = phi i32 [ 0, %outer ], [ %j.next, %inner ]
+  %j.next = add i32 %j, 1
+  %ej = icmp eq i32 %j.next, %m
+  br i1 %ej, label %outer.latch, label %inner
+outer.latch:
+  %i.next = add i32 %i, 1
+  %ei = icmp eq i32 %i.next, %n
+  br i1 %ei, label %exit, label %outer
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}nested_outer_trap
+; CHECK: LoopDepth:{{ +}}'1'
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+
+; Rotated / guarded loop: a preheader guard dominates the loop body.
+define void @guarded_loop(ptr %base, i32 %n) {
+entry:
+  %g = icmp sgt i32 %n, 0
+  br i1 %g, label %preheader, label %exit
+preheader:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %preheader ], [ %iv.next, %latch ]
+  %cmp = icmp ult i32 %iv, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %p = getelementptr i32, ptr %base, i32 %iv
+  store i32 0, ptr %p
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}guarded_loop
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown

--- a/llvm/test/Transforms/Util/TrapAnalysis/loop-structures-semantics.ll
+++ b/llvm/test/Transforms/Util/TrapAnalysis/loop-structures-semantics.ll
@@ -25,7 +25,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}single_loop
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountKnown
 
 ; Nested loops with the trap exit only in the INNER loop: exactly one edge,
 ; attributed at depth 2 (the outer loop is not double-counted).
@@ -55,7 +55,7 @@ exit:
 }
 ; CHECK: Function:{{ +}}nested_inner_trap
 ; CHECK: LoopDepth:{{ +}}'2'
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountKnown
 
 ; Loop with multiple exits: one trap exit plus one normal (non-trap) exit.
 define void @multi_exit(ptr %p, i32 %n) {
@@ -80,7 +80,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}multi_exit
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountKnown
 
 ; Nested loops with the trap exit in the OUTER loop: attributed at depth 1.
 define void @nested_outer_trap(i32 %n, i32 %m) {
@@ -107,7 +107,7 @@ exit:
 }
 ; CHECK: Function:{{ +}}nested_outer_trap
 ; CHECK: LoopDepth:{{ +}}'1'
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountKnown
 
 ; Rotated / guarded loop: a preheader guard dominates the loop body.
 define void @guarded_loop(ptr %base, i32 %n) {
@@ -133,4 +133,4 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}guarded_loop
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountKnown

--- a/llvm/test/Transforms/Util/TrapAnalysis/trap-class-semantics.ll
+++ b/llvm/test/Transforms/Util/TrapAnalysis/trap-class-semantics.ll
@@ -1,0 +1,281 @@
+; RUN: opt -passes='loop-trap-analysis' --loop-trap-analysis-explain -disable-output \
+; RUN:   -pass-remarks-output=%t.yaml %s
+; RUN: FileCheck --input-file=%t.yaml %s
+
+declare void @llvm.trap()
+declare void @llvm.ubsantrap(i8 immarg)
+declare void @llvm.looptrap()
+declare i32 @opaque()
+
+; Counted loop whose trap exit calls @llvm.ubsantrap.
+define void @counted_ubsantrap(ptr %base, i32 %n) {
+entry:
+  %c0 = icmp eq i32 %n, 0
+  br i1 %c0, label %exit, label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %cmp = icmp ult i32 %iv, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.ubsantrap(i8 25)
+  unreachable
+latch:
+  %p = getelementptr i32, ptr %base, i32 %iv
+  store i32 0, ptr %p, align 4
+  %iv.next = add nuw nsw i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}counted_ubsantrap
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+
+; Counted loop whose trap exit calls @llvm.looptrap.
+define void @counted_looptrap(ptr %base, i32 %n) {
+entry:
+  %c0 = icmp eq i32 %n, 0
+  br i1 %c0, label %exit, label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %cmp = icmp ult i32 %iv, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.looptrap()
+  unreachable
+latch:
+  %p = getelementptr i32, ptr %base, i32 %iv
+  store i32 0, ptr %p, align 4
+  %iv.next = add nuw nsw i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}counted_looptrap
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+
+; Counted loop whose trap exit calls @llvm.trap.
+define void @counted_trap(ptr %base, i32 %n) {
+entry:
+  %c0 = icmp eq i32 %n, 0
+  br i1 %c0, label %exit, label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %cmp = icmp ult i32 %iv, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %p = getelementptr i32, ptr %base, i32 %iv
+  store i32 0, ptr %p, align 4
+  %iv.next = add nuw nsw i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}counted_trap
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+
+; Trap exit driven by a pointer IV with a non-unit constant stride (i8, +2),
+; so the trip count is not computable.
+define void @stride_nonunit(ptr %base, ptr %bound) {
+entry:
+  br label %body
+body:
+  %iv = phi ptr [ %base, %entry ], [ %iv.next, %latch ]
+  %cmp = icmp ult ptr %iv, %bound
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %iv.next = getelementptr i8, ptr %iv, i32 2
+  %l = load i8, ptr %iv
+  %e = icmp eq i8 %l, 0
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}stride_nonunit
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-NotProvenMonotonic-NonUnitStride
+
+; Trap exit driven by a pointer IV whose stride is a runtime (non-constant)
+; value %s.
+define void @stride_variable(ptr %base, ptr %bound, i32 %s) {
+entry:
+  br label %body
+body:
+  %iv = phi ptr [ %base, %entry ], [ %iv.next, %latch ]
+  %cmp = icmp ult ptr %iv, %bound
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %iv.next = getelementptr i32, ptr %iv, i32 %s
+  %l = load i32, ptr %iv
+  %e = icmp eq i32 %l, 0
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}stride_variable
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-NotProvenMonotonic-NonConstantStride
+
+; Trap check outside any loop, sitting directly on the function entry block.
+define void @entry_proximate(i32 %n) {
+entry:
+  %c = icmp slt i32 %n, 0
+  br i1 %c, label %trap, label %cont
+trap:
+  call void @llvm.trap()
+  unreachable
+cont:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %cont ], [ %iv.next, %body ]
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}entry_proximate
+; CHECK: TrapClass:{{ +}}OutsideLoop-EntryProximate
+
+; Trap check outside any loop, reached only after a long straight-line chain
+; of blocks from entry (not adjacent to entry).
+define void @out_single_cmp(i32 %n, i32 %x) {
+entry:
+  br label %d1
+d1:
+  %a = add i32 %x, 1
+  br label %d2
+d2:
+  %b = add i32 %a, 1
+  br label %d3
+d3:
+  %cc = add i32 %b, 1
+  br label %d4
+d4:
+  %dd = add i32 %cc, 1
+  br label %chk
+chk:
+  %c = icmp slt i32 %dd, 0
+  br i1 %c, label %trap, label %cont
+trap:
+  call void @llvm.trap()
+  unreachable
+cont:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %cont ], [ %iv.next, %body ]
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}out_single_cmp
+; CHECK: TrapClass:{{ +}}OutsideLoop-SingleComparison
+
+; In-loop trap exit whose condition reloads %p, which a same-loop store to %q
+; could alias and modify.
+define void @store_reload(ptr %p, ptr %q) {
+entry:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %v = load i32, ptr %p
+  %cmp = icmp ult i32 %iv, %v
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  store i32 %iv, ptr %q
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, 100
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}store_reload
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-StoreReload
+
+; In-loop trap exit whose condition depends on %acc, a non-IV phi updated only
+; on some iterations (via a select).
+define void @in_loop_phi_operand(i32 %n, ptr %p) {
+entry:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %acc = phi i32 [ 0, %entry ], [ %acc.next, %latch ]
+  %cmp = icmp slt i32 %acc, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %ld = load i32, ptr %p
+  %pos = icmp sgt i32 %ld, 0
+  %acc.inc = add i32 %acc, 1
+  %acc.next = select i1 %pos, i32 %acc.inc, i32 %acc
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}in_loop_phi_operand
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-InLoopPhiOperand
+
+; In-loop trap exit whose condition operand is the result of @opaque(), which
+; has no characterizable SCEV.
+define void @opaque_other(i32 %n) {
+entry:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %o = call i32 @opaque()
+  %cmp = icmp slt i32 %o, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, 100
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}opaque_other
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-OpaqueOperand-Other
+
+; In-loop trap exit on an accumulator (%acc += %iv) whose addrec is not proven
+; monotonic (carries only a weak no-wrap flag).
+define void @not_proven_monotonic(i32 %n) {
+entry:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %acc = phi i32 [ 0, %entry ], [ %acc.next, %latch ]
+  %cmp = icmp slt i32 %acc, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %acc.next = add i32 %acc, %iv
+  %iv.next = add i32 %iv, 1
+  %e = icmp eq i32 %iv.next, 100
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+; CHECK: Function:{{ +}}not_proven_monotonic
+; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-NotProvenMonotonic

--- a/llvm/test/Transforms/Util/TrapAnalysis/trap-class-semantics.ll
+++ b/llvm/test/Transforms/Util/TrapAnalysis/trap-class-semantics.ll
@@ -29,7 +29,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}counted_ubsantrap
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountKnown
 
 ; Counted loop whose trap exit calls @llvm.looptrap.
 define void @counted_looptrap(ptr %base, i32 %n) {
@@ -53,7 +53,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}counted_looptrap
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountKnown
 
 ; Counted loop whose trap exit calls @llvm.trap.
 define void @counted_trap(ptr %base, i32 %n) {
@@ -77,7 +77,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}counted_trap
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountKnown
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountKnown
 
 ; Trap exit driven by a pointer IV with a non-unit constant stride (i8, +2),
 ; so the trip count is not computable.
@@ -100,7 +100,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}stride_nonunit
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-NotProvenMonotonic-NonUnitStride
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-NonUnitStride
 
 ; Trap exit driven by a pointer IV whose stride is a runtime (non-constant)
 ; value %s.
@@ -123,7 +123,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}stride_variable
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-NotProvenMonotonic-NonConstantStride
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic-NonConstantStride
 
 ; Trap check outside any loop, sitting directly on the function entry block.
 define void @entry_proximate(i32 %n) {
@@ -144,7 +144,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}entry_proximate
-; CHECK: TrapClass:{{ +}}OutsideLoop-EntryProximate
+; CHECK: TrapClass:{{ +}}Invariant-OutsideLoop-EntryProximate
 
 ; Trap check outside any loop, reached only after a long straight-line chain
 ; of blocks from entry (not adjacent to entry).
@@ -180,7 +180,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}out_single_cmp
-; CHECK: TrapClass:{{ +}}OutsideLoop-SingleComparison
+; CHECK: TrapClass:{{ +}}Invariant-OutsideLoop-SingleComparison
 
 ; In-loop trap exit whose condition reloads %p, which a same-loop store to %q
 ; could alias and modify.
@@ -204,7 +204,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}store_reload
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-StoreReload
+; CHECK: TrapClass:{{ +}}Opaque-InLoopExit-TripCountUnknown-StoreReload
 
 ; In-loop trap exit whose condition depends on %acc, a non-IV phi updated only
 ; on some iterations (via a select).
@@ -231,7 +231,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}in_loop_phi_operand
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-InLoopPhiOperand
+; CHECK: TrapClass:{{ +}}Opaque-InLoopExit-TripCountUnknown-InLoopPhiOperand
 
 ; In-loop trap exit whose condition operand is the result of @opaque(), which
 ; has no characterizable SCEV.
@@ -254,7 +254,7 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}opaque_other
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-OpaqueOperand-Other
+; CHECK: TrapClass:{{ +}}Opaque-InLoopExit-TripCountUnknown-OpaqueOperand-Other
 
 ; In-loop trap exit on an accumulator (%acc += %iv) whose addrec is not proven
 ; monotonic (carries only a weak no-wrap flag).
@@ -278,4 +278,4 @@ exit:
   ret void
 }
 ; CHECK: Function:{{ +}}not_proven_monotonic
-; CHECK: TrapClass:{{ +}}InLoopExit-TripCountUnknown-NotProvenMonotonic
+; CHECK: TrapClass:{{ +}}Affine-InLoopExit-TripCountUnknown-NotProvenMonotonic


### PR DESCRIPTION
LoopTrapAnalysis enhanced to provide
 - structural properties of loop that may inhibit trap hoisting
 - SCEVExpr of the conditional predicate that prevents analysis

Retained existing analysis path for BoundsSafety

From C/C++/Swift drivers, these are invoked with (-Xllvm for swift) -Rpass-analysis=loop-trap-analysis \
-mllvm -enable-loop-trap-analysis \
-mllvm -loop-trap-analysis-explain

rdar://168719891