### PR TITLE
[Cherry-pick into next] [lldb][test] Derive MODULENAME and SWIFT without subprocesses

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -257,14 +257,14 @@ endif
 #----------------------------------------------------------------------
 # Set up variables to run the Swift frontend directly.
 #----------------------------------------------------------------------
-SWIFT=$(shell dirname $(SWIFTC))/swift
+SWIFT := $(dir $(SWIFTC_PATH))swift
 SWIFT_FEFLAGS = $(shell echo $(patsubst -Xfrontend,,$(SWIFTFLAGS)) | sed -e 's/-Xlinker [^ ]*//g')
 SWIFT_FE=$(SWIFT) -frontend
 
 ifeq "$(USESWIFTDRIVER)" "1"
 #----------------------------------------------------------------------
 ifeq "$(DYLIB_NAME)" ""
-MODULENAME?=$(shell basename $(EXE) .out)
+MODULENAME?=$(patsubst %.out,%,$(notdir $(EXE)))
 # Compile with -parse-as-library when main.swift contains "@main".
 # $(file ...) requires GNU Make 4.0+, unavailable on macOS (ships with 3.81).
 ifeq "$(OS)" "Windows_NT"


### PR DESCRIPTION
```
commit 2d7bd3c30a0f552281c7b95fd5161d1361051d8c
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Aug 24 12:02:06 2026 -0700

    [lldb][test] Derive MODULENAME and SWIFT without subprocesses
    
    Assisted-by: Claude
```
