### PR TITLE
[lldb] Properly test _one_ embedded platform support

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -205,7 +205,11 @@ ifneq "$(SWIFT_CONCURRENCY)" ""
 	SWIFT_EMBEDDED_LIB_DIR = $(shell dirname $(SWIFTC))/../lib/swift/embedded/$(SWIFT_EMBEDDED_TRIPLE)
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_Concurrency.a
 	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_ConcurrencyDefaultExecutor.a
-	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswiftEmbeddedPlatformSingleThreaded.a
+	ifeq "$(OS)" "Darwin"
+		LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswiftEmbeddedPlatformMultiThreadedDarwin.a
+	else
+		LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswiftEmbeddedPlatformSingleThreaded.a
+	endif
 	LD_EXTRAS += -lc++
 	LD_EXTRAS += -Xlinker -dead_strip
 endif

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -426,13 +426,15 @@ uint32_t StackFrameList::SynthesizeInlineFrames(StackFrameSP frame_sp,
   Address next_frame_address;
   uint32_t num_inlined_frames = 0;
 
+  const bool behaves_like_zeroth_frame = frame_sp->m_behaves_like_zeroth_frame;
+
   while (unwind_sc.GetParentOfInlinedScope(curr_frame_address, next_frame_sc,
                                            next_frame_address)) {
     next_frame_sc.line_entry.ApplyFileMappings(target_sp);
     StackFrameSP inline_frame_sp = std::make_shared<StackFrame>(
         m_thread.shared_from_this(), m_frames.size(), concrete_frame_idx,
         frame_sp->GetRegisterContextSP(), cfa, next_frame_address,
-        /*behaves_like_zeroth_frame=*/false, &next_frame_sc);
+        behaves_like_zeroth_frame, &next_frame_sc);
 
     inline_frame_sp->m_frame_list_id = GetIdentifier();
     m_frames.push_back(inline_frame_sp);

--- a/lldb/test/API/lang/swift/async/stepping/step-in/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
@@ -8,7 +8,7 @@ class TestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @requireNotEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=['windows'])
     def test(self):

--- a/lldb/test/API/lang/swift/async/stepping/step-in/main.swift
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/main.swift
@@ -1,10 +1,10 @@
-@MainActor func stringNum(_ i: Int) async -> String {
+func stringNum(_ i: Int) async -> String {
   let x = await randInt(i)
   let y = await randInt(i)
   return String(x + y)
 }
 
-@MainActor func randInt(_ i: Int) async -> Int {
+func randInt(_ i: Int) async -> Int {
   return Int.random(in: 1...i)
 }
 

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -30,14 +30,17 @@ class TestCase(lldbtest.TestBase):
         )
         bkpt.SetEnabled(False) # avoid hitting multiple locations in async breakpoints
 
-        expected_line_nums = [4]  # print(x)
-        expected_line_nums += [5, 6, 7, 8, 5, 6, 7, 8, 5]  # two runs over the loop
-        expected_line_nums += [9, 10]  # if line + if block
+        line_offset = 4 # Line where print(x) is.
+        expected_line_nums = [0]  # print(x)
+        loop = [1, 2, 3, 4]
+        expected_line_nums += loop + loop + [1] # loop header
+        expected_line_nums += [5, 6]  # if line + if block
+
         for expected_line_num in expected_line_nums:
             thread.StepOver()
             stop_reason = thread.GetStopReason()
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
-            self.check_is_in_line(thread, expected_line_num)
+            self.check_is_in_line(thread, expected_line_num + line_offset)
             self.check_x_is_available(thread.frames[0])
 
     @skipEmbeddedSwift

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
@@ -12,7 +12,7 @@ class TestCase(lldbtest.TestBase):
         line_entry = frame.GetLineEntry()
         self.assertEqual(linenum, line_entry.GetLine())
 
-    @requireNotEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=["windows"])
     def test_nothrow(self):
@@ -32,7 +32,7 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.check_is_in_line(thread, expected_line_num)
 
-    @requireNotEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=["windows"])
     def test_throw(self):
@@ -44,8 +44,8 @@ class TestCase(lldbtest.TestBase):
             self, "BREAK_THROW", source_file
         )
 
-        # Step over should reach every line in the interval [34, 40]
-        expected_line_nums = range(34, 41)
+        # Step over should reach every line in the interval [34, 41]
+        expected_line_nums = range(34, 42)
         for expected_line_num in expected_line_nums:
             thread.StepOver()
             stop_reason = thread.GetStopReason()

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/main.swift
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/main.swift
@@ -12,7 +12,7 @@ func foo() async {
     async let timestamp2 = getTimestamp(x:2)
     work()
     let timestamps = await [timestamp1, timestamp2]
-    print(timestamps)
+    print(timestamps[0])
   }
   async let timestamp3 = getTimestamp(x:3)
   work()
