### PR TITLE
[stable/23.x] [lldb] Improve error message when inline tests fail to launch (#220621)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbinline.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbinline.py
@@ -146,8 +146,23 @@ class InlineTest(TestBase):
         parser.parse_source_files(source_files)
         parser.set_breakpoints(target)
 
-        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        launch_info = target.GetLaunchInfo()
+        launch_info.SetWorkingDirectory(self.get_process_working_directory())
+        error = lldb.SBError()
+        process = target.Launch(launch_info, error)
+        self.assertSuccess(error, "Failed to launch process: %s" % error.GetCString())
         self.assertIsNotNone(process, PROCESS_IS_VALID)
+        self.assertNotEqual(
+            process.GetState(),
+            lldb.eStateExited,
+            "Process exited directly after launch with status %d"
+            % process.GetExitStatus(),
+        )
+        self.assertState(
+            process.GetState(),
+            lldb.eStateStopped,
+            "Process is not stopped under debugger control after launch",
+        )
 
         hit_breakpoints = 0
 
@@ -158,9 +173,15 @@ class InlineTest(TestBase):
                 parser.handle_breakpoint(self, bp_id)
             process.Continue()
 
-        self.assertTrue(
-            hit_breakpoints > 0, "inline test did not hit a single breakpoint"
-        )
+        if hit_breakpoints == 0:
+            state = process.GetState()
+            details = "process state: %s" % lldbutil.state_type_to_str(state)
+            if state == lldb.eStateExited:
+                details += ", exit status: %d" % process.GetExitStatus()
+            self.fail(
+                "inline test did not hit a single breakpoint (%s)\n%s"
+                % (details, lldbutil.print_stacktraces(process, string_buffer=True))
+            )
         # Either the process exited or the stepping plan is complete.
         self.assertTrue(
             process.GetState() in [lldb.eStateStopped, lldb.eStateExited],


### PR DESCRIPTION
Cherry-pick of 309c55493d86ba6caf2851f0df4102cf21cabe2c onto `stable/23.x`.

Original commit: https://github.com/swiftlang/llvm-project/commit/309c55493d86ba6caf2851f0df4102cf21cabe2c