### PR TITLE
[Cherry-pick into next] [lldb] Don't inject unreadable variables into Swift expressions

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -78,6 +78,9 @@ void SwiftASTManipulatorBase::VariableInfo::Print(
   if (llvm::isa<VariableMetadataError>(m_metadata.get()))
     stream.Printf(", is_error");
 
+  if (!m_is_available)
+    stream.Printf(", is_unavailable");
+
   stream.PutChar(']');
 }
 
@@ -1096,6 +1099,14 @@ bool SwiftASTManipulator::AddExternalVariables(
       injected_nodes;
 
   for (SwiftASTManipulator::VariableInfo &variable : variables) {
+    // A variable with no readable value would fail to materialize,
+    // resulting in a fatal error for the entire expression.
+    if (!variable.IsAvailable()) {
+      LLDB_LOG(log, "Variable {0} has no readable value, not injecting it.",
+               variable.GetName());
+      continue;
+    }
+
     swift::FuncDecl *containing_function =
         GetFunctionToInjectVariableInto(variable);
     assert(containing_function && "No function to inject variable into!");

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -120,6 +120,7 @@ public:
       return m_name.str().starts_with("$pack_count_");
     }
     bool IsUnboundPack() const { return m_is_unbound_pack; }
+    bool IsAvailable() const { return m_is_available; }
 
     VariableInfo() = default;
     VariableInfo(CompilerType type, swift::Identifier name,
@@ -135,7 +136,8 @@ public:
           m_var_introducer(other.m_var_introducer),
           m_lookup_error(other.m_lookup_error.Clone()),
           m_is_capture_list(other.m_is_capture_list),
-          m_is_unbound_pack(other.m_is_unbound_pack) {}
+          m_is_unbound_pack(other.m_is_unbound_pack),
+          m_is_available(other.m_is_available) {}
 
     VariableInfo(CompilerType type, swift::Identifier name,
                  swift::VarDecl *decl)
@@ -150,6 +152,7 @@ public:
       m_lookup_error = other.m_lookup_error.Clone();
       m_is_capture_list = other.m_is_capture_list;
       m_is_unbound_pack = other.m_is_unbound_pack;
+      m_is_available = other.m_is_available;
       return *this;
     }
 
@@ -160,6 +163,7 @@ public:
       m_lookup_error = Status::FromError(std::move(error));
     }
     llvm::Error TakeLookupError() { return m_lookup_error.ToError(); }
+    void SetUnavailable() { m_is_available = false; }
 
     friend class SwiftASTManipulator;
 
@@ -173,6 +177,7 @@ public:
     Status m_lookup_error;
     bool m_is_capture_list = false;
     bool m_is_unbound_pack = false;
+    bool m_is_available = true;
   };
 
   SwiftASTManipulatorBase(swift::SourceFile &source_file,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -409,8 +409,16 @@ static llvm::Error AddVariableInfo(
   }
 
   auto ts = target_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
-  if (!ts)
-    return llvm::createStringError("type for self has no type system");
+  if (!ts) {
+    if (is_self)
+      return llvm::createStringError("type for self has no type system");
+    std::string msg =
+        llvm::formatv("discarded local '{0}', type '{1}' is not a Swift type",
+                      name, target_type.GetDisplayTypeName());
+    diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                     eDiagnosticOriginLLDB);
+    return llvm::Error::success();
+  }
 
   // If we couldn't fully realize the type, then we aren't going
   // to get very far making a local out of it, so discard it here.
