### PR TITLE
[Cherry-pick into stable/23.x] Use a fallback interval strategy for the task_for_pid request. (#217425)

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachTask.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.mm
@@ -529,6 +529,8 @@ task_t MachTask::TaskPortForProcessID(pid_t pid, DNBError &err) {
     DNBError err;
     mach_port_t task_self = mach_task_self();
     task_t task = TASK_NULL;
+    uint32_t interval = k_usec_delay;
+
     for (uint32_t i = 0; i < k_num_retries; i++) {
       DNBLog("[LaunchAttach] (%d) about to task_for_pid(%d)", getpid(), pid);
       err = ::task_for_pid(task_self, pid, &task);
@@ -556,7 +558,12 @@ task_t MachTask::TaskPortForProcessID(pid_t pid, DNBError &err) {
       }
 
       // Sleep a bit and try again
-      ::usleep(k_usec_delay);
+      // Use an increasing interval so that if there's a short term traffic
+      // jam, we skip past rather than exacerbating it.  We see this sequence
+      // timing out occasionally on heavily loaded bots, seemingly because the
+      // syspolicyd isn't keeping up.
+      interval += k_usec_delay * i;
+      ::usleep(interval);
     }
   }
   return TASK_NULL;


### PR DESCRIPTION
```
commit 7e104f1b46bdeb20b8e5a7676528b9a850b4477a
Author: jimingham <jingham@apple.com>
Date:   Wed Aug 19 13:31:52 2026 -0700

    Use a fallback interval strategy for the task_for_pid request. (#217425)
    
    We've seen cases on heavily loaded bots where task_for_pid requests get
    denied because the authentication system is overloaded. Use an
    increasing timeout to avoid piling on when this is happening.
    
    The fallback I chose does:
    
    0: 0.01
    1: 0.02
    2: 0.04
    3: 0.07
    4: 0.11
    5: 0.16
    6: 0.22
    7: 0.29
    8: 0.37
    9: 0.46
    
    which seems reasonable to me. At worst this will wait about a second,
    which is still below our test launch timeouts.
```
