### PR TITLE
[RuntimeLibcalls] Add stack protector entries for AVR

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -2582,7 +2582,9 @@ def AVRSystemLibrary
                              AVR_BUILTIN>,
               __divmodsi4, __udivmodsi4,
               // Trigonometric rtlib functions
-              avr_sin, avr_cos)>;
+              avr_sin, avr_cos,
+
+              __stack_chk_fail, __stack_chk_guard)>;
 
 //===----------------------------------------------------------------------===//
 // DXIL Runtime Libcalls

--- a/llvm/test/CodeGen/AVR/stack-protector.ll
+++ b/llvm/test/CodeGen/AVR/stack-protector.ll
@@ -1,0 +1,19 @@
+; RUN: llc -mtriple=avr -verify-machineinstrs < %s | FileCheck %s
+
+; The stack protector libcalls must be available on AVR. Lowering `sspreq`
+; needs both `__stack_chk_guard`, to load the canary, and `__stack_chk_fail`,
+; for the failure path. When either is missing from AVR's
+; SystemRuntimeLibrary, SelectionDAG reports "unable to lower stackguard" and
+; then dies in TargetLowering::makeLibCall with "unsupported library call
+; operation".
+
+define void @func() sspreq nounwind {
+; CHECK-LABEL: func:
+; CHECK: __stack_chk_guard
+; CHECK: __stack_chk_fail
+  %alloca = alloca i32, align 4
+  call void @capture(ptr %alloca)
+  ret void
+}
+
+declare void @capture(ptr)


### PR DESCRIPTION
`__stack_chk_fail` used to be part of the default set of runtime libcall impls. #148789 moved it out of that set and re-added it explicitly to each target's `SystemRuntimeLibrary`, and #154930 did the same for the `__stack_chk_guard` global. `AVRSystemLibrary` was not updated by either, so both `RTLIB::STACKPROTECTOR_CHECK_FAIL` and `RTLIB::STACK_CHECK_GUARD` are `RTLIB::Unsupported` on AVR.

Lowering a function with `sspreq` therefore fails twice: loading the canary reports "unable to lower stackguard", and the failure path dies in `TargetLowering::makeLibCall` with a `reportFatalInternalError`:

```
$ llc -mtriple=avr ssp.ll
error: unable to lower stackguard
LLVM ERROR: unsupported library call operation
```

Add the two impls directly, as Lanai, MSP430 and Hexagon do. This restores the pre-#148789 codegen, which referenced `__stack_chk_guard` and `__stack_chk_fail`.

Assisted-by: Claude Code