### PR TITLE
[stable/23.x] [lldb][test] Bump safety timeout in simulator tests to fix flakyness (#209180)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -2026,6 +2026,7 @@ def get_latest_apple_simulator(platform_name, log=None):
 
 
 def launch_exe_in_apple_simulator(
+    test,
     device_uuid,
     exe_path,
     exe_args=[],
@@ -2033,17 +2034,20 @@ def launch_exe_in_apple_simulator(
     log=None,
 ):
     exe_path = os.path.realpath(exe_path)
-    cmd = [
-        "xcrun",
-        "simctl",
+    # Resolve the path to simctl so we can launch it directly via spawnSubprocess.
+    simctl_path = (
+        subprocess.check_output(["xcrun", "-f", "simctl"]).decode("utf-8").strip()
+    )
+    args = [
         "spawn",
         "-s",
         device_uuid,
         exe_path,
     ] + exe_args
     if log:
-        log(" ".join(cmd))
-    sim_launcher = subprocess.Popen(cmd, stderr=subprocess.PIPE)
+        log(simctl_path + " " + " ".join(args))
+    # simctl itself gets terminated when the test finishes.
+    sim_launcher = test.spawnSubprocess(simctl_path, args, stderr=subprocess.PIPE)
 
     # Read stderr to try to find matches.
     # Each pattern will return the value of group[1] of the first match in the stderr.

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -76,6 +76,7 @@ class TestSimulatorPlatformLaunching(TestBase):
                 expected_platform, self.trace
             )
             _, matched_strings = lldbutil.launch_exe_in_apple_simulator(
+                self,
                 device_udid,
                 self.getBuildArtifact("a.out"),
                 exe_args=[],

--- a/lldb/test/API/macosx/simulator/hello.cpp
+++ b/lldb/test/API/macosx/simulator/hello.cpp
@@ -4,7 +4,9 @@
 
 static void print_pid() { fprintf(stderr, "PID: %d\n", getpid()); }
 
-static void sleep() { std::this_thread::sleep_for(std::chrono::seconds(10)); }
+// The test kills this process after the `platform process list` check, so this
+// sleep should never expire.
+static void sleep() { std::this_thread::sleep_for(std::chrono::seconds(600)); }
 
 int main(int argc, char **argv) {
   print_pid();

--- a/lldb/test/API/tools/lldb-server/apple-simulator/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/apple-simulator/TestAppleSimulatorOSType.py
@@ -53,9 +53,10 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         # Launch the executable in the simulator
         exe_path, matched_groups = lldbutil.launch_exe_in_apple_simulator(
+            self,
             deviceUDID,
             self.getBuildArtifact(exe_name),
-            ["print-pid", "sleep:10"],
+            ["print-pid", "sleep:600"],
             [r"PID: (.*)"],
             self.trace,
         )


### PR DESCRIPTION
Cherry-pick of 92873559f90a35f89ebc5ac94a6d7e4c3a419ecb onto `stable/23.x`.

Original commit: https://github.com/swiftlang/llvm-project/commit/92873559f90a35f89ebc5ac94a6d7e4c3a419ecb