@@ -36,8 +36,8 @@ func foo_throwing() async {
     async let timestamp2 = getTimestamp_throwing(x:2)
     work()
     let timestamps = try await [timestamp1, timestamp2]
-    print(timestamps)
-  } catch {print(error)}
+    print(timestamps[0])
+  } catch {print("error")}
   work()
 }
 

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
@@ -12,8 +12,8 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @requireNotEmbeddedSwift
     @swiftTest
+    @skipEmbeddedSwiftOnLinux
     @skipIf(oslist=['windows',])
     def test(self):
         """Test async unwind"""

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/main.swift
@@ -1,23 +1,16 @@
-import Swift
-
 func sayolleH(str : String) async {
   var str = "in sayolleH"
-  print("\(str) before calls")
-  print(str.reversed()) // break here
+  print("\(str) before calls") //break here
 }
 
 func sayHello() async {
   var str = "in hello"
-  print("\(str) before calls")
   await sayolleH(str:"hello")
-  print("\(str) after calls")
 }
 
 func sayGeneric<T>(_ msg: T) async {
   var str = "in generic"
-  print("\(str) before calls - arg \(msg)")
   await sayHello()
-  print("\(str) after calls - arg \(msg)")
 }
 
 func synchronousSayHelo() {

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFT_CONCURRENCY := 1
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
@@ -8,7 +8,7 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @requireNotEmbeddedSwift
+    @skipEmbeddedSwiftOnLinux
     @swiftTest
     @skipIf(oslist=["windows",])
     def test(self):

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/main.swift
@@ -1,5 +1,6 @@
+func foo() async throws {}
 func work() async -> Int {
-  try? await Task.sleep(for: .seconds(3))  // BREAK HERE
+  try? await foo()  // BREAK HERE
   return 10
 }
 func foo_should_step_over() async -> Int {

--- a/lldb/unittests/Target/CMakeLists.txt
+++ b/lldb/unittests/Target/CMakeLists.txt
@@ -11,6 +11,7 @@ add_lldb_unittest(TargetTests
   PathMappingListTest.cpp
   RegisterFlagsTest.cpp
   RemoteAwarePlatformTest.cpp
+  StackFrameListTest.cpp
   StackFrameRecognizerTest.cpp
   SummaryStatisticsTest.cpp
   FindFileTest.cpp
@@ -25,12 +26,17 @@ add_lldb_unittest(TargetTests
       lldbPluginPlatformLinux
       lldbPluginPlatformMacOSX
       lldbPluginPlatformAndroid
+      lldbPluginProcessUtility
       lldbPluginSymbolFileBreakpad
+      lldbPluginSymbolFileDWARF
       lldbPluginSymbolFileSymtab
+      lldbPluginScriptInterpreterNone
+      lldbPluginTypeSystemClang
       lldbTarget
       lldbSymbol
       lldbUtility
       lldbUtilityHelpers
+      LLVMTestingSupport
   )
 
 set(test_inputs
@@ -38,5 +44,6 @@ set(test_inputs
   AndroidModule.so.sym
   AndroidModule.unstripped.so
   TestModule.so
+  inlined-function.yaml
   )
 add_unittest_inputs(TargetTests "${test_inputs}")

--- a/lldb/unittests/Target/Inputs/inlined-function.yaml
+++ b/lldb/unittests/Target/Inputs/inlined-function.yaml
@@ -1,0 +1,161 @@
+# Generated from:
+#
+#   __attribute__((always_inline)) static int inner(int x) {
+#     int y = x * 3;
+#     return y + 7;
+#   }
+#
+#   int outer(int x) { return inner(x) + 1; }
+#
+#   clang --target=x86_64-pc-linux -gdwarf-4 -O0 -c inl.cpp -o inl.o
+#   obj2yaml inl.o
+#
+# -O0 keeps the inlined body from being folded away, so the CU contains exactly
+# one DW_TAG_inlined_subroutine. Sections not needed to parse blocks (.comment,
+# .note.GNU-stack, .eh_frame, .llvm_addrsig) have been dropped by hand.
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_REL
+  Machine:         EM_X86_64
+  SectionHeaderStringTable: .strtab
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x10
+    Content:         554889E5897DF48B45F48945FC6B45FC038945F88B45F883C00783C0015DC3
+  - Name:            .debug_abbrev
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x1
+    Content:         011101250E1305030E10171B0E110112060000022E016E0E030E3A0B3B0B4913200B0000030500030E3A0B3B0B49130000043400030E3A0B3B0B49130000052400030E3E0B0B0B0000062E011101120640186E0E030E3A0B3B0B49133F1900000705000218030E3A0B3B0B49130000081D01311311011206580B590B570B00000905000218311300000A340002183113000000
+  - Name:            .debug_info
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x1
+    Content:         A6000000040000000000080100000000210000000000000000000000000000000000000000001F000000020000000000000000010151000000010300000000010151000000040000000001025100000000050000000005040600000000000000001F000000015600000000000000000106510000000702917400000000010651000000082A00000000000000000000000D00000001061B0902917C3A0000000A02917845000000000000
+  - Name:            .debug_line
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x1
+    Content:         5200000004001F000000010101FB0E0D00010101010000000100000100696E6C2E637070000000000000090200000000000000001705210A74050D620507064A050A063D050C063C0524063F0514060B3C0202000101
+  - Name:            .rela.debug_info
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .debug_info
+    Relocations:
+      - Offset:          0x6
+        Symbol:          .debug_abbrev
+        Type:            R_X86_64_32
+      - Offset:          0xC
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+      - Offset:          0x12
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          102
+      - Offset:          0x16
+        Symbol:          .debug_line
+        Type:            R_X86_64_32
+      - Offset:          0x1A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          110
+      - Offset:          0x1E
+        Symbol:          .text
+        Type:            R_X86_64_64
+      - Offset:          0x2B
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          115
+      - Offset:          0x2F
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          126
+      - Offset:          0x3B
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          136
+      - Offset:          0x46
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          138
+      - Offset:          0x52
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          132
+      - Offset:          0x59
+        Symbol:          .text
+        Type:            R_X86_64_64
+      - Offset:          0x67
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          140
+      - Offset:          0x6B
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          150
+      - Offset:          0x79
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          136
+      - Offset:          0x88
+        Symbol:          .text
+        Type:            R_X86_64_64
+        Addend:          13
+  - Name:            .rela.debug_line
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .debug_line
+    Relocations:
+      - Offset:          0x2C
+        Symbol:          .text
+        Type:            R_X86_64_64
+  - Type:            SectionHeaderTable
+    Sections:
+      - Name:            .strtab
+      - Name:            .text
+      - Name:            .debug_abbrev
+      - Name:            .debug_info
+      - Name:            .rela.debug_info
+      - Name:            .debug_str
+      - Name:            .debug_line
+      - Name:            .rela.debug_line
+      - Name:            .symtab
+Symbols:
+  - Name:            inl.cpp
+    Type:            STT_FILE
+    Index:           SHN_ABS
+  - Name:            .text
+    Type:            STT_SECTION
+    Section:         .text
+  - Name:            .debug_abbrev
+    Type:            STT_SECTION
+    Section:         .debug_abbrev
+  - Name:            .debug_str
+    Type:            STT_SECTION
+    Section:         .debug_str
+  - Name:            .debug_line
+    Type:            STT_SECTION
+    Section:         .debug_line
+  - Name:            _Z5outeri
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Size:            0x1F
+DWARF:
+  debug_str:
+    - 'clang version 21.0.0 (git@github.com:apple/llvm-project.git 93469d2c8423636a21cf023a0994c63f526b6432)'
+    - inl.cpp
+    - '/tmp'
+    - _ZL5inneri
+    - inner
+    - int
+    - x
+    - y
+    - _Z5outeri
+    - outer
+...

--- a/lldb/unittests/Target/StackFrameListTest.cpp
+++ b/lldb/unittests/Target/StackFrameListTest.cpp
@@ -1,0 +1,116 @@
+//===-- StackFrameListTest.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
+#include "Plugins/Platform/Linux/PlatformLinux.h"
+#include "Plugins/Process/Utility/HistoryThread.h"
+#include "Plugins/ScriptInterpreter/None/ScriptInterpreterNone.h"
+#include "Plugins/SymbolFile/DWARF/SymbolFileDWARF.h"
+#include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "TestingSupport/SubsystemRAII.h"
+#include "TestingSupport/TestUtilities.h"
+#include "lldb/Core/Debugger.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Target/Process.h"
+#include "lldb/Utility/ArchSpec.h"
+#include "gtest/gtest.h"
+#include <mutex>
+
+using namespace lldb;
+using namespace lldb_private;
+
+namespace {
+
+class DummyProcess : public Process {
+public:
+  DummyProcess(TargetSP target_sp, ListenerSP listener_sp)
+      : Process(target_sp, listener_sp) {}
+  bool CanDebug(TargetSP, bool) override { return true; }
+  Status DoDestroy() override { return {}; }
+  void RefreshStateAfterStop() override {}
+  size_t DoReadMemory(addr_t, void *, size_t, Status &) override { return 0; }
+  bool DoUpdateThreadList(ThreadList &, ThreadList &) override { return false; }
+  llvm::StringRef GetPluginName() override { return "Dummy"; }
+};
+
+class StackFrameListTest : public ::testing::Test {
+  SubsystemRAII<FileSystem, HostInfo, TypeSystemClang, ObjectFileELF,
+                plugin::dwarf::SymbolFileDWARF, platform_linux::PlatformLinux,
+                ScriptInterpreterNone>
+      subsystems;
+
+public:
+  void SetUp() override {
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
+                   []() { Debugger::Initialize(nullptr); });
+    ArchSpec arch("x86_64-pc-linux");
+    PlatformSP platform_sp =
+        platform_linux::PlatformLinux::CreateInstance(true, &arch);
+    ASSERT_TRUE(platform_sp);
+    Platform::SetHostPlatform(platform_sp);
+
+    DebuggerSP debugger_sp = Debugger::CreateInstance();
+    ASSERT_TRUE(debugger_sp);
+    PlatformSP target_platform_sp;
+    ASSERT_TRUE(debugger_sp->GetTargetList()
+                    .CreateTarget(*debugger_sp, "", arch, eLoadDependentsNo,
+                                  target_platform_sp, m_target_sp)
+                    .Success());
+    ASSERT_TRUE(m_target_sp);
+
+    llvm::Expected<TestFile> file =
+        TestFile::fromYamlFile("inlined-function.yaml");
+    ASSERT_THAT_EXPECTED(file, llvm::Succeeded());
+    m_file.emplace(std::move(*file));
+    ModuleSP module_sp = std::make_shared<Module>(m_file->moduleSpec());
+    ASSERT_TRUE(module_sp);
+    m_target_sp->GetImages().Append(module_sp);
+    bool changed = false;
+    ASSERT_TRUE(module_sp->SetLoadAddress(*m_target_sp, 0,
+                                          /*value_is_offset=*/true, changed));
+  }
+
+protected:
+  std::optional<TestFile> m_file;
+  TargetSP m_target_sp;
+};
+
+// Frames synthesized for an inlined scope share the concrete frame's PC, so
+// they must share its symbolication convention. Resolving them at PC-1 names
+// whatever precedes the PC, which at a function's first instruction is a
+// different function entirely.
+TEST_F(StackFrameListTest, InlineFramesInheritZerothFrameSymbolication) {
+  // outer() inlines inner() starting at this offset into .text; see the
+  // generation recipe in Inputs/inlined-function.yaml.
+  const addr_t pc = 0xd;
+
+  ListenerSP listener_sp(Listener::MakeListener("dummy"));
+  ProcessSP process_sp =
+      std::make_shared<DummyProcess>(m_target_sp, listener_sp);
+  ASSERT_TRUE(process_sp);
+  // HistoryPCType::Returns makes frame zero behave like the zeroth frame.
+  ThreadSP thread_sp = std::make_shared<HistoryThread>(
+      *process_sp, /*tid=*/0x1234, std::vector<addr_t>{pc});
+
+  // An inline chain requires more than the concrete frame.
+  ASSERT_GT(thread_sp->GetStackFrameCount(), 1u)
+      << "no inline frames synthesized at pc " << pc;
+
+  for (uint32_t i = 0; i < thread_sp->GetStackFrameCount(); ++i) {
+    StackFrameSP frame_sp = thread_sp->GetStackFrameAtIndex(i);
+    ASSERT_TRUE(frame_sp);
+    if (frame_sp->GetFrameCodeAddress().GetFileAddress() != pc)
+      continue;
+    EXPECT_EQ(frame_sp->GetFrameCodeAddressForSymbolication().GetFileAddress(),
+              frame_sp->GetFrameCodeAddress().GetFileAddress())
+        << "frame " << i << " symbolicates at an adjusted address";
+  }
+}
+} // namespace


### PR DESCRIPTION
    [lldb] Properly test _one_ embedded platform support

    With the introduction of embedded platforms in [1], a new "shim" library
    is linked with binaries, and the choice of which shim to use is made
    when an executable is linked, not when the standard library is compiled.
    This shim is what defines how the concurrency threading implementation
    works, a violation of the existing debug ABI, which expects this to be
    fully contained inside libConcurrency.

    This has another consequence: macOS embedded swift also no longer uses
    global variables. So we can just rely on the existing multithreaded
    implementation.

    Solving the debug ABI problem is outside the scope of this patch, as
    well as supporting other shims.

    [1]: https://github.com/swiftlang/swift/pull/91047#issuecomment-5339128315

(the first commit is just a cherry-pick from llvm)