### PR TITLE
[ObjCARC] Move autorelease-to-release conversion to pool pop site instead of converting in place

### DIFF
--- a/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
@@ -133,9 +133,6 @@ static const Value *FindSingleUseIdentifiedObject(const Value *Arg) {
 //
 // The second retain and autorelease can be deleted.
 
-// TODO: Autorelease calls followed by objc_autoreleasePoolPop calls (perhaps in
-// ObjC++ code after inlining) can be turned into plain release calls.
-
 // TODO: Critical-edge splitting. If the optimial insertion point is
 // a critical edge, the current algorithm has to fail, because it doesn't
 // know how to split edges. It should be possible to make the optimizer
@@ -499,6 +496,14 @@ class ObjCARCOpt {
 
   DenseMap<BasicBlock *, ColorVector> BlockEHColors;
 
+  /// Cache mapping autorelease instructions to their following
+  /// autoreleasePoolPop in the same basic block (or nullptr if none).
+  DenseMap<Instruction *, Instruction *> FollowingPoolPopCache;
+
+  /// Find the autoreleasePoolPop that will drain the given autorelease
+  /// instruction in the same basic block, skipping nested pools.
+  Instruction *FindFollowingAutoreleasePoolPop(Instruction *AutoreleaseInst);
+
   bool OptimizeRetainRVCall(Function &F, Instruction *RetainRV);
   void OptimizeAutoreleaseRVCall(Function &F, Instruction *AutoreleaseRV,
                                  ARCInstKind &Class);
@@ -601,6 +606,66 @@ class ObjCARCOpt {
 };
 } // end anonymous namespace
 
+/// Find the autoreleasePoolPop that will drain the given autorelease
+/// instruction in the same basic block, skipping over nested pools.
+///
+/// Since objc_autorelease does not change the refcount (it only registers the
+/// object for a deferred release at pool drain), we can move the release to
+/// just before the pool pop instead of converting in place. This avoids the
+/// need to check for uses of the pointer between the autorelease and the pop.
+Instruction *
+ObjCARCOpt::FindFollowingAutoreleasePoolPop(Instruction *AutoreleaseInst) {
+  assert(GetBasicARCInstKind(AutoreleaseInst) == ARCInstKind::Autorelease);
+
+  auto It = FollowingPoolPopCache.find(AutoreleaseInst);
+  if (It != FollowingPoolPopCache.end()) {
+    // The cached value is a raw pointer to a pool pop. The cache is only
+    // consulted during OptimizeIndividualCalls, which runs before
+    // OptimizeAutoreleasePools can erase pool pops.
+    return It->second;
+  }
+
+  BasicBlock *BB = AutoreleaseInst->getParent();
+
+  SmallVector<SmallVector<Instruction *, 2>, 4> AutoreleasesByDepth(1);
+  AutoreleasesByDepth[0].push_back(AutoreleaseInst);
+
+  unsigned Depth = 0;
+  for (BasicBlock::iterator I = std::next(AutoreleaseInst->getIterator()),
+                            E = BB->end();
+       I != E; ++I) {
+    ARCInstKind Class = GetBasicARCInstKind(&*I);
+
+    if (Class == ARCInstKind::AutoreleasepoolPush) {
+      if (++Depth >= AutoreleasesByDepth.size())
+        AutoreleasesByDepth.emplace_back();
+      else
+        assert(AutoreleasesByDepth[Depth].empty() &&
+               "reused bucket must be empty");
+    } else if (Class == ARCInstKind::AutoreleasepoolPop) {
+      for (Instruction *J : AutoreleasesByDepth[Depth])
+        FollowingPoolPopCache[J] = &*I;
+      AutoreleasesByDepth[Depth].clear();
+      if (Depth == 0)
+        return &*I;
+      --Depth;
+    } else if (Class == ARCInstKind::Autorelease) {
+      AutoreleasesByDepth[Depth].push_back(&*I);
+    } else if (Class == ARCInstKind::Call || Class == ARCInstKind::CallOrUser) {
+      // A call can push or pop an autorelease pool, which dynamically
+      // changes the pool stack. We cannot rely on the syntactic scan anymore.
+      // Break out and cache the nullptr result for all accumulated
+      // autoreleases.
+      break;
+    }
+  }
+
+  for (const auto &Autoreleases : AutoreleasesByDepth)
+    for (Instruction *I : Autoreleases)
+      FollowingPoolPopCache[I] = nullptr;
+  return nullptr;
+}
+
 /// Turn objc_retainAutoreleasedReturnValue into objc_retain if the operand is
 /// not a return value.
 bool
@@ -610,9 +675,9 @@ ObjCARCOpt::OptimizeRetainRVCall(Function &F, Instruction *RetainRV) {
   if (const Instruction *Call = dyn_cast<CallBase>(Arg)) {
     if (Call->getParent() == RetainRV->getParent()) {
       BasicBlock::const_iterator I(Call);
-      ++I;
-      while (IsNoopInstruction(&*I))
+      do
         ++I;
+      while (IsNoopInstruction(&*I));
       if (&*I == RetainRV)
         return false;
     } else if (const InvokeInst *II = dyn_cast<InvokeInst>(Call)) {
@@ -761,6 +826,8 @@ void ObjCARCOpt::OptimizeIndividualCalls(Function &F) {
   LLVM_DEBUG(dbgs() << "\n== ObjCARCOpt::OptimizeIndividualCalls ==\n");
   // Reset all the flags in preparation for recomputing them.
   UsedInThisFunction = 0;
+  // Clear the autorelease pool pop cache for this function
+  FollowingPoolPopCache.clear();
 
   // Store any delayed AutoreleaseRV intrinsics, so they can be easily paired
   // with RetainRV and UnsafeClaimRV.
@@ -986,19 +1053,53 @@ void ObjCARCOpt::OptimizeIndividualCallImpl(Function &F, Instruction *Inst,
       Changed = true;
       ++NumAutoreleases;
 
-      // Create the declaration lazily.
       LLVMContext &C = Inst->getContext();
-
       Function *Decl = EP.get(ARCRuntimeEntryPointKind::Release);
       CallInst *NewCall = CallInst::Create(Decl, Call->getArgOperand(0), "",
                                            Call->getIterator());
       NewCall->setMetadata(MDKindCache.get(ARCMDKindID::ImpreciseRelease),
                            MDNode::get(C, {}));
 
-      LLVM_DEBUG(dbgs() << "Replacing autorelease{,RV}(x) with objc_release(x) "
-                           "since x is otherwise unused.\nOld: "
+      LLVM_DEBUG(
+          dbgs() << "Replacing objc_autorelease(x) with objc_release(x)\n");
+
+      FollowingPoolPopCache.erase(Call);
+      EraseInstruction(Call);
+      Inst = NewCall;
+      Class = ARCInstKind::Release;
+    }
+  }
+
+  // objc_autorelease(x) -> objc_release(x) moved to just before the
+  // autoreleasePoolPop. Since autorelease only registers a deferred release
+  // at pool drain time without changing the refcount, placing the release at
+  // the drain point is semantically equivalent and avoids use-after-free
+  // concerns with in-place conversion.
+  if (Class == ARCInstKind::Autorelease) {
+    if (Instruction *PoolPop = FindFollowingAutoreleasePoolPop(Inst)) {
+      CallInst *Call = cast<CallInst>(Inst);
+      Changed = true;
+      ++NumAutoreleases;
+
+      LLVMContext &C = Inst->getContext();
+      Function *Decl = EP.get(ARCRuntimeEntryPointKind::Release);
+      CallInst *NewCall = CallInst::Create(Decl, Call->getArgOperand(0), "",
+                                           PoolPop->getIterator());
+      NewCall->setMetadata(MDKindCache.get(ARCMDKindID::ImpreciseRelease),
+                           MDNode::get(C, {}));
+
+      LLVM_DEBUG(dbgs() << "Converting autorelease to release before pool pop."
+                           "\nOld: "
                         << *Call << "\nNew: " << *NewCall << "\n");
 
+      assert(Call->getType() == Call->getArgOperand(0)->getType() &&
+             "objc_autorelease result and argument types must match");
+      Call->replaceAllUsesWith(Call->getArgOperand(0));
+      // Inserting each release before the pop in visitation order changes the
+      // drain order from LIFO to FIFO. This is acceptable because the pass
+      // already does not preserve pool drain order elsewhere (e.g., the
+      // use_empty() conversion above releases immediately in place).
+      FollowingPoolPopCache.erase(Call);
       EraseInstruction(Call);
       Inst = NewCall;
       Class = ARCInstKind::Release;
@@ -1163,6 +1264,7 @@ void ObjCARCOpt::OptimizeIndividualCallImpl(Function &F, Instruction *Inst,
     }
     // Erase the original call.
     LLVM_DEBUG(dbgs() << "Erasing: " << *CInst << "\n");
+    FollowingPoolPopCache.erase(CInst);
     EraseInstruction(CInst);
   } while (!Worklist.empty());
 }
@@ -2368,6 +2470,7 @@ void ObjCARCOpt::OptimizeReturns(Function &F) {
     LLVM_DEBUG(dbgs() << "Erasing: " << *Retain << "\nErasing: " << *Autorelease
                       << "\n");
     BundledInsts->eraseInst(Retain);
+    FollowingPoolPopCache.erase(Autorelease);
     EraseInstruction(Autorelease);
   }
 }

--- a/llvm/test/Transforms/ObjCARC/basic.ll
+++ b/llvm/test/Transforms/ObjCARC/basic.ll
@@ -1860,7 +1860,7 @@ entry:
   ret void
 }
 
-; Don't the known-incremented retain+release elimination if the pointer is
+; Don't do the known-incremented retain+release elimination if the pointer is
 ; autoreleased and there's an autoreleasePoolPop.
 
 ; CHECK-LABEL: define void @test43(

--- a/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
+++ b/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
@@ -5,6 +5,7 @@
 declare ptr @llvm.objc.autoreleasePoolPush()
 declare void @llvm.objc.autoreleasePoolPop(ptr)
 declare ptr @llvm.objc.autorelease(ptr)
+declare ptr @llvm.objc.autoreleaseReturnValue(ptr)
 declare ptr @llvm.objc.retain(ptr)
 declare ptr @create_object()
 declare void @use_object(ptr)
@@ -35,7 +36,8 @@ define void @test_autorelease_to_release() {
   ret void
 }
 
-; Pool with autoreleases should not be optimized
+; Autoreleases are converted to releases before the pool pop.
+; Pool is kept because use_object may autorelease.
 define void @test_multiple_autoreleases() {
 ; CHECK-LABEL: define void @test_multiple_autoreleases() {
 ; CHECK-NEXT:    [[OBJ1:%.*]] = call ptr @create_object()
@@ -44,7 +46,7 @@ define void @test_multiple_autoreleases() {
 ; CHECK-NEXT:    call void @use_object(ptr [[OBJ1]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ1]]) #[[ATTR0]]
 ; CHECK-NEXT:    call void @use_object(ptr [[OBJ2]])
-; CHECK-NEXT:    [[TMP2:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ2]]) #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ2]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[POOL]]) #[[ATTR0]]
 ; CHECK-NEXT:    ret void
 ;
@@ -211,9 +213,7 @@ define void @test_complex_shadowing() {
 ; CHECK-NEXT:    [[OBJ3:%.*]] = call ptr @create_object()
 ; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ1]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ2]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
-; CHECK-NEXT:    [[INNER2_POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
-; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ3]]) #[[ATTR0]]
-; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[INNER2_POOL]]) #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ3]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    ret void
 ;
   %obj1 = call ptr @create_object()
@@ -221,7 +221,8 @@ define void @test_complex_shadowing() {
   %obj3 = call ptr @create_object()
   %outer_pool = call ptr @llvm.objc.autoreleasePoolPush()
 
-  ; This autorelease is outside inner pools - prevents optimization
+  ; This autorelease is outside inner pools, but is converted to a release
+  ; before the outer pool pop, so the outer pool can still be optimized.
   call ptr @llvm.objc.autorelease(ptr %obj1)
 
   ; Inner pool 1 with shadowed autorelease
@@ -328,6 +329,23 @@ define void @test_cross_function_inner_pool_caller() {
   ret void
 }
 
+; Demonstrate that autoreleaseRV is not incorrectly converted to a deferred
+; release. Converting autoreleaseRV to release before pool pop would prevent
+; the retain/autoreleaseRV pairing optimization from eliminating the pair.
+define ptr @test_retainRV_autoreleaseRV_pairing_in_pool(ptr %obj) {
+; CHECK-LABEL: define ptr @test_retainRV_autoreleaseRV_pairing_in_pool(
+; CHECK-SAME: ptr [[OBJ:%.*]]) {
+; CHECK-NEXT:    ret ptr [[OBJ]]
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+
+  %retain = call ptr @llvm.objc.retain(ptr %obj)
+  %autorelease = call ptr @llvm.objc.autoreleaseReturnValue(ptr %retain)
+
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
+  ret ptr %autorelease
+}
+
 define void @test_cross_function_inner_pool_callee() {
 ; CHECK-LABEL: define void @test_cross_function_inner_pool_callee() {
 ; CHECK-NEXT:    [[INNER_POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
@@ -373,6 +391,41 @@ define void @test_exotic_cast_bailout() {
   %int_val = ptrtoint ptr %pool to i64
   %ptr_val = inttoptr i64 %int_val to ptr
   call void @llvm.objc.autoreleasePoolPop(ptr %ptr_val)
+  ret void
+}
+
+; Use of autoreleased object between autorelease and pool pop is safe because
+; the release is moved to just before the pool pop, not converted in place.
+define void @test_use_between_autorelease_and_pop(ptr %obj) {
+; CHECK-LABEL: define void @test_use_between_autorelease_and_pop(
+; CHECK-SAME: ptr [[OBJ:%.*]]) {
+; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr [[OBJ]], align 4
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    ret void
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+  call ptr @llvm.objc.autorelease(ptr %obj)
+  ; This load uses %obj - safe because the release is placed before the pool pop,
+  ; after this load.
+  %val = load i32, ptr %obj
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
+  ret void
+}
+
+; Use of a DIFFERENT object between autorelease and pool pop should still
+; allow the optimization.
+define void @test_use_of_different_ptr_allows_optimization(ptr %obj1, ptr %obj2) {
+; CHECK-LABEL: define void @test_use_of_different_ptr_allows_optimization(
+; CHECK-SAME: ptr [[OBJ1:%.*]], ptr [[OBJ2:%.*]]) {
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ1]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr [[OBJ2]], align 4
+; CHECK-NEXT:    ret void
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+  call ptr @llvm.objc.autorelease(ptr %obj1)
+  ; This load uses %obj2, not %obj1, so it's safe to convert the autorelease.
+  %val = load i32, ptr %obj2
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
   ret void
 }
 


### PR DESCRIPTION
Instead of converting objc_autorelease(x) to objc_release(x) in place (which requires checking for uses of x between the autorelease and the pool pop), insert the release just before the matching autoreleasePoolPop. This is safe because objc_autorelease does not change the refcount; it only registers the object for a deferred release at pool drain time. Removing the autorelease and placing an explicit release at the drain point is semantically equivalent.

(cherry-picked from commit 6b7a8649cc11)