### PR TITLE
[Cherry-pick into stable/23.x] [LLDB] Let ValueObject::CanSetValue() return a reason (#217454)

### DIFF
--- a/lldb/bindings/interface/SBValueDocstrings.i
+++ b/lldb/bindings/interface/SBValueDocstrings.i
@@ -212,8 +212,21 @@ linked list."
     Returns whether this value can be modified through SetValueFromCString()
     or SetData().
 
+    Deprecated, use CanSet() instead, which reports why the value is not
+    writable.
+
     Returns False when the value is not writable. An example would be a
     variable value reconstructed from debug info via a computation or a constant.
     A True result does not guarantee a write will succeed; other
     runtime conditions may still prevent a successful write."
 ) lldb::SBValue::CanSetValue;
+
+%feature("docstring", "
+    Returns whether this value can be modified through SetValueFromCString()
+    or SetData().
+
+    Returns an SBError describing why the value is not writable. An example
+    would be a variable value reconstructed from debug info via a computation
+    or a constant. A success result does not guarantee a write will succeed;
+    other runtime conditions may still prevent a successful write."
+) lldb::SBValue::CanSet;

--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -122,7 +122,16 @@ public:
   /// constant or variable value that was reconstructed from debug
   /// info as the result of a computation). A true result does not
   /// guarantee a write will succeed.
+  LLDB_DEPRECATED_FIXME("Use variant that reports the reason", "CanSet()")
   bool CanSetValue();
+
+  /// Returns an error describing why this value cannot be modified
+  /// through SetValueFromCString() or SetData(), for instance because
+  /// it exists in the target, but has no writable storage (for example
+  /// a constant or variable value that was reconstructed from debug
+  /// info as the result of a computation). A success result does not
+  /// guarantee a write will succeed.
+  lldb::SBError CanSet();
 
   lldb::SBTypeFormat GetTypeFormat();
 

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -855,13 +855,15 @@ public:
 
   virtual bool GetIsConstant() const { return m_update_point.IsConstant(); }
 
-  /// Returns false when this value cannot be modified through
-  /// SetValueFromCString() or SetData() because it exists in the
-  /// target but has no writable storage, e.g., a constant or a
-  /// computed variable value.  A true result does not guarantee a
+  /// Check if the value may be writable. Returns an error describing
+  /// why this value cannot be modified. Success does not guarantee a
   /// write will succeed; other runtime conditions can still cause
   /// SetValue* to fail.
