### PR TITLE
Revert "[TESTS] Fix downstream C1Nano-ptraut-instructions"

### DIFF
--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Nano-ptraut-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Nano-ptraut-instructions.s
@@ -39,7 +39,7 @@
 # CHECK-NEXT:  1      4     1.00                  U     autizb	x0
 # CHECK-NEXT:  1      4     1.00                  U     pacdzb	x0
 # CHECK-NEXT:  1      4     1.00                  U     autdzb	x0
-# CHECK-NEXT:  1      4     1.00                  U     xpaci	x0
+# CHECK-NEXT:  1      4     1.00                        xpaci	x0
 # CHECK-NEXT:  1      4     1.00                        xpacd	x0
 # CHECK-NEXT:  1      4     1.00                  U     xpaclri
 # CHECK-NEXT:  2      1     1.00                  U     braa	x0, x1


### PR DESCRIPTION
This reverts commit 405f3fe9b9556cf2dda1e7a1d38917e97d51618d.

The underlying cause of the test failure has been fixed by picking 0bac69449283b44dd8cde1ed73797f320c03bd69.

rdar://185469135