### PR TITLE
[lldb] Use PC-1 in SwiftLanguageRuntime::GetRuntimeUnwindPlan

### DIFF
--- a/lldb/include/lldb/Target/RegisterContext.h
+++ b/lldb/include/lldb/Target/RegisterContext.h
@@ -226,6 +226,8 @@ public:
 
   void SetStopID(uint32_t stop_id) { m_stop_id = stop_id; }
 
+  uint32_t GetConcreteFrameIndex() const { return m_concrete_frame_idx; }
+
 protected:
   /// Indicates that this frame is currently executing code,
   /// that the PC value is not a return-pc but an actual executing

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -3504,10 +3504,18 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
   Address pc;
   pc.SetLoadAddress(regctx->GetPC(), &target);
   SymbolContext sc;
-  if (pc.IsValid())
-    if (!pc.CalculateSymbolContext(&sc, eSymbolContextFunction |
-                                            eSymbolContextSymbol))
-      return UnwindPlanSP();
+  behaves_like_zeroth_frame = regctx->GetConcreteFrameIndex() == 0;
+
+  {
+    Address pc_for_lookup = pc;
+    // If a PC is a return address, it may point to a different function.
+    if (!behaves_like_zeroth_frame)
+      pc_for_lookup.Slide(-1);
+    if (pc_for_lookup.IsValid())
+      if (!pc_for_lookup.CalculateSymbolContext(&sc, eSymbolContextFunction |
+                                                         eSymbolContextSymbol))
+        return UnwindPlanSP();
+  }
 
   Address func_start_addr;
   ConstString mangled_name;

