### PR TITLE
[clang][driver][darwin] Use DefaultDeploymentTarget when inferring deployment target from SDK

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -170,7 +170,8 @@ public:
   DarwinSDKInfo(
       std::string FilePath, llvm::Triple::OSType OS,
       llvm::Triple::EnvironmentType Environment, VersionTuple Version,
-      StringRef DisplayName, VersionTuple MaximumDeploymentTarget,
+      StringRef DisplayName, VersionTuple DefaultDeploymentTarget,
+      VersionTuple MaximumDeploymentTarget,
       PlatformInfoStorageType PlatformInfos,
       llvm::DenseMap<OSEnvPair::StorageType,
                      std::optional<RelatedTargetVersionMapping>>
@@ -179,6 +180,7 @@ public:
                              std::optional<RelatedTargetVersionMapping>>())
       : FilePath(std::move(FilePath)), OS(OS), Environment(Environment),
         Version(Version), DisplayName(DisplayName),
+        DefaultDeploymentTarget(DefaultDeploymentTarget),
         MaximumDeploymentTarget(MaximumDeploymentTarget),
         PlatformInfos(std::move(PlatformInfos)),
         VersionMappings(std::move(VersionMappings)) {
@@ -202,6 +204,10 @@ public:
   llvm::Triple::EnvironmentType getEnvironment() const { return Environment; }
 
   const llvm::VersionTuple &getVersion() const { return Version; }
+
+  const llvm::VersionTuple &getDefaultDeploymentTarget() const {
+    return DefaultDeploymentTarget;
+  }
 
   const StringRef getDisplayName() const { return DisplayName; }
 
@@ -241,6 +247,7 @@ private:
   llvm::Triple::EnvironmentType Environment;
   VersionTuple Version;
   std::string DisplayName;
+  VersionTuple DefaultDeploymentTarget;
   VersionTuple MaximumDeploymentTarget;
   PlatformInfoStorageType PlatformInfos;
   // Need to wrap the value in an optional here as the value has to be default

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -259,6 +259,9 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(std::string FilePath,
   auto Version = getVersionKey(*Obj, "Version");
   if (!Version)
     return std::nullopt;
+  auto DefaultDeploymentTarget = getVersionKey(*Obj, "DefaultDeploymentTarget");
+  if (!DefaultDeploymentTarget)
+    return std::nullopt;
   auto MaximumDeploymentVersion =
       getVersionKey(*Obj, "MaximumDeploymentTarget");
   if (!MaximumDeploymentVersion)
@@ -318,7 +321,8 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(std::string FilePath,
 
   return DarwinSDKInfo(std::move(FilePath), OSAndEnvironment.first,
                        OSAndEnvironment.second, std::move(*Version),
-                       DisplayName, std::move(*MaximumDeploymentVersion),
+                       DisplayName, std::move(*DefaultDeploymentTarget),
+                       std::move(*MaximumDeploymentVersion),
                        std::move(PlatformInfos), std::move(VersionMappings));
 }
 
@@ -350,7 +354,7 @@ DarwinSDKInfo::DarwinSDKInfo(llvm::Triple::OSType OS,
                              llvm::Triple::EnvironmentType Environment,
                              VersionTuple Version, StringRef DisplayName,
                              VersionTuple MaximumDeploymentTarget)
-    : DarwinSDKInfo("", OS, Environment, Version, DisplayName,
+    : DarwinSDKInfo("", OS, Environment, Version, DisplayName, Version,
                     MaximumDeploymentTarget,
                     legacyPlatformInfos(OS, Environment)) {}
 

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2188,7 +2188,7 @@ struct DarwinPlatform {
                                           const DarwinSDKInfo &SDKInfo) {
     const llvm::Triple &PlatformTriple = SDKInfo.getCanonicalPlatformTriple();
     const llvm::Triple::OSType OS = PlatformTriple.getOS();
-    VersionTuple Version = SDKInfo.getVersion();
+    VersionTuple Version = SDKInfo.getDefaultDeploymentTarget();
     if (OS == llvm::Triple::MacOSX)
       Version = getVersionFromString(
           getSystemOrSDKMacOSVersion(Version.getAsString()));

--- a/clang/test/Driver/darwin-default-deployment-target.c
+++ b/clang/test/Driver/darwin-default-deployment-target.c
@@ -1,0 +1,85 @@
+// Ensure that the deployment target inferred from the SDK when none is
+// specified on the command line uses "DefaultDeploymentTarget" rather than
+// "Version" when the SDK specifies both and they differ.
+// REQUIRES: system-darwin && native
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang -target arm64-apple-darwin -isysroot %t/iPhoneOS18.0.sdk -c -### %s 2>&1 \
+// RUN:   | FileCheck %s
+
+// CHECK: "-triple" "arm64-apple-ios17.0.0"
+// CHECK-SAME: -target-sdk-version=18.0
+
+// An explicit deployment target on the command line overrides the SDK's
+// "DefaultDeploymentTarget".
+// RUN: %clang -target arm64-apple-darwin -isysroot %t/iPhoneOS18.0.sdk -miphoneos-version-min=12.0 -c -### %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=OVERRIDE %s
+
+// OVERRIDE: "-triple" "arm64-apple-ios12.0.0"
+// OVERRIDE-SAME: -target-sdk-version=18.0
+
+// When "DefaultDeploymentTarget" is missing, the whole SDKSettings.json is
+// treated as unusable and the version is instead inferred from the SDK
+// path.
+// RUN: %clang -target arm64-apple-darwin -isysroot %t/iPhoneOS18.3.sdk -c -### %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=NO-DEFAULT %s
+
+// NO-DEFAULT: warning: SDK settings were ignored as 'SDKSettings.json' could not be parsed
+// NO-DEFAULT: "-triple" "arm64-apple-ios18.3.0"
+// NO-DEFAULT-SAME: -target-sdk-version=18.3
+
+//--- iPhoneOS18.0.sdk/SDKSettings.json
+{
+  "CanonicalName": "iphoneos18.0",
+  "Version": "18.0",
+  "IsBaseSDK": "YES",
+  "DisplayName": "iOS 18.0",
+  "MinimalDisplayName": "18.0",
+  "SupportedTargets": {
+    "iphoneos": {
+      "PlatformFamilyName": "iOS",
+      "PlatformFamilyDisplayName": "iOS",
+      "Archs": ["arm64e", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "",
+      "BuildVersionPlatformID": "2",
+      "ClangRuntimeLibraryPlatformName": "ios",
+      "SystemPrefix": "",
+      "DefaultDeploymentTarget": "17.0",
+      "RecommendedDeploymentTarget": "15.0",
+      "MinimumDeploymentTarget": "12.0", "MaximumDeploymentTarget": "18.0.99",
+      "ValidDeploymentTargets": ["12.0", "12.1", "12.2", "12.3", "12.4", "13.0", "13.1", "13.2", "13.3", "13.4", "13.5", "13.6", "14.0", "14.1", "14.2", "14.3", "14.4", "14.5", "14.6", "14.7", "15.0", "15.1", "15.2", "15.3", "15.4", "15.5", "15.6", "16.0", "16.1", "16.2", "16.3", "16.4", "16.5", "16.6", "17.0", "17.1", "17.2", "17.3", "17.4", "17.5", "17.6", "18.0"]
+    }
+  },
+  "DefaultDeploymentTarget": "17.0",
+  "MaximumDeploymentTarget": "18.0.99",
+  "Comments": [
+    "Modified version of the iOS SDK from Xcode 18.0 to have \"DefaultDeploymentTarget\" differ from \"Version\"."
+  ]
+}
+
+//--- iPhoneOS18.3.sdk/SDKSettings.json
+{
+  "CanonicalName": "iphoneos18.6",
+  "Version": "18.6",
+  "IsBaseSDK": "YES",
+  "DisplayName": "iOS 18.6",
+  "MinimalDisplayName": "18.6",
+  "SupportedTargets": {
+    "iphoneos": {
+      "PlatformFamilyName": "iOS",
+      "PlatformFamilyDisplayName": "iOS",
+      "Archs": ["arm64e", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "",
+      "BuildVersionPlatformID": "2",
+      "ClangRuntimeLibraryPlatformName": "ios",
+      "SystemPrefix": "",
+      "RecommendedDeploymentTarget": "15.0",
+      "MinimumDeploymentTarget": "12.0", "MaximumDeploymentTarget": "18.6.99",
+      "ValidDeploymentTargets": ["12.0", "12.1", "12.2", "12.3", "12.4", "13.0", "13.1", "13.2", "13.3", "13.4", "13.5", "13.6", "14.0", "14.1", "14.2", "14.3", "14.4", "14.5", "14.6", "14.7", "15.0", "15.1", "15.2", "15.3", "15.4", "15.5", "15.6", "16.0", "16.1", "16.2", "16.3", "16.4", "16.5", "16.6", "17.0", "17.1", "17.2", "17.3", "17.4", "17.5", "17.6", "18.0", "18.1", "18.2", "18.3", "18.4", "18.5", "18.6"]
+    }
+  },
+  "MaximumDeploymentTarget": "18.6.99",
+  "Comments": [
+    "Modified version of the iOS SDK from Xcode 18.6 with \"DefaultDeploymentTarget\" removed to test the fallback path used when it's missing. The SDK's folder name deliberately differs from \"Version\" to show the SDK path, not \"Version\", is used for the fallback."
+  ]
+}

--- a/clang/unittests/Basic/DarwinSDKInfoTest.cpp
+++ b/clang/unittests/Basic/DarwinSDKInfoTest.cpp
@@ -81,6 +81,7 @@ TEST(DarwinSDKInfo, VersionMappingParseError) {
 TEST(DarwinSDKInfo, PlatformPrefix) {
   llvm::json::Object SDKSettings({{"CanonicalName", "macosx26.0"},
                                   {"Version", "26.0"},
+                                  {"DefaultDeploymentTarget", "26.0"},
                                   {"MaximumDeploymentTarget", "26.0.99"}});
   llvm::json::Object SupportedTargets;
   llvm::json::Object MacOS({{"Archs", {"x86_64", "arm64"}},
@@ -123,6 +124,7 @@ TEST(DarwinSDKInfoTest, ParseAndTestMappingMacCatalyst) {
   llvm::json::Object Obj;
   Obj["CanonicalName"] = "macosx11.0";
   Obj["Version"] = "11.0";
+  Obj["DefaultDeploymentTarget"] = "11.0";
   Obj["MaximumDeploymentTarget"] = "11.99";
   llvm::json::Object VersionMap;
   VersionMap["10.15"] = "13.1";
@@ -170,6 +172,7 @@ TEST(DarwinSDKInfoTest, ParseAndTestMappingIOSDerived) {
   llvm::json::Object Obj;
   Obj["CanonicalName"] = "appletvos15.0";
   Obj["Version"] = "15.0";
+  Obj["DefaultDeploymentTarget"] = "15.0";
   Obj["MaximumDeploymentTarget"] = "15.0.99";
   llvm::json::Object VersionMap;
   VersionMap["10.0"] = "10.0";


### PR DESCRIPTION
Use "DefaultDeploymentTarget" from SDKSettings.json instead of "Version" for the inferred deployment target version. This only affects the deployment target; other uses of "Version" (e.g., -target-sdk-version=) are unchanged.

rdar://184842209