### PR TITLE
[lldb] Use PC-1 in SwiftLanguageRuntime::GetRuntimeUnwindPlan

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -3504,10 +3504,16 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
   Address pc;
   pc.SetLoadAddress(regctx->GetPC(), &target);
   SymbolContext sc;
-  if (pc.IsValid())
-    if (!pc.CalculateSymbolContext(&sc, eSymbolContextFunction |
-                                            eSymbolContextSymbol))
-      return UnwindPlanSP();
+  {
+    Address pc_for_lookup = pc;
+    // If a PC is a return address, it may point to a different function.
+    if (!behaves_like_zeroth_frame)
+      pc_for_lookup.Slide(-1);
+    if (pc_for_lookup.IsValid())
+      if (!pc_for_lookup.CalculateSymbolContext(&sc, eSymbolContextFunction |
+                                                         eSymbolContextSymbol))
+        return UnwindPlanSP();
+  }
 
   Address func_start_addr;
   ConstString mangled_name;

--- a/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/Makefile
@@ -1,0 +1,12 @@
+C_SOURCES := main.c
+
+swift-async-decoy.o: swift-async-decoy.s
+	$(CPP) -o swift-async-decoy.s $(SRCDIR)/swift-async-decoy.s
+	$(CC) $(CFLAGS) -c -o swift-async-decoy.o swift-async-decoy.s
+
+include Makefile.rules
+
+a.out: swift-async-decoy.o
+
+# Needs to come after include
+OBJECTS += swift-async-decoy.o

