### PR TITLE
arm64e: limit tied xpac pseudo-inst to returnaddress lowering.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -13856,10 +13856,8 @@ SDValue AArch64TargetLowering::LowerRETURNADDR(SDValue Op,
   // If we're doing LR signing, we need to fixup ReturnAddr: strip it.
   if (Subtarget->isTargetMachO() &&
       MF.getFunction().hasFnAttribute("ptrauth-returns"))
-    return DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, VT,
-                       DAG.getConstant(Intrinsic::ptrauth_strip, DL, MVT::i32),
-                       ReturnAddress,
-                       DAG.getConstant(AArch64PACKey::IB, DL, MVT::i32));
+    return SDValue(
+        DAG.getMachineNode(AArch64::XPACIuntied, DL, VT, ReturnAddress), 0);
   // If not, on Darwin, we know we will never seen a frame with a signed LR.
   else if (Subtarget->isTargetDarwin())
     return ReturnAddress;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -2122,8 +2122,8 @@ let Predicates = [HasPAuth] in {
   // mov $dst, $src
   // xpaci $dst
   def XPACIuntied : Pseudo<(outs GPR64:$dst), (ins GPR64:$src), []>, Sched<[]>;
-  def : Pat<(int_ptrauth_strip GPR64:$Rd, 0), (XPACIuntied GPR64:$Rd)>;
-  def : Pat<(int_ptrauth_strip GPR64:$Rd, 1), (XPACIuntied GPR64:$Rd)>;
+  def : Pat<(int_ptrauth_strip GPR64:$Rd, 0), (XPACI GPR64:$Rd)>;
+  def : Pat<(int_ptrauth_strip GPR64:$Rd, 1), (XPACI GPR64:$Rd)>;
 
   def XPACD : ClearAuth<1, "xpacd">;
   def : Pat<(int_ptrauth_strip GPR64:$Rd, 2), (XPACD GPR64:$Rd)>;


### PR DESCRIPTION
Using the tied xpac instruction can pessimize register allocation in general, so avoid unless we have real reasons to prefer it.

rdar://64993987&184529006

(cherry-picked from 660faf952394ed79f0d3fa25a9a1f7ef410ecc2a)

Fixes: tools/llvm-mca/AArch64/HiSilicon/hip12-ptraut-instructions.s