### PR TITLE
[clang][tmo][nfc] Lightweight TMO refactoring

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3290,9 +3290,10 @@ public:
   /// Handles the checks for format strings, non-POD arguments to vararg
   /// functions, NULL arguments passed to non-NULL parameters, diagnose_if
   /// attributes and AArch64 SME attributes.
-  void checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
-                 const Expr *ThisArg, ArrayRef<const Expr *> Args,
-                 bool IsMemberFunction, SourceLocation Loc, SourceRange Range,
+  void checkCall(NamedDecl *FDecl, const CallExpr *TheCall,
+                 const FunctionProtoType *Proto, const Expr *ThisArg,
+                 ArrayRef<const Expr *> Args, bool IsMemberFunction,
+                 SourceLocation Loc, SourceRange Range,
                  VariadicCallType CallType);
 
   /// Verify that two format strings (as understood by attribute(format) and

--- a/clang/lib/CodeGen/CGTypedMemory.cpp
+++ b/clang/lib/CodeGen/CGTypedMemory.cpp
@@ -81,7 +81,7 @@ RValue CodeGenFunction::EmitTypedMemoryCall(const CallExpr *E,
   auto *OriginalType = OriginalDecl->getType()->getAs<FunctionProtoType>();
   auto &Context = getContext();
   CGCallee Callee = EmitCallee(Target);
-  auto PropertyDescriptorType = Context.getBitIntType(true, 64);
+  auto PropertyDescriptorType = Context.getBitIntType(/*IsUnsigned=*/true, 64);
   CallArgList CallArgs;
   EmitCallArgs(CallArgs, OriginalType, E->arguments());
 
@@ -106,9 +106,10 @@ RValue CodeGenFunction::EmitTypedMemoryCall(const CallExpr *E,
 
   auto *DescriptorId = llvm::ConstantInt::get(CGM.Int64Ty, Descriptor.value());
   DescriptorId->setName("type_descriptor");
+  QualType DescriptorParamType =
+      TargetPrototype->getParamType(InferredParamIndex + 1);
   auto *ConvertedValue = EmitScalarConversion(
-      DescriptorId, PropertyDescriptorType,
-      TargetPrototype->getParamType(InferredParamIndex + 1),
+      DescriptorId, PropertyDescriptorType, DescriptorParamType,
       InferredParameter->getExprLoc());
   auto InferredTypeArg =
       CallArg(RValue::get(ConvertedValue), PropertyDescriptorType);
@@ -130,9 +131,7 @@ RValue CodeGenFunction::EmitTypedMemoryCall(const CallExpr *E,
 
   // Generate function declaration DISuprogram in order to be used
   // in debug info about call sites.
-  if (CGDebugInfo *DI = getDebugInfo()) {
-    if (auto *CalleeDecl = dyn_cast_or_null<FunctionDecl>(Target))
-      DI->EmitFuncDeclForCallSite(CallOrInvoke, Target->getType(), CalleeDecl);
-  }
+  if (CGDebugInfo *DI = getDebugInfo())
+    DI->EmitFuncDeclForCallSite(CallOrInvoke, Target->getType(), Target);
   return Call;
 }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4507,10 +4507,11 @@ void Sema::checkLifetimeCaptureBy(FunctionDecl *FD, bool IsMemberFunction,
   }
 }
 
-void Sema::checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
-                     const Expr *ThisArg, ArrayRef<const Expr *> Args,
-                     bool IsMemberFunction, SourceLocation Loc,
-                     SourceRange Range, VariadicCallType CallType) {
+void Sema::checkCall(NamedDecl *FDecl, const CallExpr *TheCall,
+                     const FunctionProtoType *Proto, const Expr *ThisArg,
+                     ArrayRef<const Expr *> Args, bool IsMemberFunction,
+                     SourceLocation Loc, SourceRange Range,
+                     VariadicCallType CallType) {
 
   if ((ThisArg && ThisArg->isInstantiationDependent()) ||
       llvm::any_of(Args, [](const Expr *E) {
@@ -4746,8 +4747,8 @@ void Sema::CheckConstructorCall(FunctionDecl *FDecl, QualType ThisType,
       Loc, FDecl, "'this'", Context.getPointerType(ThisType),
       Context.getPointerType(Ctor->getFunctionObjectParameterType()));
 
-  checkCall(FDecl, Proto, /*ThisArg=*/nullptr, Args, /*IsMemberFunction=*/true,
-            Loc, SourceRange(), CallType);
+  checkCall(FDecl, /*TheCall=*/nullptr, Proto, /*ThisArg=*/nullptr, Args,
+            /*IsMemberFunction=*/true, Loc, SourceRange(), CallType);
 }
 
 bool Sema::CheckFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall,
@@ -4790,7 +4791,7 @@ bool Sema::CheckFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall,
                       ThisTypeFromDecl);
   }
 
-  checkCall(FDecl, Proto, ImplicitThis, llvm::ArrayRef(Args, NumArgs),
+  checkCall(FDecl, TheCall, Proto, ImplicitThis, llvm::ArrayRef(Args, NumArgs),
             IsMemberFunction, TheCall->getRParenLoc(),
             TheCall->getCallee()->getSourceRange(), CallType);
 
@@ -4857,7 +4858,7 @@ bool Sema::CheckPointerCall(NamedDecl *NDecl, CallExpr *TheCall,
     CallType = VariadicCallType::Function;
   }
 
-  checkCall(NDecl, Proto, /*ThisArg=*/nullptr,
+  checkCall(NDecl, TheCall, Proto, /*ThisArg=*/nullptr,
             llvm::ArrayRef(TheCall->getArgs(), TheCall->getNumArgs()),
             /*IsMemberFunction=*/false, TheCall->getRParenLoc(),
             TheCall->getCallee()->getSourceRange(), CallType);
@@ -4868,7 +4869,7 @@ bool Sema::CheckPointerCall(NamedDecl *NDecl, CallExpr *TheCall,
 bool Sema::CheckOtherCall(CallExpr *TheCall, const FunctionProtoType *Proto) {
   VariadicCallType CallType = getVariadicCallType(/*FDecl=*/nullptr, Proto,
                                                   TheCall->getCallee());
-  checkCall(/*FDecl=*/nullptr, Proto, /*ThisArg=*/nullptr,
+  checkCall(/*FDecl=*/nullptr, TheCall, Proto, /*ThisArg=*/nullptr,
             llvm::ArrayRef(TheCall->getArgs(), TheCall->getNumArgs()),
             /*IsMemberFunction=*/false, TheCall->getRParenLoc(),
             TheCall->getCallee()->getSourceRange(), CallType);

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2558,8 +2558,8 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
 
     DiagnoseSentinelCalls(OperatorNew, PlacementLParen, CallArgs);
 
-    checkCall(OperatorNew, Proto, /*ThisArg=*/nullptr, CallArgs,
-              /*IsMemberFunction=*/false, StartLoc, Range, CallType);
+    checkCall(OperatorNew, /*TheCall=*/nullptr, Proto, /*ThisArg=*/nullptr,
+              CallArgs, /*IsMemberFunction=*/false, StartLoc, Range, CallType);
 
     // Warn if the type is over-aligned and is being allocated by (unaligned)
     // global operator new.

--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -1230,9 +1230,9 @@ bool SemaObjC::CheckObjCMethodCall(ObjCMethodDecl *Method, SourceLocation lbrac,
                                   ? VariadicCallType::Method
                                   : VariadicCallType::DoesNotApply;
 
-  SemaRef.checkCall(Method, nullptr, /*ThisArg=*/nullptr, Args,
-                    /*IsMemberFunction=*/false, lbrac, Method->getSourceRange(),
-                    CallType);
+  SemaRef.checkCall(Method, /*TheCall=*/nullptr, /*Proto=*/nullptr,
+                    /*ThisArg=*/nullptr, Args, /*IsMemberFunction=*/false,
+                    lbrac, Method->getSourceRange(), CallType);
 
   SemaRef.CheckTCBEnforcement(lbrac, Method);
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -15820,7 +15820,7 @@ ExprResult Sema::CreateOverloadedBinOp(SourceLocation OpLoc,
                             ThisTypeFromDecl);
         }
 
-        checkCall(FnDecl, nullptr, ImplicitThis, ArgsArray,
+        checkCall(FnDecl, TheCall, /*Proto=*/nullptr, ImplicitThis, ArgsArray,
                   isa<CXXMethodDecl>(FnDecl), OpLoc, TheCall->getSourceRange(),
                   VariadicCallType::DoesNotApply);
 


### PR DESCRIPTION
This is a small and simple refactoring of the TMO logic to thread information through to where it is needed in the next more significant change.

I've split this out as a NFC because it caused a pile of irrelevant noise in the real change.