### PR TITLE
Suppress codegen for switch cases matching unavailable enum elements

### DIFF
--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -1846,6 +1846,18 @@ void CodeGenFunction::EmitCaseStmtRange(const CaseStmt &S,
     Builder.ClearInsertionPoint();
 }
 
+/// Returns true if the case label expression \p E names an enumerator that is
+/// unavailable in the current availability domain configuration. Such an
+/// enumerator can't be instantiated at runtime, so the switch condition never
+/// has its value.
+static bool isNeverMatchedCaseLabel(const ASTContext &Ctx, const Expr *E) {
+  const auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts());
+  if (!DRE)
+    return false;
+  const auto *ECD = dyn_cast<EnumConstantDecl>(DRE->getDecl());
+  return ECD && Ctx.hasUnavailableFeature(ECD);
+}
+
 void CodeGenFunction::EmitCaseStmt(const CaseStmt &S,
                                    ArrayRef<const Attr *> Attrs) {
   // If there is no enclosing switch instance that we're aware of, then this
@@ -1867,6 +1879,11 @@ void CodeGenFunction::EmitCaseStmt(const CaseStmt &S,
   llvm::ConstantInt *CaseVal =
     Builder.getInt(S.getLHS()->EvaluateKnownConstInt(getContext()));
 
+  // Leave the value of a never matched case out of the switch instruction. The
+  // statements of the case are still emitted, because a preceding case can fall
+  // through into them, but the block that holds them is otherwise unreachable.
+  bool NeverMatches = isNeverMatchedCaseLabel(getContext(), S.getLHS());
+
   // Emit debuginfo for the case value if it is an enum value.
   const ConstantExpr *CE;
   if (auto ICE = dyn_cast<ImplicitCastExpr>(S.getLHS()))
@@ -1881,7 +1898,7 @@ void CodeGenFunction::EmitCaseStmt(const CaseStmt &S,
               APValue(llvm::APSInt(CaseVal->getValue())));
   }
 
-  if (SwitchLikelihood)
+  if (SwitchLikelihood && !NeverMatches)
     SwitchLikelihood->push_back(Stmt::getLikelihood(Attrs));
 
   // If the body of the case is just a 'break', try to not emit an empty block.
@@ -1894,9 +1911,11 @@ void CodeGenFunction::EmitCaseStmt(const CaseStmt &S,
 
     // Only do this optimization if there are no cleanups that need emitting.
     if (isObviouslyBranchWithoutCleanups(Block)) {
-      if (SwitchWeights)
-        SwitchWeights->push_back(getProfileCount(&S));
-      SwitchInsn->addCase(CaseVal, Block.getBlock());
+      if (!NeverMatches) {
+        if (SwitchWeights)
+          SwitchWeights->push_back(getProfileCount(&S));
+        SwitchInsn->addCase(CaseVal, Block.getBlock());
+      }
 
       // If there was a fallthrough into this case, make sure to redirect it to
       // the end of the switch as well.
@@ -1910,9 +1929,11 @@ void CodeGenFunction::EmitCaseStmt(const CaseStmt &S,
 
   llvm::BasicBlock *CaseDest = createBasicBlock("sw.bb");
   EmitBlockWithFallThrough(CaseDest, &S);
-  if (SwitchWeights)
-    SwitchWeights->push_back(getProfileCount(&S));
-  SwitchInsn->addCase(CaseVal, CaseDest);
+  if (!NeverMatches) {
+    if (SwitchWeights)
+      SwitchWeights->push_back(getProfileCount(&S));
+    SwitchInsn->addCase(CaseVal, CaseDest);
+  }
 
   // Recursively emitting the statement is acceptable, but is not wonderful for
   // code where we have many case statements nested together, i.e.:
@@ -1935,8 +1956,10 @@ void CodeGenFunction::EmitCaseStmt(const CaseStmt &S,
     CurCase = NextCase;
     llvm::ConstantInt *CaseVal =
       Builder.getInt(CurCase->getLHS()->EvaluateKnownConstInt(getContext()));
+    bool NeverMatches =
+        isNeverMatchedCaseLabel(getContext(), CurCase->getLHS());
 
-    if (SwitchWeights)
+    if (SwitchWeights && !NeverMatches)
       SwitchWeights->push_back(getProfileCount(NextCase));
     if (CGM.getCodeGenOpts().hasProfileClangInstr()) {
       CaseDest = createBasicBlock("sw.bb");
@@ -1944,10 +1967,11 @@ void CodeGenFunction::EmitCaseStmt(const CaseStmt &S,
     }
     // Since this loop is only executed when the CaseStmt has no attributes
     // use a hard-coded value.
-    if (SwitchLikelihood)
+    if (SwitchLikelihood && !NeverMatches)
       SwitchLikelihood->push_back(Stmt::LH_None);
 
-    SwitchInsn->addCase(CaseVal, CaseDest);
+    if (!NeverMatches)
+      SwitchInsn->addCase(CaseVal, CaseDest);
     NextCase = dyn_cast<CaseStmt>(CurCase->getSubStmt());
   }
 

--- a/clang/test/CodeGen/feature-availability.c
+++ b/clang/test/CodeGen/feature-availability.c
@@ -21,6 +21,7 @@
 #include <availability_domain.h>
 
 #define AVAIL 0
+#define UNAVAIL 1
 
 #ifdef USE_DOMAIN
 // DOMAIN: @g3 = extern_weak global i32, align 4
@@ -43,6 +44,15 @@ __attribute__((availability(domain:feature2, AVAIL))) int g2;
 
 struct __attribute__((availability(domain:feature1, AVAIL))) S0 {
   int d0;
+};
+
+// E0_B and E0_C can never be instantiated at runtime, so a switch on enum E0
+// never takes their values.
+enum E0 {
+  E0_A,
+  E0_B __attribute__((availability(domain:feature1, UNAVAIL))),
+  E0_C __attribute__((availability(domain:feature2, AVAIL))),
+  E0_D,
 };
 
 // CHECK-LABEL: define void @test0()
@@ -133,5 +143,95 @@ L2:
     func2();
   }
 }
+
+// The switch has no destination for E0_B or E0_C, so the blocks that hold their
+// statements have no predecessors.
+// CHECK-LABEL: define void @test6(
+// CHECK: switch i32 %{{.*}}, label %[[EPILOG:.*]] [
+// CHECK-NEXT: i32 0, label %[[BB_A:.*]]
+// CHECK-NEXT: i32 3, label %{{.*}}
+// CHECK-NEXT: ]
+//
+// CHECK: [[BB_A]]:
+// CHECK-NEXT: call i32 @func2()
+// CHECK-NEXT: br label %[[EPILOG]]
+
+void test6(enum E0 e) {
+  switch (e) {
+  case E0_A:
+    func2();
+    break;
+  case E0_B:
+    func2();
+    break;
+  case E0_C:
+    func2();
+    break;
+  case E0_D:
+    func2();
+    break;
+  }
+}
+
+// E0_A still falls through into the statements of E0_B, and E0_D still shares a
+// block with E0_C, so dropping the two values doesn't drop either block.
+// CHECK-LABEL: define void @test7(
+// CHECK: switch i32 %{{.*}}, label %[[EPILOG:.*]] [
+// CHECK-NEXT: i32 0, label %[[BB_A:.*]]
+// CHECK-NEXT: i32 3, label %[[BB_CD:.*]]
+// CHECK-NEXT: ]
+//
+// CHECK: [[BB_A]]:
+// CHECK-NEXT: call i32 @func2()
+// CHECK-NEXT: br label %[[BB_B:.*]]
+//
+// CHECK: [[BB_B]]:
+// CHECK-NEXT: call i32 @func2()
+// CHECK-NEXT: br label %[[EPILOG]]
+//
+// CHECK: [[BB_CD]]:
+// CHECK-NEXT: call i32 @func2()
+// CHECK-NEXT: br label %[[EPILOG]]
+
+void test7(enum E0 e) {
+  switch (e) {
+  case E0_A:
+    func2();
+  case E0_B:
+    func2();
+    break;
+  case E0_C:
+  case E0_D:
+    func2();
+    break;
+  }
+}
+
+#ifdef USE_DOMAIN
+
+// E1_A is guarded by a dynamic domain, so it can be instantiated at runtime and
+// keeps its destination in the switch. E1_B can't, so it loses its destination.
+enum E1 {
+  E1_A __attribute__((availability(domain:feature3, AVAIL))),
+  E1_B __attribute__((availability(domain:feature2, AVAIL))),
+};
+
+// DOMAIN-LABEL: define void @test8(
+// DOMAIN: switch i32 %{{.*}}, label %{{.*}} [
+// DOMAIN-NEXT: i32 0, label %{{.*}}
+// DOMAIN-NEXT: ]
+
+void test8(enum E1 e) {
+  switch (e) {
+  case E1_A:
+    func2();
+    break;
+  case E1_B:
+    func2();
+    break;
+  }
+}
+
+#endif
 
 #endif /* HEADER */


### PR DESCRIPTION
Don't emit basic blocks for cases in switch statements that match an enum element which is protected by an availability domain that is disabled. Such case blocks are unreachable at runtime so their code should be omitted from the compiled executable.

Resolves rdar://186091715.