### PR TITLE
[clang][lex] Fix repeated `#import` of a header missing from umbrella

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2700,6 +2700,7 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
       // actual module containing it exists (because the umbrella header is
       // incomplete).  Treat this as a textual inclusion.
       ModuleToImport = nullptr;
+      UsableClangHeaderModule = false;
     } else if (Imported.isConfigMismatch()) {
       // On a configuration mismatch, enter the header textually. We still know
       // that it's part of the corresponding module.

--- a/clang/test/Modules/repeated-include-missing-submodule.c
+++ b/clang/test/Modules/repeated-include-missing-submodule.c
@@ -1,0 +1,18 @@
+// Check that multiple include-once of a header not covered by an umbrella work.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -fsyntax-only %t/tu.c -fmodules -fimplicit-module-maps \
+// RUN:   -fmodules-cache-path=%t/cache -verify 
+
+//--- module.modulemap
+module M {
+  umbrella header "M.h"
+  module * { export * }
+}
+//--- M.h
+//--- NotCovered.h
+//--- tu.c
+#import "NotCovered.h" // expected-warning{{missing submodule 'M.NotCovered'}}
+#import "NotCovered.h" // expected-warning{{missing submodule 'M.NotCovered'}}


### PR DESCRIPTION
The PR https://github.com/llvm/llvm-project/pull/216704 fixed repeated `#import` of a header that belongs to a module in textual builds. One omission was not setting the boolean we now use to make the decision to import or skip when we tried importing a submodule but figured out it's not covered by the umbrella. This PR fixes that.

rdar://185417139
(cherry picked from commit 4e1eac798768628fcfd986d667515f72d72ed3b3)