### PR TITLE
[lldb][lldb-dap] Fix runInTerminal test

### DIFF
--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -161,7 +161,12 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
             launch the inferior with the correct environment variables using an object.
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, console="integratedTerminal", env={"FOO": "BAR"})
+        self.build_and_launch(
+            program,
+            console="integratedTerminal",
+            env={"FOO": "BAR"},
+            initCommands=["plugin disable operating-system.swift"],  # rdar://183535755
+        )
 
         self.assertEqual(
             len(self.dap_server.reverse_requests),


### PR DESCRIPTION
This is failing because of an assert in the swift operating system plugin.

The task_addr_location is not meant to change per process. This currently does not hold when the process replaces itself using exec* call. leading to the crash. Somewhere after the process has been replace. The plugin should have been given the chance to update the task_addr_location to match the new process.

This is not the case hence the crash.

Disable the swift operating system plugin for this test.

rdar://183535755