### PR TITLE
Remove overly strict assertion for this-capture in blocks (#219080)

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -1016,6 +1016,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   represent in `size_t`. The `err_struct_too_large` check now scales the
   threshold to the target's `size_t` width instead of using a fixed
   threshold of `1 << 60` regardless of the target.
+- Fixed an assertion failure when instantiating a block that captures
+  `this` via a member access through a dependent base class.
 
 ### OpenACC Specific Changes
 

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -17910,12 +17910,6 @@ TreeTransform<Derived>::TransformBlockExpr(BlockExpr *E) {
                                                  oldCapture));
       assert(blockScope->CaptureMap.count(newCapture));
     }
-
-    // The this pointer may not be captured by the instantiated block, even when
-    // it's captured by the original block, if the expression causing the
-    // capture is in the discarded branch of a constexpr if statement.
-    assert((!blockScope->isCXXThisCaptured() || oldBlock->capturesCXXThis()) &&
-           "this pointer isn't captured in the old block");
   }
 #endif
 

--- a/clang/test/CodeGenObjCXX/block-in-template-inst.mm
+++ b/clang/test/CodeGenObjCXX/block-in-template-inst.mm
@@ -68,3 +68,14 @@ namespace PR9982 {
     auto t = c(1)(10)(100);
   }
 }
+
+namespace ThisCaptureViaDependentBase {
+  // This used to crash.
+  struct Base { int m; };
+
+  template <typename T> struct S : T {
+    void f() { ^{ (void)T::m; }(); }
+  };
+
+  template struct S<Base>;
+}


### PR DESCRIPTION
TransformBlockExpr asserted that if the instantiated block captures 'this', the uninstantiated pattern block must also have captured it. This assumption doesn't always hold: a block that accesses a member through a dependent qualified-id (e.g., 'T::m' inside a template deriving from T) has no way to know at parse time that the access will resolve to an implicit 'this->m', since T is unknown. Once the template is instantiated and 'T::m' resolves to a non-static data member, the instantiated block legitimately captures 'this' even though the pattern never did.

rdar://184776458