### PR TITLE
[6.4.1][Support] Fix VersionTuple DenseMapInfo conformance (#206872)

### DIFF
--- a/llvm/include/llvm/Support/VersionTuple.h
+++ b/llvm/include/llvm/Support/VersionTuple.h
@@ -222,17 +222,7 @@ template <> struct DenseMapInfo<VersionTuple> {
     return VersionTuple(0x7FFFFFFE);
   }
   static unsigned getHashValue(const VersionTuple &Value) {
-    unsigned Result = Value.getMajor();
-    if (auto Minor = Value.getMinor())
-      Result = detail::combineHashValue(Result, *Minor);
-    if (auto Subminor = Value.getSubminor())
-      Result = detail::combineHashValue(Result, *Subminor);
-    if (auto Build = Value.getBuild())
-      Result = detail::combineHashValue(Result, *Build);
-    if (auto Subbuild = Value.getSubbuild())
-      Result = detail::combineHashValue(Result, *Subbuild);
-
-    return Result;
+    return hash_value(Value);
   }
 
   static bool isEqual(const VersionTuple &LHS, const VersionTuple &RHS) {

--- a/llvm/unittests/Support/VersionTupleTest.cpp
+++ b/llvm/unittests/Support/VersionTupleTest.cpp
@@ -99,3 +99,22 @@ TEST(VersionTuple, withMajorReplaced) {
   EXPECT_TRUE(ReplacedVersion.getSubbuild().has_value());
   EXPECT_EQ(VersionTuple(7, 11, 12, 2, 8), ReplacedVersion);
 }
+
+TEST(VersionTuple, DenseMapInfo) {
+  VersionTuple VT16(16);
+  VersionTuple VT16_0(16, 0);
+
+  VersionTuple VT17(17);
+  VersionTuple VT17_0(17, 0);
+
+  // In C++, if two objects are equal, their hashes should be equal.
+  // DenseMapInfo relies on the same relation for comparing keys.
+  // If isEqual returns true, getHashValue should return the same value.
+  EXPECT_TRUE(DenseMapInfo<VersionTuple>::isEqual(VT16, VT16_0));
+  EXPECT_EQ(DenseMapInfo<VersionTuple>::getHashValue(VT16),
+            DenseMapInfo<VersionTuple>::getHashValue(VT16_0));
+
+  EXPECT_TRUE(DenseMapInfo<VersionTuple>::isEqual(VT17, VT17_0));
+  EXPECT_EQ(DenseMapInfo<VersionTuple>::getHashValue(VT17),
+            DenseMapInfo<VersionTuple>::getHashValue(VT17_0));
+}


### PR DESCRIPTION
- **Explanation:** an incorrect implementation of `VersionTuple` hash value was creating missing errors and incorrect availability checks when defining availabilities.
- **Scope:** besides Swift's `-define-availability` version maps, there's other `DenseMap` using `VersionTuple` as a key in both LLVM code (`DarwinSDKInfo.cpp`, `Triple.cpp`) and Swift code (`TypeCheckAttr.cpp`). The test suites do not seem to surface any problems. There's also an already outdated copy of this header in the Swift repository: https://github.com/swiftlang/swift/blob/main/include/swift/RemoteInspection/RuntimeHeaders/llvm/Support/VersionTuple.h but the changes in the LLVM repository seems to be the ones that fix the problem.
- **Issues:** See LLVM llvm/llvm-project#206872 (this cherry-pick) and swiftlang/swift#90340 for the effects in Swift.
- **Risk:** Medium. While this change modifies the `-define-availability` behaviour for the better and it will be consistent, it is a breaking change in some cases (duplicated versions might start being reported, code that did not pass availability checks before because of different version spelling might start to be run), so it is not zero-risk, but previously behaviour was inconsistent.
- **Testing:** See unit test in LLVM llvm/llvm-project#206872 (this cherry-pick) and swiftlang/swift#90340 tests.
- **Notes:** This is a version of #13291 for the 6.4.1 branch instead of the 6.4.x. According to https://forums.swift.org/t/swift-6-4-release-process/85421/20 6.4.1 was created from 6.4.0 directly, so following @tshortli comment of doing this when the branches are announced, create this in 6.4.1 in order to have it as soon as possible since 6.4.0 was not longer possible some weeks ago, and keep the original in 6.4.x so at least the fix might appear in 6.4.2.