--- a/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/Makefile
@@ -1,0 +1,1 @@
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/TestSwiftAsyncSyncFrameEndingInCall.py
+++ b/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/TestSwiftAsyncSyncFrameEndingInCall.py
@@ -1,0 +1,57 @@
+"""
+Test that a sync frame whose last instruction is a call is not mistaken for an
+async frame.
+
+Such a frame's return address is one past the end of the function, i.e. the first
+byte of whichever function was placed next.  When that neighbour is an async
+funclet, resolving the return address without backing it up by one makes
+SwiftLanguageRuntime::GetRuntimeUnwindPlan build an async unwind plan -- CFA
+taken from the async context register -- for a plain sync frame.  The unwind then
+stops dead at that frame and every caller above it is lost.
+"""
+
+import lldb
+import json
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestSwiftAsyncSyncFrameEndingInCall(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipIfLLVMTargetMissing("AArch64")
+    def test(self):
+        """Test that no frames are lost above a sync frame ending in a call"""
+        target = self.dbg.CreateTarget("")
+        exe = "binary.json"
+        with open(exe) as f:
+            exe_uuid = json.load(f)["uuid"]
+
+        target.AddModule(exe, "", exe_uuid)
+        self.assertTrue(target.IsValid())
+
+        core = self.getBuildArtifact("core")
+        self.yaml2macho_core("arm64-sync-frame-ending-in-call.yaml", core, exe_uuid)
+
+        process = target.LoadCore(core)
+        self.assertTrue(process.IsValid())
+
+        if self.TraceOn():
+            self.runCmd("target modules dump symtab")
+            self.runCmd("thread backtrace --unfiltered")
+
+        thread = process.GetThreadAtIndex(0)
+        self.assertTrue(thread.IsValid())
+
+        stackframe_names = [
+            "$s1a12reportAndDies5NeverOyF",
+            "$s1a7doPanicyys6UInt32VF",
+            "$s1a12waitCompleteySbSbF",
+            "$s1a6calleryyF",
+        ]
+        self.assertEqual(thread.GetNumFrames(), len(stackframe_names))
+        for i, name in enumerate(stackframe_names):
+            self.assertEqual(
+                name, thread.GetFrameAtIndex(i).GetSymbol().GetMangledName()
+            )

--- a/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/arm64-sync-frame-ending-in-call.yaml
+++ b/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/arm64-sync-frame-ending-in-call.yaml
@@ -1,0 +1,65 @@
+# a.waitComplete(Swift.Bool) -> Swift.Bool is sync and its last instruction is a
+# `bl`, so its return address (0x100001034) is one past its end -- the first byte
+# of a.asyncDecoy() async -> ().  Resolving that return address without backing it
+# up by one names asyncDecoy, so the Swift language runtime hands out an async
+# unwind plan (CFA from x22) for a sync frame, and a.caller() is lost.
+#
+# Symbol names and address ranges are in binary.json.  Code layout:
+#
+#   0x100001000  reportAndDie  stp/mov, str x9,[x8] <- pc, b .
+#   0x100001010  doPanic       stp/mov, bl reportAndDie, nop, ldp/ret
+#   0x100001028  waitComplete  stp/mov, bl doPanic           ends 0x100001034
+#   0x100001034  asyncDecoy    async, never executed
+#   0x100001044  caller        stp/mov, bl waitComplete, nop, ldp/ret
+#
+# Two constraints on the addresses:
+#
+#  - The code must sit past the end of binary.json itself.  The TEXT section
+#    declares file_offset 0, so at low section offsets lldb reads instruction
+#    bytes out of the json file rather than from this corefile, and instruction
+#    emulation then derives a useless UnwindPlan from json text.
+#  - The nop after each bl keeps return addresses inside the function body
+#    instead of on its epilogue, which emulation reads as a torn-down frame.
+
+cpu: arm64
+threads:
+  - regsets:
+    - flavor: gpr
+      registers: [{name: sp,  value: 0x000000016fdfef00},
+                  {name: fp,  value: 0x000000016fdfef00},
+                  {name: lr,  value: 0x000000010000101c},
+                  {name: pc,  value: 0x0000000100001008},
+                  {name: x22, value: 0x000000016fdfd000}]
+
+memory-regions:
+  # Frame-pointer chain.  Each frame stores {saved fp, saved lr} at its own fp.
+  - addr: 0x16fdfef00
+    UInt64: [
+      # reportAndDie's frame
+      0x000000016fdfef10,   # -> doPanic's fp
+      0x000000010000101c,   # return into doPanic, at its nop
+      # doPanic's frame
+      0x000000016fdfef20,   # -> waitComplete's fp
+      0x0000000100001034,   # waitComplete's end == asyncDecoy's start
+      # waitComplete's frame
+      0x000000016fdfef30,   # -> caller's fp
+      0x0000000100001050,   # return into caller, at its nop
+      # caller's frame: zeroed, to end the backtrace here
+      0x0000000000000000,
+      0x0000000000000000
+    ]
+
+  # The async context register has to point at readable memory, otherwise the
+  # buggy path bails out before building a plan.
+  - addr: 0x16fdfd000
+    UInt64: [ 0x0000000000000000, 0x0000000000000000 ]
+
+  # Instructions, so lldb can derive unwind plans by emulation.
+  - addr: 0x100001000
+    UInt32: [
+      0xa9bf7bfd, 0x910003fd, 0xf9000109, 0x14000000,                          # reportAndDie
+      0xa9bf7bfd, 0x910003fd, 0x97fffffa, 0xd503201f, 0xa8c17bfd, 0xd65f03c0,  # doPanic
+      0xa9bf7bfd, 0x910003fd, 0x97fffff8,                                      # waitComplete
+      0xa9bf7bfd, 0x910003fd, 0xa8c17bfd, 0xd65f03c0,                          # asyncDecoy
+      0xa9bf7bfd, 0x910003fd, 0x97fffff7, 0xd503201f, 0xa8c17bfd, 0xd65f03c0   # caller
+    ]

--- a/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/binary.json
+++ b/lldb/test/API/lang/swift/async/unwind/sync_frame_ending_in_call/binary.json
@@ -1,0 +1,53 @@
+{
+  "triple": "arm64-apple-macosx",
+  "uuid": "8E2C4F1A-6B93-4D57-9A08-1C3E5B7D9F26",
+  "type": "executable",
+  "sections": [
+    {
+      "user_id": 100,
+      "name": "TEXT",
+      "type": "code",
+      "address": 4294967296,
+      "size": 16384,
+      "file_offset": 0,
+      "file_size": 16384,
+      "alignment": 2,
+      "flags": 514,
+      "read": true,
+      "write": false,
+      "execute": true
+    }
+  ],
+  "symbols": [
+    {
+      "name": "$s1a12reportAndDies5NeverOyF",
+      "type": "code",
+      "size": 16,
+      "address": 4294971392
+    },
+    {
+      "name": "$s1a7doPanicyys6UInt32VF",
+      "type": "code",
+      "size": 24,
+      "address": 4294971408
+    },
+    {
+      "name": "$s1a12waitCompleteySbSbF",
+      "type": "code",
+      "size": 12,
+      "address": 4294971432
+    },
+    {
+      "name": "$s1a10asyncDecoyyyYaF",
+      "type": "code",
+      "size": 16,
+      "address": 4294971444
+    },
+    {
+      "name": "$s1a6calleryyF",
+      "type": "code",
+      "size": 24,
+      "address": 4294971460
+    }
+  ]
+}


### PR DESCRIPTION
When a function ends in a `bl` (very common in no-return functions), its corresponding frame will have a PC pointing into a different function entirely. RegisterContextUnwind explicitly handles this case, but it delegates to each Runtime plugin to decide how to handle it. SwiftLanguageRuntime was not doing so.

A method was added to RegisterContextUnwind, which can live upstream. An upstream patch will be created if a use can be found for that method.

To test this, we need to carefully place an async function right after a non-async-function that ends in a bl instruction.