### PR TITLE
[Cherry-pick into next] [lldb][test] Build each resilience flavor in its own directory

### DIFF
--- a/lldb/test/API/lang/swift/resilience/Makefile
+++ b/lldb/test/API/lang/swift/resilience/Makefile
@@ -1,52 +1,39 @@
 EXE=
-all: libmod.a.dylib libmod.b.dylib main.a main.b
+FLAVORS := a b
+
+# The libraries are goals in their own right: a pattern rule's output that is
+# only reachable as a prerequisite counts as an intermediate file, which make
+# deletes once the build is done.
+all: $(FLAVORS:%=%/libmod.dylib) $(FLAVORS:%=%/main)
 
 include Makefile.rules
 
-# Both recipes below build into flavor-independent names (libmod.dylib,
-# mod.swiftinterface, main, ...) and rename the results per flavor afterwards,
-# so they are only correct when the directory does not already contain the
-# results of an earlier build or test run: `mv` descends into an existing
-# destination directory rather than replacing it, and writing to a leftover
-# symlink follows it instead of overwriting it. Clear both before building.
+# Every flavor of the library exports the same API with a different layout of S,
+# and each is built in its own directory so that no artifact has to be renamed
+# after linking: the paths a binary records for its serialized AST and for its
+# library stay valid. A test selects a combination by copying one executable and
+# one library into the top-level build directory.
 
-libmod.%.dylib: mod.%.swift \
+%/libmod.dylib: mod.%.swift \
                 $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
-	$(call RM_RF,$@.dSYM libmod.dylib libmod.dylib.dSYM \
-	             mod.swiftinterface mod.$*.swiftinterface mod.swiftmodule)
-	$(call LN_SF,$<,mod.swift)
-	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -###
-	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+	$(call MKDIR_P,$*)
+	"$(MAKE)" -C $* MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
-		DYLIB_NAME=mod \
+		DYLIB_NAME=mod DYLIB_SWIFT_SOURCES=mod.$*.swift \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
-	mv libmod.dylib $@
-	mv libmod.dylib.dSYM $@.dSYM || true
-	$(call RM,mod.swiftmodule)
-	mv mod.swiftinterface mod.$*.swiftinterface
-	mv mod.swift.o mod.$*.swift.o
-	$(call RM,mod.swift)
+	# Withhold the binary module so that the executable, and later the
+	# debugger, have to import mod from its textual interface.
+	$(call RM,$*/mod.swiftmodule)
 
-# The tool dependencies belong on the concrete targets: main.% also matches
-# main.swift, and a pattern rule whose prerequisite is its own target is only
-# harmless as long as it has no prerequisite newer than that target.
-main.a main.b: $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
-
-main.%: main.swift libmod.%.dylib
-	$(call RM_RF,main.$*.dSYM main main.dSYM)
-	$(call LN_SF,libmod.$*.dylib,libmod.dylib)
-	$(call LN_SF,libmod.$*.dylib.dSYM,libmod.dylib.dSYM)
-	$(call LN_SF,mod.$*.swiftdoc,mod.swiftdoc)
-	$(call LN_SF,mod.$*.swiftinterface,mod.swiftinterface)
-	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+%/main: main.swift %/libmod.dylib \
+        $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
+	"$(MAKE)" -C $* MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/exe.mk all
-	mv main main.$*
-	mv main.dSYM main.$*.dSYM || true
-	$(call RM_RF,libmod.dylib libmod.dylib.dSYM mod.swiftdoc mod.swiftmodule)
 
 $(DSYM):
 	$(call ECHO,"Already built by exe.mk")
 
 clean::
-	$(call RM_RF,main main.a main.b *.dylib *.dSYM *.swiftdoc *.swiftmodule mod.swift *.o)
+	$(call RM_RF,$(FLAVORS) main main.dSYM main.swiftmodule libmod.dylib \
+	             libmod.dylib.dSYM mod.swiftinterface mod.swiftmodule)

--- a/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
@@ -22,13 +22,16 @@ def execute_command(command):
 
 
 class TestSwiftResilience(TestBase):
+    # The flavors of mod store the fields of S in a different order, so the
+    # rendering of a value of type S identifies the library that is really
+    # loaded, independently of the one the executable was built against.
+    # expect() matches substrings in the order they are given.
+    G_S_SUBSTRS = {"a": ["a = 1", 's1 = "i"'], "b": ["b = 2", "a = 1"]}
+
     @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
-    # Because we rename the .swiftmodule files after building the
-    # N_AST symbol table entry is out of sync, whereas dsymutil
-    # captures the right one before the rename.
-    @skipIf(debug_info=no_match(["dsym"]))
+    @skipIf(debug_info=no_match(["dsym", "dwarf"]))
     def test_cross_module_extension_a_a(self):
         """Test that LLDB can debug across resilient boundaries"""
         self.build()
@@ -37,7 +40,7 @@ class TestSwiftResilience(TestBase):
     @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
-    @skipIf(debug_info=no_match(["dsym"]))
+    @skipIf(debug_info=no_match(["dsym", "dwarf"]))
     def test_cross_module_extension_a_b(self):
         """Test that LLDB can debug across resilient boundaries"""
         self.build()
@@ -46,7 +49,7 @@ class TestSwiftResilience(TestBase):
     @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