-  virtual bool CanSetValue() { return !GetIsConstant(); }
+  virtual llvm::Error CanSetValue() {
+    if (GetIsConstant())
+      return llvm::createStringError("value is not in a writable location");
+    return llvm::Error::success();
+  }
 
   bool NeedsUpdating() {
     const bool accept_invalid_exe_ctx =

--- a/lldb/include/lldb/ValueObject/ValueObjectVariable.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectVariable.h
@@ -64,7 +64,7 @@ public:
 
   bool SetData(DataExtractor &data, Status &error) override;
 
-  bool CanSetValue() override;
+  llvm::Error CanSetValue() override;
 
   lldb::VariableSP GetVariable() override { return m_variable_sp; }
 

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -313,12 +313,19 @@ bool SBValue::SetValueFromCString(const char *value_str, lldb::SBError &error) {
 bool SBValue::CanSetValue() {
   LLDB_INSTRUMENT_VA(this);
 
+  return CanSet().Success();
+}
+
+lldb::SBError SBValue::CanSet() {
+  LLDB_INSTRUMENT_VA(this);
+
   ValueLocker locker;
   lldb::ValueObjectSP value_sp(GetSP(locker));
   if (!value_sp)
-    return false;
+    return SBError(Status::FromErrorStringWithFormat(
+        "Could not get value: %s", locker.GetError().AsCString()));
 
-  return value_sp->CanSetValue();
+  return SBError(Status::FromError(value_sp->CanSetValue()));
 }
 
 lldb::SBTypeFormat SBValue::GetTypeFormat() {

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -821,8 +821,8 @@ uint64_t ValueObject::GetData(DataExtractor &data, Status &error) {
 
 bool ValueObject::SetData(DataExtractor &data, Status &error) {
   error.Clear();
-  if (GetIsConstant()) {
-    error = Status::FromErrorString("Cannot change the value of a constant");
+  if (llvm::Error err = CanSetValue()) {
+    error = Status::FromError(std::move(err));
     return false;
   }
   // Make sure our value is up to date first so that our location and location
@@ -1716,8 +1716,8 @@ static const char *ConvertBoolean(lldb::LanguageType language_type,
 
 bool ValueObject::SetValueFromCString(const char *value_str, Status &error) {
   error.Clear();
-  if (GetIsConstant()) {
-    error = Status::FromErrorString("Cannot change the value of a constant");
+  if (llvm::Error err = CanSetValue()) {
+    error = Status::FromError(std::move(err));
     return false;
   }
   // Make sure our value is up to date first so that our location and location

--- a/lldb/source/ValueObject/ValueObjectVariable.cpp
+++ b/lldb/source/ValueObject/ValueObjectVariable.cpp
@@ -415,10 +415,12 @@ const char *ValueObjectVariable::GetLocationAsCString() {
     return ValueObject::GetLocationAsCString();
 }
 
-bool ValueObjectVariable::CanSetValue() {
+llvm::Error ValueObjectVariable::CanSetValue() {
   // Refresh the resolved location so m_resolved_value_is_implicit is current.
   UpdateValueIfNeeded();
-  return !m_resolved_value_is_implicit && ValueObject::CanSetValue();
+  if (m_resolved_value_is_implicit)
+    return llvm::createStringError("variable is not in a writable location");
+  return ValueObject::CanSetValue();
 }
 
 bool ValueObjectVariable::SetValueFromCString(const char *value_str,
@@ -428,8 +430,8 @@ bool ValueObjectVariable::SetValueFromCString(const char *value_str,
     return false;
   }
 
-  if (m_resolved_value_is_implicit) {
-    error = Status::FromErrorString("Cannot change the value of a constant");
+  if (llvm::Error err = CanSetValue()) {
+    error = Status::FromError(std::move(err));
     return false;
   }
 
@@ -462,8 +464,8 @@ bool ValueObjectVariable::SetData(DataExtractor &data, Status &error) {
     return false;
   }
 
-  if (m_resolved_value_is_implicit) {
-    error = Status::FromErrorString("Cannot change the value of a constant");
+  if (llvm::Error err = CanSetValue()) {
+    error = Status::FromError(std::move(err));
     return false;
   }
 

--- a/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
+++ b/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
@@ -77,17 +77,21 @@ class ChangeValueAPITestCase(TestBase):
         self.assertEqual(actual_value, 12345, "Got the right changed value from val")
 
         # A normal variable backed by memory reports that it can be modified.
+        self.assertSuccess(val_value.CanSet(), "val can be modified")
         self.assertTrue(val_value.CanSetValue(), "val can be modified")
 
         # A constant expression result has no writable storage, so it cannot be
-        # modified and CanSetValue() is False.
+        # modified and CanSet() returns an error.
         const_value = frame0.EvaluateExpression("val + 1")
         self.assertTrue(const_value.IsValid(), "Got a valid expression result")
+        can_set_error = const_value.CanSet()
+        self.assertTrue(can_set_error.Fail(), "A constant cannot be modified")
+        self.assertIn("not in a writable location", can_set_error.GetCString())
         self.assertFalse(const_value.CanSetValue(), "A constant cannot be modified")
         error.Clear()
         result = const_value.SetValueFromCString("0", error)
         self.assertFalse(result, "SetValueFromCString on a constant failed")
-        self.assertIn("constant", error.GetCString())
+        self.assertIn("not in a writable location", error.GetCString())
 
         # Now check that we can set a structure element:
 


### PR DESCRIPTION
```
commit 0b97027f99653c102ae9839c744ba3039ac91987
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Aug 20 13:55:45 2026 -0700

    [LLDB] Let ValueObject::CanSetValue() return a reason (#217454)
    
    This API will be called, for example, by DIL to determine whether
    expressions with assignments can be evaluated. In these cases it will be
    beneficial to also return a reason for the denial to the user.
    
    This patch also updates the SBAPI variant of this
    method. Unfortunately `bool SBValue::CanSetValue()` is already in the
    stable/23.x branch, so I am adding a new method `SBError
    SBValue::CanSet()`. The "Value" in the name is redundant, so this should
    be a nice API cleanup.
```
