### PR TITLE
[swift/release/6.4.x] Obfuscate availability domain global variable names

### DIFF
--- a/clang/lib/Headers/availability_domain.h
+++ b/clang/lib/Headers/availability_domain.h
@@ -31,21 +31,32 @@ struct __AvailabilityDomain {
   int (*const runtimeQuery)(void);
 };
 
+/// The name of the global variable that represents `domain`. Like the layout of
+/// `__AvailabilityDomain`, this name is an implementation detail of the
+/// compiler and is subject to change, so don't reference it directly. It is
+/// prefixed to keep the name of the domain itself available for other
+/// declarations.
+#define __CLANG_AVAILABILITY_DOMAIN_VAR(domain)                                \
+  __clang_availability_domain_##domain
+
 #define CLANG_DYNAMIC_AVAILABILITY_DOMAIN(domain, query)                       \
-  static struct __AvailabilityDomain domain __attribute__((                    \
-      availability_domain(domain))) = {__AVAILABILITY_DOMAIN_DYNAMIC, query}
+  static struct __AvailabilityDomain __CLANG_AVAILABILITY_DOMAIN_VAR(domain)   \
+      __attribute__((availability_domain(domain), unused)) = {                 \
+          __AVAILABILITY_DOMAIN_DYNAMIC, query}
 
 #define CLANG_ENABLED_AVAILABILITY_DOMAIN(domain)                              \
-  static struct __AvailabilityDomain domain __attribute__((                    \
-      availability_domain(domain))) = {__AVAILABILITY_DOMAIN_ENABLED, 0}
+  static struct __AvailabilityDomain __CLANG_AVAILABILITY_DOMAIN_VAR(domain)   \
+      __attribute__((availability_domain(domain), unused)) = {                 \
+          __AVAILABILITY_DOMAIN_ENABLED, 0}
 
 #define CLANG_DISABLED_AVAILABILITY_DOMAIN(domain)                             \
-  static struct __AvailabilityDomain domain __attribute__((                    \
-      availability_domain(domain))) = {__AVAILABILITY_DOMAIN_DISABLED, 0}
+  static struct __AvailabilityDomain __CLANG_AVAILABILITY_DOMAIN_VAR(domain)   \
+      __attribute__((availability_domain(domain), unused)) = {                 \
+          __AVAILABILITY_DOMAIN_DISABLED, 0}
 
 #define CLANG_ALWAYS_ENABLED_AVAILABILITY_DOMAIN(domain)                       \
-  static struct __AvailabilityDomain domain                                    \
-      __attribute__((availability_domain(domain))) = {                         \
+  static struct __AvailabilityDomain __CLANG_AVAILABILITY_DOMAIN_VAR(domain)   \
+      __attribute__((availability_domain(domain), unused)) = {                 \
           __AVAILABILITY_DOMAIN_ALWAYS_ENABLED, 0}
 
 #endif /* __AVAILABILITY_DOMAIN_H */

--- a/clang/test/CodeGen/feature-availability.c
+++ b/clang/test/CodeGen/feature-availability.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple arm64-apple-macosx -fblocks -ffeature-availability=feature1:on -ffeature-availability=feature2:off -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fblocks -emit-llvm -o - -DUSE_DOMAIN %s | FileCheck --check-prefixes=CHECK,DOMAIN %s
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fblocks -emit-llvm -o - -DUSE_DOMAIN -DALWAYS_ENABLED %s | FileCheck --check-prefixes=CHECK,DOMAIN %s
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fblocks -emit-llvm -o - -DUSE_DOMAIN -Werror=unused-variable %s | FileCheck --check-prefixes=CHECK,DOMAIN %s
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fblocks -emit-llvm -o - -DUSE_DOMAIN -DALWAYS_ENABLED -Werror=unused-variable %s | FileCheck --check-prefixes=CHECK,DOMAIN %s
 
 // RUN: %clang_cc1 -triple arm64-apple-macosx -fblocks -ffeature-availability=feature1:on -ffeature-availability=feature2:off -emit-pch -o %t %s
 // RUN: %clang_cc1 -triple arm64-apple-macosx -fblocks -ffeature-availability=feature1:on -ffeature-availability=feature2:off -include-pch %t -emit-llvm -o - %s | FileCheck %s

--- a/clang/test/Sema/feature-availability.c
+++ b/clang/test/Sema/feature-availability.c
@@ -47,6 +47,9 @@ __attribute__((deprecated))
 CLANG_ENABLED_AVAILABILITY_DOMAIN(deprecated_feature2);
 #endif
 
+// A domain name doesn't name a declaration, so it stays available for other uses.
+int g13 = feature1; // expected-error {{use of undeclared identifier 'feature1'}}
+
 #pragma clang attribute push (__attribute__((availability(domain:feature1, AVAIL))), apply_to=any(function))
 void func12(void);
 #pragma clang attribute pop


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/13987.

The availability domain macros each declared a global variable named after the domain itself, which could collide with any other declaration of the same name.

The variable name is an implementation detail, so prefix it with `__clang_availability_domain_`.

Resolves rdar://185738607.