### PR TITLE
[Cherry-pick into stable/23.x] [lldb] Preserve language order in Target::GetScratchTypeSystems

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -83,6 +83,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <sstream>
 
 #ifdef LLDB_ENABLE_SWIFT
@@ -2798,7 +2799,14 @@ Target::GetScratchTypeSystems(bool create_on_demand) {
   // Some TypeSystem instances are associated with several LanguageTypes so
   // they will show up several times in the loop below. The SetVector filters
   // out all duplicates as they serve no use for the caller.
-  std::vector<lldb::TypeSystemSP> scratch_type_systems;
+  //
+  // The insertion order matters: callers such as SBTarget::GetBasicType query
+  // the TypeSystems in order and use the first one that can answer, so the
+  // result has to be a function of the languages and not of where the
+  // instances happen to live in memory.
+  llvm::SetVector<lldb::TypeSystemSP, std::vector<lldb::TypeSystemSP>,
+                  std::set<lldb::TypeSystemSP>>
+      scratch_type_systems;
 
   LanguageSet languages_for_expressions =
       Language::GetLanguagesSupportingTypeSystemsForExpressions();
@@ -2813,15 +2821,11 @@ Target::GetScratchTypeSystems(bool create_on_demand) {
           "Language '{1}' has expression support but no scratch type "
           "system available: {0}",
           Language::GetNameForLanguageType(language));
-    else
-      if (auto ts = *type_system_or_err)
-        scratch_type_systems.push_back(ts);
+    else if (auto ts = *type_system_or_err)
+      scratch_type_systems.insert(ts);
   }
 
-  std::sort(scratch_type_systems.begin(), scratch_type_systems.end());
-  scratch_type_systems.erase(llvm::unique(scratch_type_systems),
-                             scratch_type_systems.end());
-  return scratch_type_systems;
+  return scratch_type_systems.takeVector();
 }
 
 PersistentExpressionState *

--- a/lldb/unittests/Target/ScratchTypeSystemTest.cpp
+++ b/lldb/unittests/Target/ScratchTypeSystemTest.cpp
@@ -8,14 +8,20 @@
 
 #include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
 #include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
+#include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "TestingSupport/SubsystemRAII.h"
 #include "TestingSupport/TestUtilities.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
+#include "lldb/Symbol/Type.h"
+#include "lldb/Target/Target.h"
 #include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Testing/Support/Error.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using namespace lldb;
@@ -56,4 +62,79 @@ TEST_F(TestTypeSystemMap, GetScratchTypeSystemForLanguage) {
   EXPECT_THAT_EXPECTED(
       target.GetScratchTypeSystemForLanguage(lldb::eLanguageTypeModula2),
       llvm::FailedWithMessage("TypeSystem for language modula2 doesn't exist"));
+}
+
+namespace {
+/// A TypeSystem that claims only the single language it was constructed for, so
+/// that registering two of them yields two distinct scratch instances.
+class MockTypeSystem : public TypeSystemClang {
+public:
+  explicit MockTypeSystem(lldb::LanguageType language)
+      : TypeSystemClang("mock", llvm::Triple("x86_64-apple-macosx")),
+        m_language(language) {}
+
+  bool SupportsLanguage(lldb::LanguageType language) override {
+    return language == m_language;
+  }
+
+private:
+  lldb::LanguageType m_language;
+};
+
+/// Fortran77 (0x0007) and Fortran90 (0x0008) are adjacent in LanguageType order
+/// and neither is a language TypeSystemClang claims, so the two mocks below are
+/// the only TypeSystems in play.
+lldb::TypeSystemSP g_fortran77_type_system;
+lldb::TypeSystemSP g_fortran90_type_system;
+
+/// TypeSystem::CreateInstance calls every registered callback in turn, so each
+/// one has to decline the languages it doesn't handle.
+lldb::TypeSystemSP CreateFortran77TypeSystem(lldb::LanguageType language,
+                                             Module *, Target *) {
+  return language == lldb::eLanguageTypeFortran77 ? g_fortran77_type_system
+                                                  : lldb::TypeSystemSP();
+}
+
+lldb::TypeSystemSP CreateFortran90TypeSystem(lldb::LanguageType language,
+                                             Module *, Target *) {
+  return language == lldb::eLanguageTypeFortran90 ? g_fortran90_type_system
+                                                  : lldb::TypeSystemSP();
+}
+} // namespace
+
+TEST_F(TestTypeSystemMap, GetScratchTypeSystemsIsOrderedByLanguage) {
+  ArchSpec arch("x86_64-apple-macosx-");
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
+
+  // Create the Fortran90 mock first so that it lands at the lower address. The
+  // order in memory is then the reverse of the order of the languages, and an
+  // implementation that deduplicates by sorting on pointer identity returns the
+  // two the wrong way round.
+  g_fortran90_type_system =
+      std::make_shared<MockTypeSystem>(lldb::eLanguageTypeFortran90);
+  g_fortran77_type_system =
+      std::make_shared<MockTypeSystem>(lldb::eLanguageTypeFortran77);
+  ASSERT_LT(g_fortran90_type_system.get(), g_fortran77_type_system.get());
+
+  LanguageSet fortran77;
+  fortran77.Insert(lldb::eLanguageTypeFortran77);
+  LanguageSet fortran90;
+  fortran90.Insert(lldb::eLanguageTypeFortran90);
+  ASSERT_TRUE(PluginManager::RegisterPlugin(
+      "mock-fortran77", "", CreateFortran77TypeSystem, fortran77, fortran77));
+  ASSERT_TRUE(PluginManager::RegisterPlugin(
+      "mock-fortran90", "", CreateFortran90TypeSystem, fortran90, fortran90));
+  llvm::scope_exit unregister([]() {
+    PluginManager::UnregisterPlugin(CreateFortran77TypeSystem);
+    PluginManager::UnregisterPlugin(CreateFortran90TypeSystem);
+    g_fortran77_type_system.reset();
+    g_fortran90_type_system.reset();
+  });
+
+  m_debugger_sp = Debugger::CreateInstance();
+  auto &target = m_debugger_sp->GetDummyTarget();
+
+  EXPECT_THAT(
+      target.GetScratchTypeSystems(),
+      testing::ElementsAre(g_fortran77_type_system, g_fortran90_type_system));
 }


### PR DESCRIPTION
```
commit f787744d79627a7f698985a184c69f2c0935c16b
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Aug 20 09:50:50 2026 -0700

    [lldb] Preserve language order in Target::GetScratchTypeSystems
    
    cfaa5c344d5b introduced an llvm::SetVector here to deduplicate the
    TypeSystems that several LanguageTypes map to, deliberately keeping
    the order in which the languages were queried. In 6eaedbb52f2a I
    changed the element type from TypeSystem * to TypeSystemSP and
    replaced the SetVector with std::sort plus llvm::unique, which sorts
    shared_ptrs by the address they hold. The returned order became a
    function of the heap layout rather than of the languages, which broke
    the original guarantee as callers like SBTarget::GetBasicType and
    SBTarget::FindTypes depend on the order.
    
    Restore the SetVector using the three-argument form, which avoids the
    missing DenseMapInfo<shared_ptr> that presumably motivated the switch.
    
    Assisted-by: Claude
```
