### PR TITLE
🍒[next][lldb][test] Fix TestSwiftStructChangeRerun failing when it runs too quickly

### DIFF
--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -59,6 +59,10 @@ class TestSwiftStructChangeRerun(TestBase):
         self.assertFalse(var_a_c.IsValid(), "make sure a.c doesn't exist")
         process.Kill()
 
+        # The updated copied_main_swift might not get rebuilt by Make if it is
+        # changed within the same second, as they will have the same mtime.
+        # A clean build fixes this.
+        self.build(make_targets=["clean"])
         
         print('build with main2.swift')
         cleanup()


### PR DESCRIPTION

(cherry picked from commit 5843b92fd4143bf63b95862f0fc505b4c12d8527)