-    @skipIf(debug_info=no_match(["dsym"]))
+    @skipIf(debug_info=no_match(["dsym", "dwarf"]))
     def test_cross_module_extension_b_a(self):
         """Test that LLDB can debug across resilient boundaries"""
         self.build()
@@ -55,7 +58,7 @@ class TestSwiftResilience(TestBase):
     @requireNotEmbeddedSwift
     @skipUnlessDarwin
     @swiftTest
-    @skipIf(debug_info=no_match(["dsym"]))
+    @skipIf(debug_info=no_match(["dsym", "dwarf"]))
     def test_cross_module_extension_b_b(self):
         """Test that LLDB can debug across resilient boundaries"""
         self.build()
@@ -63,23 +66,24 @@ class TestSwiftResilience(TestBase):
 
 
     def createSymlinks(self, exe_flavor, mod_flavor):
-        execute_command("cp " + self.getBuildArtifact("main." + exe_flavor) + " " + self.getBuildArtifact("main"))
-        execute_command("ln -sf " + self.getBuildArtifact("main." + exe_flavor + ".dSYM") + " " + self.getBuildArtifact("main.dSYM"))
+        execute_command("cp " + self.getBuildArtifact(exe_flavor + "/main") + " " + self.getBuildArtifact("main"))
+        execute_command("ln -sfn " + self.getBuildArtifact(exe_flavor + "/main.dSYM") + " " + self.getBuildArtifact("main.dSYM"))
+        # The executable records the path of its serialized AST relative to
+        # itself, so the module has to sit next to the copy, not next to the
+        # original.
+        execute_command("ln -sfn " + self.getBuildArtifact(exe_flavor + "/main.swiftmodule") + " " + self.getBuildArtifact("main.swiftmodule"))
 
-        execute_command("cp " + self.getBuildArtifact("libmod." + mod_flavor + ".dylib") + " " + self.getBuildArtifact("libmod.dylib"))
-        execute_command("ln -sf " + self.getBuildArtifact("libmod." + mod_flavor + ".dylib.dSYM") + " " + self.getBuildArtifact("libmod.dylib.dSYM"))
-
-        execute_command("ln -sf " + self.getBuildArtifact("mod." + mod_flavor + ".swiftinterface") + " " + self.getBuildArtifact("mod.swiftinterface"))
+        execute_command("cp " + self.getBuildArtifact(mod_flavor + "/libmod.dylib") + " " + self.getBuildArtifact("libmod.dylib"))
+        execute_command("ln -sfn " + self.getBuildArtifact(mod_flavor + "/libmod.dylib.dSYM") + " " + self.getBuildArtifact("libmod.dylib.dSYM"))
 
     def cleanupSymlinks(self):
         execute_command(
-            "rm " +
+            "rm -rf " +
             self.getBuildArtifact("main") + " " +
             self.getBuildArtifact("main.dSYM") + " " +
+            self.getBuildArtifact("main.swiftmodule") + " " +
             self.getBuildArtifact("libmod.dylib") + " " +
-            self.getBuildArtifact("libmod.dylib.dSYM") + " " +
-            self.getBuildArtifact("mod.swiftdoc") + " " +
-            self.getBuildArtifact("mod.swiftmodule"))
+            self.getBuildArtifact("libmod.dylib.dSYM"))
 
     def check_global(self, symbol_name, substrs):
         self.expect("target var " + symbol_name,
@@ -91,6 +95,12 @@ class TestSwiftResilience(TestBase):
 
     def doTestWithFlavor(self, exe_flavor, mod_flavor):
         self.createSymlinks(exe_flavor, mod_flavor)
+        # Both flavors of mod are on disk under the same module name, so which
+        # one SwiftASTContext imports is decided by the order in which the
+        # module search paths are consulted, while reflection always describes
+        # the library that is actually loaded. Cross-checking the two type
+        # systems is therefore not meaningful here.
+        self.runCmd("settings set symbols.swift-validate-typesystem false")
 
         target, process, _, breakpoint = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift"),
@@ -120,7 +130,7 @@ class TestSwiftResilience(TestBase):
         
         # Test global variable inside the module defining S.
         self.check_global("g_b", ["hello"])
-        self.check_global("g_s", ["a = 1"])
+        self.check_global("g_s", self.G_S_SUBSTRS[mod_flavor])
         self.check_global("g_t", ["a = 1", "a = 1"])
         self.check_global("g_c", ["a = 1"])
         # Test defining global variables in the expression evaluator


### PR DESCRIPTION
```
commit bead1fafba698832de6ea6361700297cec20f990
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Aug 24 15:05:59 2026 -0700

    [lldb][test] Build each resilience flavor in its own directory
    
    The test built both flavors of mod into the same fixed file names and
    renamed the results afterwards, so the recipes were only correct in a
    clean directory and the .swiftmodule at the shared path no longer
    matched the executable that recorded it. That is why only the dsym
    variants ran: dsymutil captured the AST before the rename.
    
    Give each flavor its own directory instead. Nothing is renamed, so the
    paths a binary records for its serialized AST and for its library stay
    valid, the recipes are idempotent, and the dwarf variants pass as well,
    doubling the number of configurations covered.
    
    Both flavors remain on disk under the same module name, so which
    interface SwiftASTContext imports depends on module search path order
    while reflection follows the loaded library. Cross-checking the two
    type systems is not meaningful under those conditions, so the test
    disables it.
    
    Assisted-by: Claude
```
