### PR TITLE
[Cherry-pick into next] [lldb] Make the Swift language plugin re-initializable

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -85,7 +85,8 @@ void SwiftLanguage::Initialize() {
       .emplace(g_NSArrayClass1,
                lldb_private::formatters::swift::ArraySyntheticFrontEndCreator);
 
-  initializeSwiftModules();
+  static std::once_flag g_initialize_swift_modules_once;
+  std::call_once(g_initialize_swift_modules_once, initializeSwiftModules);
 }
 
 void SwiftLanguage::Terminate() {
@@ -105,6 +106,7 @@ void SwiftLanguage::Terminate() {
       .erase(g_NSArrayClass1);
 
   PluginManager::UnregisterPlugin(CreateInstance);
+  LogChannelSwift::Terminate();
 }
 
 bool SwiftLanguage::SymbolNameFitsToLanguage(const Mangled &mangled) const {


### PR DESCRIPTION
```
commit c3655f54cacb4897dc09126657d254e9438290ee
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Aug 21 10:43:58 2026 -0700

    [lldb] Make the Swift language plugin re-initializable
    
    LogChannelSwift::Terminate() existed but had no callers, so the "swift"
    log channel stayed registered. Every other LLDB log channel unregisters
    from its owning plugin's Terminate(); call it and match that
    convention.
    
    initializeSwiftModules() registers global SIL class metatypes with the
    Swift compiler's bridging layer, which has no unregister counterpart,
    so guard that call with std::call_once instead.
    
    Assisted-by: Claude
```
