### PR TITLE
[Support] Don't create unbuffered stream in MirroringOutputBackend (#220648)

### DIFF
--- a/llvm/lib/Support/VirtualOutputBackends.cpp
+++ b/llvm/lib/Support/VirtualOutputBackends.cpp
@@ -131,11 +131,8 @@ vfs::makeMirroringOutputBackend(IntrusiveRefCntPtr<OutputBackend> Backend1,
                     std::unique_ptr<OutputFileImpl> F2)
         : PreferredBufferSize(std::max(F1->getOS().GetBufferSize(),
                                        F1->getOS().GetBufferSize())),
-          F1(std::move(F1)), F2(std::move(F2)) {
-      // Don't double buffer.
-      this->F1->getOS().SetUnbuffered();
-      this->F2->getOS().SetUnbuffered();
-    }
+          F1(std::move(F1)), F2(std::move(F2)) {}
+
     size_t PreferredBufferSize;
     std::unique_ptr<OutputFileImpl> F1;
     std::unique_ptr<OutputFileImpl> F2;


### PR DESCRIPTION
MirroringOutputBackend is creating underlying stream to be unbuffered with the intention to avoid double buffering. But if mirrored stream needs to perform file system write, this results in unbuffered write to file system and can cause significant I/O overhead which completely outweights the benefit. Disable the default unbuffered stream setting to fix the slowdown when using MirroringOutputBackend.

rdar://186469637
(cherry picked from commit 11bc6ce46e227718c3b54aa6889d7458656e8ab4)