### PR TITLE
[swift/release/6.4.x][Coroutines] Pack the frame when a spill's alignment was clamped

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -485,10 +485,18 @@ StructType *FrameTypeBuilder::finish(StringRef Name) {
 
   // We need to produce a packed struct type if there's a field whose
   // assigned offset isn't a multiple of its natural type alignment.
+  //
+  // Test against the field type's real ABI alignment rather than F.TyAlignment.
+  // addField deliberately lowers TyAlignment below the type's ABI alignment for
+  // spills that exceed MaxFrameAlignment, and emits the spill accesses at that
+  // reduced alignment. But the struct body still holds the original type, so if
+  // we left the struct unpacked DataLayout would re-impose the ABI alignment we
+  // just decided to ignore, and its element offsets would no longer match the
+  // ones we assigned here.
   bool Packed = [&] {
     for (auto &LayoutField : LayoutFields) {
       auto &F = getField(LayoutField);
-      if (!isAligned(F.TyAlignment, LayoutField.Offset))
+      if (!isAligned(DL.getABITypeAlign(F.Ty), LayoutField.Offset))
         return true;
     }
     return false;


### PR DESCRIPTION
**Explanation**: 

Resolves an issue found in Swift https://github.com/swiftlang/swift/issues/91639

The issue comes down to the coroutine frame being laid out with one alignment and emitted with another, so the frame ends up larger than the async context that was allocated for it, and the tail of the frame overwrites whatever follows the context.

This manifests in the linked Swift reproducer by corrupting the tasklocal allocator, but could manifest in other ways I suppose.

Builds with assertions catch this actually:

```
Assertion failed: (Layout->getElementOffset(F.LayoutFieldIndex) == F.Offset),
  function finish, file CoroFrame.cpp, line 534.
While splitting coroutine @"$s4main5outeryySS_s5SIMD3VySdGt_tYaKF"
```

Here's a swift side test for it: https://github.com/swiftlang/swift/pull/91809


**Scope**: 

Corrects how frames are laid out for coroutines.


**Risk**: 

Low, existing code was was triggering an assertion, and the fix corrects the calculations.


**Testing**: 
- CI testing, added new testing in Swift that confirms the fix

**Original PR**:
- This is already fixed on `next` so no other PR exists, we'd like to fix this for 6.4 as well though

**Reviewed by**:
- @drexin 

**Issues**: 
- Resolves https://github.com/swiftlang/swift/issues/91639
- Resolves rdar://185503097

-----


**Other branches**

This code does not exist on `next` anymore, since the entire `finish()` function (and much more) was changed quite substantially in 6719ec1e9512 "[Coroutines] Replace struct alloca frame with byte array and ptradd" (llvm.org#178359).

Picking that change is a bit tricky though, since it's a many files change and would cause us to pick a few more commits and refactors (AFAICS eef6b62dccde, a927d37f8544, 925b033fce54, 02232b9a61b1, and e3c786874ae4 maybe), so I think we should take the small fix here, and we don't need to do anything on next.

The test on swiftlang will prevent regressing when we move on to newer llvm as well.

