### PR TITLE
[BoundsSafety][TMO] don't generate explicit cast exprs in bounds checks

### DIFF
--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
@@ -124,15 +124,17 @@ struct AssignedDeclRefResult {
 };
 
 static ExprResult CastToCharPointer(Sema &S, Expr *PointerToCast) {
-  SourceLocation Loc = PointerToCast->getBeginLoc();
   auto PtrTy = PointerToCast->getType()->getAs<PointerType>();
+  if (PtrTy->getPointeeType()->isCharType())
+    return PointerToCast;
   auto SQT = PtrTy->getPointeeType().split();
   SQT.Ty = S.Context.CharTy.getTypePtr();
   QualType QualifiedChar = S.Context.getQualifiedType(SQT);
   QualType CharPtrTy = S.Context.getPointerType(
       QualifiedChar, PtrTy->getPointerAttributes());
-  return S.BuildCStyleCastExpr(
-      Loc, S.Context.getTrivialTypeSourceInfo(CharPtrTy), Loc, PointerToCast);
+  return ImplicitCastExpr::Create(S.Context, CharPtrTy, CK_BitCast, PointerToCast,
+                                  /*BasePath=*/nullptr, VK_PRValue,
+                                  S.CurFPFeatureOverrides());
 }
 
 /// getInnerType - This returns "Level" nested pointee type.

