### PR TITLE
[DWARFLinker] Cherrypick module import commits

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
@@ -33,8 +33,8 @@ void DIEAttributeCloner::clone() {
       DWARFDataExtractor(DIECopy, Data.isLittleEndian(), Data.getAddressSize());
 
   // Modify the copy with relocated addresses.
-  InUnit.getContaingFile().Addresses->applyValidRelocs(DIECopy, Offset,
-                                                       Data.isLittleEndian());
+  InUnit.getContainingFile().Addresses->applyValidRelocs(DIECopy, Offset,
+                                                         Data.isLittleEndian());
 
   // Reset the Offset to 0 as we will be working on the local copy of
   // the data.
@@ -312,7 +312,7 @@ size_t DIEAttributeCloner::cloneScalarAttr(
   case dwarf::DW_AT_macro_info: {
     if (std::optional<uint64_t> Offset = Val.getAsSectionOffset()) {
       const DWARFDebugMacro *Macro =
-          InUnit.getContaingFile().Dwarf->getDebugMacinfo();
+          InUnit.getContainingFile().Dwarf->getDebugMacinfo();
       if (Macro == nullptr || !Macro->hasEntryForOffset(*Offset))
         return 0;
 
@@ -326,7 +326,7 @@ size_t DIEAttributeCloner::cloneScalarAttr(
   case dwarf::DW_AT_macros: {
     if (std::optional<uint64_t> Offset = Val.getAsSectionOffset()) {
       const DWARFDebugMacro *Macro =
-          InUnit.getContaingFile().Dwarf->getDebugMacro();
+          InUnit.getContainingFile().Dwarf->getDebugMacro();
       if (Macro == nullptr || !Macro->hasEntryForOffset(*Offset))
         return 0;
 
@@ -712,7 +712,7 @@ uint64_t DIEAttributeCloner::constrainHighPC(uint64_t HighPC, bool IsLength) {
   if (!LowPC)
     return HighPC;
   uint64_t Constrained =
-      InUnit.getContaingFile().Addresses->constrainCodeRangeHighPC(
+      InUnit.getContainingFile().Addresses->constrainCodeRangeHighPC(
           *LowPC, IsLength ? *LowPC + HighPC : HighPC, *FuncAddressAdjustment);
   return IsLength ? Constrained - *LowPC : Constrained;
 }

--- a/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
@@ -253,6 +253,31 @@ size_t DIEAttributeCloner::cloneDieRefAttr(
   if (RefDIEInfo.needToPlaceInTypeTable())
     RefTypeName = RefDiePair->CU->getDieTypeEntry(RefDiePair->DieEntry);
 
+  // The importing unit's DW_TAG_module skeleton can have a different
+  // DW_AT_LLVM_include_path than the unit built from the .pcm and the import
+  // must use the latter. The type pool already merges copies, so a reference
+  // with a type entry resolves correctly. Without one, the module's anchor is
+  // the only link between the two, and it is not known until the unit
+  // describing the module has been emitted.
+  if (RefDiePair->DieEntry->getTag() == dwarf::DW_TAG_module &&
+      AttrSpec.Attr == dwarf::DW_AT_import && !OutUnit.isTypeUnit() &&
+      !RefTypeName) {
+    SmallString<128> Path;
+    if (RefDiePair->CU->getModulePath(RefDiePair->DieEntry, Path)) {
+      ModuleAnchor *Anchor =
+          InUnit.getGlobalData().getModulePool().getOrCreate(Path);
+
+      DebugInfoOutputSection.notePatchWithOffsetUpdate(
+          DebugDieModuleRefPatch{
+              AttrOutOffset, RefDiePair->CU,
+              RefDiePair->CU->getDIEIndex(RefDiePair->DieEntry), Anchor},
+          PatchesOffsets);
+      return Generator
+          .addScalarAttribute(AttrSpec.Attr, dwarf::DW_FORM_ref_addr, 0xBADDEF)
+          .second;
+    }
+  }
+
   if (OutUnit.isTypeUnit()) {
     assert(RefTypeName && "Type name for referenced DIE is not set");
     assert(InUnit.getDieTypeEntry(InputDIEIdx) &&

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -929,7 +929,7 @@ Error CompileUnit::cloneAndEmitDebugMacro() {
   if (std::optional<uint64_t> MacroAttr =
           dwarf::toSectionOffset(OrigUnitDie.find(dwarf::DW_AT_macros))) {
     if (const DWARFDebugMacro *Table =
-            getContaingFile().Dwarf->getDebugMacro()) {
+            getContainingFile().Dwarf->getDebugMacro()) {
       emitMacroTableImpl(Table, *MacroAttr, true);
     }
   }
@@ -938,7 +938,7 @@ Error CompileUnit::cloneAndEmitDebugMacro() {
   if (std::optional<uint64_t> MacroAttr =
           dwarf::toSectionOffset(OrigUnitDie.find(dwarf::DW_AT_macro_info))) {
     if (const DWARFDebugMacro *Table =
-            getContaingFile().Dwarf->getDebugMacinfo()) {
+            getContainingFile().Dwarf->getDebugMacinfo()) {
       emitMacroTableImpl(Table, *MacroAttr, false);
     }
   }
@@ -1398,7 +1398,7 @@ DIE *CompileUnit::createPlainDIEandCloneAttributes(
   if (InputDieEntry->getTag() == dwarf::DW_TAG_subprogram) {
     // Get relocation adjustment value for the current function.
     FuncAddressAdjustment =
-        getContaingFile().Addresses->getSubprogramRelocAdjustment(
+        getContainingFile().Addresses->getSubprogramRelocAdjustment(
             getDIE(InputDieEntry), false);
   } else if (InputDieEntry->getTag() == dwarf::DW_TAG_label) {
     // Get relocation adjustment value for the current label.
@@ -1412,7 +1412,7 @@ DIE *CompileUnit::createPlainDIEandCloneAttributes(
   } else if (InputDieEntry->getTag() == dwarf::DW_TAG_variable) {
     // Get relocation adjustment value for the current variable.
     std::pair<bool, std::optional<int64_t>> LocExprAddrAndRelocAdjustment =
-        getContaingFile().Addresses->getVariableRelocAdjustment(
+        getContainingFile().Addresses->getVariableRelocAdjustment(
             getDIE(InputDieEntry), false);
 
     HasLocationExpressionAddress = LocExprAddrAndRelocAdjustment.first;
@@ -1570,7 +1570,7 @@ TypeEntry *CompileUnit::createTypeDIEandCloneAttributes(
 
 Error CompileUnit::cloneAndEmitLineTable(const Triple &TargetTriple) {
   const DWARFDebugLine::LineTable *InputLineTable =
-      getContaingFile().Dwarf->getLineTableForUnit(&getOrigUnit());
+      getContainingFile().Dwarf->getLineTableForUnit(&getOrigUnit());
   if (InputLineTable == nullptr) {
     if (getOrigUnit().getUnitDIE().find(dwarf::DW_AT_stmt_list))
       warn("cann't load line table.");

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -256,6 +256,84 @@ void CompileUnit::cleanupDataAfterClonning() {
   getOrigUnit().clear();
 }
 
+bool CompileUnit::getModulePath(const DWARFDebugInfoEntry *DieEntry,
+                                SmallVectorImpl<char> &Path) {
+  assert(DieEntry->getTag() == dwarf::DW_TAG_module);
+
+  SmallVector<StringRef, 4> Names;
+  for (const DWARFDebugInfoEntry *CurEntry = DieEntry;
+       CurEntry && CurEntry->getTag() == dwarf::DW_TAG_module;
+       CurEntry = getParent(CurEntry).getDebugInfoEntry()) {
+    StringRef Name = dwarf::toStringRef(find(CurEntry, dwarf::DW_AT_name));
+    if (Name.empty())
+      return false;
+    Names.push_back(Name);
+  }
+
+  for (StringRef Name : reverse(Names)) {
+    Path.append(Name.begin(), Name.end());
+    Path.push_back('\0');
+  }
+
+  return true;
+}
+
+void CompileUnit::noteModuleAnchors() {
+  const DWARFDebugInfoEntry *UnitEntry = getUnitDIE().getDebugInfoEntry();
+  assert(UnitEntry && "unit reached cloning without loaded DIEs");
+
+  // Find the root, ignoring the skeletons for the imported module.
+  const DWARFDebugInfoEntry *Root = nullptr;
+  for (const DWARFDebugInfoEntry *CurChild = getFirstChildEntry(UnitEntry);
+       CurChild && CurChild->getAbbreviationDeclarationPtr();
+       CurChild = getSiblingEntry(CurChild)) {
+    if (CurChild->getTag() == dwarf::DW_TAG_module &&
+        dwarf::toStringRef(find(CurChild, dwarf::DW_AT_name)) ==
+            getClangModuleName()) {
+      Root = CurChild;
+      break;
+    }
+  }
+  if (!Root)
+    return;
+
+  SmallString<128> Path;
+
+  // Submodules nest inside the module which declares them, so following the
+  // DW_TAG_module chain down from the root visits every module this unit
+  // describes, without walking the types they contain.
+  SmallVector<const DWARFDebugInfoEntry *, 4> WorkList = {Root};
+  while (!WorkList.empty()) {
+    const DWARFDebugInfoEntry *DieEntry = WorkList.pop_back_val();
+
+    for (const DWARFDebugInfoEntry *CurChild = getFirstChildEntry(DieEntry);
+         CurChild && CurChild->getAbbreviationDeclarationPtr();
+         CurChild = getSiblingEntry(CurChild))
+      if (CurChild->getTag() == dwarf::DW_TAG_module)
+        WorkList.push_back(CurChild);
+
+    Path.clear();
+    if (!getModulePath(DieEntry, Path))
+      continue;
+
+    ModuleAnchor Anchor;
+    Anchor.Priority = getPriority();
+    if (getDIEInfo(DieEntry).needToPlaceInTypeTable())
+      Anchor.TypeName = getDieTypeEntry(DieEntry);
+    if (!Anchor.TypeName) {
+      // Don't create a dangling reference to a DIE without a type entry or
+      // output offset.
+      uint64_t OutOffset = getDieOutOffset(DieEntry);
+      if (!OutOffset)
+        continue;
+      Anchor.Section = &getSectionDescriptor(DebugSectionKind::DebugInfo);
+      Anchor.LocalOffset = OutOffset;
+    }
+
+    getGlobalData().getModulePool().set(Path, Anchor);
+  }
+}
+
 /// Collect references to parseable Swift interfaces in imported
 /// DW_TAG_module blocks.
 void CompileUnit::analyzeImportedModule(const DWARFDebugInfoEntry *DieEntry) {
@@ -364,6 +442,15 @@ void CompileUnit::updateDieRefPatchesWithClonedOffsets() {
     (*DebugInfoSection)
         ->ListDebugULEB128DieRefPatch.forEach(
             [&](DebugULEB128DieRefPatch &Patch) {
+              /// Replace stored DIE indexes with DIE output offsets.
+              Patch.RefDieIdxOrClonedOffset =
+                  Patch.RefCU.getPointer()->getDieOutOffset(
+                      Patch.RefDieIdxOrClonedOffset);
+            });
+
+    (*DebugInfoSection)
+        ->ListDebugDieModuleRefPatch.forEach(
+            [&](DebugDieModuleRefPatch &Patch) {
               /// Replace stored DIE indexes with DIE output offsets.
               Patch.RefDieIdxOrClonedOffset =
                   Patch.RefCU.getPointer()->getDieOutOffset(

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -114,7 +114,8 @@ public:
   /// Returns DWARFFile containing this compile unit.
   const DWARFFile &getContainingFile() const { return File; }
 
-  /// Set deterministic priority for type DIE allocation ordering.
+  /// Set deterministic priority for type DIE allocation ordering. Units compare
+  /// by \p ObjFileIdx first and by \p LocalIdx second.
   /// Lower priority values win when multiple CUs race to define the same type.
   llvm::Error setPriority(uint64_t ObjFileIdx, uint64_t LocalIdx);
 

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -114,6 +114,16 @@ public:
   /// Returns DWARFFile containing this compile unit.
   const DWARFFile &getContainingFile() const { return File; }
 
+  /// Appends the names of the DW_TAG_module enclosing \p DieEntry, outermost
+  /// first. Returns false when one of them has no name making the module
+  /// unidentifiable across units.
+  bool getModulePath(const DWARFDebugInfoEntry *DieEntry,
+                     SmallVectorImpl<char> &Path);
+
+  /// Must run while the output offsets are still available, and once they are
+  /// final.
+  void noteModuleAnchors();
+
   /// Set deterministic priority for type DIE allocation ordering. Units compare
   /// by \p ObjFileIdx first and by \p LocalIdx second.
   /// Lower priority values win when multiple CUs race to define the same type.

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -112,7 +112,7 @@ public:
   StringEntry *getFileName(unsigned FileIdx, StringPool &GlobalStrings);
 
   /// Returns DWARFFile containing this compile unit.
-  const DWARFFile &getContaingFile() const { return File; }
+  const DWARFFile &getContainingFile() const { return File; }
 
   /// Set deterministic priority for type DIE allocation ordering.
   /// Lower priority values win when multiple CUs race to define the same type.

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerGlobalData.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerGlobalData.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIB_DWARFLINKER_PARALLEL_DWARFLINKERGLOBALDATA_H
 #define LLVM_LIB_DWARFLINKER_PARALLEL_DWARFLINKERGLOBALDATA_H
 
+#include "ModulePool.h"
 #include "TypePool.h"
 #include "llvm/DWARFLinker/Parallel/DWARFLinker.h"
 #include "llvm/DWARFLinker/StringPool.h"
@@ -91,6 +92,8 @@ public:
   /// Returns global string pool.
   StringPool &getStringPool() { return Strings; }
 
+  ModulePool &getModulePool() { return Modules; }
+
   /// Returns linking options.
   const DWARFLinkerOptions &getOptions() const { return Options; }
 
@@ -144,6 +147,7 @@ public:
 protected:
   llvm::parallel::PerThreadBumpPtrAllocator Allocator;
   StringPool Strings;
+  ModulePool Modules;
   DWARFLinkerOptions Options;
   MessageHandlerTy WarningHandler;
   MessageHandlerTy ErrorHandler;

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -46,19 +46,6 @@ DWARFLinkerImpl::LinkContext::LinkContext(LinkingGlobalData &GlobalData,
   }
 }
 
-DWARFLinkerImpl::LinkContext::RefModuleUnit::RefModuleUnit(
-    DWARFFile &File, std::unique_ptr<CompileUnit> Unit)
-    : File(File), Unit(std::move(Unit)) {}
-
-DWARFLinkerImpl::LinkContext::RefModuleUnit::RefModuleUnit(
-    LinkContext::RefModuleUnit &&Other)
-    : File(Other.File), Unit(std::move(Other.Unit)) {}
-
-void DWARFLinkerImpl::LinkContext::addModulesCompileUnit(
-    LinkContext::RefModuleUnit &&Unit) {
-  ModulesCompileUnits.emplace_back(std::move(Unit));
-}
-
 void DWARFLinkerImpl::addObjectFile(DWARFFile &File, ObjFileLoaderTy Loader,
                                     CompileUnitHandlerTy OnCUDieLoaded,
                                     CASLoaderTy CASLoader) {
@@ -157,10 +144,10 @@ Error DWARFLinkerImpl::link() {
     // language, so they have to be part of this scan as well. A module unit
     // can be the only ODR unit of a link, and any unit which deduplicates
     // types requires the artificial type unit to exist.
-    for (const LinkContext::RefModuleUnit &Module :
+    for (const std::unique_ptr<CompileUnit> &Module :
          Context->ModulesCompileUnits) {
       if (!Language) {
-        if (std::optional<uint16_t> LangVal = Module.Unit->getLanguage())
+        if (std::optional<uint16_t> LangVal = Module->getLanguage())
           if (isODRLanguage(*LangVal))
             Language = *LangVal;
       }
@@ -224,9 +211,9 @@ Error DWARFLinkerImpl::link() {
   if (DWARFLinkerBase::SwiftInterfacesMapTy *SwiftInterfaces =
           GlobalData.Options.ParseableSwiftInterfaces) {
     for (std::unique_ptr<LinkContext> &Context : ObjectContexts) {
-      for (LinkContext::RefModuleUnit &ModuleUnit :
+      for (std::unique_ptr<CompileUnit> &ModuleUnit :
            Context->ModulesCompileUnits)
-        ModuleUnit.Unit->mergeSwiftInterfaces(*SwiftInterfaces);
+        ModuleUnit->mergeSwiftInterfaces(*SwiftInterfaces);
       for (std::unique_ptr<CompileUnit> &CU : Context->CompileUnits)
         CU->mergeSwiftInterfaces(*SwiftInterfaces);
     }
@@ -499,9 +486,9 @@ Error DWARFLinkerImpl::LinkContext::loadClangModule(
   }
 
   if (Unit) {
-    ModulesCompileUnits.emplace_back(RefModuleUnit{*PCM, std::move(Unit)});
+    ModulesCompileUnits.emplace_back(std::move(Unit));
     // Preload line table, as it can't be loaded asynchronously.
-    ModulesCompileUnits.back().Unit->loadLineTable();
+    ModulesCompileUnits.back()->loadLineTable();
   }
 
   return Error::success();
@@ -518,14 +505,18 @@ Error DWARFLinkerImpl::LinkContext::link(TypeUnit *ArtificialTypeUnit) {
 
   // Assign deterministic priorities to module CUs for type DIE allocation.
   uint64_t LocalCUIdx = 0;
-  for (auto &Mod : ModulesCompileUnits) {
-    if (Error E = Mod.Unit->setPriority(ObjectFileIdx, LocalCUIdx++))
+  for (std::unique_ptr<CompileUnit> &Mod : ModulesCompileUnits) {
+    if (Error E = Mod->setPriority(ObjectFileIdx, LocalCUIdx++))
       return E;
   }
 
   // Link modules compile units first.
-  parallelForEach(ModulesCompileUnits, [&](RefModuleUnit &RefModule) {
-    linkSingleCompileUnit(*RefModule.Unit, ArtificialTypeUnit);
+  parallelForEach(ModulesCompileUnits, [&](std::unique_ptr<CompileUnit> &Mod) {
+    // A module unit describes DIEs which no address reaches, so nothing marks
+    // it inter-connected and the inter-connected loops below, which iterate
+    // CompileUnits alone, would never advance it.
+    assert(!Mod->isInterconnectedCU() && "module unit is inter-connected");
+    linkSingleCompileUnit(*Mod, ArtificialTypeUnit);
   });
 
   // Check for live relocations. If there is no any live relocation then we
@@ -1194,9 +1185,10 @@ void DWARFLinkerImpl::forEachObjectSectionsSet(
 
   // Then all modules(before regular compilation units).
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)
-    for (LinkContext::RefModuleUnit &ModuleUnit : Context->ModulesCompileUnits)
-      if (ModuleUnit.Unit->getStage() != CompileUnit::Stage::Skipped)
-        SectionsSetHandler(*ModuleUnit.Unit);
+    for (std::unique_ptr<CompileUnit> &ModuleUnit :
+         Context->ModulesCompileUnits)
+      if (ModuleUnit->getStage() != CompileUnit::Stage::Skipped)
+        SectionsSetHandler(*ModuleUnit);
 
   // Finally all compilation units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts) {
@@ -1217,9 +1209,10 @@ void DWARFLinkerImpl::forEachCompileAndTypeUnit(
 
   // Enumerate module units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)
-    for (LinkContext::RefModuleUnit &ModuleUnit : Context->ModulesCompileUnits)
-      if (ModuleUnit.Unit->getStage() != CompileUnit::Stage::Skipped)
-        UnitHandler(ModuleUnit.Unit.get());
+    for (std::unique_ptr<CompileUnit> &ModuleUnit :
+         Context->ModulesCompileUnits)
+      if (ModuleUnit->getStage() != CompileUnit::Stage::Skipped)
+        UnitHandler(ModuleUnit.get());
 
   // Enumerate compile units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)
@@ -1232,9 +1225,10 @@ void DWARFLinkerImpl::forEachCompileUnit(
     function_ref<void(CompileUnit *CU)> UnitHandler) {
   // Enumerate module units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)
-    for (LinkContext::RefModuleUnit &ModuleUnit : Context->ModulesCompileUnits)
-      if (ModuleUnit.Unit->getStage() != CompileUnit::Stage::Skipped)
-        UnitHandler(ModuleUnit.Unit.get());
+    for (std::unique_ptr<CompileUnit> &ModuleUnit :
+         Context->ModulesCompileUnits)
+      if (ModuleUnit->getStage() != CompileUnit::Stage::Skipped)
+        UnitHandler(ModuleUnit.get());
 
   // Enumerate compile units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -720,7 +720,7 @@ void DWARFLinkerImpl::LinkContext::linkSingleCompileUnit(
           // Clone input compile unit.
           if (CU.isClangModule() ||
               GlobalData.getOptions().UpdateIndexTablesOnly ||
-              CU.getContaingFile().Addresses->hasValidRelocs()) {
+              CU.getContainingFile().Addresses->hasValidRelocs()) {
             if (Error Err = CU.cloneAndEmit(GlobalData.getTargetTriple(),
                                             ArtificialTypeUnit))
               return std::move(Err);

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -734,6 +734,13 @@ void DWARFLinkerImpl::LinkContext::linkSingleCompileUnit(
         case CompileUnit::Stage::Cloned:
           // Update DIEs referencies.
           CU.updateDieRefPatchesWithClonedOffsets();
+
+          // Later than cloning, so that the offsets are final, and no later,
+          // because a unit which got this far can no longer be skipped and have
+          // its section dropped from the output.
+          if (CU.isClangModule())
+            CU.noteModuleAnchors();
+
           CU.setStage(CompileUnit::Stage::PatchesUpdated);
           break;
 

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -29,10 +29,11 @@ DWARFLinkerImpl::DWARFLinkerImpl(MessageHandlerTy ErrorHandler,
 DWARFLinkerImpl::LinkContext::LinkContext(LinkingGlobalData &GlobalData,
                                           DWARFFile &File, uint64_t ObjFileIdx,
                                           StringMap<uint64_t> &ClangModules,
+                                          uint64_t &ModuleUnitIdx,
                                           std::atomic<size_t> &UniqueUnitID)
     : OutputSections(GlobalData), InputDWARFFile(File),
       ObjectFileIdx(ObjFileIdx), ClangModules(ClangModules),
-      UniqueUnitID(UniqueUnitID) {
+      ModuleUnitIdx(ModuleUnitIdx), UniqueUnitID(UniqueUnitID) {
 
   if (File.Dwarf) {
     if (!File.Dwarf->compile_units().empty())
@@ -50,7 +51,8 @@ void DWARFLinkerImpl::addObjectFile(DWARFFile &File, ObjFileLoaderTy Loader,
                                     CompileUnitHandlerTy OnCUDieLoaded,
                                     CASLoaderTy CASLoader) {
   ObjectContexts.emplace_back(std::make_unique<LinkContext>(
-      GlobalData, File, ObjectContexts.size(), ClangModules, UniqueUnitID));
+      GlobalData, File, FirstObjFileIdx + ObjectContexts.size(), ClangModules,
+      ModuleUnitIdx, UniqueUnitID));
 
   if (ObjectContexts.back()->InputDWARFFile.Dwarf) {
     for (const std::unique_ptr<DWARFUnit> &CU :
@@ -486,6 +488,12 @@ Error DWARFLinkerImpl::LinkContext::loadClangModule(
   }
 
   if (Unit) {
+    // Incrementing the shared counter needs no synchronization: reaching this
+    // point requires a loader, and only the serial pass over the object files
+    // supplies one.
+    if (Error E = Unit->setPriority(ModuleUnitObjFileIdx, ModuleUnitIdx++))
+      return E;
+
     ModulesCompileUnits.emplace_back(std::move(Unit));
     // Preload line table, as it can't be loaded asynchronously.
     ModulesCompileUnits.back()->loadLineTable();
@@ -502,13 +510,6 @@ Error DWARFLinkerImpl::LinkContext::link(TypeUnit *ArtificialTypeUnit) {
   // Preload macro tables, as they can't be loaded asynchronously.
   InputDWARFFile.Dwarf->getDebugMacinfo();
   InputDWARFFile.Dwarf->getDebugMacro();
-
-  // Assign deterministic priorities to module CUs for type DIE allocation.
-  uint64_t LocalCUIdx = 0;
-  for (std::unique_ptr<CompileUnit> &Mod : ModulesCompileUnits) {
-    if (Error E = Mod->setPriority(ObjectFileIdx, LocalCUIdx++))
-      return E;
-  }
 
   // Link modules compile units first.
   parallelForEach(ModulesCompileUnits, [&](std::unique_ptr<CompileUnit> &Mod) {
@@ -532,6 +533,7 @@ Error DWARFLinkerImpl::LinkContext::link(TypeUnit *ArtificialTypeUnit) {
 
   // Create CompileUnit structures to keep information about source
   // DWARFUnit`s, load line tables.
+  uint64_t LocalCUIdx = 0;
   for (const auto &OrigCU : InputDWARFFile.Dwarf->compile_units()) {
     // Load only unit DIE at this stage.
     auto CUDie = OrigCU->getUnitDIE();

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
@@ -181,6 +181,8 @@ protected:
 
     StringMap<uint64_t> &ClangModules;
 
+    uint64_t &ModuleUnitIdx;
+
     /// Flag indicating that new inter-connected compilation units were
     /// discovered. It is used for restarting units processing
     /// if new inter-connected units were found.
@@ -193,7 +195,7 @@ protected:
 
     LinkContext(LinkingGlobalData &GlobalData, DWARFFile &File,
                 uint64_t ObjFileIdx, StringMap<uint64_t> &ClangModules,
-                std::atomic<size_t> &UniqueUnitID);
+                uint64_t &ModuleUnitIdx, std::atomic<size_t> &UniqueUnitID);
 
     /// Check whether specified \p CUDie is a Clang module reference.
     /// if \p Quiet is false then display error messages.
@@ -385,6 +387,15 @@ protected:
   /// Enumerate common sections and put their data into the output stream.
   void writeCommonSectionsToTheOutput();
 
+  /// The object file index given to every clang module unit. It sorts below
+  /// every object file's, which makes a module unit outrank all of them: the
+  /// definition a module gives of what it defines wins over the copy an
+  /// importer carries.
+  static constexpr uint64_t ModuleUnitObjFileIdx = 0;
+
+  /// Object file indices follow the module units'.
+  static constexpr uint64_t FirstObjFileIdx = ModuleUnitObjFileIdx + 1;
+
   /// \defgroup Data members accessed asinchroniously.
   ///
   /// @{
@@ -395,6 +406,10 @@ protected:
   /// Mapping the PCM filename to the DwoId. Only ever touched from
   /// addObjectFile(), which runs serially, so it needs no synchronization.
   StringMap<uint64_t> ClangModules;
+
+  /// Numbers the clang module units of the whole link, so that they form one
+  /// priority sequence regardless of which object file referenced a .pcm first.
+  uint64_t ModuleUnitIdx = 0;
 
   /// Type unit.
   std::unique_ptr<TypeUnit> ArtificialTypeUnit;

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
@@ -159,18 +159,6 @@ protected:
   struct LinkContext : public OutputSections {
     using UnitListTy = SmallVector<std::unique_ptr<CompileUnit>>;
 
-    /// Keep information for referenced clang module: already loaded DWARF info
-    /// of the clang module and a CompileUnit of the module.
-    struct RefModuleUnit {
-      RefModuleUnit(DWARFFile &File, std::unique_ptr<CompileUnit> Unit);
-      RefModuleUnit(RefModuleUnit &&Other);
-      RefModuleUnit(const RefModuleUnit &) = delete;
-
-      DWARFFile &File;
-      std::unique_ptr<CompileUnit> Unit;
-    };
-    using ModuleUnitListTy = SmallVector<RefModuleUnit>;
-
     /// Object file descriptor.
     DWARFFile &InputDWARFFile;
 
@@ -178,7 +166,7 @@ protected:
     UnitListTy CompileUnits;
 
     /// Set of Compile Units for modules.
-    ModuleUnitListTy ModulesCompileUnits;
+    UnitListTy ModulesCompileUnits;
 
     /// Index of this object file in the link order (used for deterministic
     /// type DIE allocation).
@@ -232,9 +220,6 @@ protected:
                           const std::string &PCMFile,
                           CompileUnitHandlerTy OnCUDieLoaded,
                           CASLoaderTy CASLoader, unsigned Indent = 0);
-
-    /// Add Compile Unit corresponding to the module.
-    void addModulesCompileUnit(RefModuleUnit &&Unit);
 
     /// Computes the total size of the debug info.
     uint64_t getInputDebugInfoSize() const {
@@ -407,9 +392,9 @@ protected:
   /// Unique ID for compile unit.
   std::atomic<size_t> UniqueUnitID;
 
-  /// Mapping the PCM filename to the DwoId.
+  /// Mapping the PCM filename to the DwoId. Only ever touched from
+  /// addObjectFile(), which runs serially, so it needs no synchronization.
   StringMap<uint64_t> ClangModules;
-  std::mutex ClangModulesMutex;
 
   /// Type unit.
   std::unique_ptr<TypeUnit> ArtificialTypeUnit;

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -988,7 +988,7 @@ bool DependencyTracker::isLiveVariableEntry(const UnitEntryPairTy &Entry,
       // don't want a static variable in a function to force us to keep the
       // enclosing function, unless requested explicitly.
       std::pair<bool, std::optional<int64_t>> LocExprAddrAndRelocAdjustment =
-          Entry.CU->getContaingFile().Addresses->getVariableRelocAdjustment(
+          Entry.CU->getContainingFile().Addresses->getVariableRelocAdjustment(
               DIE, Entry.CU->getGlobalData().getOptions().Verbose);
 
       if (LocExprAddrAndRelocAdjustment.first)
@@ -1026,7 +1026,7 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
     Info.setHasAnAddress();
 
     RelocAdjustment =
-        Entry.CU->getContaingFile().Addresses->getSubprogramRelocAdjustment(
+        Entry.CU->getContainingFile().Addresses->getSubprogramRelocAdjustment(
             DIE, Verbose);
     if (!RelocAdjustment)
       return false;
@@ -1067,9 +1067,8 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
           Entry.CU->getOrigUnit().getUnitDIE().find(dwarf::DW_AT_language), 0);
       if (Language == dwarf::DW_LANG_Mips_Assembler ||
           Language == dwarf::DW_LANG_Assembly) {
-        if (auto Range =
-                Entry.CU->getContaingFile().Addresses->getSymbolRangeForAddress(
-                    *LowPc))
+        if (auto Range = Entry.CU->getContainingFile()
+                             .Addresses->getSymbolRangeForAddress(*LowPc))
           Entry.CU->addFunctionRange(Range->LowPC, Range->HighPC,
                                      *RelocAdjustment);
       }
@@ -1086,7 +1085,7 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
 
   Entry.CU->addFunctionRange(
       *LowPc,
-      Entry.CU->getContaingFile().Addresses->constrainCodeRangeHighPC(
+      Entry.CU->getContainingFile().Addresses->constrainCodeRangeHighPC(
           *LowPc, *HighPc, *RelocAdjustment),
       *RelocAdjustment);
   return true;

--- a/llvm/lib/DWARFLinker/Parallel/ModulePool.h
+++ b/llvm/lib/DWARFLinker/Parallel/ModulePool.h
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_DWARFLINKER_PARALLEL_MODULEPOOL_H
+#define LLVM_LIB_DWARFLINKER_PARALLEL_MODULEPOOL_H
+
+#include "TypePool.h"
+#include "llvm/ADT/StringMap.h"
+#include <limits>
+#include <mutex>
+
+namespace llvm {
+namespace dwarf_linker {
+namespace parallel {
+
+struct SectionDescriptor;
+
+/// Where the DW_TAG_module DIE describing a clang module ended up in the
+/// output. Clang imposes a one-definition rule (ODR) on module names regardless
+/// of the source language, so a module is described once and every importer
+/// resolves to that description.
+///
+/// A module DIE lands either in the artificial type unit, or in the plain DWARF
+/// of the unit which emitted it.
+struct ModuleAnchor {
+  bool isSet() const { return TypeName != nullptr || Section != nullptr; }
+
+  TypeEntry *TypeName = nullptr;
+  SectionDescriptor *Section = nullptr;
+  uint64_t LocalOffset = 0;
+
+  /// Priority of the unit which recorded this anchor.
+  uint64_t Priority = std::numeric_limits<uint64_t>::max();
+};
+
+class ModulePool {
+public:
+  ModuleAnchor *getOrCreate(StringRef Path) {
+    std::lock_guard<std::mutex> Guard(Mutex);
+
+    // The underlying StringMap guarantees the pointer remains stable. The
+    // pointee is written while cloning, so it may only be read afterwards.
+    return &Anchors[Path];
+  }
+
+  void set(StringRef Path, const ModuleAnchor &Location) {
+    std::lock_guard<std::mutex> Guard(Mutex);
+
+    // Anchors are keyed by module name while a unit is created per .pcm, so a
+    // module built more than once has a unit for each copy. The lowest priority
+    // wins, as in the type pool, guaranteeing determinism.
+    ModuleAnchor &Anchor = Anchors[Path];
+    if (!Anchor.isSet() || Location.Priority < Anchor.Priority)
+      Anchor = Location;
+  }
+
+private:
+  /// Unlike the type pool this is not a per-DIE structure. It is accessed once
+  /// for each DW_TAG_module cloned and once for each DW_AT_import cloned.
+  std::mutex Mutex;
+  StringMap<ModuleAnchor> Anchors;
+};
+
+} // end of namespace parallel
+} // end of namespace dwarf_linker
+} // end of namespace llvm
+
+#endif // LLVM_LIB_DWARFLINKER_PARALLEL_MODULEPOOL_H

--- a/llvm/lib/DWARFLinker/Parallel/OutputSections.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/OutputSections.cpp
@@ -67,6 +67,7 @@ void SectionDescriptor::clearAllSectionData() {
   ListDebugULEB128DieRefPatch.erase();
   ListDebugOffsetPatch.erase();
   ListDebugDieTypeRefPatch.erase();
+  ListDebugDieModuleRefPatch.erase();
   ListDebugType2TypeDieRefPatch.erase();
   ListDebugTypeDeclFilePatch.erase();
   ListDebugTypeLineStrPatch.erase();
@@ -430,6 +431,34 @@ void OutputSections::applyPatches(
     Section.apply(Patch.PatchOffset, dwarf::DW_FORM_ref_addr,
                   TypeEntry->getFinalDie().getOffset());
   });
+
+  Section.ListDebugDieModuleRefPatch.forEach(
+      [&](DebugDieModuleRefPatch &Patch) {
+        const ModuleAnchor &Anchor = *Patch.Anchor;
+
+        uint64_t FinalOffset;
+        if (Anchor.TypeName) {
+          assert(TypeUnitPtr != nullptr);
+          TypeEntryBody *TypeEntry = Anchor.TypeName->getValue().load();
+          assert(TypeEntry &&
+                 formatv("No data for type {0}", Anchor.TypeName->getKey())
+                     .str()
+                     .c_str());
+
+          FinalOffset = TypeEntry->getFinalDie().getOffset();
+        } else if (Anchor.Section) {
+          FinalOffset = Anchor.Section->StartOffset + Anchor.LocalOffset;
+        } else {
+          // No unit describes this module in full, so the importer's own
+          // skeleton is all the output has.
+          FinalOffset = Patch.RefDieIdxOrClonedOffset +
+                        Patch.RefCU.getPointer()
+                            ->getSectionDescriptor(DebugSectionKind::DebugInfo)
+                            .StartOffset;
+        }
+
+        Section.apply(Patch.PatchOffset, dwarf::DW_FORM_ref_addr, FinalOffset);
+      });
 
   Section.ListDebugType2TypeDieRefPatch.forEach(
       [&](DebugType2TypeDieRefPatch &Patch) {

--- a/llvm/lib/DWARFLinker/Parallel/OutputSections.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/OutputSections.cpp
@@ -66,6 +66,7 @@ void SectionDescriptor::clearAllSectionData() {
   ListDebugDieRefPatch.erase();
   ListDebugULEB128DieRefPatch.erase();
   ListDebugOffsetPatch.erase();
+  ListDebugDieTypeRefPatch.erase();
   ListDebugType2TypeDieRefPatch.erase();
   ListDebugTypeDeclFilePatch.erase();
   ListDebugTypeLineStrPatch.erase();

--- a/llvm/lib/DWARFLinker/Parallel/OutputSections.h
+++ b/llvm/lib/DWARFLinker/Parallel/OutputSections.h
@@ -10,6 +10,7 @@
 #define LLVM_LIB_DWARFLINKER_PARALLEL_OUTPUTSECTIONS_H
 
 #include "ArrayList.h"
+#include "ModulePool.h"
 #include "StringEntryToDwarfStringPoolEntryMap.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
@@ -100,6 +101,19 @@ struct DebugDieTypeRefPatch : SectionPatch {
   TypeEntry *RefTypeName = nullptr;
 };
 
+/// This structure is used to update a DW_AT_import reference to a
+/// DW_TAG_module. The reference resolves to the module's anchor once the link
+/// has filled it in, and to the inherited target otherwise. The inherited
+/// target is always resolved as an inter-CU reference, so that the attribute
+/// keeps the width it was emitted with whichever of the two wins.
+struct DebugDieModuleRefPatch : DebugDieRefPatch {
+  DebugDieModuleRefPatch(uint64_t PatchOffset, CompileUnit *RefCU,
+                         uint32_t RefIdx, ModuleAnchor *Anchor)
+      : DebugDieRefPatch(PatchOffset, nullptr, RefCU, RefIdx), Anchor(Anchor) {}
+
+  ModuleAnchor *Anchor = nullptr;
+};
+
 /// This structure is used to update reference to the type DIE.
 struct DebugType2TypeDieRefPatch : SectionPatch {
   DebugType2TypeDieRefPatch(uint64_t PatchOffset, DIE *Die, TypeEntry *TypeName,
@@ -163,6 +177,7 @@ struct SectionDescriptor : SectionDescriptorBase {
         ListDebugULEB128DieRefPatch(&GlobalData.getAllocator()),
         ListDebugOffsetPatch(&GlobalData.getAllocator()),
         ListDebugDieTypeRefPatch(&GlobalData.getAllocator()),
+        ListDebugDieModuleRefPatch(&GlobalData.getAllocator()),
         ListDebugType2TypeDieRefPatch(&GlobalData.getAllocator()),
         ListDebugTypeStrPatch(&GlobalData.getAllocator()),
         ListDebugTypeLineStrPatch(&GlobalData.getAllocator()),
@@ -202,6 +217,7 @@ public:
   ADD_PATCHES_LIST(DebugULEB128DieRefPatch)
   ADD_PATCHES_LIST(DebugOffsetPatch)
   ADD_PATCHES_LIST(DebugDieTypeRefPatch)
+  ADD_PATCHES_LIST(DebugDieModuleRefPatch)
   ADD_PATCHES_LIST(DebugType2TypeDieRefPatch)
   ADD_PATCHES_LIST(DebugTypeStrPatch)
   ADD_PATCHES_LIST(DebugTypeLineStrPatch)

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/1.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/1.ll
@@ -1,0 +1,35 @@
+; Test input for ../X86/module-import-canonical-priority.test.
+;
+; An object file importing module M, whose own DW_TAG_module names a different
+; include path than the module's own unit does.
+
+target triple = "x86_64-apple-darwin"
+
+define void @main() !dbg !100 { ret void }
+
+!llvm.dbg.cu = !{!0, !20}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            imports: !30)
+!1 = !DIFile(filename: "1.m", directory: "")
+!100 = distinct !DISubprogram(name: "main", scope: !0, file: !1, line: 1,
+                              type: !101, unit: !0,
+                              spFlags: DISPFlagDefinition)
+!101 = !DISubroutineType(types: !102)
+!102 = !{null}
+!30 = !{!31}
+!31 = !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !0,
+                        entity: !32, line: 1)
+!32 = !DIModule(scope: !0, name: "M",
+                includePath: "/tmp/M.framework/Modules/M.swiftmodule")
+
+; The skeleton unit referencing M.pcm. Its dwo id has to match M-odr.ll's.
+!20 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !21,
+                              producer: "test", emissionKind: FullDebug,
+                              splitDebugFilename: "M.pcm", dwoId: 42)
+!21 = !DIFile(filename: "M", directory: "")
+
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/2.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/2.ll
@@ -1,0 +1,36 @@
+; Test input for ../X86/module-import-canonical.test.
+;
+; A second object file importing the same module M. Only the first object file
+; to reference M.pcm gets a module unit, so this one has to resolve its import
+; to a DIE another object file owns.
+
+target triple = "x86_64-apple-darwin"
+
+define void @main2() !dbg !100 { ret void }
+
+!llvm.dbg.cu = !{!0, !20}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            imports: !30)
+!1 = !DIFile(filename: "2.m", directory: "")
+!100 = distinct !DISubprogram(name: "main2", scope: !0, file: !1, line: 1,
+                              type: !101, unit: !0,
+                              spFlags: DISPFlagDefinition)
+!101 = !DISubroutineType(types: !102)
+!102 = !{null}
+!30 = !{!31}
+!31 = !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !0,
+                        entity: !32, line: 1)
+!32 = !DIModule(scope: !0, name: "M",
+                includePath: "/tmp/M.framework/Modules/M.swiftmodule")
+
+; The skeleton unit referencing M.pcm. Its dwo id has to match M.ll's.
+!20 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !21,
+                              producer: "test", emissionKind: FullDebug,
+                              splitDebugFilename: "M.pcm", dwoId: 42)
+!21 = !DIFile(filename: "M", directory: "")
+
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/3.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/3.ll
@@ -1,0 +1,37 @@
+; Test input for ../X86/module-import-canonical-priority.test.
+;
+; Like 1.ll, but in an ODR language and without a skeleton unit for M.pcm, so
+; this object file contributes a DW_TAG_module for M to the type table without
+; owning the unit which describes M in full. It does own N.pcm, which puts the
+; module units of the link in a different order than the object files.
+
+target triple = "x86_64-apple-darwin"
+
+define void @main3() !dbg !100 { ret void }
+
+!llvm.dbg.cu = !{!0, !40}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC_plus_plus, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            imports: !30)
+!1 = !DIFile(filename: "3.mm", directory: "")
+!100 = distinct !DISubprogram(name: "main3", scope: !0, file: !1, line: 1,
+                              type: !101, unit: !0,
+                              spFlags: DISPFlagDefinition)
+!101 = !DISubroutineType(types: !102)
+!102 = !{null}
+!30 = !{!31}
+!31 = !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !0,
+                        entity: !32, line: 1)
+!32 = !DIModule(scope: !0, name: "M",
+                includePath: "/tmp/M.framework/Modules/M.swiftmodule")
+
+; The skeleton unit referencing N.pcm. Its dwo id has to match N-odr.ll's.
+!40 = distinct !DICompileUnit(language: DW_LANG_ObjC_plus_plus, file: !41,
+                              producer: "test", emissionKind: FullDebug,
+                              splitDebugFilename: "N.pcm", dwoId: 43)
+!41 = !DIFile(filename: "N", directory: "")
+
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/M-odr.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/M-odr.ll
@@ -1,0 +1,24 @@
+; Test input for ../X86/module-import-canonical-priority.test.
+;
+; The module M in an ODR language, which places the DW_TAG_module describing it
+; in the type table rather than in the module unit.
+
+target triple = "x86_64-apple-darwin"
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC_plus_plus, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            retainedTypes: !2, dwoId: 42)
+!1 = !DIFile(filename: "M", directory: "")
+!2 = !{!3}
+!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "S", scope: !4,
+                      file: !1, line: 1, size: 32, elements: !5)
+!4 = !DIModule(scope: null, name: "M", includePath: "/tmp/M.framework")
+!5 = !{!6}
+!6 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !3, file: !1,
+                    line: 2, baseType: !7, size: 32)
+!7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/M.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/M.ll
@@ -1,0 +1,25 @@
+; Test input for ../X86/module-import-canonical.test.
+;
+; Stands in for the Clang module of a framework: one compile unit holding the
+; DW_TAG_module that describes the module itself, with the include path
+; pointing at the framework bundle.
+
+target triple = "x86_64-apple-darwin"
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            retainedTypes: !2, dwoId: 42)
+!1 = !DIFile(filename: "M", directory: "")
+!2 = !{!3}
+!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "S", scope: !4,
+                      file: !1, line: 1, size: 32, elements: !5)
+!4 = !DIModule(scope: null, name: "M", includePath: "/tmp/M.framework")
+!5 = !{!6}
+!6 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !3, file: !1,
+                    line: 2, baseType: !7, size: 32)
+!7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/N-odr.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/N-odr.ll
@@ -1,0 +1,24 @@
+; Test input for ../X86/module-import-canonical-priority.test.
+;
+; A second module, in an ODR language like M-odr.ll, so that the link holds more
+; than one module unit and they are owned by different object files.
+
+target triple = "x86_64-apple-darwin"
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC_plus_plus, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            retainedTypes: !2, dwoId: 43)
+!1 = !DIFile(filename: "N", directory: "")
+!2 = !{!3}
+!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "T", scope: !4,
+                      file: !1, line: 1, size: 32, elements: !5)
+!4 = !DIModule(scope: null, name: "N", includePath: "/tmp/N.framework")
+!5 = !{!6}
+!6 = !DIDerivedType(tag: DW_TAG_member, name: "count", scope: !3, file: !1,
+                    line: 2, baseType: !7, size: 32)
+!7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/debug-map-duplicate.map
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/debug-map-duplicate.map
@@ -1,0 +1,10 @@
+---
+triple:          'x86_64-apple-darwin'
+objects:
+  - filename: dup1.o
+    symbols:
+      - { sym: _main, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }
+  - filename: dup2.o
+    symbols:
+      - { sym: _main2, objAddr: 0x0, binAddr: 0x20000, size: 0x10 }
+...

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/debug-map-priority.map
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/debug-map-priority.map
@@ -1,0 +1,10 @@
+---
+triple:          'x86_64-apple-darwin'
+objects:
+  - filename: 3.o
+    symbols:
+      - { sym: _main3, objAddr: 0x0, binAddr: 0x30000, size: 0x10 }
+  - filename: 1.o
+    symbols:
+      - { sym: _main, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }
+...

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/debug-map.map
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/debug-map.map
@@ -1,0 +1,10 @@
+---
+triple:          'x86_64-apple-darwin'
+objects:
+  - filename: 1.o
+    symbols:
+      - { sym: _main, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }
+  - filename: 2.o
+    symbols:
+      - { sym: _main2, objAddr: 0x0, binAddr: 0x20000, size: 0x10 }
+...

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/dup-a.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/dup-a.ll
@@ -1,0 +1,24 @@
+; Test input for ../X86/module-import-canonical-duplicate.test.
+;
+; One of two builds of module M. Stands in for the copy the first object file
+; of the link was built against.
+
+target triple = "x86_64-apple-darwin"
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            retainedTypes: !2, dwoId: 42)
+!1 = !DIFile(filename: "M", directory: "")
+!2 = !{!3}
+!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "S", scope: !4,
+                      file: !1, line: 1, size: 32, elements: !5)
+!4 = !DIModule(scope: null, name: "M", includePath: "/tmp/A.framework")
+!5 = !{!6}
+!6 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !3, file: !1,
+                    line: 2, baseType: !7, size: 32)
+!7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/dup-b.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/dup-b.ll
@@ -1,0 +1,24 @@
+; Test input for ../X86/module-import-canonical-duplicate.test.
+;
+; The other build of module M, naming a different include path. Reached through
+; a different .pcm path, so the link gets a unit for this copy too.
+
+target triple = "x86_64-apple-darwin"
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            retainedTypes: !2, dwoId: 43)
+!1 = !DIFile(filename: "M", directory: "")
+!2 = !{!3}
+!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "S", scope: !4,
+                      file: !1, line: 1, size: 32, elements: !5)
+!4 = !DIModule(scope: null, name: "M", includePath: "/tmp/B.framework")
+!5 = !{!6}
+!6 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !3, file: !1,
+                    line: 2, baseType: !7, size: 32)
+!7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/dup1.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/dup1.ll
@@ -1,0 +1,33 @@
+; Test input for ../X86/module-import-canonical-duplicate.test.
+;
+; The first object file of the link, built against the copy of M under a/.
+
+target triple = "x86_64-apple-darwin"
+
+define void @main() !dbg !100 { ret void }
+
+!llvm.dbg.cu = !{!0, !20}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            imports: !30)
+!1 = !DIFile(filename: "dup1.m", directory: "")
+!100 = distinct !DISubprogram(name: "main", scope: !0, file: !1, line: 1,
+                              type: !101, unit: !0,
+                              spFlags: DISPFlagDefinition)
+!101 = !DISubroutineType(types: !102)
+!102 = !{null}
+!30 = !{!31}
+!31 = !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !0,
+                        entity: !32, line: 1)
+!32 = !DIModule(scope: !0, name: "M", includePath: "/tmp/importer1")
+
+; The skeleton unit referencing a/M.pcm. Its dwo id has to match dup-a.ll's.
+!20 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !21,
+                              producer: "test", emissionKind: FullDebug,
+                              splitDebugFilename: "a/M.pcm", dwoId: 42)
+!21 = !DIFile(filename: "M", directory: "")
+
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/Inputs/module-import-canonical/dup2.ll
+++ b/llvm/test/tools/dsymutil/Inputs/module-import-canonical/dup2.ll
@@ -1,0 +1,33 @@
+; Test input for ../X86/module-import-canonical-duplicate.test.
+;
+; The second object file of the link, built against the copy of M under b/.
+
+target triple = "x86_64-apple-darwin"
+
+define void @main2() !dbg !100 { ret void }
+
+!llvm.dbg.cu = !{!0, !20}
+!llvm.module.flags = !{!10, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !1,
+                            producer: "test", emissionKind: FullDebug,
+                            imports: !30)
+!1 = !DIFile(filename: "dup2.m", directory: "")
+!100 = distinct !DISubprogram(name: "main2", scope: !0, file: !1, line: 1,
+                              type: !101, unit: !0,
+                              spFlags: DISPFlagDefinition)
+!101 = !DISubroutineType(types: !102)
+!102 = !{null}
+!30 = !{!31}
+!31 = !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !0,
+                        entity: !32, line: 1)
+!32 = !DIModule(scope: !0, name: "M", includePath: "/tmp/importer2")
+
+; The skeleton unit referencing b/M.pcm. Its dwo id has to match dup-b.ll's.
+!20 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !21,
+                              producer: "test", emissionKind: FullDebug,
+                              splitDebugFilename: "b/M.pcm", dwoId: 43)
+!21 = !DIFile(filename: "M", directory: "")
+
+!10 = !{i32 2, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/dsymutil/X86/module-import-canonical-duplicate.test
+++ b/llvm/test/tools/dsymutil/X86/module-import-canonical-duplicate.test
@@ -1,0 +1,47 @@
+# A module can be built more than once in one link, under a different .pcm path
+# each time. A unit is created per .pcm but a module is anchored by name, so
+# both units describe module M and only one of them can be the import target.
+# The choice has to follow the link order, not the order the units happen to
+# finish cloning, or the dSYM stops being reproducible.
+
+RUN: rm -rf %t && mkdir -p %t/a %t/b
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/a/M.pcm %p/../Inputs/module-import-canonical/dup-a.ll
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/b/M.pcm %p/../Inputs/module-import-canonical/dup-b.ll
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/dup1.o %p/../Inputs/module-import-canonical/dup1.ll
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/dup2.o %p/../Inputs/module-import-canonical/dup2.ll
+
+RUN: dsymutil --linker parallel -f \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map-duplicate.map \
+RUN:     -oso-prepend-path %t -o %t/parallel.dwarf
+RUN: llvm-dwarfdump --verify %t/parallel.dwarf
+RUN: llvm-dwarfdump --debug-info %t/parallel.dwarf | FileCheck %s
+
+# Threading must not decide which copy wins.
+
+RUN: dsymutil --linker parallel -f --num-threads 1 \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map-duplicate.map \
+RUN:     -oso-prepend-path %t -o %t/serial.dwarf
+RUN: cmp %t/parallel.dwarf %t/serial.dwarf
+
+# The copy reached through the first object file of the link is the one every
+# importer resolves to, because its unit takes the lower priority.
+
+CHECK:      DW_TAG_compile_unit
+CHECK:        DW_AT_name {{.*}}"M"
+CHECK:      0x0[[MODULE:[0-9a-f]+]]: DW_TAG_module
+CHECK-NEXT:   DW_AT_name {{.*}}"M"
+CHECK-NEXT:   DW_AT_LLVM_include_path {{.*}}"/tmp/A.framework"
+
+CHECK:      DW_TAG_compile_unit
+CHECK:        DW_AT_name {{.*}}"dup1.m"
+CHECK:        DW_TAG_imported_declaration
+CHECK:          DW_AT_import {{.*}}(0x{{0*}}[[MODULE]] "M")
+
+CHECK:      DW_TAG_compile_unit
+CHECK:        DW_AT_name {{.*}}"dup2.m"
+CHECK:        DW_TAG_imported_declaration
+CHECK:          DW_AT_import {{.*}}(0x{{0*}}[[MODULE]] "M")

--- a/llvm/test/tools/dsymutil/X86/module-import-canonical-priority.test
+++ b/llvm/test/tools/dsymutil/X86/module-import-canonical-priority.test
@@ -1,0 +1,51 @@
+# A clang module holds the definitive description of what it defines, so when
+# several units contribute a copy of the same DW_TAG_module to the type table,
+# the one from the unit built from the .pcm has to win. Otherwise the module DIE
+# consumers read carries an importer's DW_AT_LLVM_include_path.
+#
+# The object file which owns the module unit is not necessarily the first one:
+# it is whichever object file referenced the .pcm first. Here 3.o comes first and
+# contributes a DW_TAG_module for M without referencing M.pcm, and 1.o, which
+# does reference it, comes second. 3.o owns N.pcm instead, so the unit which
+# describes M is not the first module unit of the link either.
+
+RUN: rm -rf %t && mkdir -p %t
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/M.pcm %p/../Inputs/module-import-canonical/M-odr.ll
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/N.pcm %p/../Inputs/module-import-canonical/N-odr.ll
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/1.o %p/../Inputs/module-import-canonical/1.ll
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/3.o %p/../Inputs/module-import-canonical/3.ll
+
+RUN: dsymutil --linker parallel -f \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map-priority.map \
+RUN:     -oso-prepend-path %t -o %t/out.dwarf
+RUN: llvm-dwarfdump --verify %t/out.dwarf
+RUN: llvm-dwarfdump --debug-info %t/out.dwarf | FileCheck %s
+
+RUN: dsymutil --linker parallel -f --num-threads 1 \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map-priority.map \
+RUN:     -oso-prepend-path %t -o %t/serial.dwarf
+RUN: cmp %t/out.dwarf %t/serial.dwarf
+
+# The type table holds one DW_TAG_module for M, and it is the module unit's copy.
+# Both module units of the link reach the type table, and no third module DIE
+# joins them there.
+
+CHECK:      DW_TAG_compile_unit
+CHECK:        DW_AT_name {{.*}}"__artificial_type_unit"
+CHECK:      0x0[[MODULE:[0-9a-f]+]]: DW_TAG_module
+CHECK-NEXT:   DW_AT_name {{.*}}"M"
+CHECK-NEXT:   DW_AT_LLVM_include_path {{.*}}"/tmp/M.framework"
+CHECK:        DW_TAG_module
+CHECK-NEXT:   DW_AT_name {{.*}}"N"
+CHECK-NEXT:   DW_AT_LLVM_include_path {{.*}}"/tmp/N.framework"
+CHECK-NOT:  DW_TAG_module
+CHECK:      Compile Unit
+
+# An importer whose own DW_TAG_module was uniqued into the type table shares that
+# entry, so its DW_AT_import resolves to the winner.
+
+CHECK:        DW_AT_import {{.*}}(0x{{0*}}[[MODULE]] "M")

--- a/llvm/test/tools/dsymutil/X86/module-import-canonical.test
+++ b/llvm/test/tools/dsymutil/X86/module-import-canonical.test
@@ -1,0 +1,99 @@
+# An importing compile unit emits its own DW_TAG_module skeleton for a module,
+# and that skeleton can name a different DW_AT_LLVM_include_path than the
+# module's own compile unit: a Swift unit names the .swiftmodule while the
+# companion Clang module names the framework bundle. Consumers compare the
+# search paths of two imported modules to tell whether they belong to the same
+# framework, so every importer has to resolve a module to the DIE of the unit
+# describing that module in full.
+#
+# Only the first object file which references a .pcm gets a module unit for it,
+# so the second object file below resolves its import across object file
+# boundaries.
+
+RUN: rm -rf %t && mkdir -p %t
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/M.pcm %p/../Inputs/module-import-canonical/M.ll
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/1.o %p/../Inputs/module-import-canonical/1.ll
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/2.o %p/../Inputs/module-import-canonical/2.ll
+
+RUN: dsymutil --linker parallel -f \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map.map \
+RUN:     -oso-prepend-path %t -o %t/parallel.dwarf
+RUN: llvm-dwarfdump --verify %t/parallel.dwarf
+RUN: llvm-dwarfdump --debug-info %t/parallel.dwarf | FileCheck %s
+
+# The output must not depend on thread interleaving.
+
+RUN: dsymutil --linker parallel -f --num-threads 1 \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map.map \
+RUN:     -oso-prepend-path %t -o %t/serial.dwarf
+RUN: cmp %t/parallel.dwarf %t/serial.dwarf
+
+# The classic linker resolves the imports to the same DIE.
+
+RUN: dsymutil --linker classic -f \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map.map \
+RUN:     -oso-prepend-path %t -o %t/classic.dwarf
+RUN: llvm-dwarfdump --verify %t/classic.dwarf
+RUN: llvm-dwarfdump --debug-info %t/classic.dwarf | FileCheck %s
+
+# When the module unit is in an ODR language, the DW_TAG_module describing the
+# module lands in the type table, and an import has to resolve to that copy.
+# The classic linker has no type table, so it is not run over this variant.
+
+RUN: mkdir -p %t/odr && cp %t/1.o %t/2.o %t/odr
+RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj \
+RUN:     -o %t/odr/M.pcm %p/../Inputs/module-import-canonical/M-odr.ll
+
+RUN: dsymutil --linker parallel -f \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map.map \
+RUN:     -oso-prepend-path %t/odr -o %t/odr.dwarf
+RUN: llvm-dwarfdump --verify %t/odr.dwarf
+RUN: llvm-dwarfdump --debug-info %t/odr.dwarf | FileCheck %s --check-prefix=ODR
+
+RUN: dsymutil --linker parallel -f --num-threads 1 \
+RUN:     -y %p/../Inputs/module-import-canonical/debug-map.map \
+RUN:     -oso-prepend-path %t/odr -o %t/odr-serial.dwarf
+RUN: cmp %t/odr.dwarf %t/odr-serial.dwarf
+
+# The module's own compile unit holds the DW_TAG_module carrying the bundle
+# path. Capture its offset. The DIE label strips leading zeros differently from
+# DW_AT_import, so anchor on the significant digits.
+
+CHECK:      DW_TAG_compile_unit
+CHECK:        DW_AT_name {{.*}}"M"
+CHECK:      0x0[[MODULE:[0-9a-f]+]]: DW_TAG_module
+CHECK-NEXT:   DW_AT_name {{.*}}"M"
+CHECK-NEXT:   DW_AT_LLVM_include_path {{.*}}"/tmp/M.framework"
+
+# Each importing unit resolves its import to that DIE, not to any skeleton of
+# its own naming a different include path.
+
+CHECK:      DW_TAG_compile_unit
+CHECK:        DW_AT_name {{.*}}"1.m"
+CHECK:        DW_TAG_imported_declaration
+CHECK:          DW_AT_import {{.*}}(0x{{0*}}[[MODULE]] "M")
+
+CHECK:      DW_TAG_compile_unit
+CHECK:        DW_AT_name {{.*}}"2.m"
+CHECK:        DW_TAG_imported_declaration
+CHECK:          DW_AT_import {{.*}}(0x{{0*}}[[MODULE]] "M")
+
+# The type table holds the module DIE carrying the bundle path, and both
+# importing units resolve to it.
+
+ODR:      DW_TAG_compile_unit
+ODR:        DW_AT_name {{.*}}"__artificial_type_unit"
+ODR:      0x0[[TYPEMODULE:[0-9a-f]+]]: DW_TAG_module
+ODR-NEXT:   DW_AT_name {{.*}}"M"
+ODR-NEXT:   DW_AT_LLVM_include_path {{.*}}"/tmp/M.framework"
+
+ODR:      DW_TAG_compile_unit
+ODR:        DW_AT_name {{.*}}"1.m"
+ODR:        DW_AT_import {{.*}}(0x{{0*}}[[TYPEMODULE]] "M")
+
+ODR:      DW_TAG_compile_unit
+ODR:        DW_AT_name {{.*}}"2.m"
+ODR:        DW_AT_import {{.*}}(0x{{0*}}[[TYPEMODULE]] "M")

--- a/llvm/test/tools/dsymutil/X86/modules.m
+++ b/llvm/test/tools/dsymutil/X86/modules.m
@@ -42,6 +42,34 @@ EOF
 // RUN: llvm-dwarfdump -v --debug-info %t.parallel.dSYM \
 // RUN:     | FileCheck --check-prefix=ACCEL %s
 
+// Foo imports Bar, so Foo.pcm carries a skeleton of Bar next to the module it
+// describes. That import has to resolve to the unit built from Bar.pcm, which
+// is the only one describing Bar in full. Both units offer the parallel linker
+// an anchor for Bar, so the winner must not depend on which is cloned first.
+
+// RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/modules \
+// RUN:   -y %p/dummy-debug-map.map -o %t.threaded
+// RUN: dsymutil --linker parallel -f --num-threads 1 \
+// RUN:   -oso-prepend-path=%p/../Inputs/modules \
+// RUN:   -y %p/dummy-debug-map.map -o %t.serial
+// RUN: cmp %t.threaded %t.serial
+// RUN: llvm-dwarfdump --debug-info %t.threaded \
+// RUN:     | FileCheck --check-prefix=MODIMPORT %s
+
+// MODIMPORT:      0x0[[BAR:[0-9a-f]+]]: DW_TAG_module
+// MODIMPORT-NEXT:   DW_AT_name {{.*}}"Bar"
+// MODIMPORT:          DW_TAG_structure_type
+// MODIMPORT-NEXT:       DW_AT_name {{.*}}"Bar"
+// MODIMPORT:              DW_AT_name {{.*}}"value"
+// MODIMPORT:          DW_TAG_structure_type
+// MODIMPORT-NEXT:       DW_AT_name {{.*}}"PruneMeNot"
+
+// MODIMPORT:      DW_TAG_module
+// MODIMPORT-NEXT:   DW_AT_name {{.*}}"Foo"
+// MODIMPORT:      DW_TAG_imported_declaration
+// MODIMPORT-NOT:    DW_TAG
+// MODIMPORT:        DW_AT_import {{.*}}(0x{{0*}}[[BAR]] "Bar")
+
 // ACCEL: DW_TAG_compile_unit
 
 // WARN-NOT: warning: hash mismatch

--- a/llvm/test/tools/dsymutil/X86/submodules.m
+++ b/llvm/test/tools/dsymutil/X86/submodules.m
@@ -24,7 +24,7 @@ EOF
 // RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/submodules \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump -v --debug-info - \
-// RUN:     | FileCheck %s --check-prefix=CHECK
+// RUN:     | FileCheck %s --check-prefixes=CHECK,PARALLEL
 
 // ---------------------------------------------------------------------
 #ifdef CHILD_H
@@ -34,7 +34,7 @@ EOF
 // CHECK-NOT:        DW_TAG
 // CHECK:              DW_TAG_module
 // CHECK-NEXT:           DW_AT_name{{.*}}"Parent"
-// CHECK:                DW_TAG_module
+// CHECK:      0x0[[CHILD:.*]]: DW_TAG_module
 // CHECK-NEXT:             DW_AT_name{{.*}}"Child"
 // CHECK:                  DW_TAG_structure_type
 // CHECK-NOT:                DW_TAG
@@ -51,7 +51,23 @@ struct PruneMeNot;
 // CLASSIC: 0x0[[EMPTY:.*]]: DW_TAG_module
 // CLASSIC-NEXT:             DW_AT_name{{.*}}"Empty"
 
-// CLASSIC:     DW_AT_import  {{.*}}0x{{0*}}[[EMPTY]]
+// Parent.pcm describes no Empty submodule, so both linkers leave that import
+// pointing at the skeleton the importing unit emitted. Only the offsets differ,
+// because the classic linker prunes the Parent and Child skeletons next to it.
+
+// PARALLEL:                DW_TAG_module
+// PARALLEL-NEXT:             DW_AT_name{{.*}}"Parent"
+// PARALLEL:                  DW_TAG_module
+// PARALLEL-NEXT:               DW_AT_name{{.*}}"Child"
+// PARALLEL:      0x0[[EMPTY:.*]]: DW_TAG_module
+// PARALLEL-NEXT:               DW_AT_name{{.*}}"Empty"
+
+// A submodule which is described elsewhere is imported through the module
+// unit's DIE, not through the skeleton the importing unit emits for it.
+
+// CHECK:       DW_AT_import  {{.*}}0x{{0*}}[[CHILD]]
+
+// CHECK:       DW_AT_import  {{.*}}0x{{0*}}[[EMPTY]]
 @import Parent.Child;
 @import Parent.Empty;
 int main(int argc, char **argv) { return 0; }


### PR DESCRIPTION
| # | Commit | PR | Subject | 
|---|--------|----|---------|
| 1 | 8beec63edd89 | [#217758](https://github.com/llvm/llvm-project/pull/217758) | [DWARFLinker] Simplify clang module unit bookkeeping (NFC) | 
| 2 | 6b17aa057658 | [#217957](https://github.com/llvm/llvm-project/pull/217957) | [DWARFLinker] Fix getContaingFile typo (NFC) | 
| 3 | 24e41647ccb1 | [#217989](https://github.com/llvm/llvm-project/pull/217989) | [DWARFLinker] Erase the type ref patch list with the section data | 
| 4 | f03b9d709525 | [#218079](https://github.com/llvm/llvm-project/pull/218079) | [DWARFLinker] Let a clang module unit outrank every object file | 
| 5 | 141f9017ad4d | [#218575](https://github.com/llvm/llvm-project/pull/218575) | [DWARFLinker] Resolve a module import through the module's anchor |