### PR TITLE
[cherry-pick next][lldb][embedded] Keep clang typealiases when building field descriptors

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -368,8 +368,8 @@ public:
         continue;
       auto member_compiler_type = member_type->GetForwardCompilerType();
 
-      // TypeRefBuilder expects types to be canonical.
-      CompilerType canonical = m_type_system.Canonicalize(member_compiler_type);
+      CompilerType canonical =
+          m_type_system.CanonicalizeForTypeRefBuilder(member_compiler_type);
       if (!canonical) {
         LLDB_LOG(GetLog(LLDBLog::Types), "Could not build canonical type: {0}",
                  member_compiler_type.GetMangledTypeName());
@@ -450,9 +450,8 @@ public:
       if (member_type) {
         CompilerType member_compiler_type =
             member_type->GetForwardCompilerType();
-        // TypeRefBuilder expects types to be canonical.
         CompilerType canonical =
-            m_type_system.Canonicalize(member_compiler_type);
+            m_type_system.CanonicalizeForTypeRefBuilder(member_compiler_type);
         if (!canonical) {
           LLDB_LOG(GetLog(LLDBLog::Types),
                    "Could not build canonical type: {0}",

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1695,16 +1695,21 @@ TypeSystemSwiftTypeRef::DesugarNode(swift::Demangle::Demangler &dem,
       dem, node, [&](NodePointer node) { return Desugar(dem, node); });
 }
 
-swift::Demangle::NodePointer
-TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
-                                     swift::Demangle::NodePointer node,
-                                     swift::Mangle::ManglingFlavor flavor) {
+swift::Demangle::NodePointer TypeSystemSwiftTypeRef::Canonicalize(
+    swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+    swift::Mangle::ManglingFlavor flavor, bool preserve_clang_type_aliases) {
   assert(node);
   node = Desugar(dem, node);
   auto kind = node->getKind();
   switch (kind) {
   case Node::Kind::BoundGenericTypeAlias:
   case Node::Kind::TypeAlias: {
+    if (preserve_clang_type_aliases) {
+      llvm::SmallVector<CompilerContext, 2> decl_context;
+      bool ignore_modules = false;
+      if (IsClangImportedType(node, decl_context, ignore_modules))
+        return node;
+    }
     // Safeguard against cyclic aliases.
     for (unsigned alias_depth = 0; alias_depth < 64; ++alias_depth) {
       auto node_clangtype = ResolveTypeAlias(dem, node, flavor);
@@ -1722,7 +1727,7 @@ TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
       if (node->getKind() != Node::Kind::BoundGenericTypeAlias &&
           node->getKind() != Node::Kind::TypeAlias)
         // Resolve any type aliases in the resolved type.
-        return GetCanonicalNode(dem, node, flavor);
+        return GetCanonicalNode(dem, node, flavor, preserve_clang_type_aliases);
       // This type alias resolved to another type alias.
     }
     // Hit the safeguard limit.
@@ -1734,7 +1739,9 @@ TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
   return node;
 }
 
-CompilerType TypeSystemSwiftTypeRef::Canonicalize(CompilerType type) {
+CompilerType
+TypeSystemSwiftTypeRef::Canonicalize(CompilerType type,
+                                     bool preserve_clang_type_aliases) {
   using namespace swift::Demangle;
   auto mangled_name = type.GetMangledTypeName();
   if (!mangled_name)
@@ -1744,16 +1751,21 @@ CompilerType TypeSystemSwiftTypeRef::Canonicalize(CompilerType type) {
   if (!node)
     return {};
   auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
-  NodePointer canonical = GetCanonicalNode(dem, node, flavor);
+  NodePointer canonical =
+      GetCanonicalNode(dem, node, flavor, preserve_clang_type_aliases);
   NodePointer type_node = dem.createNode(Node::Kind::Type);
   type_node->addChild(canonical, dem);
   return RemangleAsType(dem, type_node, flavor);
 }
 
-swift::Demangle::NodePointer
-TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
-                                         swift::Demangle::NodePointer node,
-                                         swift::Mangle::ManglingFlavor flavor) {
+CompilerType
+TypeSystemSwiftTypeRef::CanonicalizeForTypeRefBuilder(CompilerType type) {
+  return Canonicalize(type, /*preserve_clang_type_aliases=*/true);
+}
+
+swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetCanonicalNode(
+    swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+    swift::Mangle::ManglingFlavor flavor, bool preserve_clang_type_aliases) {
   if (!node)
     return nullptr;
   // This is a pre-order traversal, which is necessary to resolve
@@ -1763,12 +1775,13 @@ TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
   // SomeAlias<WhatSomeOtherAliasResolvesTo> because it tries to
   // preserve all sugar.
   using namespace swift::Demangle;
-  node = Canonicalize(dem, node, flavor);
+  node = Canonicalize(dem, node, flavor, preserve_clang_type_aliases);
 
   llvm::SmallVector<NodePointer, 2> children;
   bool changed = false;
   for (NodePointer child : *node) {
-    NodePointer transformed_child = GetCanonicalNode(dem, child, flavor);
+    NodePointer transformed_child =
+        GetCanonicalNode(dem, child, flavor, preserve_clang_type_aliases);
     changed |= (child != transformed_child);
     children.push_back(transformed_child);
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -531,9 +531,10 @@ public:
   /// context, which some of the special stdlib builtins do not have.
   lldb::TypeSP FindBuiltinTypeInModule(ConstString mangled_name);
 
-  /// Desugar a CompilerType and resolve type aliases by looking up
-  /// their types in the debug info.
-  CompilerType Canonicalize(CompilerType type);
+  /// Desugar \p type and resolve its type aliases into the form the
+  /// swift::reflection TypeRefBuilder expects, that is, with
+  /// Clang-imported type aliases unresolved.
+  CompilerType CanonicalizeForTypeRefBuilder(CompilerType type);
 
   /// Determine if this type contains a type from a module that looks
   /// like it was JIT-compiled by LLDB.
@@ -596,19 +597,29 @@ protected:
                                  lldb::opaque_compiler_type_t type,
                                  const ExecutionContext *exe_ctx = nullptr);
 
+  /// Desugar a CompilerType and resolve type aliases by looking up
+  /// their types in the debug info.
+  CompilerType Canonicalize(CompilerType type,
+                            bool preserve_clang_type_aliases = false);
+
   /// Desugar to this node and if it is a type alias resolve it by
   /// looking up its type in the debug info.
+  ///
+  /// CanonicalizeForTypeRefBuilder() documents \p
+  /// preserve_clang_type_aliases.
   swift::Demangle::NodePointer
   Canonicalize(swift::Demangle::Demangler &dem,
                swift::Demangle::NodePointer node,
-               swift::Mangle::ManglingFlavor flavor);
+               swift::Mangle::ManglingFlavor flavor,
+               bool preserve_clang_type_aliases = false);
 
   /// Iteratively desugar and resolve all type aliases in \p node by
   /// looking up their types in the debug info.
   swift::Demangle::NodePointer
   GetCanonicalNode(swift::Demangle::Demangler &dem,
                    swift::Demangle::NodePointer node,
-                   swift::Mangle::ManglingFlavor flavor);
+                   swift::Mangle::ManglingFlavor flavor,
+                   bool preserve_clang_type_aliases = false);
 
   /// If \p node is a Struct/Class/Typedef in the __C module, return a
   /// Swiftified node by looking up the name in the corresponding APINotes and

--- a/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
+++ b/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftCTypeIvar(TestBase):
-    @skipEmbeddedSwift
+    @skipEmbeddedSwiftOnWindows
     @swiftTest
     @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
     def test(self):
@@ -30,7 +30,7 @@ class TestSwiftCTypeIvar(TestBase):
         b = self.frame().FindVariable("b")
         lldbutil.check_variable(
             self,
-            a.GetChildAtIndex(0),
+            b.GetChildAtIndex(0).GetChildAtIndex(0),
             typename="Swift.Optional<Foo.BridgedPtr>",
             value="nil",
         )


### PR DESCRIPTION
Typically, we want to canonicalize types before building field
descriptors, as reflection metadata doesn't store field descriptors
either. However, when building a descriptor for an aliased clang type,
reflection metadata keeps the typelias, which it asks the type info
provider to resolve. When  building descriptors out of DWARF, match what
reflection metadata does, and don't resolve clang typealiases when
canonicalizing.

Assisted-by: Claude

rdar://185156293

(cherry picked from commit 9094a098bb81829b350e96bf477b897acd3ec9ce)
