### PR TITLE
[clang][tmo][nfc] Extract the rewrite-target signature check

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -15427,7 +15427,13 @@ def err_tmo_invalid_inferred_parameter_type : Error<
   "invalid parameter type for inference at index %0. %1 is not an integer type">;
 
 def err_tmo_function_kind_error : Error<
-  "%select{untyped|typed}0 memory operation %1 %select{cannot be a variadic function|cannot be an instance method|must have a prototype|must be a function}2">;
+  "%select{untyped|typed}0 memory operation %1 "
+  "%enum_select<TMOErrorKind>{"
+     "%Variadic{cannot be a variadic function}|"
+     "%InstanceMethod{cannot be an instance method}|"
+     "%NoPrototype{must have a prototype}|"
+     "%NotAFunction{must be a function}"
+  "}2">;
 
 def err_tmo_rewrite_target_is_overloaded : Error<
   "typed memory operation %0 has multiple overloads">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5700,6 +5700,13 @@ public:
   /// implementation of std::span or sized_allocation_t in P0901R11.
   bool CheckSpanLikeType(const AttributeCommonInfo &CI, const QualType &Ty);
 
+  /// Check that the Target function for the typed retargeting is valid for
+  /// the source function.
+  bool checkTypedMemorySignature(const AttributeCommonInfo &CI,
+                                 const FunctionDecl *Source,
+                                 const FunctionDecl *Target,
+                                 ParamIdx InferredParameterIdx);
+
   /// Check if IdxExpr is a valid parameter index for a function or
   /// instance method D.  May output an error.
   ///

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8928,17 +8928,6 @@ static void handleEnforceTCBAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   D->addAttr(AttrTy::Create(S.Context, Argument, AL));
 }
 
