### PR TITLE
[stable/23.x] [lldb] Don't double-wrap the children of sugared types in Type nodes

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1581,6 +1581,11 @@ Desugar(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
   assert(node->getNumChildren() >= 1 && node->getNumChildren() <= 2 &&
          "Sugared types should only have 1 or 2 children");
   for (NodePointer child : *node) {
+    // Don't wrap types in another type node.
+    if (child->getKind() == Node::Kind::Type) {
+      type_list->addChild(child, dem);
+      continue;
+    }
     NodePointer type = dem.createNode(Node::Kind::Type);
     type->addChild(child, dem);
     type_list->addChild(type, dem);

--- a/lldb/test/API/lang/swift/sugared_type_substitution/Makefile
+++ b/lldb/test/API/lang/swift/sugared_type_substitution/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/sugared_type_substitution/TestSwiftSugaredTypeSubstitution.py
+++ b/lldb/test/API/lang/swift/sugared_type_substitution/TestSwiftSugaredTypeSubstitution.py
@@ -1,0 +1,36 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import ValueCheck
+
+class TestCase(lldbtest.TestBase):
+    @skipEmbeddedSwift
+    @swiftTest
+    def test(self):
+        """Canonicalizing a sugared type must yield a canonical mangled name"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        # Desugaring the [[Int]] in the key path's value type used to produce
+        # a Type(Type(...)) demangle tree, which defeated the remangler's
+        # structural substitution matching. The resulting mangled name was not
+        # canonical, which tripped an assertion in CompilerType.
+        self.expect_var_path("kp", type="WritableKeyPath<S, [[Int]]>")
+        self.expect_var_path(
+            "s",
+            children=[
+                ValueCheck(
+                    children=[
+                        ValueCheck(
+                            summary="2 values",
+                            children=[
+                                ValueCheck(name="[0]", value="1"),
+                                ValueCheck(name="[1]", value="2"),
+                            ],
+                        ),
+                    ],
+                )
+            ],
+        )

--- a/lldb/test/API/lang/swift/sugared_type_substitution/main.swift
+++ b/lldb/test/API/lang/swift/sugared_type_substitution/main.swift
@@ -1,0 +1,15 @@
+// The debug info type of `kp` is
+// WritableKeyPath<f() -> [Int].(S), [[Int]]>, where the [[Int]] is
+// spelled with the debugger-only "sugared array" mangling, while the [Int]
+// in the enclosing function's return value is spelled out as Array<Int>.
+func f() -> [Int] {
+  struct S {
+    var values: [[Int]] = [[1, 2]]
+  }
+  let kp = \S.values
+  let s = S()
+  print(s[keyPath: kp]) // break here
+  return [0]
+}
+
+_ = f()


### PR DESCRIPTION
Cherry-pick of 35c64d75bf9851f571c9b967c97d285d8e985c5a onto `stable/23.x`.

Original commit: https://github.com/swiftlang/llvm-project/commit/35c64d75bf9851f571c9b967c97d285d8e985c5a