### PR TITLE
[StackSafety] Skip a caller's callee operand typed GlobalVariable

### DIFF
--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -527,7 +527,8 @@ void StackSafetyLocalAnalysis::analyzeAllUses(Value *Ptr,
         // dso_preemptable aliases or aliases with interposable linkage.
         const GlobalValue *Callee =
             dyn_cast<GlobalValue>(CB.getCalledOperand()->stripPointerCasts());
-        if (!Callee || isa<GlobalIFunc>(Callee)) {
+        if (!Callee || isa<GlobalIFunc>(Callee) ||
+            isa<GlobalVariable>(Callee)) {
           US.addRange(I, UnknownRange, /*IsSafe=*/false);
           break;
         }

--- a/llvm/test/Analysis/StackSafetyAnalysis/local.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/local.ll
@@ -1136,5 +1136,32 @@ entry:
   ret ptr null
 }
 
+@blob = external global [16 x i8]
+
+define dso_local void @CallGlobalVariable(ptr noundef %uaddr) local_unnamed_addr {
+; CHECK-LABEL: @CallGlobalVariable{{$}}
+; CHECK-NEXT: args uses:
+; CHECK-NEXT: uaddr[]: full-set{{$}}
+; CHECK-NEXT: allocas uses:
+; GLOBAL-NEXT: safe accesses:
+; CHECK-EMPTY:
+entry:
+  tail call i64 @blob(ptr noundef %uaddr)
+  ret void
+}
+
+define dso_local void @CallGlobalVariableAlloca() local_unnamed_addr {
+; CHECK-LABEL: @CallGlobalVariableAlloca{{$}}
+; CHECK-NEXT: args uses:
+; CHECK-NEXT: allocas uses:
+; CHECK-NEXT: x[4]: full-set{{$}}
+; GLOBAL-NEXT: safe accesses:
+; CHECK-EMPTY:
+entry:
+  %x = alloca i32, align 4
+  call i64 @blob(ptr noundef %x)
+  ret void
+}
+
 declare void @llvm.lifetime.start.p0(ptr nocapture)
 declare void @llvm.lifetime.end.p0(ptr nocapture)


### PR DESCRIPTION
The callee operand of a call can be a function pointer global. A GlobalVariable is not analyzable locally. Otherwise the compiler could crash.

Claude (Claude-Opus-5) noreply@anthropic.com

rdar://184777590
pick deec59b150d2346732ba59d155f1449447abd56d