### PR TITLE
[LoopTrapAnalysis] Add per-edge LoopTrapEdge remark behind a flag

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/LoopTrapAnalysis.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopTrapAnalysis.h
@@ -9,13 +9,33 @@
 #ifndef LLVM_TRANSFORMS_SCALAR_LoopTrapAnalysis_H
 #define LLVM_TRANSFORMS_SCALAR_LoopTrapAnalysis_H
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/IR/PassManager.h"
+#include <string>
 
 namespace llvm {
 
 struct LoopTrapAnalysisPass : public PassInfoMixin<LoopTrapAnalysisPass> {
+  // Tag appended to remark Names so the pass can run at more than one pipeline
+  // point with distinguishable output. Empty (default) keeps the bare Names.
+  std::string Tag;
+
+  // Per-Function run() counter, emitted as InvocationSeq (gated by
+  // -loop-trap-analysis-explain) so consumers can dedup repeated invocations
+  // by max(seq) per (function, src_bb, trap_bb). mutable: bookkeeping side
+  // channel, not analysis state; single-threaded per FunctionAnalysisManager.
+  mutable DenseMap<const Function *, unsigned> InvocationCount;
+
+  LoopTrapAnalysisPass(StringRef Tag = "") : Tag(Tag.str()) {}
+
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+
+  static bool isRequired() { return true; }
+
+  void printPipeline(raw_ostream &OS,
+                     function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 } // end namespace llvm

--- a/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTrapAnalysis.cpp
@@ -30,6 +30,87 @@ static cl::opt<bool> BoundsSafetyTrapsOnly(
     cl::desc(
         "We only check for -fbounds-safety traps if the flag is false we can check "
         "for any hoistable traps."));
+static cl::opt<bool> LTAEmitExplain(
+    "loop-trap-analysis-explain", cl::init(false),
+    cl::desc("Emit the explanatory trap analysis: the refined TrapClass "
+             "classification plus per-loop and per-edge explanatory fields "
+             "(DominatesLatch / IV-update / operand-class). When false "
+             "(default), only the pre-explanation fields and compact TrapClass "
+             "are emitted, so the framework can be A/B compared and reverted "
+             "by toggling this flag alone."));
+
+/// Print a stable, non-empty label for \p BB, so remark args that identify
+/// BasicBlocks stay useful when the BB has no source-level name (numeric IR,
+/// stripped names, or non-C frontends such as swiftc's IRGen).
+///
+/// Preferred: `BB->getName()`. Fallback: `printAsOperand` slot-tracker form
+/// (`%5` etc.), which is parseable and unique within the function. Never
+/// returns empty.
+static std::string bbLabel(const BasicBlock *BB) {
+  if (!BB)
+    return "<null>";
+  if (BB->hasName())
+    return BB->getName().str();
+  std::string S;
+  raw_string_ostream OS(S);
+  BB->printAsOperand(OS, /*PrintType=*/false);
+  return S.empty() ? std::string("<unnamed>") : S;
+}
+
+/// Minimal trap-block predicate for the per-edge explain output: \p BB ends in
+/// `unreachable` immediately preceded by a trap-like terminating call,
+/// identified by its semantic property rather than an intrinsic allowlist: a
+/// `noreturn` call touching only inaccessible memory (the shared property of
+/// @llvm.trap / @llvm.ubsantrap and any future trap intrinsic).
+static bool isTrapEdgeBlock(BasicBlock *BB) {
+  if (!BB || BB->empty())
+    return false;
+  Instruction *Term = BB->getTerminator();
+  if (!isa<UnreachableInst>(Term))
+    return false;
+  if (Term == &BB->front())
+    return false;
+  if (auto *CI = dyn_cast<CallInst>(Term->getPrevNode()))
+    return CI->doesNotReturn() && CI->onlyAccessesInaccessibleMemory();
+  return false;
+}
+
+/// Emit one LoopTrapEdge remark per conditional branch whose one successor is a
+/// trap block (see isTrapEdgeBlock). Gated by -loop-trap-analysis-explain.
+static void emitPerTrapEdge(Function &F, LoopInfo &LI,
+                            OptimizationRemarkEmitter &ORE, StringRef Tag) {
+  std::string Name =
+      Tag.empty() ? std::string("LoopTrapEdge") : ("LoopTrapEdge" + Tag).str();
+  for (BasicBlock &BB : F) {
+    auto *BI = dyn_cast<CondBrInst>(BB.getTerminator());
+    if (!BI)
+      continue;
+    BasicBlock *TrapSucc = nullptr;
+    for (BasicBlock *Succ : BI->successors())
+      if (isTrapEdgeBlock(Succ)) {
+        TrapSucc = Succ;
+        break;
+      }
+    if (!TrapSucc)
+      continue;
+
+    Loop *Innermost = LI.getLoopFor(&BB);
+    bool IsLoopExit = Innermost && !Innermost->contains(TrapSucc);
+
+    OptimizationRemarkAnalysis Rem(REMARK_PASS, Name, BI);
+    Rem << "Function " << NV("Function", F.getName())
+        << " src_bb=" << NV("SourceBB", bbLabel(&BB))
+        << " trap_bb=" << NV("TrapBB", bbLabel(TrapSucc)) << " loop_depth="
+        << NV("LoopDepth", Innermost ? Innermost->getLoopDepth() : 0u)
+        << " loop_header="
+        << NV("LoopHeader",
+              Innermost ? bbLabel(Innermost->getHeader()) : std::string(""))
+        << " is_innermost="
+        << NV("IsInnermost", (bool)(Innermost && Innermost->isInnermost()))
+        << " is_loop_exit=" << NV("IsLoopExit", IsLoopExit);
+    ORE.emit(Rem);
+  }
+}
 
 /// Check for an unreachable instruction that has an edge to any of \p L basic
 /// blocks. if `--use-bounds-safety-traps-only` is used make sure that the trap and
@@ -173,5 +254,14 @@ PreservedAnalyses LoopTrapAnalysisPass::run(Function &F,
   auto &SE = AM.getResult<ScalarEvolutionAnalysis>(F);
   auto &ORE = AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
   emitRemarks(F, LI, ORE, SE);
+  if (LTAEmitExplain)
+    emitPerTrapEdge(F, LI, ORE, Tag);
   return PreservedAnalyses::all();
+}
+
+void LoopTrapAnalysisPass::printPipeline(
+    raw_ostream &OS, function_ref<StringRef(StringRef)> MapClassName2PassName) {
+  OS << "loop-trap-analysis";
+  if (!Tag.empty())
+    OS << "<tag=" << Tag << ">";
 }

--- a/llvm/test/Transforms/Util/TrapAnalysis/loop-trap-edge-basic.ll
+++ b/llvm/test/Transforms/Util/TrapAnalysis/loop-trap-edge-basic.ll
@@ -1,0 +1,39 @@
+; RUN: opt -passes='loop-trap-analysis' -loop-trap-analysis-explain -disable-output \
+; RUN:   -pass-remarks-output=%t.yaml %s
+; RUN: FileCheck --input-file=%t.yaml %s
+
+declare void @llvm.trap()
+
+; A counted loop whose in-loop check branches to an @llvm.trap+unreachable
+; block. The per-edge explain output should emit one LoopTrapEdge record for
+; the cond-br in %body whose trap successor is %trap.
+define void @counted_trap(ptr %base, i32 %n) {
+entry:
+  br label %body
+body:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %cmp = icmp ult i32 %iv, %n
+  br i1 %cmp, label %latch, label %trap
+trap:
+  call void @llvm.trap()
+  unreachable
+latch:
+  %p = getelementptr i32, ptr %base, i32 %iv
+  store i32 0, ptr %p, align 4
+  %iv.next = add nuw nsw i32 %iv, 1
+  %e = icmp eq i32 %iv.next, %n
+  br i1 %e, label %exit, label %body
+exit:
+  ret void
+}
+
+; CHECK:      --- !Analysis
+; CHECK:      Name:{{ +}}LoopTrapEdge
+; CHECK-NEXT: Function:{{ +}}counted_trap
+; CHECK:        - Function:{{ +}}counted_trap
+; CHECK:        - SourceBB:{{ +}}body
+; CHECK:        - TrapBB:{{ +}}trap
+; CHECK:        - LoopDepth:{{ +}}'1'
+; CHECK:        - LoopHeader:{{ +}}body
+; CHECK:        - IsInnermost:{{ +}}'true'
+; CHECK:        - IsLoopExit:{{ +}}'true'


### PR DESCRIPTION
Add -loop-trap-analysis-explain (default off) to gate a more detailed
trap analysis. First increment: one LoopTrapEdge remark per conditional
branch to a trap block, with the function, source/trap blocks, and loop
context. Flag off leaves output unchanged. Adds loop-trap-edge-basic.ll.
