### PR TITLE
Revert "[lldb][test] Disable two breakpoint tests for debugserver (#2…

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -14,8 +14,6 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
 
     @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
-    # Fails with a sanitized build of debugserver.
-    @llgs_test
     def test_write_memory_with_hw_break(self):
         self.build()
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/functionalities/breakpoint/write_over_software_breakpoint/TestWriteOverSoftwareBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/write_over_software_breakpoint/TestWriteOverSoftwareBreakpoint.py
@@ -15,8 +15,6 @@ class WriteOverSoftwareBreakpoint(TestBase):
 
     # Could not find a way to make place_break_here visible to lldb on Windows.
     @skipIfWindows
-    # Fails with a sanitized build of debugserver.
-    @llgs_test
     def test_write_over_breakpoint(self):
         TestBase.setUp(self)
         self.line = line_number("main.c", "// break here")


### PR DESCRIPTION
…18636)"

This reverts commit 7ea6d83f49d975d64ef2548561a46619c86b3570.

The tests should now pass.