--- a/clang/test/BoundsSafety-legacy-checks/AST/sized_by_or_null_call.c
+++ b/clang/test/BoundsSafety-legacy-checks/AST/sized_by_or_null_call.c
@@ -542,7 +542,7 @@ void caller_9(int *__sized_by(*len) *out, int *len){
 // CHECK: {{^}}    | |-OpaqueValueExpr [[ove_22]] {{.*}} 'int *__single __sized_by_or_null(count)*__bidi_indexable'
 // CHECK: {{^}}    | `-OpaqueValueExpr [[ove_23]] {{.*}} 'int *__bidi_indexable'
 // CHECK: {{^}}    |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: {{^}}    | |-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && !p || len <= (char *)__builtin_get_pointer_upper_bound(p) - (char *__bidi_indexable)p && 0 <= len'
+// CHECK: {{^}}    | |-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && !p || len <= __builtin_get_pointer_upper_bound(p) - p && 0 <= len'
 // CHECK: {{^}}    | | |-BinaryOperator {{.+}} 'int *__single __sized_by_or_null(count)':'int *__single' '='
 // CHECK: {{^}}    | | | |-DeclRefExpr {{.+}} [[var_p_5]]
 // CHECK: {{^}}    | | | `-ImplicitCastExpr {{.+}} 'int *__single __sized_by_or_null(count)':'int *__single' <BoundsSafetyPointerCast>
@@ -569,11 +569,11 @@ void caller_9(int *__sized_by(*len) *out, int *len){
 // CHECK: {{^}}    | |       | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // CHECK: {{^}}    | |       | | `-OpaqueValueExpr [[ove_27:0x[^ ]+]] {{.*}} 'int'
 // CHECK: {{^}}    | |       | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: {{^}}    | |       |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK: {{^}}    | |       |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK: {{^}}    | |       |   | `-GetBoundExpr {{.+}} upper
 // CHECK: {{^}}    | |       |   |   `-OpaqueValueExpr [[ove_24]] {{.*}} 'int *__bidi_indexable'
 // CHECK: {{^}}    | |       |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: {{^}}    | |       |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK: {{^}}    | |       |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK: {{^}}    | |       |       `-OpaqueValueExpr [[ove_24]] {{.*}} 'int *__bidi_indexable'
 // CHECK: {{^}}    | |       `-BinaryOperator {{.+}} 'int' '<='
 // CHECK: {{^}}    | |         |-IntegerLiteral {{.+}} 0

--- a/clang/test/BoundsSafety/AST/arithmetic-ops-in-counted-by-assign.c
+++ b/clang/test/BoundsSafety/AST/arithmetic-ops-in-counted-by-assign.c
@@ -138,7 +138,7 @@ void local_count_size(void) {
 // CHECK:    |-DeclStmt
 // CHECK:    | `-VarDecl [[var_arr_2:0x[^ ]+]]
 // CHECK:    |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:    | |-BoundsCheckExpr {{.+}} 'size_t':'unsigned long' 'arr <= __builtin_get_pointer_upper_bound(arr) && __builtin_get_pointer_lower_bound(arr) <= arr && 10 * 4 <= (char *)__builtin_get_pointer_upper_bound(arr) - (char *__bidi_indexable)arr'
+// CHECK:    | |-BoundsCheckExpr {{.+}} 'size_t':'unsigned long' 'arr <= __builtin_get_pointer_upper_bound(arr) && __builtin_get_pointer_lower_bound(arr) <= arr && 10 * 4 <= __builtin_get_pointer_upper_bound(arr) - arr'
 // CHECK:    | | |-BinaryOperator {{.+}} 'size_t':'unsigned long' '='
 // CHECK:    | | | |-DeclRefExpr {{.+}} [[var_nelems]]
 // CHECK:    | | | `-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'size_t':'unsigned long'
@@ -160,11 +160,11 @@ void local_count_size(void) {
 // CHECK:    | |     | `-OpaqueValueExpr [[ove_7:0x[^ ]+]] {{.*}} 'size_t':'unsigned long'
 // CHECK:    | |     `-ImplicitCastExpr {{.+}} 'size_t':'unsigned long' <IntegralCast>
 // CHECK:    | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:    | |         |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:    | |         |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:    | |         | `-GetBoundExpr {{.+}} upper
 // CHECK:    | |         |   `-OpaqueValueExpr [[ove_6]] {{.*}} 'void *__bidi_indexable'
 // CHECK:    | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:    | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK:    | |           `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK:    | |             `-OpaqueValueExpr [[ove_6]] {{.*}} 'void *__bidi_indexable'
 // CHECK:    | |-OpaqueValueExpr [[ove_5]]
 // CHECK:    | | `-ImplicitCastExpr {{.+}} 'size_t':'unsigned long' <IntegralCast>

--- a/clang/test/BoundsSafety/AST/bounds-attributed-in-return.c
+++ b/clang/test/BoundsSafety/AST/bounds-attributed-in-return.c
@@ -184,7 +184,7 @@ int *__counted_by(*count) cb_out_from_single(int *__single count, int *__single 
 // CHECK: |-ParmVarDecl [[var_p_4:0x[^ ]+]]
 // CHECK: `-CompoundStmt
 // CHECK:   `-ReturnStmt
-// CHECK:     `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && size <= (char *)__builtin_get_pointer_upper_bound(p) - (char *__bidi_indexable)p && 0 <= size'
+// CHECK:     `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && size <= __builtin_get_pointer_upper_bound(p) - p && 0 <= size'
 // CHECK:       |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(size)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK:       | `-OpaqueValueExpr [[ove_8:0x[^ ]+]] {{.*}} 'void *__bidi_indexable'
 // CHECK:       |-BinaryOperator {{.+}} 'int' '&&'
@@ -204,11 +204,11 @@ int *__counted_by(*count) cb_out_from_single(int *__single count, int *__single 
 // CHECK:       |   | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // CHECK:       |   | | `-OpaqueValueExpr [[ove_9:0x[^ ]+]] {{.*}} 'int'
 // CHECK:       |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:       |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:       |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:       |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:       |   |   |   `-OpaqueValueExpr [[ove_8]] {{.*}} 'void *__bidi_indexable'
 // CHECK:       |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:       |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK:       |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK:       |   |       `-OpaqueValueExpr [[ove_8]] {{.*}} 'void *__bidi_indexable'
 // CHECK:       |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:       |     |-IntegerLiteral {{.+}} 0

--- a/clang/test/BoundsSafety/AST/compound-literal-sized_by.c
+++ b/clang/test/BoundsSafety/AST/compound-literal-sized_by.c
@@ -79,7 +79,7 @@ void receive_transparent_union(union TransparentUnion);
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -115,16 +115,14 @@ void receive_transparent_union(union TransparentUnion);
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -154,7 +152,7 @@ void assign_via_ptr(struct sb* ptr, int new_count,
 // CHECK-NEXT: |     |-DeclRefExpr {{.+}} 'struct sb' lvalue Var {{.+}} 'new' 'struct sb'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -190,16 +188,14 @@ void assign_via_ptr(struct sb* ptr, int new_count,
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -228,7 +224,7 @@ void assign_operator(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |     `-VarDecl {{.+}} new 'struct sb' cinit
 // CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |         `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |             |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |             | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |             | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -264,16 +260,14 @@ void assign_operator(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |             |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |             |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |             |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |             |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |             |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |             |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |             |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |             |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |             |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |             |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |             |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |             |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |             |     `-OpaqueValueExpr {{.+}} 'int'
@@ -301,7 +295,7 @@ void local_var_init(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |     | `-DeclRefExpr {{.+}} 'void (struct sb)' Function {{.+}} 'consume_sb' 'void (struct sb)'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -337,16 +331,14 @@ void local_var_init(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -372,7 +364,7 @@ void call_arg(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |   `-ReturnStmt {{.+}}
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -408,16 +400,14 @@ void call_arg(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -443,7 +433,7 @@ struct sb return_sb(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |   `-CStyleCastExpr {{.+}} 'void' <ToVoid>
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue> part_of_explicit_cast
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -479,16 +469,14 @@ struct sb return_sb(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -555,7 +543,7 @@ void assign_via_ptr_nullptr(struct sb* ptr, int new_count) {
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct nested_sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct nested_sb' lvalue
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'struct nested_sb'
-// CHECK-NEXT: |           |-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           |-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           | |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -591,16 +579,14 @@ void assign_via_ptr_nullptr(struct sb* ptr, int new_count) {
 // CHECK-NEXT: |           | |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           | |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           | |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           | |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           | |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           | |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           | |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           | |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           | |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           | |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           | |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           | |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           | |   `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           | |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           | |     `-OpaqueValueExpr {{.+}} 'int'
@@ -636,7 +622,7 @@ void assign_via_ptr_nested(struct nested_sb* ptr,
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'struct nested_sb'
 // CHECK-NEXT: |           |-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |           | `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |           |   `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           |   `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |     |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -672,16 +658,14 @@ void assign_via_ptr_nested(struct nested_sb* ptr,
 // CHECK-NEXT: |           |     |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'int'
@@ -714,11 +698,11 @@ void assign_via_ptr_nested_v2(struct nested_sb* ptr,
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct nested_and_outer_sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct nested_and_outer_sb *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct nested_and_outer_sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct nested_and_outer_sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct nested_and_outer_sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct nested_and_outer_sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct nested_and_outer_sb'
 // CHECK-NEXT: |           | |-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |           | | `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |           | |   `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           | |   `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           | |     |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -754,16 +738,14 @@ void assign_via_ptr_nested_v2(struct nested_sb* ptr,
 // CHECK-NEXT: |           | |     |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           | |     |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           | |     |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           | |     |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           | |     |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           | |     |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           | |     |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |     |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           | |     |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           | |     |   `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           | |     |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           | |     |     `-OpaqueValueExpr {{.+}} 'int'
@@ -810,16 +792,14 @@ void assign_via_ptr_nested_v2(struct nested_sb* ptr,
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -850,7 +830,7 @@ void assign_via_ptr_nested_v3(struct nested_and_outer_sb* ptr,
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used arr 'struct sb[2]' cinit
 // CHECK-NEXT: |   |   `-CompoundLiteralExpr {{.+}} 'struct sb[2]'
 // CHECK-NEXT: |   |     `-InitListExpr {{.+}} 'struct sb[2]'
-// CHECK-NEXT: |   |       |-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |   |       |-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |   |       | |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |   |       | | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |       | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -886,16 +866,14 @@ void assign_via_ptr_nested_v3(struct nested_and_outer_sb* ptr,
 // CHECK-NEXT: |   |       | |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |       | |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |   |       | |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |       | |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |       | |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |       | |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |       | |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |       | |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |       | |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |       | |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |       | |   `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |       | |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |       | |     `-OpaqueValueExpr {{.+}} 'int'
@@ -958,7 +936,7 @@ void array_of_struct_init(char* __bidi_indexable new_ptr,
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sb_with_other_data *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb_with_other_data *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb_with_other_data' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb_with_other_data' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb_with_other_data'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -997,16 +975,14 @@ void array_of_struct_init(char* __bidi_indexable new_ptr,
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -1084,7 +1060,7 @@ void assign_via_ptr_other_data_side_effect_zero_ptr(struct sb_with_other_data* p
 // CHECK-NEXT: |       `-InitListExpr {{.+}} 'union TransparentUnion' field Field {{.+}} 'sb' 'struct sb_with_other_data'
 // CHECK-NEXT: |         `-ImplicitCastExpr {{.+}} 'struct sb_with_other_data' <LValueToRValue>
 // CHECK-NEXT: |           `-CompoundLiteralExpr {{.+}} 'struct sb_with_other_data' lvalue
-// CHECK-NEXT: |             `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |             `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |               |-InitListExpr {{.+}} 'struct sb_with_other_data'
 // CHECK-NEXT: |               | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |               | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1121,16 +1097,14 @@ void assign_via_ptr_other_data_side_effect_zero_ptr(struct sb_with_other_data* p
 // CHECK-NEXT: |               |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |               |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |               |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |               |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |               |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |               |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |               |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |               |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |               |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |               |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |               |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |               |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |               |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |               |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |               |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |               |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |               |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |               |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |               |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |               |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |               |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |               |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |               |     `-OpaqueValueExpr {{.+}} 'int'
@@ -1163,7 +1137,7 @@ void call_arg_transparent_union(int new_count,
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'union TransparentUnion' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'union TransparentUnion' lvalue
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'union TransparentUnion' field Field {{.+}} 'sb' 'struct sb_with_other_data'
-// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |             |-InitListExpr {{.+}} 'struct sb_with_other_data'
 // CHECK-NEXT: |             | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |             | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1200,16 +1174,14 @@ void call_arg_transparent_union(int new_count,
 // CHECK-NEXT: |             |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |             |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |             |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |             |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |             |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |             |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |             |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |             |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |             |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |             |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |             |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |             |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |             |     `-OpaqueValueExpr {{.+}} 'int'
@@ -1248,7 +1220,7 @@ void call_arg_transparent_union_untransparently(int new_count,
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr->buf <= __builtin_get_pointer_upper_bound(ptr->buf) && __builtin_get_pointer_lower_bound(ptr->buf) <= ptr->buf && ptr->count <= (char *)__builtin_get_pointer_upper_bound(ptr->buf) - (char *__bidi_indexable)ptr->buf && 0 <= ptr->count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr->buf <= __builtin_get_pointer_upper_bound(ptr->buf) && __builtin_get_pointer_lower_bound(ptr->buf) <= ptr->buf && ptr->count <= __builtin_get_pointer_upper_bound(ptr->buf) - ptr->buf && 0 <= ptr->count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1548,120 +1520,118 @@ void call_arg_transparent_union_untransparently(int new_count,
 // CHECK-NEXT: |           |   | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
 // CHECK-NEXT: |           |   | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |   `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |   |   |       | | |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | | |     `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |   |   |       | | | |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | | | |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | | |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |     `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |   |   |       | | |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | | |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |   |       | |-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | | `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | |-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |   |   |       | |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |     `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |   |   |       |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       |-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       | `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       |-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |   |   |       |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |       `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
-// CHECK-NEXT: |           |   |   |         `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |           `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |   |   |             `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |   |               `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |                 `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |   `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |   |   |     | | |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | | |     `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |   |   |     | | | |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | | | |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | | |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |     `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |   |   |     | | |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | | |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |   |     | |-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | | `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | |-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |   |   |     | |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |     `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |   |   |     |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     |-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     | `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     |-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |   |   |     |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |     `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
+// CHECK-NEXT: |           |   |   |       `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |         `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |   |   |           `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |   |             `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |               `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |   `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |   |           | | |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | | |     `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |   |           | | | |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | | | |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | | |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |     `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |   |           | | |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | | |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |           | |-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | | `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | |-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |   |           | |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
-// CHECK-NEXT: |           |   |           |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |     `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |   |           |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |           |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |           |-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |           | `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |           |-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |   |           |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |           |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
-// CHECK-NEXT: |           |   |           `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
-// CHECK-NEXT: |           |   |             `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |               `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |   |                 `-OpaqueValueExpr {{.+}} 'struct sb *__single'
-// CHECK-NEXT: |           |   |                   `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |                     `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |   `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |   |         | | |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | | |     `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |   |         | | | |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | | | |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | | |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |     `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |   |         | | |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | | |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |         | |-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | | `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | |-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |   |         | |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
+// CHECK-NEXT: |           |   |         |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |     `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |   |         |       `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |         |         `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |           `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |         |-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |         | `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |         |-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |   |         |     `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |         |       `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |         `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
+// CHECK-NEXT: |           |   |         `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count)':'char *__single'
+// CHECK-NEXT: |           |   |           `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |             `-MemberExpr {{.+}} 'char *__single __sized_by(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |   |               `-OpaqueValueExpr {{.+}} 'struct sb *__single'
+// CHECK-NEXT: |           |   |                 `-ImplicitCastExpr {{.+}} 'struct sb *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |                   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -1748,7 +1718,7 @@ void assign_via_ptr_from_ptr(struct sb* ptr) {
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sb *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1909,66 +1879,64 @@ void assign_via_ptr_from_ptr(struct sb* ptr) {
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -2024,7 +1992,7 @@ void assign_via_ptr_from_sb(struct sb* ptr, int new_count,
 // CHECK-NEXT: |     |-DeclRefExpr {{.+}} 'struct sb' lvalue Var {{.+}} 'new' 'struct sb'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2185,66 +2153,64 @@ void assign_via_ptr_from_sb(struct sb* ptr, int new_count,
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -2300,7 +2266,7 @@ void assign_operator_from_sb(int new_count,
 // CHECK-NEXT: |     `-VarDecl {{.+}} new 'struct sb' cinit
 // CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |         `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |             |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |             | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |             | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2461,66 +2427,64 @@ void assign_operator_from_sb(int new_count,
 // CHECK-NEXT: |             |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |             |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |             |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |             |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |             |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |             |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |             |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |             |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |             |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |             |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |             |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |             |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |             |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |             |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |             |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |             |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |             |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |             |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |             |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |             |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |             |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |             |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |             |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |             |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |             |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |             |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |             |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |             |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |             |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |             |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |             |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |             |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |             |     `-OpaqueValueExpr {{.+}} 'int'
@@ -2575,7 +2539,7 @@ void local_var_init_from_sb(int new_count,
 // CHECK-NEXT: |     | `-DeclRefExpr {{.+}} 'void (struct sb)' Function {{.+}} 'consume_sb' 'void (struct sb)'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2736,66 +2700,64 @@ void local_var_init_from_sb(int new_count,
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -2848,7 +2810,7 @@ void call_arg_from_sb(int new_count,
 // CHECK-NEXT: |   `-ReturnStmt {{.+}}
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -3009,66 +2971,64 @@ void call_arg_from_sb(int new_count,
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -3121,7 +3081,7 @@ struct sb return_sb_from_sb(int new_count,
 // CHECK-NEXT: |   `-CStyleCastExpr {{.+}} 'void' <ToVoid>
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue> part_of_explicit_cast
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -3282,66 +3242,64 @@ struct sb return_sb_from_sb(int new_count,
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -3399,7 +3357,7 @@ void construct_not_used_from_sb(int new_count,
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct nested_sb' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct nested_sb' lvalue
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'struct nested_sb'
-// CHECK-NEXT: |           |-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           |-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           | |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           | | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -3560,66 +3518,64 @@ void construct_not_used_from_sb(int new_count,
 // CHECK-NEXT: |           | |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           | |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           | |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           | |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           | |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           | |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           | |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           | |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           | |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           | |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           | |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           | |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           | |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           | |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           | |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           | |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           | |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           | |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           | |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           | |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           | |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           | |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           | |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           | |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           | |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           | |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           | |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           | |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           | |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           | |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           | |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           | |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           | |     `-OpaqueValueExpr {{.+}} 'int'
@@ -3681,7 +3637,7 @@ void assign_via_ptr_nested_from_sb(struct nested_sb* ptr,
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'struct nested_sb'
 // CHECK-NEXT: |           |-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |           | `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |           |   `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           |   `-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |     |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |           |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -3842,66 +3798,64 @@ void assign_via_ptr_nested_from_sb(struct nested_sb* ptr,
 // CHECK-NEXT: |           |     |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'int'
@@ -3957,7 +3911,7 @@ void assign_via_ptr_nested_v2_from_sb(struct nested_sb* ptr,
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used arr 'struct sb[2]' cinit
 // CHECK-NEXT: |   |   `-CompoundLiteralExpr {{.+}} 'struct sb[2]'
 // CHECK-NEXT: |   |     `-InitListExpr {{.+}} 'struct sb[2]'
-// CHECK-NEXT: |   |       |-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |   |       |-BoundsCheckExpr {{.+}} 'struct sb' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |   |       | |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |   |       | | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |       | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -4118,66 +4072,64 @@ void assign_via_ptr_nested_v2_from_sb(struct nested_sb* ptr,
 // CHECK-NEXT: |   |       | |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |       | |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |   |       | |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |       | |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |       | |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |       | |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |       | |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |       | |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |       | |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |       | |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |   |       | |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |   |       | |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |   |       | |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |       | |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |       | |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |       | |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |       | |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |       | |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |   |       | |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |   |       | |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |       | |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |       | |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |       | |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |       | |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |       | |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |       | |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |   |       | |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |   |       | |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |   |       | |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |       | |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |       | |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |       | |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |       | |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |   |       | |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |   |       | |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |       | |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |       | |     `-OpaqueValueExpr {{.+}} 'int'
@@ -4258,7 +4210,7 @@ void array_of_struct_init_from_sb(char* __sized_by(new_count) new_ptr,
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sb_with_other_data *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sb_with_other_data *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sb_with_other_data' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sb_with_other_data' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sb_with_other_data'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -4422,66 +4374,64 @@ void array_of_struct_init_from_sb(char* __sized_by(new_count) new_ptr,
 // CHECK-NEXT: |           |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
-// CHECK-NEXT: |           |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by(new_count)':'char *__single'
+// CHECK-NEXT: |           |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     `-OpaqueValueExpr {{.+}} 'int'
@@ -4585,7 +4535,7 @@ void assign_via_ptr_other_data_side_effect_zero_ptr_from_sb(struct sb_with_other
 // CHECK-NEXT: |       `-InitListExpr {{.+}} 'union TransparentUnion' field Field {{.+}} 'sb' 'struct sb_with_other_data'
 // CHECK-NEXT: |         `-ImplicitCastExpr {{.+}} 'struct sb_with_other_data' <LValueToRValue>
 // CHECK-NEXT: |           `-CompoundLiteralExpr {{.+}} 'struct sb_with_other_data' lvalue
-// CHECK-NEXT: |             `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |             `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |               |-InitListExpr {{.+}} 'struct sb_with_other_data'
 // CHECK-NEXT: |               | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |               | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -4622,16 +4572,14 @@ void assign_via_ptr_other_data_side_effect_zero_ptr_from_sb(struct sb_with_other
 // CHECK-NEXT: |               |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |               |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |               |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |               |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |               |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |               |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |               |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |               |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |               |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |               |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |               |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |               |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |               |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |               |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |               |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |               |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |               |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |               |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |               |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |               |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |               |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |               |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |               |     `-OpaqueValueExpr {{.+}} 'int'
@@ -4665,7 +4613,7 @@ void call_arg_transparent_union_from_sb(int new_count,
 // CHECK-NEXT:       `-ImplicitCastExpr {{.+}} 'union TransparentUnion' <LValueToRValue>
 // CHECK-NEXT:         `-CompoundLiteralExpr {{.+}} 'union TransparentUnion' lvalue
 // CHECK-NEXT:           `-InitListExpr {{.+}} 'union TransparentUnion' field Field {{.+}} 'sb' 'struct sb_with_other_data'
-// CHECK-NEXT:             `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT:             `-BoundsCheckExpr {{.+}} 'struct sb_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT:               |-InitListExpr {{.+}} 'struct sb_with_other_data'
 // CHECK-NEXT:               | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT:               | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -4702,16 +4650,14 @@ void call_arg_transparent_union_from_sb(int new_count,
 // CHECK-NEXT:               |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT:               |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT:               |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT:               |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT:               |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT:               |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT:               |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT:               |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT:               |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT:               |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT:               |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT:               |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT:               |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT:               |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT:               |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT:               |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT:               |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT:               |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT:               |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT:               |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT:               |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT:               |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT:               |     `-OpaqueValueExpr {{.+}} 'int'

--- a/clang/test/BoundsSafety/AST/compound-literal-sized_by_or_null.c
+++ b/clang/test/BoundsSafety/AST/compound-literal-sized_by_or_null.c
@@ -80,7 +80,7 @@ void receive_transparent_union(union TransparentUnion);
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -121,16 +121,14 @@ void receive_transparent_union(union TransparentUnion);
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -160,7 +158,7 @@ void assign_via_ptr(struct sbon* ptr, int new_count,
 // CHECK-NEXT: |     |-DeclRefExpr {{.+}} 'struct sbon' lvalue Var {{.+}} 'new' 'struct sbon'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -201,16 +199,14 @@ void assign_via_ptr(struct sbon* ptr, int new_count,
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -239,7 +235,7 @@ void assign_operator(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |     `-VarDecl {{.+}} new 'struct sbon' cinit
 // CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |         `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |             |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |             | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |             | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -280,16 +276,14 @@ void assign_operator(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |             |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |             |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |             |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |             |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |             |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |             |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |             |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |             |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |             |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |             |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |             |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |             |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |             |       `-OpaqueValueExpr {{.+}} 'int'
@@ -317,7 +311,7 @@ void local_var_init(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |     | `-DeclRefExpr {{.+}} 'void (struct sbon)' Function {{.+}} 'consume_sbon' 'void (struct sbon)'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -358,16 +352,14 @@ void local_var_init(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -393,7 +385,7 @@ void call_arg(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |   `-ReturnStmt {{.+}}
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -434,16 +426,14 @@ void call_arg(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -469,7 +459,7 @@ struct sbon return_sbon(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |   `-CStyleCastExpr {{.+}} 'void' <ToVoid>
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue> part_of_explicit_cast
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -510,16 +500,14 @@ struct sbon return_sbon(int new_count, char* __bidi_indexable new_ptr) {
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -588,7 +576,7 @@ void assign_via_ptr_nullptr(struct sbon* ptr, int new_count) {
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct nested_sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct nested_sbon' lvalue
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'struct nested_sbon'
-// CHECK-NEXT: |           |-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           |-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           | |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -629,16 +617,14 @@ void assign_via_ptr_nullptr(struct sbon* ptr, int new_count) {
 // CHECK-NEXT: |           | |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           | |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           | |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           | |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           | |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           | |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           | |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           | |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           | |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           | |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           | |     `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           | |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           | |       `-OpaqueValueExpr {{.+}} 'int'
@@ -674,7 +660,7 @@ void assign_via_ptr_nested(struct nested_sbon* ptr,
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'struct nested_sbon'
 // CHECK-NEXT: |           |-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |           | `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |           |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |     |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -715,16 +701,14 @@ void assign_via_ptr_nested(struct nested_sbon* ptr,
 // CHECK-NEXT: |           |     |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |     `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'int'
@@ -757,11 +741,11 @@ void assign_via_ptr_nested_v2(struct nested_sbon* ptr,
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct nested_and_outer_sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct nested_and_outer_sbon *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct nested_and_outer_sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct nested_and_outer_sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct nested_and_outer_sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct nested_and_outer_sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct nested_and_outer_sbon'
 // CHECK-NEXT: |           | |-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |           | | `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |           | |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           | |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           | |     |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -802,16 +786,14 @@ void assign_via_ptr_nested_v2(struct nested_sbon* ptr,
 // CHECK-NEXT: |           | |     |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           | |     |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |     |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           | |     |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           | |     |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           | |     |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           | |     |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           | |     |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           | |     |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           | |     |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |     |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           | |     |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           | |     |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           | |     |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           | |     |     `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           | |     |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           | |     |       `-OpaqueValueExpr {{.+}} 'int'
@@ -863,16 +845,14 @@ void assign_via_ptr_nested_v2(struct nested_sbon* ptr,
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -903,7 +883,7 @@ void assign_via_ptr_nested_v3(struct nested_and_outer_sbon* ptr,
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used arr 'struct sbon[2]' cinit
 // CHECK-NEXT: |   |   `-CompoundLiteralExpr {{.+}} 'struct sbon[2]'
 // CHECK-NEXT: |   |     `-InitListExpr {{.+}} 'struct sbon[2]'
-// CHECK-NEXT: |   |       |-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |   |       |-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |   |       | |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |   |       | | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |       | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -944,16 +924,14 @@ void assign_via_ptr_nested_v3(struct nested_and_outer_sbon* ptr,
 // CHECK-NEXT: |   |       | |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |       | |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |   |       | |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |       | |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |       | |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |       | |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |       | |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |       | |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |       | |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |       | |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |       | |     `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |       | |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |       | |       `-OpaqueValueExpr {{.+}} 'int'
@@ -1018,7 +996,7 @@ void array_of_struct_init(char* __bidi_indexable new_ptr,
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sbon_with_other_data *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon_with_other_data *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon_with_other_data' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon_with_other_data' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon_with_other_data'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1062,16 +1040,14 @@ void array_of_struct_init(char* __bidi_indexable new_ptr,
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |           |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |           |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -1151,7 +1127,7 @@ void assign_via_ptr_other_data_side_effect_zero_ptr(struct sbon_with_other_data*
 // CHECK-NEXT: |       `-InitListExpr {{.+}} 'union TransparentUnion' field Field {{.+}} 'sbon' 'struct sbon_with_other_data'
 // CHECK-NEXT: |         `-ImplicitCastExpr {{.+}} 'struct sbon_with_other_data' <LValueToRValue>
 // CHECK-NEXT: |           `-CompoundLiteralExpr {{.+}} 'struct sbon_with_other_data' lvalue
-// CHECK-NEXT: |             `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |             `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |               |-InitListExpr {{.+}} 'struct sbon_with_other_data'
 // CHECK-NEXT: |               | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |               | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1193,16 +1169,14 @@ void assign_via_ptr_other_data_side_effect_zero_ptr(struct sbon_with_other_data*
 // CHECK-NEXT: |               |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |               |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |               |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |               |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |               |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |               |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |               |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |               |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |               |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |               |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |               |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |               |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |               |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |               |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |               |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |               |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |               |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |               |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |               |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |               |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |               |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |               |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |               |       `-OpaqueValueExpr {{.+}} 'int'
@@ -1235,7 +1209,7 @@ void call_arg_transparent_union(int new_count,
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'union TransparentUnion' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'union TransparentUnion' lvalue
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'union TransparentUnion' field Field {{.+}} 'sbon' 'struct sbon_with_other_data'
-// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |             |-InitListExpr {{.+}} 'struct sbon_with_other_data'
 // CHECK-NEXT: |             | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |             | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1277,16 +1251,14 @@ void call_arg_transparent_union(int new_count,
 // CHECK-NEXT: |             |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |             |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |             |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |             |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |             |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |             |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |             |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |             |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |             |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |             |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |             |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |             |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |             |       `-OpaqueValueExpr {{.+}} 'int'
@@ -1325,7 +1297,7 @@ void call_arg_transparent_union_untransparently(int new_count,
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr->buf <= __builtin_get_pointer_upper_bound(ptr->buf) && __builtin_get_pointer_lower_bound(ptr->buf) <= ptr->buf && !ptr->buf || ptr->count <= (char *)__builtin_get_pointer_upper_bound(ptr->buf) - (char *__bidi_indexable)ptr->buf && 0 <= ptr->count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr->buf <= __builtin_get_pointer_upper_bound(ptr->buf) && __builtin_get_pointer_lower_bound(ptr->buf) <= ptr->buf && !ptr->buf || ptr->count <= __builtin_get_pointer_upper_bound(ptr->buf) - ptr->buf && 0 <= ptr->count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1682,120 +1654,118 @@ void call_arg_transparent_union_untransparently(int new_count,
 // CHECK-NEXT: |           |     | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
 // CHECK-NEXT: |           |     | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |   `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |     |   |       | | |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | | |     `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |     |   |       | | | |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | | | |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | | |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |     `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |     |   |       | | |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | | |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |       | |-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | | `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | |-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |     |   |       | |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |     `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |     |   |       |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       |-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       | `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       |-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |     |   |       |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
-// CHECK-NEXT: |           |     |   |         `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |     |   |             `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |   |               `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |                 `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |   `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |     |   |     | | |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | | |     `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |     |   |     | | | |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | | | |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | | |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |     `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |     |   |     | | |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | | |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |     | |-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | | `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | |-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |     |   |     | |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |     `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |     |   |     |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     |-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     | `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     |-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |     |   |     |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
+// CHECK-NEXT: |           |     |   |       `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |     |   |           `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |   |             `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |               `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |   `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |     |           | | |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | | |     `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |     |           | | | |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | | | |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | | |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |     `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |     |           | | |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | | |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |           | |-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | | `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | |-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |     |           | |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
-// CHECK-NEXT: |           |     |           |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |     `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |     |           |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           |-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           | `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           |-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
-// CHECK-NEXT: |           |     |           |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
-// CHECK-NEXT: |           |     |           `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
-// CHECK-NEXT: |           |     |             `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |               `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
-// CHECK-NEXT: |           |     |                 `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
-// CHECK-NEXT: |           |     |                   `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |                     `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |   `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |     |         | | |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | | |     `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |     |         | | | |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | | | |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | | |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |     `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |     |         | | |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | | |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |         | |-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | | `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | |-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |     |         | |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
+// CHECK-NEXT: |           |     |         |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |     `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |     |         |       `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         |         `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |           `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         |-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         | `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         |-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |   `-MemberExpr {{.+}} 'int' lvalue ->count {{.+}}
+// CHECK-NEXT: |           |     |         |     `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         |       `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |         `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
+// CHECK-NEXT: |           |     |         `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single'
+// CHECK-NEXT: |           |     |           `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |             `-MemberExpr {{.+}} 'char *__single __sized_by_or_null(count)':'char *__single' lvalue ->buf {{.+}}
+// CHECK-NEXT: |           |     |               `-OpaqueValueExpr {{.+}} 'struct sbon *__single'
+// CHECK-NEXT: |           |     |                 `-ImplicitCastExpr {{.+}} 'struct sbon *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |                   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -1882,7 +1852,7 @@ void assign_via_ptr_from_ptr(struct sbon* ptr) {
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sbon *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2073,66 +2043,64 @@ void assign_via_ptr_from_ptr(struct sbon* ptr) {
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -2188,7 +2156,7 @@ void assign_via_ptr_from_sbon(struct sbon* ptr, int new_count,
 // CHECK-NEXT: |     |-DeclRefExpr {{.+}} 'struct sbon' lvalue Var {{.+}} 'new' 'struct sbon'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2379,66 +2347,64 @@ void assign_via_ptr_from_sbon(struct sbon* ptr, int new_count,
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -2494,7 +2460,7 @@ void assign_operator_from_sbon(int new_count,
 // CHECK-NEXT: |     `-VarDecl {{.+}} new 'struct sbon' cinit
 // CHECK-NEXT: |       `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |         `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |             |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |             | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |             | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2685,66 +2651,64 @@ void assign_operator_from_sbon(int new_count,
 // CHECK-NEXT: |             |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |             |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |             |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |             |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |             |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |             |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |             |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |             |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |             |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |             |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |             |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |             |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |             |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |             |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |             |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |             |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |             |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |             |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |             |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |             |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |             |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |             |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |             |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |             |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |             |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |             |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |             |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |             |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |             |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |             |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |             |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |             |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |             |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |             |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |             |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |             |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |             |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |             |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |             |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |             |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |             |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |             |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |             |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |             |       `-OpaqueValueExpr {{.+}} 'int'
@@ -2799,7 +2763,7 @@ void local_var_init_from_sbon(int new_count,
 // CHECK-NEXT: |     | `-DeclRefExpr {{.+}} 'void (struct sbon)' Function {{.+}} 'consume_sbon' 'void (struct sbon)'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2990,66 +2954,64 @@ void local_var_init_from_sbon(int new_count,
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -3102,7 +3064,7 @@ void call_arg_from_sbon(int new_count,
 // CHECK-NEXT: |   `-ReturnStmt {{.+}}
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -3293,66 +3255,64 @@ void call_arg_from_sbon(int new_count,
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -3405,7 +3365,7 @@ struct sbon return_sbon_from_sbon(int new_count,
 // CHECK-NEXT: |   `-CStyleCastExpr {{.+}} 'void' <ToVoid>
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue> part_of_explicit_cast
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -3596,66 +3556,64 @@ struct sbon return_sbon_from_sbon(int new_count,
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -3713,7 +3671,7 @@ void construct_not_used_from_sbon(int new_count,
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct nested_sbon' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct nested_sbon' lvalue
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'struct nested_sbon'
-// CHECK-NEXT: |           |-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           |-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           | |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           | | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -3904,66 +3862,64 @@ void construct_not_used_from_sbon(int new_count,
 // CHECK-NEXT: |           | |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           | |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           | |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           | |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           | |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           | |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           | |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           | |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           | |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           | |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           | |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           | |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           | |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           | |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           | |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           | |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           | |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           | |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           | |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           | |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           | |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           | |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           | |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           | |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           | |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           | |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           | |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           | |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           | |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           | |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           | |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           | |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           | |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           | |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           | |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           | |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           | |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           | |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           | |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           | |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           | |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           | |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           | |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           | |       `-OpaqueValueExpr {{.+}} 'int'
@@ -4025,7 +3981,7 @@ void assign_via_ptr_nested_from_sbon(struct nested_sbon* ptr,
 // CHECK-NEXT: |         `-InitListExpr {{.+}} 'struct nested_sbon'
 // CHECK-NEXT: |           |-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |           | `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |           |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |           |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |     |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |           |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -4216,66 +4172,64 @@ void assign_via_ptr_nested_from_sbon(struct nested_sbon* ptr,
 // CHECK-NEXT: |           |     |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |     |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'int'
@@ -4331,7 +4285,7 @@ void assign_via_ptr_nested_v2_from_sbon(struct nested_sbon* ptr,
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used arr 'struct sbon[2]' cinit
 // CHECK-NEXT: |   |   `-CompoundLiteralExpr {{.+}} 'struct sbon[2]'
 // CHECK-NEXT: |   |     `-InitListExpr {{.+}} 'struct sbon[2]'
-// CHECK-NEXT: |   |       |-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |   |       |-BoundsCheckExpr {{.+}} 'struct sbon' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |   |       | |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |   |       | | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |       | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -4522,66 +4476,64 @@ void assign_via_ptr_nested_v2_from_sbon(struct nested_sbon* ptr,
 // CHECK-NEXT: |   |       | |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |       | |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |   |       | |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |       | |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |       | |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |       | |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |       | |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |       | |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |       | |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |       | |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |   |       | |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |   |       | |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |   |       | |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |       | |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |       | |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |       | |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |       | |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |       | |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |   |       | |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |   |       | |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |       | |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |       | |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |       | |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |       | |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |       | |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |       | |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |       | |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |   |       | |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |   |       | |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |   |       | |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |   |       | |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |       | |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |       | |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |       | |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |       | |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |       | |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |       | |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |       | |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |   |       | |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |   |       | |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |   |       | |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |       | |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |       | |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |   |       | |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |       | |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |       | |       `-OpaqueValueExpr {{.+}} 'int'
@@ -4664,7 +4616,7 @@ void array_of_struct_init_from_sbon(char* __sized_by_or_null(new_count) new_ptr,
 // CHECK-NEXT: |     |   `-DeclRefExpr {{.+}} 'struct sbon_with_other_data *__single' lvalue ParmVar {{.+}} 'ptr' 'struct sbon_with_other_data *__single'
 // CHECK-NEXT: |     `-ImplicitCastExpr {{.+}} 'struct sbon_with_other_data' <LValueToRValue>
 // CHECK-NEXT: |       `-CompoundLiteralExpr {{.+}} 'struct sbon_with_other_data' lvalue
-// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |         `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |           |-InitListExpr {{.+}} 'struct sbon_with_other_data'
 // CHECK-NEXT: |           | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |           | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -4858,66 +4810,64 @@ void array_of_struct_init_from_sbon(char* __sized_by_or_null(new_count) new_ptr,
 // CHECK-NEXT: |           |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |           |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |           |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |           |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |           |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |           |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |           |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |           |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |           |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |           |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |           |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |           |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |           |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
-// CHECK-NEXT: |           |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |           |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
-// CHECK-NEXT: |           |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |           |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |           |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |           |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |           |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |           |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |           |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |           |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |           |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
+// CHECK-NEXT: |           |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |           |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(new_count)':'char *__single' lvalue ParmVar {{.+}} 'new_ptr' 'char *__single __sized_by_or_null(new_count)':'char *__single'
+// CHECK-NEXT: |           |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |           |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |           |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |           |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |           |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |           |       `-OpaqueValueExpr {{.+}} 'int'
@@ -5023,7 +4973,7 @@ void assign_via_ptr_other_data_side_effect_zero_ptr_from_sbon(struct sbon_with_o
 // CHECK-NEXT: |       `-InitListExpr {{.+}} 'union TransparentUnion' field Field {{.+}} 'sbon' 'struct sbon_with_other_data'
 // CHECK-NEXT: |         `-ImplicitCastExpr {{.+}} 'struct sbon_with_other_data' <LValueToRValue>
 // CHECK-NEXT: |           `-CompoundLiteralExpr {{.+}} 'struct sbon_with_other_data' lvalue
-// CHECK-NEXT: |             `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT: |             `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT: |               |-InitListExpr {{.+}} 'struct sbon_with_other_data'
 // CHECK-NEXT: |               | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |               | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -5065,16 +5015,14 @@ void assign_via_ptr_other_data_side_effect_zero_ptr_from_sbon(struct sbon_with_o
 // CHECK-NEXT: |               |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |               |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT: |               |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |               |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |               |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |               |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |               |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |               |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |               |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |               |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |               |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |               |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |               |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |               |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |               |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |               |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |               |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |               |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |               |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |               |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |               |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |               |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |               |       `-OpaqueValueExpr {{.+}} 'int'
@@ -5108,7 +5056,7 @@ void call_arg_transparent_union_from_sbon(int new_count,
 // CHECK-NEXT:       `-ImplicitCastExpr {{.+}} 'union TransparentUnion' <LValueToRValue>
 // CHECK-NEXT:         `-CompoundLiteralExpr {{.+}} 'union TransparentUnion' lvalue
 // CHECK-NEXT:           `-InitListExpr {{.+}} 'union TransparentUnion' field Field {{.+}} 'sbon' 'struct sbon_with_other_data'
-// CHECK-NEXT:             `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= (char *)__builtin_get_pointer_upper_bound(new_ptr) - (char *__bidi_indexable)new_ptr && 0 <= new_count'
+// CHECK-NEXT:             `-BoundsCheckExpr {{.+}} 'struct sbon_with_other_data' 'new_ptr <= __builtin_get_pointer_upper_bound(new_ptr) && __builtin_get_pointer_lower_bound(new_ptr) <= new_ptr && !new_ptr || new_count <= __builtin_get_pointer_upper_bound(new_ptr) - new_ptr && 0 <= new_count'
 // CHECK-NEXT:               |-InitListExpr {{.+}} 'struct sbon_with_other_data'
 // CHECK-NEXT:               | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT:               | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -5150,16 +5098,14 @@ void call_arg_transparent_union_from_sbon(int new_count,
 // CHECK-NEXT:               |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT:               |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'new_count' 'int'
 // CHECK-NEXT:               |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT:               |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT:               |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT:               |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT:               |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT:               |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT:               |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT:               |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT:               |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT:               |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT:               |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT:               |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT:               |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT:               |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT:               |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
+// CHECK-NEXT:               |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT:               |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT:               |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'new_ptr' 'char *__bidi_indexable'
 // CHECK-NEXT:               |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT:               |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT:               |       `-OpaqueValueExpr {{.+}} 'int'

--- a/clang/test/BoundsSafety/AST/dynamic-count-assignment-in-comma-op.c
+++ b/clang/test/BoundsSafety/AST/dynamic-count-assignment-in-comma-op.c
@@ -18,7 +18,7 @@ void preincdec_init(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |         `-ParenExpr
 // CHECK: |           `-BinaryOperator {{.+}} 'char *__single __sized_by(len)':'char *__single' ','
 // CHECK: |             |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |             | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= (char *)__builtin_get_pointer_upper_bound(p + 1UL) - (char *__bidi_indexable)p + 1UL'
+// CHECK: |             | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= __builtin_get_pointer_upper_bound(p + 1UL) - p + 1UL'
 // CHECK: |             | | |-UnaryOperator {{.+}} prefix '--'
 // CHECK: |             | | | `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} lvalue
 // CHECK: |             | | `-BinaryOperator {{.+}} 'int' '&&'
@@ -40,12 +40,10 @@ void preincdec_init(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |             | |     |-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'unsigned long long'
 // CHECK: |             | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |             | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |             | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK: |             | |         | `-GetBoundExpr {{.+}} upper
-// CHECK: |             | |         |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |             | |         |-GetBoundExpr {{.+}} upper
+// CHECK: |             | |         | `-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |             | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: |             | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK: |             | |             `-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |             | |           `-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |             | |-OpaqueValueExpr [[ove]]
 // CHECK: |             | | `-DeclRefExpr {{.+}} [[var_len]]
 // CHECK: |             | |-OpaqueValueExpr [[ove_5]]
@@ -98,7 +96,7 @@ void postincdec(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: | `-CompoundStmt
 // CHECK: |   `-BinaryOperator {{.+}} 'unsigned long long' ','
 // CHECK: |     |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |     | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= (char *)__builtin_get_pointer_upper_bound(p + 1UL) - (char *__bidi_indexable)p + 1UL'
+// CHECK: |     | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= __builtin_get_pointer_upper_bound(p + 1UL) - p + 1UL'
 // CHECK: |     | | |-UnaryOperator {{.+}} postfix '++'
 // CHECK: |     | | | `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} lvalue
 // CHECK: |     | | `-BinaryOperator {{.+}} 'int' '&&'
@@ -120,12 +118,10 @@ void postincdec(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |     | |     |   | `-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} lvalue
 // CHECK: |     | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |     | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |     | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK: |     | |         | `-GetBoundExpr {{.+}} upper
-// CHECK: |     | |         |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |     | |         |-GetBoundExpr {{.+}} upper
+// CHECK: |     | |         | `-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |     | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: |     | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK: |     | |             `-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |     | |           `-OpaqueValueExpr [[ove_1]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |     | |-OpaqueValueExpr [[ove]]
 // CHECK: |     | | `-DeclRefExpr {{.+}} [[var_p]]
 // CHECK: |     | |-OpaqueValueExpr [[ove_1]]
@@ -182,7 +178,7 @@ void postincdec_init(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |         `-ParenExpr
 // CHECK: |           `-BinaryOperator {{.+}} 'char *__single __sized_by(len)':'char *__single' ','
 // CHECK: |             |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |             | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= (char *)__builtin_get_pointer_upper_bound(p + 1UL) - (char *__bidi_indexable)p + 1UL'
+// CHECK: |             | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= __builtin_get_pointer_upper_bound(p + 1UL) - p + 1UL'
 // CHECK: |             | | |-UnaryOperator {{.+}} postfix '--'
 // CHECK: |             | | | `-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} lvalue
 // CHECK: |             | | `-BinaryOperator {{.+}} 'int' '&&'
@@ -204,12 +200,10 @@ void postincdec_init(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |             | |     |-OpaqueValueExpr [[ove_11:0x[^ ]+]] {{.*}} 'unsigned long long'
 // CHECK: |             | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |             | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |             | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK: |             | |         | `-GetBoundExpr {{.+}} upper
-// CHECK: |             | |         |   `-OpaqueValueExpr [[ove_7]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |             | |         |-GetBoundExpr {{.+}} upper
+// CHECK: |             | |         | `-OpaqueValueExpr [[ove_7]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |             | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: |             | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK: |             | |             `-OpaqueValueExpr [[ove_7]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |             | |           `-OpaqueValueExpr [[ove_7]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |             | |-OpaqueValueExpr [[ove_6]]
 // CHECK: |             | | `-DeclRefExpr {{.+}} [[var_len_1]]
 // CHECK: |             | |-OpaqueValueExpr [[ove_11]]
@@ -265,7 +259,7 @@ void compound_assign_init(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |       `-ParenExpr
 // CHECK: |         `-BinaryOperator {{.+}} 'unsigned long long' ','
 // CHECK: |           |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |           | |-BoundsCheckExpr {{.+}} 'p + 1 <= __builtin_get_pointer_upper_bound(p + 1) && __builtin_get_pointer_lower_bound(p + 1) <= p + 1 && len - 1 <= (char *)__builtin_get_pointer_upper_bound(p + 1) - (char *__bidi_indexable)p + 1'
+// CHECK: |           | |-BoundsCheckExpr {{.+}} 'p + 1 <= __builtin_get_pointer_upper_bound(p + 1) && __builtin_get_pointer_lower_bound(p + 1) <= p + 1 && len - 1 <= __builtin_get_pointer_upper_bound(p + 1) - p + 1'
 // CHECK: |           | | |-CompoundAssignOperator {{.+}} ComputeResultTy='char *__single
 // CHECK: |           | | | |-OpaqueValueExpr [[ove_12:0x[^ ]+]] {{.*}} lvalue
 // CHECK: |           | | | `-OpaqueValueExpr [[ove_13:0x[^ ]+]] {{.*}} 'int'
@@ -289,12 +283,10 @@ void compound_assign_init(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |           | |     |   `-OpaqueValueExpr [[ove_19:0x[^ ]+]] {{.*}} 'unsigned long long'
 // CHECK: |           | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |           | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |           | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK: |           | |         | `-GetBoundExpr {{.+}} upper
-// CHECK: |           | |         |   `-OpaqueValueExpr [[ove_14]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |           | |         |-GetBoundExpr {{.+}} upper
+// CHECK: |           | |         | `-OpaqueValueExpr [[ove_14]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |           | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: |           | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK: |           | |             `-OpaqueValueExpr [[ove_14]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |           | |           `-OpaqueValueExpr [[ove_14]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |           | |-OpaqueValueExpr [[ove_13]]
 // CHECK: |           | | `-IntegerLiteral {{.+}} 1
 // CHECK: |           | |-OpaqueValueExpr [[ove_12]]
@@ -361,7 +353,7 @@ void compound_assign_assign(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |     `-ParenExpr
 // CHECK: |       `-BinaryOperator {{.+}} 'unsigned long long' ','
 // CHECK: |         |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |         | |-BoundsCheckExpr {{.+}} 'p + 1 <= __builtin_get_pointer_upper_bound(p + 1) && __builtin_get_pointer_lower_bound(p + 1) <= p + 1 && len - 1 <= (char *)__builtin_get_pointer_upper_bound(p + 1) - (char *__bidi_indexable)p + 1'
+// CHECK: |         | |-BoundsCheckExpr {{.+}} 'p + 1 <= __builtin_get_pointer_upper_bound(p + 1) && __builtin_get_pointer_lower_bound(p + 1) <= p + 1 && len - 1 <= __builtin_get_pointer_upper_bound(p + 1) - p + 1'
 // CHECK: |         | | |-CompoundAssignOperator {{.+}} ComputeResultTy='char *__single
 // CHECK: |         | | | |-OpaqueValueExpr [[ove_20:0x[^ ]+]] {{.*}} lvalue
 // CHECK: |         | | | `-OpaqueValueExpr [[ove_21:0x[^ ]+]] {{.*}} 'int'
@@ -385,12 +377,10 @@ void compound_assign_assign(char *__sized_by(len) p, unsigned long long len) {
 // CHECK: |         | |     |   `-OpaqueValueExpr [[ove_27:0x[^ ]+]] {{.*}} 'unsigned long long'
 // CHECK: |         | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |         | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |         | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK: |         | |         | `-GetBoundExpr {{.+}} upper
-// CHECK: |         | |         |   `-OpaqueValueExpr [[ove_22]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |         | |         |-GetBoundExpr {{.+}} upper
+// CHECK: |         | |         | `-OpaqueValueExpr [[ove_22]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |         | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: |         | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK: |         | |             `-OpaqueValueExpr [[ove_22]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |         | |           `-OpaqueValueExpr [[ove_22]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |         | |-OpaqueValueExpr [[ove_21]]
 // CHECK: |         | | `-IntegerLiteral {{.+}} 1
 // CHECK: |         | |-OpaqueValueExpr [[ove_20]]
@@ -491,7 +481,7 @@ void assign_init(char *__sized_by(len) p, unsigned long long len,
 // CHECK: |       `-ParenExpr
 // CHECK: |         `-BinaryOperator {{.+}} 'unsigned long long' ','
 // CHECK: |           |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |           | |-BoundsCheckExpr {{.+}} 'ip <= __builtin_get_pointer_upper_bound(ip) && __builtin_get_pointer_lower_bound(ip) <= ip && ilen <= (char *)__builtin_get_pointer_upper_bound(ip) - (char *__bidi_indexable)ip'
+// CHECK: |           | |-BoundsCheckExpr {{.+}} 'ip <= __builtin_get_pointer_upper_bound(ip) && __builtin_get_pointer_lower_bound(ip) <= ip && ilen <= __builtin_get_pointer_upper_bound(ip) - ip'
 // CHECK: |           | | |-BinaryOperator {{.+}} 'char *__single __sized_by(len)':'char *__single' '='
 // CHECK: |           | | | |-DeclRefExpr {{.+}} [[var_p_5]]
 // CHECK: |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(len)':'char *__single' <BoundsSafetyPointerCast>
@@ -512,12 +502,10 @@ void assign_init(char *__sized_by(len) p, unsigned long long len,
 // CHECK: |           | |     |-OpaqueValueExpr [[ove_31:0x[^ ]+]] {{.*}} 'unsigned long long'
 // CHECK: |           | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |           | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |           | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK: |           | |         | `-GetBoundExpr {{.+}} upper
-// CHECK: |           | |         |   `-OpaqueValueExpr [[ove_30]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |           | |         |-GetBoundExpr {{.+}} upper
+// CHECK: |           | |         | `-OpaqueValueExpr [[ove_30]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |           | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: |           | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK: |           | |             `-OpaqueValueExpr [[ove_30]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |           | |           `-OpaqueValueExpr [[ove_30]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |           | |-OpaqueValueExpr [[ove_30]]
 // CHECK: |           | | `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
 // CHECK: |           | |   `-DeclRefExpr {{.+}} [[var_ip]]
@@ -561,7 +549,7 @@ void assign_assign(char *__sized_by(len) p, unsigned long long len,
 // CHECK: |   |       `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |   |         `-IntegerLiteral {{.+}} 0
 // CHECK: |   |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | |-BoundsCheckExpr {{.+}} '(len = ilen, p = ip) <= __builtin_get_pointer_upper_bound((len = ilen, p = ip)) && __builtin_get_pointer_lower_bound((len = ilen, p = ip)) <= (len = ilen, p = ip) && 0 <= (char *)__builtin_get_pointer_upper_bound((len = ilen, p = ip)) - (char *__single)(len = ilen, p = ip)'
+// CHECK: |   | |-BoundsCheckExpr {{.+}} '(len = ilen, p = ip) <= __builtin_get_pointer_upper_bound((len = ilen, p = ip)) && __builtin_get_pointer_lower_bound((len = ilen, p = ip)) <= (len = ilen, p = ip) && 0 <= __builtin_get_pointer_upper_bound((len = ilen, p = ip)) - (len = ilen, p = ip)'
 // CHECK: |   | | |-BinaryOperator {{.+}} 'char *__single __sized_by(llen)':'char *__single' '='
 // CHECK: |   | | | |-DeclRefExpr {{.+}} [[var_lp_1]]
 // CHECK: |   | | | `-OpaqueValueExpr [[ove_32:0x[^ ]+]] {{.*}} 'char *__single __sized_by(len)':'char *__single'
@@ -583,17 +571,15 @@ void assign_assign(char *__sized_by(len) p, unsigned long long len,
 // CHECK: |   | |     |-OpaqueValueExpr [[ove_35:0x[^ ]+]] {{.*}} 'unsigned long long'
 // CHECK: |   | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |   | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |   | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK: |   | |         | `-GetBoundExpr {{.+}} upper
-// CHECK: |   | |         |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK: |   | |         |     `-OpaqueValueExpr [[ove_32]] {{.*}} 'char *__single __sized_by(len)':'char *__single'
-// CHECK: |   | |         `-CStyleCastExpr {{.+}} 'char *__single' <NoOp>
-// CHECK: |   | |           `-OpaqueValueExpr [[ove_32]] {{.*}} 'char *__single __sized_by(len)':'char *__single'
+// CHECK: |   | |         |-GetBoundExpr {{.+}} upper
+// CHECK: |   | |         | `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BoundsSafetyPointerCast>
+// CHECK: |   | |         |   `-OpaqueValueExpr [[ove_32]] {{.*}} 'char *__single __sized_by(len)':'char *__single'
+// CHECK: |   | |         `-OpaqueValueExpr [[ove_32]] {{.*}} 'char *__single __sized_by(len)':'char *__single'
 // CHECK: |   | |-OpaqueValueExpr [[ove_32]]
 // CHECK: |   | | `-ParenExpr
 // CHECK: |   | |   `-BinaryOperator {{.+}} 'char *__single __sized_by(len)':'char *__single' ','
 // CHECK: |   | |     |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK: |   | |     | |-BoundsCheckExpr {{.+}} 'ip <= __builtin_get_pointer_upper_bound(ip) && __builtin_get_pointer_lower_bound(ip) <= ip && ilen <= (char *)__builtin_get_pointer_upper_bound(ip) - (char *__bidi_indexable)ip'
+// CHECK: |   | |     | |-BoundsCheckExpr {{.+}} 'ip <= __builtin_get_pointer_upper_bound(ip) && __builtin_get_pointer_lower_bound(ip) <= ip && ilen <= __builtin_get_pointer_upper_bound(ip) - ip'
 // CHECK: |   | |     | | |-BinaryOperator {{.+}} 'unsigned long long' '='
 // CHECK: |   | |     | | | |-DeclRefExpr {{.+}} [[var_len_6]]
 // CHECK: |   | |     | | | `-OpaqueValueExpr [[ove_33]] {{.*}} 'unsigned long long'
@@ -613,12 +599,10 @@ void assign_assign(char *__sized_by(len) p, unsigned long long len,
 // CHECK: |   | |     | |     |-OpaqueValueExpr [[ove_33]] {{.*}} 'unsigned long long'
 // CHECK: |   | |     | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK: |   | |     | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |   | |     | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK: |   | |     | |         | `-GetBoundExpr {{.+}} upper
-// CHECK: |   | |     | |         |   `-OpaqueValueExpr [[ove_34]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |   | |     | |         |-GetBoundExpr {{.+}} upper
+// CHECK: |   | |     | |         | `-OpaqueValueExpr [[ove_34]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |   | |     | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: |   | |     | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK: |   | |     | |             `-OpaqueValueExpr [[ove_34]] {{.*}} 'char *__bidi_indexable'
+// CHECK: |   | |     | |           `-OpaqueValueExpr [[ove_34]] {{.*}} 'char *__bidi_indexable'
 // CHECK: |   | |     | |-OpaqueValueExpr [[ove_33]]
 // CHECK: |   | |     | | `-ImplicitCastExpr {{.+}} 'unsigned long long' <LValueToRValue>
 // CHECK: |   | |     | |   `-DeclRefExpr {{.+}} [[var_ilen_1]]
@@ -681,7 +665,7 @@ char for_cond_inc(char *__sized_by(len) p, unsigned long long len) {
 // CHECK:   |-ForStmt
 // CHECK:   | |-BinaryOperator {{.+}} 'unsigned long long' ','
 // CHECK:   | | |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:   | | | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= (char *)__builtin_get_pointer_upper_bound(p + 1UL) - (char *__bidi_indexable)p + 1UL'
+// CHECK:   | | | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= __builtin_get_pointer_upper_bound(p + 1UL) - p + 1UL'
 // CHECK:   | | | | |-UnaryOperator {{.+}} postfix '++'
 // CHECK:   | | | | | `-OpaqueValueExpr [[ove_38:0x[^ ]+]] {{.*}} lvalue
 // CHECK:   | | | | `-BinaryOperator {{.+}} 'int' '&&'
@@ -703,12 +687,10 @@ char for_cond_inc(char *__sized_by(len) p, unsigned long long len) {
 // CHECK:   | | | |     |   | `-OpaqueValueExpr [[ove_43:0x[^ ]+]] {{.*}} lvalue
 // CHECK:   | | | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK:   | | | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:   | | | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK:   | | | |         | `-GetBoundExpr {{.+}} upper
-// CHECK:   | | | |         |   `-OpaqueValueExpr [[ove_39]] {{.*}} 'char *__bidi_indexable'
+// CHECK:   | | | |         |-GetBoundExpr {{.+}} upper
+// CHECK:   | | | |         | `-OpaqueValueExpr [[ove_39]] {{.*}} 'char *__bidi_indexable'
 // CHECK:   | | | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:   | | | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK:   | | | |             `-OpaqueValueExpr [[ove_39]] {{.*}} 'char *__bidi_indexable'
+// CHECK:   | | | |           `-OpaqueValueExpr [[ove_39]] {{.*}} 'char *__bidi_indexable'
 // CHECK:   | | | |-OpaqueValueExpr [[ove_38]]
 // CHECK:   | | | | `-DeclRefExpr {{.+}} [[var_p_7]]
 // CHECK:   | | | |-OpaqueValueExpr [[ove_39]]
@@ -757,7 +739,7 @@ char for_cond_inc(char *__sized_by(len) p, unsigned long long len) {
 // CHECK:   | |   `-IntegerLiteral {{.+}} 0
 // CHECK:   | |-BinaryOperator {{.+}} 'unsigned long long' ','
 // CHECK:   | | |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:   | | | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= (char *)__builtin_get_pointer_upper_bound(p + 1UL) - (char *__bidi_indexable)p + 1UL'
+// CHECK:   | | | |-BoundsCheckExpr {{.+}} 'p + 1UL <= __builtin_get_pointer_upper_bound(p + 1UL) && __builtin_get_pointer_lower_bound(p + 1UL) <= p + 1UL && len - 1ULL <= __builtin_get_pointer_upper_bound(p + 1UL) - p + 1UL'
 // CHECK:   | | | | |-UnaryOperator {{.+}} postfix '++'
 // CHECK:   | | | | | `-OpaqueValueExpr [[ove_44:0x[^ ]+]] {{.*}} lvalue
 // CHECK:   | | | | `-BinaryOperator {{.+}} 'int' '&&'
@@ -779,12 +761,10 @@ char for_cond_inc(char *__sized_by(len) p, unsigned long long len) {
 // CHECK:   | | | |     |   | `-OpaqueValueExpr [[ove_49:0x[^ ]+]] {{.*}} lvalue
 // CHECK:   | | | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK:   | | | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:   | | | |         |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK:   | | | |         | `-GetBoundExpr {{.+}} upper
-// CHECK:   | | | |         |   `-OpaqueValueExpr [[ove_45]] {{.*}} 'char *__bidi_indexable'
+// CHECK:   | | | |         |-GetBoundExpr {{.+}} upper
+// CHECK:   | | | |         | `-OpaqueValueExpr [[ove_45]] {{.*}} 'char *__bidi_indexable'
 // CHECK:   | | | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:   | | | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK:   | | | |             `-OpaqueValueExpr [[ove_45]] {{.*}} 'char *__bidi_indexable'
+// CHECK:   | | | |           `-OpaqueValueExpr [[ove_45]] {{.*}} 'char *__bidi_indexable'
 // CHECK:   | | | |-OpaqueValueExpr [[ove_44]]
 // CHECK:   | | | | `-DeclRefExpr {{.+}} [[var_p_7]]
 // CHECK:   | | | |-OpaqueValueExpr [[ove_45]]

--- a/clang/test/BoundsSafety/AST/flexible-array-member-promotion-assignment-uint64.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-promotion-assignment-uint64.c
@@ -157,7 +157,7 @@ void promote_to_sized_by(struct flexible *flex) {
 // CHECK:   |-DeclStmt
 // CHECK:   | `-VarDecl [[var_s_1:0x[^ ]+]]
 // CHECK:   |   |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:   |   | |-BoundsCheckExpr {{.+}} 'flex <= __builtin_get_pointer_upper_bound(flex) && __builtin_get_pointer_lower_bound(flex) <= flex && sizeof(struct flexible) + sizeof(int) * flex->count <= (char *)__builtin_get_pointer_upper_bound(flex) - (char *__bidi_indexable)flex'
+// CHECK:   |   | |-BoundsCheckExpr {{.+}} 'flex <= __builtin_get_pointer_upper_bound(flex) && __builtin_get_pointer_lower_bound(flex) <= flex && sizeof(struct flexible) + sizeof(int) * flex->count <= __builtin_get_pointer_upper_bound(flex) - flex'
 // CHECK:   |   | | |-BinaryOperator {{.+}} 'unsigned long long' '='
 // CHECK:   |   | | | |-DeclRefExpr {{.+}} [[var_siz]]
 // CHECK:   |   | | | `-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'unsigned long long'
@@ -178,11 +178,11 @@ void promote_to_sized_by(struct flexible *flex) {
 // CHECK:   |   | |     |-OpaqueValueExpr [[ove_6]] {{.*}} 'unsigned long long'
 // CHECK:   |   | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK:   |   | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:   |   | |         |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:   |   | |         |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:   |   | |         | `-GetBoundExpr {{.+}} upper
 // CHECK:   |   | |         |   `-OpaqueValueExpr [[ove_7]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:   |   | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:   |   | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK:   |   | |           `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK:   |   | |             `-OpaqueValueExpr [[ove_7]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:   |   | |-OpaqueValueExpr [[ove_6]]
 // CHECK:   |   | | `-BinaryOperator {{.+}} 'unsigned long long' '+'

--- a/clang/test/BoundsSafety/AST/flexible-array-member-promotion-assignment.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-promotion-assignment.c
@@ -140,7 +140,7 @@ void promote_to_sized_by(struct flexible *flex) {
 // CHECK:   |-DeclStmt
 // CHECK:   | `-VarDecl [[var_s_1:0x[^ ]+]]
 // CHECK:   |   |-MaterializeSequenceExpr {{.+}} <Bind>
-// CHECK:   |   | |-BoundsCheckExpr {{.+}} 'flex <= __builtin_get_pointer_upper_bound(flex) && __builtin_get_pointer_lower_bound(flex) <= flex && sizeof(struct flexible) + sizeof(int) * flex->count <= (char *)__builtin_get_pointer_upper_bound(flex) - (char *__bidi_indexable)flex'
+// CHECK:   |   | |-BoundsCheckExpr {{.+}} 'flex <= __builtin_get_pointer_upper_bound(flex) && __builtin_get_pointer_lower_bound(flex) <= flex && sizeof(struct flexible) + sizeof(int) * flex->count <= __builtin_get_pointer_upper_bound(flex) - flex'
 // CHECK:   |   | | |-BinaryOperator {{.+}} 'unsigned long long' '='
 // CHECK:   |   | | | |-DeclRefExpr {{.+}} [[var_siz]]
 // CHECK:   |   | | | `-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'unsigned long long'
@@ -161,11 +161,11 @@ void promote_to_sized_by(struct flexible *flex) {
 // CHECK:   |   | |     |-OpaqueValueExpr [[ove_6]] {{.*}} 'unsigned long long'
 // CHECK:   |   | |     `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>
 // CHECK:   |   | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:   |   | |         |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:   |   | |         |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:   |   | |         | `-GetBoundExpr {{.+}} upper
 // CHECK:   |   | |         |   `-OpaqueValueExpr [[ove_7]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:   |   | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:   |   | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK:   |   | |           `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK:   |   | |             `-OpaqueValueExpr [[ove_7]] {{.*}} 'struct flexible *__bidi_indexable'
 // CHECK:   |   | |-OpaqueValueExpr [[ove_6]]
 // CHECK:   |   | | `-ImplicitCastExpr {{.+}} 'unsigned long long' <IntegralCast>

--- a/clang/test/BoundsSafety/AST/forward-declared-type.c
+++ b/clang/test/BoundsSafety/AST/forward-declared-type.c
@@ -20,7 +20,7 @@ void unsizedSizedByToSizedBy(struct unsized * __sized_by(len) p, int len) {
     int size = len;
 // CHECK: |   `-DeclStmt
 // CHECK: |     `-VarDecl [[var_p2:0x[^ ]+]]
-// CHECK: |       `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && size <= (char *)__builtin_get_pointer_upper_bound(p) - (char *__bidi_indexable)p && 0 <= size'
+// CHECK: |       `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && size <= __builtin_get_pointer_upper_bound(p) - p && 0 <= size'
 // CHECK: |         |-ImplicitCastExpr {{.+}} 'struct unsized *__single __sized_by(size)':'struct unsized *__single' <BoundsSafetyPointerCast>
 // CHECK: |         | `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'struct unsized *__bidi_indexable'
 // CHECK: |         |     | | |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'struct unsized *__single __sized_by(len)':'struct unsized *__single'
@@ -41,11 +41,11 @@ void unsizedSizedByToSizedBy(struct unsized * __sized_by(len) p, int len) {
 // CHECK: |         |   |-BinaryOperator {{.+}} 'int' '<='
 // CHECK: |         |   | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} '__ptrdiff_t':'long'
 // CHECK: |         |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK: |         |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK: |         |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK: |         |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK: |         |   |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'struct unsized *__bidi_indexable'
 // CHECK: |         |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK: |         |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK: |         |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK: |         |   |       `-OpaqueValueExpr [[ove]] {{.*}} 'struct unsized *__bidi_indexable'
 // CHECK: |         |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK: |         |     |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -95,7 +95,7 @@ void structMemberUnsizedSizedBy(struct unsized * p, int len) {
 // CHECK:   `-CompoundStmt
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl [[var_bar:0x[^ ]+]]
-// CHECK:     |   `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && 10 <= (char *)__builtin_get_pointer_upper_bound(p) - (char *__single)p && 0 <= 10'
+// CHECK:     |   `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && 10 <= __builtin_get_pointer_upper_bound(p) - p && 0 <= 10'
 // CHECK:     |     |-InitListExpr
 // CHECK:     |     | |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'int'
 // CHECK:     |     | `-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'struct unsized *__single'
@@ -116,11 +116,11 @@ void structMemberUnsizedSizedBy(struct unsized * p, int len) {
 // CHECK:     |     |   | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // CHECK:     |     |   | | `-OpaqueValueExpr [[ove_4]] {{.*}} 'int'
 // CHECK:     |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:     |     |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:     |     |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:     |     |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:     |     |   |   |   `-ImplicitCastExpr {{.+}} 'struct unsized *__bidi_indexable' <BoundsSafetyPointerCast>
 // CHECK:     |     |   |   |     `-OpaqueValueExpr [[ove_5]] {{.*}} 'struct unsized *__single'
-// CHECK:     |     |   |   `-CStyleCastExpr {{.+}} 'char *__single' <BitCast>
+// CHECK:     |     |   |   `-ImplicitCastExpr {{.+}} 'char *__single' <BitCast>
 // CHECK:     |     |   |     `-OpaqueValueExpr [[ove_5]] {{.*}} 'struct unsized *__single'
 // CHECK:     |     |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:     |     |     |-IntegerLiteral {{.+}} 0
@@ -144,7 +144,7 @@ void structMemberUnsizedSizedBy(struct unsized * p, int len) {
 
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl [[var_bar2:0x[^ ]+]]
-// CHECK:     |   `-BoundsCheckExpr {{.+}} 'bar.p <= __builtin_get_pointer_upper_bound(bar.p) && __builtin_get_pointer_lower_bound(bar.p) <= bar.p && len <= (char *)__builtin_get_pointer_upper_bound(bar.p) - (char *__bidi_indexable)bar.p && 0 <= len'
+// CHECK:     |   `-BoundsCheckExpr {{.+}} 'bar.p <= __builtin_get_pointer_upper_bound(bar.p) && __builtin_get_pointer_lower_bound(bar.p) <= bar.p && len <= __builtin_get_pointer_upper_bound(bar.p) - bar.p && 0 <= len'
 // CHECK:     |     |-InitListExpr
 // CHECK:     |     | |-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'int'
 // CHECK:     |     | `-ImplicitCastExpr {{.+}} 'struct unsized *__single __sized_by(size)':'struct unsized *__single' <BoundsSafetyPointerCast>
@@ -169,11 +169,11 @@ void structMemberUnsizedSizedBy(struct unsized * p, int len) {
 // CHECK:     |     |   | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // CHECK:     |     |   | | `-OpaqueValueExpr [[ove_6]] {{.*}} 'int'
 // CHECK:     |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:     |     |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:     |     |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:     |     |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:     |     |   |   |   `-OpaqueValueExpr [[ove_7]] {{.*}} 'struct unsized *__bidi_indexable'
 // CHECK:     |     |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:     |     |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK:     |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK:     |     |   |       `-OpaqueValueExpr [[ove_7]] {{.*}} 'struct unsized *__bidi_indexable'
 // CHECK:     |     |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:     |     |     |-IntegerLiteral {{.+}} 0
@@ -279,7 +279,7 @@ void unsizedSizedByToSizedByTypecast(struct unsized * __sized_by(len) p, int len
     int size = len;
 // CHECK:     `-DeclStmt
 // CHECK:       `-VarDecl [[var_p2_3:0x[^ ]+]]
-// CHECK:         `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && size <= (char *)__builtin_get_pointer_upper_bound(p) - (char *__bidi_indexable)p && 0 <= size'
+// CHECK:         `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && size <= __builtin_get_pointer_upper_bound(p) - p && 0 <= size'
 // CHECK:           |-ImplicitCastExpr {{.+}} 'struct other *__single __sized_by(size)':'struct other *__single' <BoundsSafetyPointerCast>
 // CHECK:           | `-OpaqueValueExpr [[ove_18:0x[^ ]+]] {{.*}} 'struct other *__bidi_indexable'
 // CHECK:           |       | | |-OpaqueValueExpr [[ove_19:0x[^ ]+]] {{.*}} 'struct unsized *__single __sized_by(len)':'struct unsized *__single'
@@ -300,11 +300,11 @@ void unsizedSizedByToSizedByTypecast(struct unsized * __sized_by(len) p, int len
 // CHECK:           |   |-BinaryOperator {{.+}} 'int' '<='
 // CHECK:           |   | |-OpaqueValueExpr [[ove_21:0x[^ ]+]] {{.*}} '__ptrdiff_t':'long'
 // CHECK:           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:           |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:           |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:           |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:           |   |   |   `-OpaqueValueExpr [[ove_18]] {{.*}} 'struct other *__bidi_indexable'
 // CHECK:           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK:           |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK:           |   |       `-OpaqueValueExpr [[ove_18]] {{.*}} 'struct other *__bidi_indexable'
 // CHECK:           |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:           |     |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -355,7 +355,7 @@ void voidSizedByToVoidSizedBy(void * __sized_by(len) p, int len) {
 // CHECK:     |   `-DependerDeclsAttr
 // CHECK:     `-DeclStmt
 // CHECK:       `-VarDecl [[var_p2_4:0x[^ ]+]]
-// CHECK:         `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && size <= (char *)__builtin_get_pointer_upper_bound(p) - (char *__bidi_indexable)p && 0 <= size'
+// CHECK:         `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && size <= __builtin_get_pointer_upper_bound(p) - p && 0 <= size'
 // CHECK:           |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(size)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK:           | `-OpaqueValueExpr [[ove_22:0x[^ ]+]] {{.*}} 'void *__bidi_indexable'
 // CHECK:           |     | | |-OpaqueValueExpr [[ove_23:0x[^ ]+]] {{.*}} 'void *__single __sized_by(len)':'void *__single'
@@ -376,11 +376,11 @@ void voidSizedByToVoidSizedBy(void * __sized_by(len) p, int len) {
 // CHECK:           |   |-BinaryOperator {{.+}} 'int' '<='
 // CHECK:           |   | |-OpaqueValueExpr [[ove_25:0x[^ ]+]] {{.*}} '__ptrdiff_t':'long'
 // CHECK:           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:           |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:           |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:           |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:           |   |   |   `-OpaqueValueExpr [[ove_22]] {{.*}} 'void *__bidi_indexable'
 // CHECK:           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK:           |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK:           |   |       `-OpaqueValueExpr [[ove_22]] {{.*}} 'void *__bidi_indexable'
 // CHECK:           |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:           |     |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -511,7 +511,7 @@ void unsizedBidiForgedToSizedBy(struct unsized * __sized_by(len) p, int len) {
     int size = len;
 // CHECK:     `-DeclStmt
 // CHECK:       `-VarDecl [[var_p2_9:0x[^ ]+]]
-// CHECK:         `-BoundsCheckExpr {{.+}} '((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len))) <= __builtin_get_pointer_upper_bound(((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len)))) && __builtin_get_pointer_lower_bound(((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len)))) <= ((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len))) && size <= (char *)__builtin_get_pointer_upper_bound(((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len)))) - (char *__bidi_indexable)((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len))) && 0 <= size'
+// CHECK:         `-BoundsCheckExpr {{.+}} '((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len))) <= __builtin_get_pointer_upper_bound(((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len)))) && __builtin_get_pointer_lower_bound(((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len)))) <= ((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len))) && size <= __builtin_get_pointer_upper_bound(((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len)))) - ((struct unsized *__bidi_indexable)__builtin_unsafe_forge_bidi_indexable((p), (len))) && 0 <= size'
 // CHECK:           |-ImplicitCastExpr {{.+}} 'struct unsized *__single __sized_by(size)':'struct unsized *__single' <BoundsSafetyPointerCast>
 // CHECK:           | `-OpaqueValueExpr [[ove_28:0x[^ ]+]] {{.*}} 'struct unsized *__bidi_indexable'
 // CHECK:           |         | | | |-OpaqueValueExpr [[ove_29:0x[^ ]+]] {{.*}} 'struct unsized *__single __sized_by(len)':'struct unsized *__single'
@@ -532,11 +532,11 @@ void unsizedBidiForgedToSizedBy(struct unsized * __sized_by(len) p, int len) {
 // CHECK:           |   |-BinaryOperator {{.+}} 'int' '<='
 // CHECK:           |   | |-OpaqueValueExpr [[ove_31:0x[^ ]+]] {{.*}} '__ptrdiff_t':'long'
 // CHECK:           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:           |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:           |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:           |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:           |   |   |   `-OpaqueValueExpr [[ove_28]] {{.*}} 'struct unsized *__bidi_indexable'
 // CHECK:           |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK:           |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK:           |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK:           |   |       `-OpaqueValueExpr [[ove_28]] {{.*}} 'struct unsized *__bidi_indexable'
 // CHECK:           |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:           |     |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -634,7 +634,7 @@ void unsizedSingleForgedToSizedBy(int p, int len) {
     int size = len; // expected-note{{size initialized here}}
 // CHECK:    `-DeclStmt
 // CHECK:      `-VarDecl [[var_p2_13:0x[^ ]+]]
-// CHECK:        `-BoundsCheckExpr {{.+}} '(struct unsized *__single)__builtin_unsafe_forge_single((p)) <= __builtin_get_pointer_upper_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) && __builtin_get_pointer_lower_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) <= (struct unsized *__single)__builtin_unsafe_forge_single((p)) && size <= (char *)__builtin_get_pointer_upper_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) - (char *__single)(struct unsized *__single)__builtin_unsafe_forge_single((p)) && 0 <= size'
+// CHECK:        `-BoundsCheckExpr {{.+}} '(struct unsized *__single)__builtin_unsafe_forge_single((p)) <= __builtin_get_pointer_upper_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) && __builtin_get_pointer_lower_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) <= (struct unsized *__single)__builtin_unsafe_forge_single((p)) && size <= __builtin_get_pointer_upper_bound((struct unsized *__single)__builtin_unsafe_forge_single((p))) - (struct unsized *__single)__builtin_unsafe_forge_single((p)) && 0 <= size'
 // CHECK:          |-ParenExpr
 // CHECK:          | `-OpaqueValueExpr [[ove_32:0x[^ ]+]] {{.*}} 'struct unsized *__single'
 // CHECK:          |-BinaryOperator {{.+}} 'int' '&&'
@@ -653,11 +653,11 @@ void unsizedSingleForgedToSizedBy(int p, int len) {
 // CHECK:          |   |-BinaryOperator {{.+}} 'int' '<='
 // CHECK:          |   | |-OpaqueValueExpr [[ove_33:0x[^ ]+]] {{.*}} '__ptrdiff_t':'long'
 // CHECK:          |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:          |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:          |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:          |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:          |   |   |   `-ImplicitCastExpr {{.+}} 'struct unsized *__bidi_indexable' <BoundsSafetyPointerCast>
 // CHECK:          |   |   |     `-OpaqueValueExpr [[ove_32]] {{.*}} 'struct unsized *__single'
-// CHECK:          |   |   `-CStyleCastExpr {{.+}} 'char *__single' <BitCast>
+// CHECK:          |   |   `-ImplicitCastExpr {{.+}} 'char *__single' <BitCast>
 // CHECK:          |   |     `-OpaqueValueExpr [[ove_32]] {{.*}} 'struct unsized *__single'
 // CHECK:          |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:          |     |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
@@ -728,7 +728,7 @@ void unsizedSingleToSizedByToBidiVoid(void * p) { // rdar://112462891
 // CHECK:   `-CompoundStmt
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl [[var_p2_16:0x[^ ]+]]
-// CHECK:     |   `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && 0 <= (char *)__builtin_get_pointer_upper_bound(p) - (char *__single)p && 0 <= 0'
+// CHECK:     |   `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && 0 <= __builtin_get_pointer_upper_bound(p) - p && 0 <= 0'
 // CHECK:     |     |-ImplicitCastExpr {{.+}} 'void *__single' <LValueToRValue>
 // CHECK:     |     | `-DeclRefExpr {{.+}} [[var_p_13]]
 // CHECK:     |     |-BinaryOperator {{.+}} 'int' '&&'
@@ -747,11 +747,11 @@ void unsizedSingleToSizedByToBidiVoid(void * p) { // rdar://112462891
 // CHECK:     |     |   |-BinaryOperator {{.+}} 'int' '<='
 // CHECK:     |     |   | |-OpaqueValueExpr [[ove_37:0x[^ ]+]] {{.*}} '__ptrdiff_t':'long'
 // CHECK:     |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:     |     |   |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK:     |     |   |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:     |     |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:     |     |   |   |   `-ImplicitCastExpr {{.+}} 'void *__bidi_indexable' <BoundsSafetyPointerCast>
 // CHECK:     |     |   |   |     `-OpaqueValueExpr [[ove_36]] {{.*}} 'void *__single'
-// CHECK:     |     |   |   `-CStyleCastExpr {{.+}} 'char *__single' <BitCast>
+// CHECK:     |     |   |   `-ImplicitCastExpr {{.+}} 'char *__single' <BitCast>
 // CHECK:     |     |   |     `-OpaqueValueExpr [[ove_36]] {{.*}} 'void *__single'
 // CHECK:     |     |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:     |     |     |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>

--- a/clang/test/BoundsSafety/AST/init-struct-const-count-new-checks-disabled.c
+++ b/clang/test/BoundsSafety/AST/init-struct-const-count-new-checks-disabled.c
@@ -919,7 +919,7 @@ void consume_sb(struct sb);
 // CHECK-NEXT: | `-CompoundStmt {{.+}}
 // CHECK-NEXT: |   |-DeclStmt {{.+}}
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sb' cinit
-// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |     |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |   |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1080,66 +1080,64 @@ void consume_sb(struct sb);
 // CHECK-NEXT: |   |     |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |     |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |     |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |     |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |     |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |     |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |     |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |     |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |   |     |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |     |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |     |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |     |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |     |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |     |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |   |     |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |     |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |     |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |     |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |     |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |   |     |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |     |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |     |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |     |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |     |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |   |     |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |     |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |     |     `-OpaqueValueExpr {{.+}} 'int'
@@ -1192,7 +1190,7 @@ void init_list_sb(int count_param, char*__sized_by(count_param) ptr) {
 // CHECK-NEXT: | `-CompoundStmt {{.+}}
 // CHECK-NEXT: |   |-DeclStmt {{.+}}
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sb' cinit
-// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |     |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |   |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1228,16 +1226,14 @@ void init_list_sb(int count_param, char*__sized_by(count_param) ptr) {
 // CHECK-NEXT: |   |     |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |     |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |     |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |     |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |     |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |     |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |     |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |     |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |     |   `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |     |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |     |     `-OpaqueValueExpr {{.+}} 'int'
@@ -1353,7 +1349,7 @@ void consume_sbon(struct sbon);
 // CHECK-NEXT: | `-CompoundStmt {{.+}}
 // CHECK-NEXT: |   |-DeclStmt {{.+}}
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sbon' cinit
-// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |     |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |   |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1544,66 +1540,64 @@ void consume_sbon(struct sbon);
 // CHECK-NEXT: |   |     |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |     |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |     |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |     |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |     |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |     |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |     |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |     |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |   |     |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |     |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |     |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |     |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |     |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |     |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |   |     |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |     |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |     |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |     |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |     |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |   |     |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |     |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |     |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |     |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |     |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |   |     |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |     |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |     |       `-OpaqueValueExpr {{.+}} 'int'
@@ -1656,7 +1650,7 @@ void init_list_sbon(int count_param, char*__sized_by_or_null(count_param) ptr) {
 // CHECK-NEXT: | `-CompoundStmt {{.+}}
 // CHECK-NEXT: |   |-DeclStmt {{.+}}
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sbon' cinit
-// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |     |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |   |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1697,16 +1691,14 @@ void init_list_sbon(int count_param, char*__sized_by_or_null(count_param) ptr) {
 // CHECK-NEXT: |   |     |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |     |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |     |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |     |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |     |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |     |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |     |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |     |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |     |     `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |     |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |     |       `-OpaqueValueExpr {{.+}} 'int'

--- a/clang/test/BoundsSafety/AST/init-struct-const-count-new-checks-enabled.c
+++ b/clang/test/BoundsSafety/AST/init-struct-const-count-new-checks-enabled.c
@@ -1500,7 +1500,7 @@ void consume_sb(struct sb);
 // CHECK-NEXT: | `-CompoundStmt {{.+}}
 // CHECK-NEXT: |   |-DeclStmt {{.+}}
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sb' cinit
-// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |     |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |   |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1661,66 +1661,64 @@ void consume_sb(struct sb);
 // CHECK-NEXT: |   |     |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |     |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |     |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |     |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |     |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |     |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |     |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |     |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |   |     |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |     |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |     |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |     |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |     |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |     |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |   |     |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |     |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |     |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |     |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |     |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |   |     |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |     |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |     |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |     |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |     |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |   |     |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |     |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |     |     `-OpaqueValueExpr {{.+}} 'int'
@@ -1773,7 +1771,7 @@ void init_list_sb(int count_param, char*__sized_by(count_param) ptr) {
 // CHECK-NEXT: | `-CompoundStmt {{.+}}
 // CHECK-NEXT: |   |-DeclStmt {{.+}}
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sb' cinit
-// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |     |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |   |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -1809,16 +1807,14 @@ void init_list_sb(int count_param, char*__sized_by(count_param) ptr) {
 // CHECK-NEXT: |   |     |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |     |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |     |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |     |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |     |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |     |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |     |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |     |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |     |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |     |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |     |   `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |     |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |     |     `-OpaqueValueExpr {{.+}} 'int'
@@ -1849,7 +1845,7 @@ void init_list_bidi(int count_param, char*__bidi_indexable ptr) {
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sb' cinit
 // CHECK-NEXT: |   |   `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |   |     `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |   |       `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |       `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |         |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |   |         | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |         | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2010,66 +2006,64 @@ void init_list_bidi(int count_param, char*__bidi_indexable ptr) {
 // CHECK-NEXT: |   |         |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |         |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |         |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |         |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |         |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |         |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |   |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |         |   |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |         |   |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |   |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |         |   |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |         |   |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |   |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |         |   |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |   |         |   |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |   |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |         |   |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |   |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |         |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |   |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |         |   |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |         |   |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |   |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |         |   |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |         |   |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |   |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |   |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |   |         |   |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |   |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |   |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |   |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |         |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |         |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |         |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |   |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |         |   |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |         |   |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |   |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |         |   |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |         |   |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |   |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |         |   |           | | `-<<<NULL>>>
-// CHECK-NEXT: |   |         |   |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |   |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |         |   |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |   |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |   |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |   |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |         |   |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |         |   |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |   |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |         |   |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |         |   |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |   |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |   |         | | `-<<<NULL>>>
+// CHECK-NEXT: |   |         |   |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |   |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |   |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |   |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |   |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |         |   `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |         |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |         |     `-OpaqueValueExpr {{.+}} 'int'
@@ -2124,7 +2118,7 @@ void compound_literal_init_sb(int count_param, char*__sized_by(count_param) ptr)
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sb' cinit
 // CHECK-NEXT: |   |   `-ImplicitCastExpr {{.+}} 'struct sb' <LValueToRValue>
 // CHECK-NEXT: |   |     `-CompoundLiteralExpr {{.+}} 'struct sb' lvalue
-// CHECK-NEXT: |   |       `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |       `-BoundsCheckExpr {{.+}} 'struct sb' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |         |-InitListExpr {{.+}} 'struct sb'
 // CHECK-NEXT: |   |         | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |         | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2160,16 +2154,14 @@ void compound_literal_init_sb(int count_param, char*__sized_by(count_param) ptr)
 // CHECK-NEXT: |   |         |   | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |         |   | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |         |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |         |   |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |         |   |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |         |   |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |   |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |   |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |         |   |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |   |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |         |   |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |         |   |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |         |   |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |   |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |         |   |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |   |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |   |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |         |   |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |         |   `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |         |     |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |         |     `-OpaqueValueExpr {{.+}} 'int'
@@ -2211,7 +2203,7 @@ void consume_sbon(struct sbon);
 // CHECK-NEXT: | `-CompoundStmt {{.+}}
 // CHECK-NEXT: |   |-DeclStmt {{.+}}
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sbon' cinit
-// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |     |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |   |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2402,66 +2394,64 @@ void consume_sbon(struct sbon);
 // CHECK-NEXT: |   |     |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |     |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |     |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |     |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |     |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |     |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |     |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |     |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |   |     |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |     |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |     |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |     |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |     |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |     |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |   |     |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |     |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |     |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |     |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |     |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |   |     |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |     |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |     |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |     |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |     |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |     |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |     |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |     |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |   |     |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |     |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |     |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |     |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |     |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |     |       `-OpaqueValueExpr {{.+}} 'int'
@@ -2514,7 +2504,7 @@ void init_list_sbon(int count_param, char*__sized_by_or_null(count_param) ptr) {
 // CHECK-NEXT: | `-CompoundStmt {{.+}}
 // CHECK-NEXT: |   |-DeclStmt {{.+}}
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sbon' cinit
-// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |   `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |     |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |   |     | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2555,16 +2545,14 @@ void init_list_sbon(int count_param, char*__sized_by_or_null(count_param) ptr) {
 // CHECK-NEXT: |   |     |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |     |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |     |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |     |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |     |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |     |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |     |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |     |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |     |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |     |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |     |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: |   |     |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |     |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: |   |     |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT: |   |     |     `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |     |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |     |       `-OpaqueValueExpr {{.+}} 'int'
@@ -2595,7 +2583,7 @@ void init_list_sbon_bidi(int count_param, char*__bidi_indexable ptr) {
 // CHECK-NEXT: |   | `-VarDecl {{.+}} used c 'struct sbon' cinit
 // CHECK-NEXT: |   |   `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT: |   |     `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT: |   |       `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT: |   |       `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT: |   |         |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT: |   |         | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT: |   |         | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2786,66 +2774,64 @@ void init_list_sbon_bidi(int count_param, char*__bidi_indexable ptr) {
 // CHECK-NEXT: |   |         |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT: |   |         |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |         |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: |   |         |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT: |   |         |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT: |   |         |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |     |   |     `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |         |     |   |       |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |         |     |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |     |   |       | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |   |       | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |   |       | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |   |       | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |         |     |   |       | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |         |     |   |       | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |   |       | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |   |       | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |   |       | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |     |   |       | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |   |       | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |         |     |   |       | | `-<<<NULL>>>
-// CHECK-NEXT: |   |         |     |   |       | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |   |       | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |   |       | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |   |       | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |     |   |       |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |   |       |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |         |     |   |       |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |   |       | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |   |       |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |   |       `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |     |   |         `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |   |           `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT: |   |         |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |     |   |   `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |         |     |   |     |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |         |     |   |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |     |   |     | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |   |     | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |   |     | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |   |     | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |         |     |   |     | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |         |     |   |     | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |   |     | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |   |     | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |   |     | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |     |   |     | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |   |     | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |     |   |     | | `-<<<NULL>>>
+// CHECK-NEXT: |   |         |     |   |     | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |   |     | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |   |     | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |   |     | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |     |   |     |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |   |     |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |     |   |     |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |   |     | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |   |     |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |   |     `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |     |   |       `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |   |         `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |         |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |         |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT: |   |         |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |     |         `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
-// CHECK-NEXT: |   |         |     |           |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
-// CHECK-NEXT: |   |         |     |           | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT: |   |         |     |           | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |           | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |           | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |           | | |-BinaryOperator {{.+}} 'char *' '+'
-// CHECK-NEXT: |   |         |     |           | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: |   |         |     |           | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |           | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |           | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |           | | | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |     |           | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |           | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |         |     |           | | `-<<<NULL>>>
-// CHECK-NEXT: |   |         |     |           | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |           | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |           | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |           | `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |     |           |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |           |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
-// CHECK-NEXT: |   |         |     |           |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |           | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |           |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
-// CHECK-NEXT: |   |         |     |           `-OpaqueValueExpr {{.+}} 'int'
-// CHECK-NEXT: |   |         |     |             `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
-// CHECK-NEXT: |   |         |     |               `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |     |       `-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Unbind>
+// CHECK-NEXT: |   |         |     |         |-MaterializeSequenceExpr {{.+}} 'char *__bidi_indexable' <Bind>
+// CHECK-NEXT: |   |         |     |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT: |   |         |     |         | | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |         | | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |         | | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |         | | |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: |   |         |     |         | | | |-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: |   |         |     |         | | | | `-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |         | | | |   `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |         | | | |     `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |         | | | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |     |         | | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |         | | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |     |         | | `-<<<NULL>>>
+// CHECK-NEXT: |   |         |     |         | |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |         | | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |         | |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |         | `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |     |         |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |         |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
+// CHECK-NEXT: |   |         |     |         |-OpaqueValueExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |         | `-ImplicitCastExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |         |   `-DeclRefExpr {{.+}} 'char *__single __sized_by_or_null(count_param)':'char *__single' lvalue ParmVar {{.+}} 'ptr' 'char *__single __sized_by_or_null(count_param)':'char *__single'
+// CHECK-NEXT: |   |         |     |         `-OpaqueValueExpr {{.+}} 'int'
+// CHECK-NEXT: |   |         |     |           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: |   |         |     |             `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT: |   |         |     `-BinaryOperator {{.+}} <<invalid sloc>, line:{{.+}}> 'int' '<='
 // CHECK-NEXT: |   |         |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT: |   |         |       `-OpaqueValueExpr {{.+}} 'int'
@@ -2900,7 +2886,7 @@ void compound_literal_init_sbon(int count_param, char*__sized_by_or_null(count_p
 // CHECK-NEXT:     | `-VarDecl {{.+}} used c 'struct sbon' cinit
 // CHECK-NEXT:     |   `-ImplicitCastExpr {{.+}} 'struct sbon' <LValueToRValue>
 // CHECK-NEXT:     |     `-CompoundLiteralExpr {{.+}} 'struct sbon' lvalue
-// CHECK-NEXT:     |       `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= (char *)__builtin_get_pointer_upper_bound(ptr) - (char *__bidi_indexable)ptr && 0 <= count_param'
+// CHECK-NEXT:     |       `-BoundsCheckExpr {{.+}} 'struct sbon' 'ptr <= __builtin_get_pointer_upper_bound(ptr) && __builtin_get_pointer_lower_bound(ptr) <= ptr && !ptr || count_param <= __builtin_get_pointer_upper_bound(ptr) - ptr && 0 <= count_param'
 // CHECK-NEXT:     |         |-InitListExpr {{.+}} 'struct sbon'
 // CHECK-NEXT:     |         | |-OpaqueValueExpr {{.+}} 'int'
 // CHECK-NEXT:     |         | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -2941,16 +2927,14 @@ void compound_literal_init_sbon(int count_param, char*__sized_by_or_null(count_p
 // CHECK-NEXT:     |         |     | |   `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
 // CHECK-NEXT:     |         |     | |     `-DeclRefExpr {{.+}} 'int' lvalue ParmVar {{.+}} 'count_param' 'int'
 // CHECK-NEXT:     |         |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT:     |         |     |   |-CStyleCastExpr {{.+}} 'char *' <NoOp>
-// CHECK-NEXT:     |         |     |   | `-GetBoundExpr {{.+}} 'char *' upper
-// CHECK-NEXT:     |         |     |   |   `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT:     |         |     |   |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT:     |         |     |   |       `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT:     |         |     |   |-GetBoundExpr {{.+}} 'char *' upper
+// CHECK-NEXT:     |         |     |   | `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT:     |         |     |   |   `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT:     |         |     |   |     `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT:     |         |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT:     |         |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <NoOp>
-// CHECK-NEXT:     |         |     |       `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
-// CHECK-NEXT:     |         |     |         `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT:     |         |     |           `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
+// CHECK-NEXT:     |         |     |     `-OpaqueValueExpr {{.+}} 'char *__bidi_indexable'
+// CHECK-NEXT:     |         |     |       `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT:     |         |     |         `-DeclRefExpr {{.+}} 'char *__bidi_indexable' lvalue ParmVar {{.+}} 'ptr' 'char *__bidi_indexable'
 // CHECK-NEXT:     |         |     `-BinaryOperator {{.+}} <<invalid sloc>, col:{{.+}}> 'int' '<='
 // CHECK-NEXT:     |         |       |-IntegerLiteral {{.+}} <<invalid sloc>> 'int' 0
 // CHECK-NEXT:     |         |       `-OpaqueValueExpr {{.+}} 'int'

--- a/clang/test/BoundsSafety/AST/materialize-unsafe-forge-ptr.c
+++ b/clang/test/BoundsSafety/AST/materialize-unsafe-forge-ptr.c
@@ -35,11 +35,11 @@ void test() {
 // CHECK:           |   |-BinaryOperator {{.+}} 'int' '<='
 // CHECK:           |   | |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} '__ptrdiff_t':'long'
 // CHECK:           |   | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK:           |   |   |-CStyleCastExpr {{.+}} 'const char *' <BitCast>
+// CHECK:           |   |   |-ImplicitCastExpr {{.+}} 'const char *' <BitCast>
 // CHECK:           |   |   | `-GetBoundExpr {{.+}} upper
 // CHECK:           |   |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'const void *__bidi_indexable'
 // CHECK:           |   |   `-ImplicitCastExpr {{.+}} 'const char *' <BoundsSafetyPointerCast>
-// CHECK:           |   |     `-CStyleCastExpr {{.+}} 'const char *__bidi_indexable' <BitCast>
+// CHECK:           |   |     `-ImplicitCastExpr {{.+}} 'const char *__bidi_indexable' <BitCast>
 // CHECK:           |   |       `-OpaqueValueExpr [[ove]] {{.*}} 'const void *__bidi_indexable'
 // CHECK:           |   `-BinaryOperator {{.+}} 'int' '<='
 // CHECK:           |     |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>

--- a/clang/test/BoundsSafety/AST/sized_by_or_null_call.c
+++ b/clang/test/BoundsSafety/AST/sized_by_or_null_call.c
@@ -537,7 +537,7 @@ void caller_9(int *__sized_by(*len) *out, int *len){
 // CHECK-NEXT: {{^}}    | |-OpaqueValueExpr [[ove_22]] {{.*}} 'int *__single __sized_by_or_null(count)*__bidi_indexable'
 // CHECK:      {{^}}    | `-OpaqueValueExpr [[ove_23]] {{.*}} 'int *__bidi_indexable'
 // CHECK:      {{^}}    `-ReturnStmt
-// CHECK-NEXT: {{^}}      `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && !p || len <= (char *)__builtin_get_pointer_upper_bound(p) - (char *__bidi_indexable)p && 0 <= len'
+// CHECK-NEXT: {{^}}      `-BoundsCheckExpr {{.+}} 'p <= __builtin_get_pointer_upper_bound(p) && __builtin_get_pointer_lower_bound(p) <= p && !p || len <= __builtin_get_pointer_upper_bound(p) - p && 0 <= len'
 // CHECK-NEXT: {{^}}        |-ImplicitCastExpr {{.+}} 'int *__single __sized_by_or_null(len)':'int *__single' <BoundsSafetyPointerCast>
 // CHECK-NEXT: {{^}}        | `-OpaqueValueExpr [[ove_24:0x[^ ]+]] {{.*}} 'int *__bidi_indexable'
 // CHECK:      {{^}}        |     | | |-OpaqueValueExpr [[ove_25:0x[^ ]+]] {{.*}} 'int *__single __sized_by_or_null(count)':'int *__single'
@@ -562,11 +562,11 @@ void caller_9(int *__sized_by(*len) *out, int *len){
 // CHECK-NEXT: {{^}}        |     | |-ImplicitCastExpr {{.+}} '__ptrdiff_t':'long' <IntegralCast>
 // CHECK-NEXT: {{^}}        |     | | `-OpaqueValueExpr [[ove_27:0x[^ ]+]] {{.*}} 'int'
 // CHECK:      {{^}}        |     | `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
-// CHECK-NEXT: {{^}}        |     |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK-NEXT: {{^}}        |     |   |-ImplicitCastExpr {{.+}} 'char *' <BitCast>
 // CHECK-NEXT: {{^}}        |     |   | `-GetBoundExpr {{.+}} upper
 // CHECK-NEXT: {{^}}        |     |   |   `-OpaqueValueExpr [[ove_24]] {{.*}} 'int *__bidi_indexable'
 // CHECK:      {{^}}        |     |   `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
-// CHECK-NEXT: {{^}}        |     |     `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK-NEXT: {{^}}        |     |     `-ImplicitCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
 // CHECK-NEXT: {{^}}        |     |       `-OpaqueValueExpr [[ove_24]] {{.*}} 'int *__bidi_indexable'
 // CHECK:      {{^}}        |     `-BinaryOperator {{.+}} 'int' '<='
 // CHECK-NEXT: {{^}}        |       |-IntegerLiteral {{.+}} 0

--- a/clang/test/BoundsSafety/AST/value-dependence.cpp
+++ b/clang/test/BoundsSafety/AST/value-dependence.cpp
@@ -142,7 +142,7 @@ T bar(int x) {
 // BOUNDS-CHECK: |     |   `-DependerDeclsAttr
 // BOUNDS-CHECK: |     | `-VarDecl {{.*}} p 'int *__single __sized_by_or_null(4UL * y)':'int *__single'
 // BOUNDS-CHECK: |     |-MaterializeSequenceExpr {{.*}} <Bind>
-// BOUNDS-CHECK: |     | |-BoundsCheckExpr {{.*}} 'mymalloc<int>(x) <= __builtin_get_pointer_upper_bound(mymalloc<int>(x)) && __builtin_get_pointer_lower_bound(mymalloc<int>(x)) <= mymalloc<int>(x) && !mymalloc<int>(x) || 4UL * x <= (char *)__builtin_get_pointer_upper_bound(mymalloc<int>(x)) - (char *__single)mymalloc<int>(x)'
+// BOUNDS-CHECK: |     | |-BoundsCheckExpr {{.*}} 'mymalloc<int>(x) <= __builtin_get_pointer_upper_bound(mymalloc<int>(x)) && __builtin_get_pointer_lower_bound(mymalloc<int>(x)) <= mymalloc<int>(x) && !mymalloc<int>(x) || 4UL * x <= __builtin_get_pointer_upper_bound(mymalloc<int>(x)) - mymalloc<int>(x)'
 // BOUNDS-CHECK: |     | | |-BinaryOperator {{.*}} 'int *__single __sized_by_or_null(4UL * y)':'int *__single' lvalue '='
 // BOUNDS-CHECK: |     | | | |-DeclRefExpr {{.*}} 'p'
 // BOUNDS-CHECK: |     | | | `-OpaqueValueExpr
@@ -422,7 +422,7 @@ void method_call(int o) {
 // BOUNDS-CHECK: |   | | |-ParmVarDecl {{.*}} q 'int'
 // BOUNDS-CHECK: |   | | `-CompoundStmt
 // BOUNDS-CHECK: |   | |   |-MaterializeSequenceExpr
-// BOUNDS-CHECK: |   | |   | |-BoundsCheckExpr {{.*}} 'this->mymalloc_m(q) <= __builtin_get_pointer_upper_bound(this->mymalloc_m(q)) && __builtin_get_pointer_lower_bound(this->mymalloc_m(q)) <= this->mymalloc_m(q) && !this->mymalloc_m(q) || q <= (char *)__builtin_get_pointer_upper_bound(this->mymalloc_m(q)) - (char *__single)this->mymalloc_m(q) && 0 <= q'
+// BOUNDS-CHECK: |   | |   | |-BoundsCheckExpr {{.*}} 'this->mymalloc_m(q) <= __builtin_get_pointer_upper_bound(this->mymalloc_m(q)) && __builtin_get_pointer_lower_bound(this->mymalloc_m(q)) <= this->mymalloc_m(q) && !this->mymalloc_m(q) || q <= __builtin_get_pointer_upper_bound(this->mymalloc_m(q)) - this->mymalloc_m(q) && 0 <= q'
 // BOUNDS-CHECK: |   | |   | | |-BinaryOperator {{.*}} '='
 // BOUNDS-CHECK: |   | |   | | | |-MemberExpr {{.*}} ->p_m
 // BOUNDS-CHECK: |   | |   | | | | `-CXXThisExpr {{.*}} 'Outer<int>::Inner *'
@@ -464,7 +464,7 @@ void method_call(int o) {
 // BOUNDS-CHECK: |   |   |   `-DependerDeclsAttr
 // BOUNDS-CHECK: |   |   | `-VarDecl {{.*}} p1 'int *__single __sized_by_or_null(l)':'int *__single'
 // BOUNDS-CHECK: |   |   |-MaterializeSequenceExpr {{.*}} <Bind>
-// BOUNDS-CHECK: |   |   | |-BoundsCheckExpr {{.*}} 'this->inner.mymalloc_m(m) <= __builtin_get_pointer_upper_bound(this->inner.mymalloc_m(m)) && __builtin_get_pointer_lower_bound(this->inner.mymalloc_m(m)) <= this->inner.mymalloc_m(m) && !this->inner.mymalloc_m(m) || m <= (char *)__builtin_get_pointer_upper_bound(this->inner.mymalloc_m(m)) - (char *__single)this->inner.mymalloc_m(m) && 0 <= m'
+// BOUNDS-CHECK: |   |   | |-BoundsCheckExpr {{.*}} 'this->inner.mymalloc_m(m) <= __builtin_get_pointer_upper_bound(this->inner.mymalloc_m(m)) && __builtin_get_pointer_lower_bound(this->inner.mymalloc_m(m)) <= this->inner.mymalloc_m(m) && !this->inner.mymalloc_m(m) || m <= __builtin_get_pointer_upper_bound(this->inner.mymalloc_m(m)) - this->inner.mymalloc_m(m) && 0 <= m'
 // BOUNDS-CHECK: |   |   | | |-BinaryOperator {{.*}} '='
 // BOUNDS-CHECK: |   |   | | | |-DeclRefExpr {{.*}} 'p1' 'int *__single __sized_by_or_null(l)':'int *__single'
 // BOUNDS-CHECK: |   |   | | | `-CXXMemberCallExpr {{.*}} 'int *__single __sized_by_or_null(4UL * n)':'int *__single'

--- a/clang/test/BoundsSafety/Sema/typed-memory-operation-synthesized-cast.c
+++ b/clang/test/BoundsSafety/Sema/typed-memory-operation-synthesized-cast.c
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -fbounds-safety -ftyped-memory-operations -fsyntax-only -verify %s
+
+// Check that casts generated as part of bounds check expressions don't trip up
+// the type allocator analysis.
+
+// expected-no-diagnostics
+
+#include <ptrcheck.h>
+
+#define _TYPED_ALLOC(rewrite_target, type_param_pos)                           \
+  __attribute__((typed_memory_operation(rewrite_target, type_param_pos)))
+
+void *__sized_by_or_null(size) typed_alloc(__SIZE_TYPE__ size,
+                                           unsigned long long descriptor);
+void *__sized_by_or_null(size) my_alloc(__SIZE_TYPE__ size)
+    _TYPED_ALLOC(typed_alloc, 1);
+
+struct foo {
+  int a;
+  int b;
+};
+
+struct bar {
+  int len;
+  struct foo *__sized_by_or_null(len) p;
+};
+
+void g(struct bar *s, int n) {
+  s->p = my_alloc((__SIZE_TYPE__)n * sizeof(struct foo));
+  s->len = n;
+}


### PR DESCRIPTION
The fact that -fbounds-safety creates cast expressions that are not
ImplicitCastExpr after TMO analysis has already processed explicit casts
tripped an assertion. Implicitly generating explicit cast expressions
feels like an anti-pattern, so this fixes the root cause rather than the
TMO processing.

rdar://184764817

Also adds a cleanup where we avoid inserting redundant casts when the pointer already has the target type.