### PR TITLE
🍒 Cherry-pick most of #13576 to stable/23.x

### DIFF
--- a/compiler-rt/test/bounds_safety/bidi_indexable/lower_upper_check_inline_bad_read.c
+++ b/compiler-rt/test/bounds_safety/bidi_indexable/lower_upper_check_inline_bad_read.c
@@ -1,3 +1,5 @@
+// This is a variant of `lower_upper_check` that requests inlining of `bad_read`
+// that can lead to LLVM discovering UB in soft trap mode.
 // RUN: %clang_bsafe %s -o %t
 // RUN: %expect-no-trap %t
 // RUN: %expect-trap --verify-prefix=lower-trap %s %t arg1
@@ -6,12 +8,9 @@
 #include <stdio.h>
 #include "soft_trap_runtime_impl.h"
 
-// `noinline` here is used to prevent inlining which can indirectly lead to
-// LLVM figuring out UB is happening during soft traps and emit a hard trap
-// after the soft trap call. This is a workaround for rdar://183581715
 // lower-trap-merged{bad_read}
 // upper-trap-merged{bad_read}
-__attribute__((noinline)) int bad_read(int *__bidi_indexable ptr, int idx) {
+__attribute__((always_inline)) int bad_read(int *__bidi_indexable ptr, int idx) {
   // lower-trap@+2{indexing below lower bound in 'ptr[idx]'}
   // upper-trap@+1{indexing above upper bound in 'ptr[idx]'}
   return ptr[idx];

--- a/compiler-rt/test/bounds_safety/scripts/expect_trap.py
+++ b/compiler-rt/test/bounds_safety/scripts/expect_trap.py
@@ -453,6 +453,44 @@ def check_trap(lldb, process, expectation, verify_source, merged_traps=False,
     return 0
 
 
+def resume_and_expect_clean_exit(lldb, process):
+    """Resume a process stopped at a soft trap and require a clean exit.
+
+    Soft traps are non-fatal: after the trap is validated the process must run
+    to completion and exit with status 0. This is what distinguishes a soft
+    trap from a hard trap and is what catches miscompiles that turn a soft trap
+    into a fatal one. Assumes exactly one soft trap fires before exit (we do not
+    yet support multiple verify expectations); a second stop is reported as a
+    failure rather than silently passing.
+    """
+    # LLDBProcessContextManager runs in synchronous mode (SetAsync(False)), so
+    # Continue() blocks until the process next stops or exits.
+    error = process.Continue()
+    if error.Fail():
+        log.error("failed to resume process after soft trap: %s", error)
+        return 1
+
+    state = process.GetState()
+    if state != lldb.eStateExited:
+        log.error(
+            "process did not exit after soft trap (state=%s); the soft trap "
+            "may have become fatal", state,
+        )
+        log_stop_info(process.GetSelectedThread())
+        return 1
+
+    exit_status = process.GetExitStatus()
+    if exit_status != 0:
+        log.error(
+            "process exited with status %d after soft trap (expected 0)",
+            exit_status,
+        )
+        return 1
+
+    log.info("Process exited cleanly after soft trap")
+    return 0
+
+
 def run_debugger(binary, args, lldb_python_path, verify_source, verify_prefix,
                   merged_traps=False, soft_traps=False):
     # Parse and validate verify comments before launching the debugger so we
@@ -513,10 +551,21 @@ def run_debugger(binary, args, lldb_python_path, verify_source, verify_prefix,
             return 1
 
         if soft_traps and not has_plugin:
-            return check_soft_trap_no_plugin(lldb, ctx.process, expectation,
-                                             verify_source)
-        return check_trap(lldb, ctx.process, expectation, verify_source,
-                          merged_traps, soft_traps)
+            rc = check_soft_trap_no_plugin(lldb, ctx.process, expectation,
+                                           verify_source)
+        else:
+            rc = check_trap(lldb, ctx.process, expectation, verify_source,
+                            merged_traps, soft_traps)
+        if rc != 0:
+            return rc
+
+        # Hard/merged traps: stopping at the trap is the entire check.
+        if not soft_traps:
+            return 0
+
+        # Soft traps are non-fatal: after validating the trap the process must
+        # resume and run to a clean exit.
+        return resume_and_expect_clean_exit(lldb, ctx.process)
 
 
 def main():


### PR DESCRIPTION
This is a partial cherry-pick of https://github.com/swiftlang/llvm-project/pull/13576. That PR was to adapt to -fbounds-safety runtime tests failing due to a codegen change that caused soft traps to have hard traps occur due to UB being optimized to a `brk`.

The `stable/23.x` branch currently doesn't have the codegen change that caused this regression however we should try to cherry-pick as much as we can from that PR to avoid unnecessary divergence between `next` and `stable/23.x`.

This PR is almost identical to the one for `main` except we don't have

  ```
  // FIXME: With soft-traps in optimized builds LLVM can detect that the lower bound
  // access leads to UB and emits a trap (rdar://183581715).
  // XFAIL: soft-traps && optimized
  ```

in `compiler-rt/test/bounds_safety/bidi_indexable/lower_upper_check_inline_bad_read.c`:
  
