### PR TITLE
[lldb] Disable TestDAP_module.py on Darwin platforms (#216163)

### DIFF
--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -17,6 +17,10 @@ from lldbsuite.test.tools.lldb_dap.types import (
 
 
 @skipIfTargetDoesNotSupportSharedLibraries()
+@skipIf(
+    oslist=lldbplatformutil.getDarwinOSTriples(),
+    bugnumber="https://github.com/llvm/llvm-project/issues/216150",
+)
 class TestDAP_module(DAPTestCaseBase):
     def run_test(self, symbol_basename: str, expect_debug_info_size: bool):
         session = self.build_and_create_session()


### PR DESCRIPTION
This has been very flaky on Green Dragon.

(cherry picked from commit c122b2c95c861f2180dea397bd12bb52c90b7bac)