### PR TITLE
[lldb] Merge source path maps before remapping clang args (NFCI) 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2205,6 +2205,9 @@ void SwiftASTContext::ApplyDiagnosticOptions() {
 
 void SwiftASTContext::RemapClangImporterOptions(
     const PathMappingList &path_map) {
+  if (path_map.IsEmpty())
+    return;
+
   auto &options = GetClangImporterOptions();
   ConstString remapped;
   if (path_map.RemapPath(ConstString(options.BridgingHeader), remapped)) {
@@ -2770,12 +2773,15 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   else
     swift_ast_sp->AddUserClangArgs(Target::GetGlobalProperties());
 
-  // Apply source path remappings found in the module's dSYM.
-  swift_ast_sp->RemapClangImporterOptions(module.GetSourceMappingList());
-
-  // Apply source path remappings found in the target settings.
-  if (target)
-    swift_ast_sp->RemapClangImporterOptions(target->GetSourcePathMap());
+  // Collect the source path remappings found in the module's dSYM and
+  // in the target settings, then apply them in one go.
+  {
+    PathMappingList path_map;
+    path_map.Append(module.GetSourceMappingList(), /*notify=*/false);
+    if (target)
+      path_map.Append(target->GetSourcePathMap(), /*notify=*/false);
+    swift_ast_sp->RemapClangImporterOptions(path_map);
+  }
   swift_ast_sp->FilterClangImporterOptions(
       swift_ast_sp->GetClangImporterOptions().ExtraArgs, swift_ast_sp.get());
 
@@ -3568,14 +3574,19 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     }
   }
 
-  // Apply source path remappings found in each module's dSYM.
-  for (ModuleSP module : modules.Modules())
-    if (module)
-      swift_ast_sp->RemapClangImporterOptions(module->GetSourceMappingList());
-
-  // Apply source path remappings found in the target settings.
-  if (target_sp)
-    swift_ast_sp->RemapClangImporterOptions(target_sp->GetSourcePathMap());
+  // Collect the source path remappings found in each module's dSYM
+  // and in the target settings, then apply them in one go. The
+  // expectation is that there are orders of magnitude more modules
+  // than path remappings.
+  {
+    PathMappingList path_map;
+    for (ModuleSP module : modules.Modules())
+      if (module)
+        path_map.Append(module->GetSourceMappingList(), /*notify=*/false);
+    if (target_sp)
+      path_map.Append(target_sp->GetSourcePathMap(), /*notify=*/false);
+    swift_ast_sp->RemapClangImporterOptions(path_map);
+  }
   swift_ast_sp->FilterClangImporterOptions(
       swift_ast_sp->GetClangImporterOptions().ExtraArgs, swift_ast_sp.get());
 

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -36,6 +36,59 @@ class TestSwiftRewriteClangPaths(TestBase):
     def testWithoutRemap(self):
         self.dotest(False)
 
+    @skipEmbeddedSwift
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipUnlessDarwin
+    @swiftTest
+    @skipIf(debug_info=no_match(["dsym"]))
+    def testTargetSourceMapWins(self):
+        """Document which remapping takes effect when the module's dSYM and
+        target.source-map both match the same prefix: target.source-map is
+        applied and the dSYM's DBGSourcePathRemapping is not, even though the
+        dSYM's is the one that points at the real headers."""
+        self.build()
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+        self.expect("settings set symbols.swift-typesystem-compiler-fallback true")
+
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+        self.runCmd("settings set symbols.use-swift-dwarfimporter false")
+
+        botdir = os.path.realpath(self.getBuildArtifact("buildbot"))
+        userdir = os.path.realpath(self.getBuildArtifact("user"))
+        self.assertTrue(os.path.isfile(self.find_plist()))
+
+        # The dSYM's DBGSourcePathRemapping maps botdir onto userdir, which is
+        # where the headers really are. Aim target.source-map at an empty
+        # directory instead, so that it is observable which of the two is
+        # applied. The directory has to exist because target.source-map
+        # rejects a replacement path that does not.
+        decoydir = os.path.realpath(self.getBuildArtifact("decoy"))
+        lldbutil.mkdir_p(decoydir)
+        self.runCmd("settings set target.source-map %s %s" % (botdir, decoydir))
+
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('Foo.swift'),
+            extra_images=['Foo'])
+
+        # Because target.source-map is what gets applied, the include paths
+        # end up in the empty decoy directory and the module cannot be built.
+        self.expect("expression foo", error=True)
+        self.filecheck_log(log, __file__, "--check-prefix=CHECK_DECOY")
+
+        # Nothing was remapped onto the dSYM's destination.
+        with open(log) as f:
+            remaps = [l for l in f.read().splitlines() if "remapped " in l]
+        self.assertTrue(remaps, "the ClangImporter paths were remapped")
+        self.assertEqual(
+            [l for l in remaps if userdir in l.split("->")[-1]], [],
+            "the dSYM's remapping must not have been applied")
+
     def find_plist(self):
         import glob
         plist = self.getBuildArtifact("libFoo.dylib.dSYM/Contents/Resources/*.plist")
@@ -104,3 +157,7 @@ class TestSwiftRewriteClangPaths(TestBase):
 # CHECK_REMAP-DAG: SwiftASTContextForExpressions(module: "Foo"{{.*}}/buildbot/Frameworks{{.*}} -> {{.*}}/user/Frameworks
 # CHECK_REMAP-DAG: SwiftASTContextForExpressions(module: "Foo"{{.*}}/nonexisting-rootdir{{.*}} -> {{.*}}/user
 # CHECK_REMAP-DAG: SwiftASTContextForExpressions(module: "Foo"{{.*}}/buildbot/Foo/overlay.yaml{{.*}} -> {{.*}}/user/Foo/overlay.yaml
+
+# CHECK_DECOY-DAG: SwiftASTContextForExpressions(module: "Foo"{{.*}}/buildbot/Foo{{.*}} -> {{.*}}/decoy/Foo
+# CHECK_DECOY-DAG: SwiftASTContextForExpressions(module: "Foo"{{.*}}/buildbot/I-single{{.*}} -> {{.*}}/decoy/I-single
+# CHECK_DECOY-DAG: SwiftASTContextForExpressions(module: "Foo"{{.*}}/buildbot/Frameworks{{.*}} -> {{.*}}/decoy/Frameworks


### PR DESCRIPTION
RemapClangImporterOptions() parses the entire ClangImporter argument list. The expectation is that there are orders of magnitude more modules than path remappings, so processing the arguments only once should be significantly faster.

This patch also adds a shortcut for the common case of 0 remappings.

This also raised the question in which order path remappings are applied, so this patch also adds a test to ensure that a target mapping wins over mappings found in dSYMs.

rdar://185263747

Assisted-by: Claude