### PR TITLE
[AST] Make err_struct_too_large check target-aware

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -1001,6 +1001,16 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 - Fixed a crash when passing one sized implicitly casted vector to a `abs` function. (#GH204777)
 - Fixed a crash when diagnosing an invalid out-of-line definition of a member class template. (#GH201490)
 - Fixed a crash in the parser when a missing semicolon after a tag definition is followed by a template-id not preceded by `::`. (#GH207992)
+||||||| parent of 92efec0854b2 ([AST] Make err_struct_too_large check target-aware (#218749))
+- Fixed a crash in CTAD for type alias templates when the aggregate deduction guide could not be resolved. (#GH206994)
+- Fixed a crash when instantiating an invalid dependent friend destructor declaration in a class template. (#GH210234)
+- Fixed an assertion failure in `-extract-api` when a documentation comment
+  contains invalid UTF-8. (#GH212393)
+- Fixed a crash when generating fake uses for parameters of bodyless destructors with `-fextend-variable-liveness`.
+- Fixed a crash in codegen on 32-bit targets caused by a struct too large to
+  represent in `size_t`. The `err_struct_too_large` check now scales the
+  threshold to the target's `size_t` width instead of using a fixed
+  threshold of `1 << 60` regardless of the target.
 
 ### OpenACC Specific Changes
 

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -3463,7 +3463,10 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
 
   ASTRecordLayouts[D] = NewEntry;
 
-  constexpr uint64_t MaxStructSizeInBytes = 1ULL << 60;
+  // Cap at the target's size_t width (up to 60 bits) so oversized layouts on
+  // narrow targets are diagnosed instead of overflowing size_t in codegen.
+  uint64_t MaxStructSizeInBytes =
+      1ULL << std::min<unsigned>(getTypeSize(getSizeType()), 60);
   CharUnits StructSize = NewEntry->getSize();
   if (static_cast<uint64_t>(StructSize.getQuantity()) >= MaxStructSizeInBytes) {
     getDiagnostics().Report(D->getLocation(), diag::err_struct_too_large)

--- a/clang/test/AST/absurdly_big_struct.cpp
+++ b/clang/test/AST/absurdly_big_struct.cpp
@@ -1,8 +1,9 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -triple x86_64-linux-gnu
+// RUN: %clang_cc1 -fsyntax-only -verify=bit64 %s -triple x86_64-linux-gnu
+// RUN: %clang_cc1 -fsyntax-only -verify=bit32 %s -triple armv7-unknown-linux-gnueabi
 
-struct a { // expected-error {{structure 'a' is too large, which exceeds maximum allowed size of 1152921504606846976 bytes}}
-  char x[1ull<<60]; 
-  char x2[1ull<<60]; 
+struct a { // bit64-error {{structure 'a' is too large, which exceeds maximum allowed size of 1152921504606846976 bytes}}
+  char x[1ull<<60]; // bit32-error {{array is too large}}
+  char x2[1ull<<60]; // bit32-error {{array is too large}}
 };
 
 a z[1];
@@ -10,4 +11,14 @@ long long x() { return sizeof(a); }
 long long x2() { return sizeof(a::x); }
 long long x3() { return sizeof(a::x2); }
 long long x4() { return sizeof(z); }
+
+// On 32-bit architectures, the struct size must be below (1 << 32).
+// This used to crash in CodeGen.
+struct b { // bit32-error {{structure 'b' is too large, which exceeds maximum allowed size of 4294967296 bytes}}
+  char c[0xFFFFFFFE];
+  char c1[4];
+  char c2[2];
+};
+
+long long y(int i) { return __builtin_offsetof(b, c2[i]); }
 


### PR DESCRIPTION
ASTContext::getASTRecordLayout used a fixed 1ULL << 60 threshold for err_struct_too_large, regardless of the target's size_t width.

Scale the threshold to the target's size_t width instead, so it is below (1 << 32) on 32-bit architectures. Diagnosing the overflow in Sema avoids the crash in codegen.

rdar://183351516