### PR TITLE
[lldb][swift] Update the ActiveTask symbol name

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -3887,9 +3887,9 @@ private:
   std::optional<lldb::addr_t> m_tls_file_addr;
 };
 
-// (anonymous namespace)::ActiveTask::Value in the Swift concurrency runtime.
+// The exported current-task thread-local in the Swift concurrency runtime.
 static constexpr llvm::StringLiteral g_cxx_thread_local_task_symbol =
-    "_ZN12_GLOBAL__N_110ActiveTask5ValueE";
+    "_swift_concurrency_currentTask";
 
 CxxThreadLocalTaskFinder::CxxThreadLocalTaskFinder(ModuleSP concurrency_module)
     : m_concurrency_module(std::move(concurrency_module)) {


### PR DESCRIPTION
Swift is changing the symbol so that the debugger doesn't have to rely on mangled names nor on non-exoported symbols.

(cherry picked from commit 1825f7afbb4668790b2cb6a4f527d688130c258e)