### PR TITLE
[Cherry-pick into stable/21.x] [debugserver] Move constants into TaskPortForProcessID (NFC) (#166670)

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachTask.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.h
@@ -79,9 +79,7 @@ public:
   void TaskPortChanged(task_t task);
   task_t TaskPort() const { return m_task; }
   task_t TaskPortForProcessID(DNBError &err, bool force = false);
-  static task_t TaskPortForProcessID(pid_t pid, DNBError &err,
-                                     uint32_t num_retries = 10,
-                                     uint32_t usec_interval = 10000);
+  static task_t TaskPortForProcessID(pid_t pid, DNBError &err);
 
   MachProcess *Process() { return m_process; }
   const MachProcess *Process() const { return m_process; }

--- a/lldb/tools/debugserver/source/MacOSX/MachTask.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.mm
@@ -506,14 +506,15 @@ task_t MachTask::TaskPortForProcessID(DNBError &err, bool force) {
 //----------------------------------------------------------------------
 // MachTask::TaskPortForProcessID
 //----------------------------------------------------------------------
-task_t MachTask::TaskPortForProcessID(pid_t pid, DNBError &err,
-                                      uint32_t num_retries,
-                                      uint32_t usec_interval) {
+task_t MachTask::TaskPortForProcessID(pid_t pid, DNBError &err) {
+  static constexpr uint32_t k_num_retries = 10;
+  static constexpr uint32_t k_usec_delay = 10000;
+
   if (pid != INVALID_NUB_PROCESS) {
     DNBError err;
     mach_port_t task_self = mach_task_self();
     task_t task = TASK_NULL;
-    for (uint32_t i = 0; i < num_retries; i++) {
+    for (uint32_t i = 0; i < k_num_retries; i++) {
       DNBLog("[LaunchAttach] (%d) about to task_for_pid(%d)", getpid(), pid);
       err = ::task_for_pid(task_self, pid, &task);
 
@@ -540,7 +541,7 @@ task_t MachTask::TaskPortForProcessID(pid_t pid, DNBError &err,
       }
 
       // Sleep a bit and try again
-      ::usleep(usec_interval);
+      ::usleep(k_usec_delay);
     }
   }
   return TASK_NULL;

--- a/lldb/tools/debugserver/source/MacOSX/MachTask.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.mm
@@ -514,6 +514,8 @@ task_t MachTask::TaskPortForProcessID(pid_t pid, DNBError &err) {
     DNBError err;
     mach_port_t task_self = mach_task_self();
     task_t task = TASK_NULL;
+    uint32_t interval = k_usec_delay;
+
     for (uint32_t i = 0; i < k_num_retries; i++) {
       DNBLog("[LaunchAttach] (%d) about to task_for_pid(%d)", getpid(), pid);
       err = ::task_for_pid(task_self, pid, &task);
@@ -541,7 +543,12 @@ task_t MachTask::TaskPortForProcessID(pid_t pid, DNBError &err) {
       }
 
       // Sleep a bit and try again
-      ::usleep(k_usec_delay);
+      // Use an increasing interval so that if there's a short term traffic
+      // jam, we skip past rather than exacerbating it.  We see this sequence
+      // timing out occasionally on heavily loaded bots, seemingly because the
+      // syspolicyd isn't keeping up.
+      interval += k_usec_delay * i;
+      ::usleep(interval);
     }
   }
   return TASK_NULL;


### PR DESCRIPTION
```
commit bd9030e762c0bd27f536a3e81d8e8e6c012b49d6
Author: Jonas Devlieghere <jonas@devlieghere.com>
Date:   Wed Nov 5 16:32:36 2025 -0800

    [debugserver] Move constants into TaskPortForProcessID (NFC) (#166670)
    
    I was looking at the calls to `usleep` in debugserver and noticed that
    these default arguments are never overwritten. I converted them to
    constants in the function, which makes it easier to reason about.

commit 7e104f1b46bdeb20b8e5a7676528b9a850b4477a
Author: jimingham <jingham@apple.com>
Date:   Wed Aug 19 13:31:52 2026 -0700

    Use a fallback interval strategy for the task_for_pid request. (#217425)
    
    We've seen cases on heavily loaded bots where task_for_pid requests get
    denied because the authentication system is overloaded. Use an
    increasing timeout to avoid piling on when this is happening.
    
    The fallback I chose does:
    
    0: 0.01
    1: 0.02
    2: 0.04
    3: 0.07
    4: 0.11
    5: 0.16
    6: 0.22
    7: 0.29
    8: 0.37
    9: 0.46
    
    which seems reasonable to me. At worst this will wait about a second,
    which is still below our test launch timeouts.
```
