### PR TITLE
[llvm][AArch64] Avoid iterating off the beginning of a BB in a backwa…

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -367,12 +367,12 @@ void AArch64PointerAuthImpl::authenticateLR(
   // outside the red-zone.
   SmallVector<MachineInstr *, 2> SPMods;
   if (ArgumentStackToRestore > 0) {
-    for (auto I = MBBI; I->getFlag(MachineInstr::FrameDestroy); --I) {
-      if ((I->getOpcode() == AArch64::ADDXri ||
-           I->getOpcode() == AArch64::SUBXri) &&
-          I->getOperand(0).getReg() == AArch64::SP &&
-          I->getOperand(1).getReg() == AArch64::SP)
-        SPMods.push_back(&*I);
+    for (MachineInstr &MI : reverse(make_range(MBB.begin(), MBBI))) {
+      if ((MI.getOpcode() == AArch64::ADDXri ||
+           MI.getOpcode() == AArch64::SUBXri) &&
+          MI.getOperand(0).getReg() == AArch64::SP &&
+          MI.getOperand(1).getReg() == AArch64::SP)
+        SPMods.push_back(&MI);
     }
   }
   for (auto *MI : SPMods)


### PR DESCRIPTION
…rd scan (#217752)

... using a reversed range, rather than raw iterator comparisons, which got us in trouble previously in a block that was entirely made up of FrameDestroy instructions.

rdar://185425744
(cherry picked from commit ab0b549b6b9855e176f6f7ea3f9e5ffe930061c6)

I am leaving out the test because we need this fix ASAP, and I am not sure how to correctly adjust the test to pass on this branch. The author of the original commit promised to follow up on that.