@@ -477,14 +485,19 @@ static llvm::Error AddVariableInfo(
   SwiftASTManipulatorBase::VariableMetadataSP metadata_sp(
       new SwiftASTManipulatorBase::VariableMetadataVariable(
           patched_variable_sp));
-  local_variables.emplace_back(
+  auto &variable_info = local_variables.emplace_back(
       target_type, ast_context.GetASTContext()->getIdentifier(overridden_name),
       metadata_sp,
       variable_sp->IsConstant() ? swift::VarDecl::Introducer::Let
                                 : swift::VarDecl::Introducer::Var,
       false, is_unbound_pack);
-  if (variable_status.Fail())
-    local_variables.back().SetLookupError(variable_status.takeError());
+  if (variable_status.Fail()) {
+    variable_info.SetLookupError(variable_status.takeError());
+    // Unavailable self is handled separately by downgrading the
+    // method to a freestanding function.
+    if (!is_self)
+      variable_info.SetUnavailable();
+  }
 
   processed_variables.insert(overridden_name);
   return llvm::Error::success();

--- a/lldb/test/API/lang/swift/materialize_unreadable_variable/Lib.swift
+++ b/lldb/test/API/lang/swift/materialize_unreadable_variable/Lib.swift
@@ -1,0 +1,18 @@
+import NoRefl
+
+// A resilient struct with one field whose reflection metadata is missing.
+// Laying out the record fails, so a value of this type cannot be read at all.
+public struct Unreadable {
+    public var opaque: Opaque
+    public var tag: Int
+    public init(tag: Int) {
+        self.opaque = Opaque(x: 1)
+        self.tag = tag
+    }
+}
+
+// A fully reflectable sibling.
+public struct Plain {
+    public var value: Int = 7
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/materialize_unreadable_variable/Makefile
+++ b/lldb/test/API/lang/swift/materialize_unreadable_variable/Makefile
@@ -1,0 +1,26 @@
+SWIFT_SOURCES := main.swift
+
+# Both libraries are resilient so that Unreadable is address-only in the
+# consumer, matching the frame shapes this failure is reported from.
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR) -enable-library-evolution
+LD_EXTRAS = -L$(BUILDDIR) -lLib -lNoRefl
+
+all: Lib.swiftmodule $(EXE)
+
+include Makefile.rules
+
+Lib.swiftmodule: $(SRCDIR)/Lib.swift NoRefl.swiftmodule
+	"$(MAKE)" -f $(MAKEFILE_RULES) \
+		DYLIB_ONLY=YES \
+		DYLIB_NAME=Lib \
+		DYLIB_SWIFT_SOURCES=Lib.swift \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		LD_EXTRAS="-L$(BUILDDIR) -lNoRefl"
+
+# -disable-reflection-metadata is what makes Opaque unreadable.
+NoRefl.swiftmodule: $(SRCDIR)/NoRefl.swift
+	"$(MAKE)" -f $(MAKEFILE_RULES) \
+		DYLIB_ONLY=YES \
+		DYLIB_NAME=NoRefl \
+		DYLIB_SWIFT_SOURCES=NoRefl.swift \
+		SWIFTFLAGS_EXTRAS="-enable-library-evolution -Xfrontend -disable-reflection-metadata"

--- a/lldb/test/API/lang/swift/materialize_unreadable_variable/NoRefl.swift
+++ b/lldb/test/API/lang/swift/materialize_unreadable_variable/NoRefl.swift
@@ -1,0 +1,6 @@
+// Compiled with -disable-reflection-metadata, so LLDB cannot find reflection
+// information for this type.
+public struct Opaque {
+    public var x: Int
+    public init(x: Int) { self.x = x }
+}

--- a/lldb/test/API/lang/swift/materialize_unreadable_variable/TestSwiftMaterializeUnreadableVariable.py
+++ b/lldb/test/API/lang/swift/materialize_unreadable_variable/TestSwiftMaterializeUnreadableVariable.py
@@ -1,0 +1,46 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftMaterializeUnreadableVariable(lldbtest.TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipEmbeddedSwift
+    @swiftTest
+    def test_unreadable_variable(self):
+        """A frame with two locals: `p`, which reads fine, and `unreadable`, a
+        resilient struct with a field whose reflection metadata is missing, so
+        its value cannot be read at all.
+
+        All assertions share one launch, since launching the process dominates
+        the runtime of this test."""
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self,
+            "break here",
+            lldb.SBFileSpec("main.swift"),
+            extra_images=["Lib", "NoRefl"],
+        )
+        frame = thread.frames[0]
+
+        # The unreadable variable reports an error, and a readable sibling in
+        # the same frame is unaffected.
+        lldbutil.check_variable(
+            self, frame.FindVariable("p").GetChildMemberWithName("value"), value="7"
+        )
+        unreadable = frame.FindVariable("unreadable")
+        self.assertTrue(unreadable.IsValid(), "'unreadable' was found")
+        self.assertTrue(unreadable.GetError().Fail(), "'unreadable' cannot be read")
+
+        # An unreadable variable that the expression does not reference must not
+        # make the whole evaluation fail.
+        self.expect_expr("p.value", result_value="7")
+
+        # An expression that does need the unreadable variable has to fail and
+        # the failure reason given needs to be actionable.
+        value = self.frame().EvaluateExpression("unreadable.tag")
+        error = value.GetError().GetCString() or ""
+        self.assertIn("cannot find 'unreadable' in scope", error)
+        self.assertIn('Missing debug information for variable "unreadable"', error)

--- a/lldb/test/API/lang/swift/materialize_unreadable_variable/main.swift
+++ b/lldb/test/API/lang/swift/materialize_unreadable_variable/main.swift
@@ -1,0 +1,10 @@
+import Lib
+
+// `unreadable` is never mentioned by the expressions the test evaluates. It is
+// in scope, which is enough for the Swift expression parser to inject it into
+// the expression wrapper and for the materializer to have to read it.
+func inspect(_ unreadable: Unreadable, _ p: Plain) {
+    print(p.value) // break here
+}
+
+inspect(Unreadable(tag: 42), Plain())


### PR DESCRIPTION
```
commit 00a31544b5a8a702c404c773bb2c70a4f826ad94
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Aug 24 11:29:19 2026 -0700

    [lldb] Don't inject unreadable variables into Swift expressions
    
    The Swift expression parser brings every variable in scope into the
    expression wrapper, and EntityVariableBase::Materialize treats a
    failure to read any one of them as fatal.
    
    Mark such a variable unavailable and skip injecting it. The record is
    kept, so an expression that does reference the variable still reports
    both the compiler's "cannot find 'unreadable' in scope" and the recorded
    lookup error explaining why it is missing.
    
    Also stop treating a non-Swift type as fatal for variables other than
    self, and discard the variable with a warning instead, matching how a
    type that cannot be realized is handled.
    
    rdar://185263551
    
    Assisted-by: Claude
```