-static bool typedMemoryTypesAreEquivalentOrDependent(const ASTContext &Context,
-                                                     QualType SourceType,
-                                                     QualType DestinationType) {
-  SourceType = Context.getCanonicalType(SourceType).getUnqualifiedType();
-  DestinationType =
-      Context.getCanonicalType(DestinationType).getUnqualifiedType();
-  if (SourceType->isDependentType() || DestinationType->isDependentType())
-    return true;
-  return SourceType == DestinationType;
-}
-
 static void handleTypedMemory(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (!S.getLangOpts().TypedMemoryOperations)
     return;
@@ -8946,7 +8935,9 @@ static void handleTypedMemory(Sema &S, Decl *D, const ParsedAttr &AL) {
   FunctionDecl *SourceDecl = D->getAsFunction();
   if (isFunctionOrMethodVariadic(D) || isInstanceMethod(D)) {
     S.Diag(SourceDecl->getBeginLoc(), diag::err_tmo_function_kind_error)
-        << 0 << SourceDecl << (isFunctionOrMethodVariadic(D) ? 0 : 1);
+        << 0 << SourceDecl
+        << (isFunctionOrMethodVariadic(D) ? diag::TMOErrorKind::Variadic
+                                          : diag::TMOErrorKind::InstanceMethod);
     AL.setInvalid();
     return;
   }
@@ -8954,7 +8945,8 @@ static void handleTypedMemory(Sema &S, Decl *D, const ParsedAttr &AL) {
   auto Loc = AL.getLoc();
   if (!SourceDecl) {
     auto *ND = cast<NamedDecl>(D);
-    S.Diag(Loc, diag::err_tmo_function_kind_error) << 0 << ND << 3;
+    S.Diag(Loc, diag::err_tmo_function_kind_error)
+        << 0 << ND << diag::TMOErrorKind::NotAFunction;
     AL.setInvalid();
     return;
   }
@@ -8976,7 +8968,8 @@ static void handleTypedMemory(Sema &S, Decl *D, const ParsedAttr &AL) {
     TargetName = DRE->getNameInfo();
     if (!TargetDecl) {
       S.Diag(Loc, diag::err_tmo_function_kind_error)
-          << DRE->getSourceRange() << 1 << DRE->getNameInfo().getName() << 3;
+          << DRE->getSourceRange() << 1 << DRE->getNameInfo().getName()
+          << diag::TMOErrorKind::NotAFunction;
       AL.setInvalid();
       return;
     }
@@ -8993,7 +8986,8 @@ static void handleTypedMemory(Sema &S, Decl *D, const ParsedAttr &AL) {
     }
   } else {
     S.Diag(Loc, diag::err_tmo_function_kind_error)
-        << TargetExpr->getSourceRange() << 1 << TargetExpr << 3;
+        << TargetExpr->getSourceRange() << 1 << TargetExpr
+        << diag::TMOErrorKind::NotAFunction;
     AL.setInvalid();
     return;
   }
@@ -9025,77 +9019,22 @@ static void handleTypedMemory(Sema &S, Decl *D, const ParsedAttr &AL) {
 
   if (!hasFunctionProto(TargetDecl) || isFunctionOrMethodVariadic(TargetDecl) ||
       isInstanceMethod(TargetDecl)) {
-    unsigned MessageSelector = !hasFunctionProto(TargetDecl)            ? 2u
-                               : isFunctionOrMethodVariadic(TargetDecl) ? 1u
-                                                                        : 0u;
+    auto MessageSelector = !hasFunctionProto(TargetDecl)
+                               ? diag::TMOErrorKind::NoPrototype
+                           : isFunctionOrMethodVariadic(TargetDecl)
+                               ? diag::TMOErrorKind::Variadic
+                               : diag::TMOErrorKind::InstanceMethod;
     S.Diag(Loc, diag::err_tmo_function_kind_error)
         << 1 << TargetDecl << MessageSelector;
     AL.setInvalid();
     return;
   }
 
-  auto reportTargetTypeMismatchError = [&]() {
-    std::vector<QualType> ExpectedArguments;
-    for (size_t I = 0; I < InferredParameterIdx.getSourceIndex(); I++)
-      ExpectedArguments.push_back(SourceDecl->getParamDecl(I)->getType());
-    ExpectedArguments.push_back(S.Context.getIntTypeForBitwidth(64, false));
-    for (size_t I = InferredParameterIdx.getSourceIndex();
-         I < SourceDecl->getNumParams(); I++)
-      ExpectedArguments.push_back(SourceDecl->getParamDecl(I)->getType());
-    FunctionProtoType::ExtProtoInfo EPI = {};
-    auto ExpectedType = S.Context.getFunctionType(SourceDecl->getReturnType(),
-                                                  ExpectedArguments, EPI);
-    S.Diag(Loc, diag::err_tmo_rewrite_target_type_mismatch)
-        << TargetDecl->getNameInfo().getName() << ExpectedType
-        << TargetDecl->getType();
-    S.Diag(TargetDecl->getLocation(),
-           diag::note_tmo_rewrite_target_type_mismatch);
+  if (S.checkTypedMemorySignature(AL, SourceDecl, TargetDecl,
+                                  InferredParameterIdx)) {
     AL.setInvalid();
-  };
-
-  if (!typedMemoryTypesAreEquivalentOrDependent(S.Context,
-                                                TargetDecl->getReturnType(),
-                                                SourceDecl->getReturnType())) {
-    reportTargetTypeMismatchError();
     return;
   }
-
-  if (getFunctionOrMethodNumParams(TargetDecl) !=
-      getFunctionOrMethodNumParams(SourceDecl) + 1) {
-    reportTargetTypeMismatchError();
-    return;
-  }
-
-  auto *TargetTypeDescriptorParam = getFunctionOrMethodParam(
-      TargetDecl, InferredParameterIdx.getASTIndex() + 1);
-  auto TargetTypeDescriptorType = TargetTypeDescriptorParam->getType();
-  if (!TargetTypeDescriptorType->isDependentType()) {
-    if (!TargetTypeDescriptorType->isIntegerType() ||
-        S.Context.getTypeSize(TargetTypeDescriptorType) != 64) {
-      reportTargetTypeMismatchError();
-      return;
-    }
-  }
-
-  size_t SourceParameterIdx = 0;
-  size_t TargetParameterIdx = 0;
-  for (; SourceParameterIdx < getFunctionOrMethodNumParams(SourceDecl);
-       SourceParameterIdx++, TargetParameterIdx++) {
-    auto *SourceParamDecl =
-        getFunctionOrMethodParam(SourceDecl, SourceParameterIdx);
-    auto *TargetParamDecl =
-        getFunctionOrMethodParam(TargetDecl, TargetParameterIdx);
-    if (!typedMemoryTypesAreEquivalentOrDependent(S.Context,
-                                                  SourceParamDecl->getType(),
-                                                  TargetParamDecl->getType())) {
-      reportTargetTypeMismatchError();
-      return;
-    }
-    if (SourceParameterIdx == InferredParameterIdx.getASTIndex())
-      TargetParameterIdx++;
-  }
-  if (AL.isInvalid())
-    return;
 
   auto *TMA = ::new (S.Context)
       TypedMemoryAttr(S.Context, AL, TargetDecl, InferredParameterIdx);

--- a/clang/lib/Sema/SemaTypedMemory.cpp
+++ b/clang/lib/Sema/SemaTypedMemory.cpp
@@ -19,6 +19,7 @@
 #include "clang/Basic/PartialDiagnostic.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Lex/Preprocessor.h"
+#include "clang/Sema/Attr.h"
 #include "clang/Sema/Initialization.h"
 #include "clang/Sema/SemaHLSL.h"
 #include "clang/Sema/SemaObjC.h"
@@ -136,6 +137,73 @@ static void emitTMOInferenceDiagnostics(Sema &S, const Expr *CallExpr,
   assert(InferredType);
   emitTMODescriptorRemarks(S, CallExpr, Callee, RewriteTarget, TypeSourceRange,
                            TypeDescriptor, *InferredType);
+}
+
+static bool typedMemoryTypesAreEquivalentOrDependent(const ASTContext &Context,
+                                                     QualType SourceType,
+                                                     QualType DestinationType) {
+  SourceType = Context.getCanonicalType(SourceType).getUnqualifiedType();
+  DestinationType =
+      Context.getCanonicalType(DestinationType).getUnqualifiedType();
+  if (SourceType->isDependentType() || DestinationType->isDependentType())
+    return true;
+  return SourceType == DestinationType;
+}
+
+bool Sema::checkTypedMemorySignature(const AttributeCommonInfo &CI,
+                                     const FunctionDecl *Source,
+                                     const FunctionDecl *Target,
+                                     ParamIdx InferredParameterIdx) {
+  SourceLocation Loc = CI.getLoc();
+  auto reportTargetTypeMismatchError = [&]() {
+    std::vector<QualType> ExpectedArguments;
+    for (size_t I = 0; I < InferredParameterIdx.getSourceIndex(); I++)
+      ExpectedArguments.push_back(Source->getParamDecl(I)->getType());
+    ExpectedArguments.push_back(Context.getIntTypeForBitwidth(64, false));
+    for (size_t I = InferredParameterIdx.getSourceIndex();
+         I < Source->getNumParams(); I++)
+      ExpectedArguments.push_back(Source->getParamDecl(I)->getType());
+    FunctionProtoType::ExtProtoInfo EPI = {};
+    auto ExpectedType = Context.getFunctionType(Source->getReturnType(),
+                                                ExpectedArguments, EPI);
+    Diag(Loc, diag::err_tmo_rewrite_target_type_mismatch)
+        << Target->getNameInfo().getName() << ExpectedType << Target->getType();
+    Diag(Target->getLocation(), diag::note_tmo_rewrite_target_type_mismatch);
+    return true;
+  };
+
+  if (!typedMemoryTypesAreEquivalentOrDependent(
+          Context, Target->getReturnType(), Source->getReturnType()))
+    return reportTargetTypeMismatchError();
+
+  if (getFunctionOrMethodNumParams(Target) !=
+      getFunctionOrMethodNumParams(Source) + 1)
+    return reportTargetTypeMismatchError();
+
+  auto *TargetTypeDescriptorParam =
+      getFunctionOrMethodParam(Target, InferredParameterIdx.getASTIndex() + 1);
+  auto TargetTypeDescriptorType = TargetTypeDescriptorParam->getType();
+  if (!TargetTypeDescriptorType->isDependentType()) {
+    if (!TargetTypeDescriptorType->isIntegerType() ||
+        Context.getTypeSize(TargetTypeDescriptorType) != 64)
+      return reportTargetTypeMismatchError();
+  }
+
+  size_t SourceParameterIdx = 0;
+  size_t TargetParameterIdx = 0;
+  for (; SourceParameterIdx < getFunctionOrMethodNumParams(Source);
+       SourceParameterIdx++, TargetParameterIdx++) {
+    auto *SourceParamDecl =
+        getFunctionOrMethodParam(Source, SourceParameterIdx);
+    auto *TargetParamDecl =
+        getFunctionOrMethodParam(Target, TargetParameterIdx);
+    if (!typedMemoryTypesAreEquivalentOrDependent(
+            Context, SourceParamDecl->getType(), TargetParamDecl->getType()))
+      return reportTargetTypeMismatchError();
+    if (SourceParameterIdx == InferredParameterIdx.getASTIndex())
+      TargetParameterIdx++;
+  }
+  return false;
 }
 
 void TypedMemoryCallsiteContext::recordInfoForInferredCall(


### PR DESCRIPTION
This is more or less entirely code motion: checkTypedMemorySignature needs to be reused as part of future module and pch rationalization so this pre-flights that code motion. Now that it is not TU static I've moved it into the TMO Sema implementation file to clean up the TMO sema logic.

In addition this also switches to enum select based diagnostic selection as that makes everything easier to understand - while verifying the movement I (the original author) struggled to understand the diagnostic flags.