--- a/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/TestSwiftAsyncSyncFrameEndingInCall.py
+++ b/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/TestSwiftAsyncSyncFrameEndingInCall.py
@@ -1,0 +1,90 @@
+"""
+Test that a sync frame whose last instruction is a call is not mistaken for an
+async frame.
+
+Such a frame's return address is one past the end of the function, i.e. the first
+byte of whichever function was placed next.  When that neighbour is an async
+funclet, resolving the return address without backing it up by one makes
+SwiftLanguageRuntime::GetRuntimeUnwindPlan build an async unwind plan -- CFA
+taken from the async context register -- for a plain sync frame.  The unwind then
+stops dead at that frame and every caller above it is lost.
+
+The binary is hand-written assembly using real Swift mangled names, which is all
+the Swift language runtime inspects.  No Swift compiler is involved, so the
+layout the test depends on is fixed by the source rather than chosen by an
+optimizer.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftAsyncSyncFrameEndingInCall(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    # swift-async-decoy.s is AArch64 assembly.
+    @skipIf(archs=no_match(["aarch64", "arm64", "arm64e"]))
+    @skipIf(oslist=no_match(lldbplatformutil.getDarwinOSTriples()))
+    def test(self):
+        """Test that no frames are lost above a sync frame ending in a call"""
+        self.build()
+
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, lldbtest.VALID_TARGET)
+
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertTrue(process, lldbtest.PROCESS_IS_VALID)
+        thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonException)
+        self.assertTrue(thread, "Failed to stop on the bad memory access")
+
+        self.check_layout(target)
+
+        expected = [
+            "reportAndDie",
+            "doPanic",
+            "waitComplete",
+            "caller",
+            "enter_swift",
+            "main",
+        ]
+        names = [frame.GetFunctionName() or "" for frame in thread.frames]
+        self.assertGreaterEqual(
+            len(names), len(expected), "backtrace was truncated: %s" % names
+        )
+        for index, expected_name in enumerate(expected):
+            self.assertIn(expected_name, names[index], "frame #%d" % index)
+
+    def check_layout(self, target):
+        """The two properties the bug needs.  Both are fixed by
+        swift-async-decoy.s, so a failure here means the assembler or linker
+        reordered something rather than that a compiler changed its mind."""
+        sync = self.find_symbol(target, "$s1a12waitCompleteySbSbF")
+        decoy = self.find_symbol(target, "$s1a9lynxWriteyyYaF")
+
+        # GetName() is the fully demangled name, which spells out "async".
+        # GetDisplayName() drops it.
+        self.assertNotIn("async", sync.GetName())
+        self.assertIn("async", decoy.GetName())
+
+        # 1. waitComplete's last instruction is a call, so its return address
+        #    lands one past the end of the function.
+        instructions = sync.GetInstructions(target)
+        self.assertGreater(instructions.GetSize(), 0)
+        last = instructions.GetInstructionAtIndex(instructions.GetSize() - 1)
+        self.assertEqual(last.GetMnemonic(target), "bl")
+
+        # 2. The async decoy occupies exactly that address.
+        self.assertEqual(
+            sync.GetEndAddress().GetLoadAddress(target),
+            decoy.GetStartAddress().GetLoadAddress(target),
+        )
+
+    def find_symbol(self, target, mangled_name):
+        symbols = target.FindSymbols(mangled_name)
+        self.assertEqual(symbols.GetSize(), 1, "one symbol named %s" % mangled_name)
+        return symbols.GetContextAtIndex(0).GetSymbol()

--- a/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/main.c
+++ b/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/main.c
@@ -1,0 +1,7 @@
+// The Swift mangled names in swift-async-decoy.s cannot be spelled in C.
+void enter_swift(void);
+
+int main() {
+  enter_swift();
+  return 0;
+}

--- a/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/swift-async-decoy.s
+++ b/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/swift-async-decoy.s
@@ -1,0 +1,115 @@
+#define ASYNC_CONTEXT_REG x22
+
+  .text
+
+//--------------------------------------
+// enter_swift(): plain C-callable entry point, since the mangled names below
+// cannot be spelled in C.
+//--------------------------------------
+  .globl _enter_swift
+  .p2align 2
+_enter_swift:
+  .cfi_startproc
+  stp x29, x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -8
+  .cfi_offset w29, -16
+  mov x29, sp
+  .cfi_def_cfa w29, 16
+  bl _$s1a6calleryyF
+  ldp x29, x30, [sp], #16
+  ret
+  .cfi_endproc
+
+//--------------------------------------
+// a.caller() -> (): sync.  Primes the async context register, then calls
+// waitComplete.  This is the innermost frame that goes missing.
+//--------------------------------------
+  .globl _$s1a6calleryyF
+  .p2align 2
+_$s1a6calleryyF:
+  .cfi_startproc
+  stp x29, x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -8
+  .cfi_offset w29, -16
+  mov x29, sp
+  .cfi_def_cfa w29, 16
+  // The buggy path reads this register to build its CFA.  Point it at readable
+  // memory so it produces a plan instead of bailing out early.
+  adrp ASYNC_CONTEXT_REG, _async_context@PAGE
+  add ASYNC_CONTEXT_REG, ASYNC_CONTEXT_REG, _async_context@PAGEOFF
+  bl _$s1a12waitCompleteySbSbF
+  ldp x29, x30, [sp], #16
+  ret
+  .cfi_endproc
+
+//--------------------------------------
+// a.reportAndDie() -> Swift.Never: faults, giving the test a deterministic stop.
+//--------------------------------------
+  .globl _$s1a12reportAndDies5NeverOyF
+  .p2align 2
+_$s1a12reportAndDies5NeverOyF:
+  .cfi_startproc
+  mov w8, #8
+  mov w9, #1
+  str x9, [x8]                  // EXC_BAD_ACCESS / SIGSEGV
+Lspin:
+  b Lspin
+  .cfi_endproc
+
+//--------------------------------------
+// a.doPanic(Swift.UInt32) -> (): also ends in a `bl`, which is what the Swift
+// optimizer emits for a body that is a single call to a Never function.
+//--------------------------------------
+  .globl _$s1a7doPanicyys6UInt32VF
+  .p2align 2
+_$s1a7doPanicyys6UInt32VF:
+  .cfi_startproc
+  stp x29, x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -8
+  .cfi_offset w29, -16
+  mov x29, sp
+  .cfi_def_cfa w29, 16
+  bl _$s1a12reportAndDies5NeverOyF
+  .cfi_endproc
+
+//--------------------------------------
+// a.waitComplete(Swift.Bool) -> Swift.Bool: sync, and the `bl` is its last
+// instruction.  The frame under test.
+//--------------------------------------
+  .globl _$s1a12waitCompleteySbSbF
+  .p2align 2
+_$s1a12waitCompleteySbSbF:
+  .cfi_startproc
+  stp x29, x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -8
+  .cfi_offset w29, -16
+  mov x29, sp
+  .cfi_def_cfa w29, 16
+  bl _$s1a7doPanicyys6UInt32VF
+  .cfi_endproc
+
+//--------------------------------------
+// a.lynxWrite() async -> (): the decoy.  Must be laid out immediately after
+// waitComplete; the test asserts the adjacency.  Never executed.
+//--------------------------------------
+  .globl _$s1a9lynxWriteyyYaF
+  .p2align 2
+_$s1a9lynxWriteyyYaF:
+  .cfi_startproc
+  stp x29, x30, [sp, #-16]!
+  mov x29, sp
+  ldp x29, x30, [sp], #16
+  ret
+  .cfi_endproc
+
+  .data
+  .p2align 3
+// A minimal async context: { parent context, resume pc }.  Only needs to be
+// readable for the buggy path to build a plan from it.
+_async_context:
+  .quad 0
+  .quad 0


### PR DESCRIPTION
When a function ends in a `bl` (very common in no-return functions), its corresponding frame will have a PC pointing into a different function entirely. RegisterContextUnwind explicitly handles this case, but it delegates to each Runtime plugin to decide how to handle it. SwiftLanguageRuntime was not doing so.

To test this, we need to carefully place an async function right after a non-async-function that ends in a bl instruction.

rdar://185435065