### PR TITLE
[lldb] Remove extraneous space after @_silgen_name (NFC)

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -341,12 +341,12 @@ static Status WrapExpression(
 
   if (playground) {
     const char *playground_logger_declarations = R"(
-@_silgen_name ("playground_logger_initialize") func __builtin_logger_initialize ()
-@_silgen_name ("playground_log_hidden") func __builtin_log_with_id<T> (_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
-@_silgen_name ("playground_log_scope_entry") func __builtin_log_scope_entry (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
-@_silgen_name ("playground_log_scope_exit") func __builtin_log_scope_exit (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
-@_silgen_name ("playground_log_postprint") func __builtin_postPrint (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
-@_silgen_name ("DVTSendPlaygroundLogData") func __builtin_send_data (_ :  AnyObject!)
+@_silgen_name("playground_logger_initialize") func __builtin_logger_initialize ()
+@_silgen_name("playground_log_hidden") func __builtin_log_with_id<T> (_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
+@_silgen_name("playground_log_scope_entry") func __builtin_log_scope_entry (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
+@_silgen_name("playground_log_scope_exit") func __builtin_log_scope_exit (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
+@_silgen_name("playground_log_postprint") func __builtin_postPrint (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
+@_silgen_name("DVTSendPlaygroundLogData") func __builtin_send_data (_ :  AnyObject!)
 __builtin_logger_initialize()
 )";
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/dylib/PlaygroundStub.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/dylib/PlaygroundStub.swift
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-@_silgen_name ("playground_logger_initialize") func builtin_initialize();
-@_silgen_name ("GetOutput") func get_output() -> String;
+@_silgen_name("playground_logger_initialize") func builtin_initialize();
+@_silgen_name("GetOutput") func get_output() -> String;
 
 builtin_initialize();
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/dylib/PlaygroundsRuntime.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/dylib/PlaygroundsRuntime.swift
@@ -57,36 +57,36 @@ class LogRecord {
   }
 }
 
-@_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
+@_silgen_name("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
+@_silgen_name("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
   print((object as! LogRecord).text)
   PlaygroundOutput.append((object as! LogRecord).text)
   PlaygroundOutput.append("\n")
 }
 
-@_silgen_name ("GetOutput") public func get_output() -> String {
+@_silgen_name("GetOutput") public func get_output() -> String {
   return PlaygroundOutput
 }
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/invalid_input/PlaygroundStub.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/invalid_input/PlaygroundStub.swift
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-@_silgen_name ("playground_logger_initialize") func builtin_initialize();
-@_silgen_name ("GetOutput") func get_output() -> String;
+@_silgen_name("playground_logger_initialize") func builtin_initialize();
+@_silgen_name("GetOutput") func get_output() -> String;
 
 builtin_initialize();
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/invalid_input/PlaygroundsRuntime.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/invalid_input/PlaygroundsRuntime.swift
@@ -57,36 +57,36 @@ class LogRecord {
   }
 }
 
-@_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
+@_silgen_name("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
+@_silgen_name("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
   print((object as! LogRecord).text)
   PlaygroundOutput.append((object as! LogRecord).text)
   PlaygroundOutput.append("\n")
 }
 
-@_silgen_name ("GetOutput") public func get_output() -> String {
+@_silgen_name("GetOutput") public func get_output() -> String {
   return PlaygroundOutput
 }
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/last_line_assignment_log/PlaygroundStub.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/last_line_assignment_log/PlaygroundStub.swift
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-@_silgen_name ("playground_logger_initialize") func builtin_initialize();
-@_silgen_name ("GetOutput") func get_output() -> String;
+@_silgen_name("playground_logger_initialize") func builtin_initialize();
+@_silgen_name("GetOutput") func get_output() -> String;
 
 builtin_initialize();
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/last_line_assignment_log/PlaygroundsRuntime.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/last_line_assignment_log/PlaygroundsRuntime.swift
@@ -57,36 +57,36 @@ class LogRecord {
   }
 }
 
-@_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
+@_silgen_name("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
+@_silgen_name("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
   print((object as! LogRecord).text)
   PlaygroundOutput.append((object as! LogRecord).text)
   PlaygroundOutput.append("\n")
 }
 
-@_silgen_name ("GetOutput") public func get_output() -> String {
+@_silgen_name("GetOutput") public func get_output() -> String {
   return PlaygroundOutput
 }
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/long_loops/PlaygroundStub.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/long_loops/PlaygroundStub.swift
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-@_silgen_name ("playground_logger_initialize") func builtin_initialize();
-@_silgen_name ("GetOutput") func get_output() -> String;
+@_silgen_name("playground_logger_initialize") func builtin_initialize();
+@_silgen_name("GetOutput") func get_output() -> String;
 
 builtin_initialize();
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/long_loops/PlaygroundsRuntime.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/long_loops/PlaygroundsRuntime.swift
@@ -57,36 +57,36 @@ class LogRecord {
   }
 }
 
-@_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
+@_silgen_name("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
+@_silgen_name("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
   print((object as! LogRecord).text)
   PlaygroundOutput.append((object as! LogRecord).text)
   PlaygroundOutput.append("\n")
 }
 
-@_silgen_name ("GetOutput") public func get_output() -> String {
+@_silgen_name("GetOutput") public func get_output() -> String {
   return PlaygroundOutput
 }
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/old_playground/PlaygroundStub.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/old_playground/PlaygroundStub.swift
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-@_silgen_name ("playground_logger_initialize") func builtin_initialize();
-@_silgen_name ("GetOutput") func get_output() -> String;
+@_silgen_name("playground_logger_initialize") func builtin_initialize();
+@_silgen_name("GetOutput") func get_output() -> String;
 
 builtin_initialize();
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/old_playground/PlaygroundsRuntime.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/old_playground/PlaygroundsRuntime.swift
@@ -57,36 +57,36 @@ class LogRecord {
   }
 }
 
-@_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
+@_silgen_name("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
+@_silgen_name("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
   print((object as! LogRecord).text)
   PlaygroundOutput.append((object as! LogRecord).text)
   PlaygroundOutput.append("\n")
 }
 
-@_silgen_name ("GetOutput") public func get_output() -> String {
+@_silgen_name("GetOutput") public func get_output() -> String {
   return PlaygroundOutput
 }
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/two_valid_inputs/PlaygroundStub.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/two_valid_inputs/PlaygroundStub.swift
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-@_silgen_name ("playground_logger_initialize") func builtin_initialize();
-@_silgen_name ("GetOutput") func get_output() -> String;
+@_silgen_name("playground_logger_initialize") func builtin_initialize();
+@_silgen_name("GetOutput") func get_output() -> String;
 
 builtin_initialize();
 

--- a/lldb/test/API/lang/swift/playgrounds-repl/two_valid_inputs/PlaygroundsRuntime.swift
+++ b/lldb/test/API/lang/swift/playgrounds-repl/two_valid_inputs/PlaygroundsRuntime.swift
@@ -57,36 +57,36 @@ class LogRecord {
   }
 }
 
-@_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
+@_silgen_name("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
+@_silgen_name("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
   print((object as! LogRecord).text)
   PlaygroundOutput.append((object as! LogRecord).text)
   PlaygroundOutput.append("\n")
 }
 
-@_silgen_name ("GetOutput") public func get_output() -> String {
+@_silgen_name("GetOutput") public func get_output() -> String {
   return PlaygroundOutput
 }
 

--- a/lldb/test/API/lang/swift/playgrounds/PlaygroundStub.swift
+++ b/lldb/test/API/lang/swift/playgrounds/PlaygroundStub.swift
@@ -10,7 +10,7 @@
 //
 // -----------------------------------------------------------------------------
 
-@_silgen_name ("playground_logger_initialize") func builtin_initialize();
+@_silgen_name("playground_logger_initialize") func builtin_initialize();
 
 builtin_initialize();
 

--- a/lldb/test/API/lang/swift/playgrounds/PlaygroundsRuntime.swift
+++ b/lldb/test/API/lang/swift/playgrounds/PlaygroundsRuntime.swift
@@ -57,36 +57,36 @@ class LogRecord {
   }
 }
 
-@_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
+@_silgen_name("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+@_silgen_name("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
+@_silgen_name("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {
   print((object as! LogRecord).text)
   PlaygroundOutput.append((object as! LogRecord).text)
   PlaygroundOutput.append("\n")
 }
 
-@_silgen_name ("GetOutput") public func get_output() -> String {
+@_silgen_name("GetOutput") public func get_output() -> String {
   return PlaygroundOutput
 }
 


### PR DESCRIPTION
Fixes the following warning which is a future error.

```
extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode
```