### PR TITLE
[BoundsSafety] Analyze block literal bodies as their own analysis unit

### DIFF
--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
@@ -2092,6 +2092,11 @@ public:
   }
   bool TraverseUnaryOperator(UnaryOperator *E);
   bool TraverseStmtExpr(StmtExpr *E) { return true; }
+  /// A block body is in neither the enclosing decl's CFG nor its ParentMap
+  /// (BlockExpr has no children), so descending into it here would register
+  /// assignments that cannot then be rewritten. Sema::ActOnBlockStmtExpr runs
+  /// the analysis on each block separately instead.
+  bool TraverseBlockExpr(BlockExpr *E) { return true; }
   bool TraverseOpaqueValueExpr(OpaqueValueExpr *E) {
     return TraverseStmt(E->getSourceExpr());
   }
@@ -3337,9 +3342,41 @@ void CheckCountAttributedDeclAssignments::HandleVarInit(VarDecl *VD) {
 // The bounds check will load all dependent decls and verify if the dynamic
 // bound pointer has enough bytes.
 bool CheckCountAttributedDeclAssignments::TraverseReturnStmt(ReturnStmt *S) {
-  const auto *FD = cast<FunctionDecl>(AC.getDecl());
+  /// This pass only runs in -fbounds-safety, on a function body, an
+  /// Objective-C method body, or a block body.
+  QualType RetTy;
+  const Decl *D = AC.getDecl();
+  if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
+    RetTy = FD->getReturnType();
+  } else if (const auto *MD = dyn_cast<ObjCMethodDecl>(D)) {
+    RetTy = MD->getReturnType();
+  } else if (const auto *BD = dyn_cast<BlockDecl>(D)) {
+    /// XXX: Bounds attributes on blocks aren't yet properly supported.
+    /// A bounds attribute is silently dropped on block return type.
+#ifndef NDEBUG
+    /// getSignatureAsWritten() holds only what the user wrote: the whole function
+    /// type when the parameter list was written (^int *(void){}), or just the
+    /// return type when it was omitted (^int *{}).
+    QualType BlockRetTy;
+    if (const TypeSourceInfo *TSI = BD->getSignatureAsWritten()) {
+      QualType SigTy = TSI->getType();
+      if (const auto *FT = SigTy->getAs<FunctionType>())
+        BlockRetTy = FT->getReturnType();
+      else
+        BlockRetTy = SigTy;
+    }
+    /// It should be diagnosed in the parser.
+    /// The assertion below is a tripwire for whoever wires that up: once a
+    /// block return type can carry a bounds attribute, this early return
+    /// silently skips the return size check and needs to handle it instead.
+    assert((BlockRetTy.isNull() || !isa<BoundsAttributedType>(BlockRetTy)) &&
+           "bounds attributes on block return types are not yet supported");
+#endif
+    return BaseVisitor::TraverseReturnStmt(S);
+  } else {
+    llvm_unreachable("unexpected decl kind");
+  }
 
-  QualType RetTy = FD->getReturnType();
   const auto *RetBATy = RetTy->getAs<BoundsAttributedType>();
   if (!RetBATy)
     return BaseVisitor::TraverseReturnStmt(S);

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -20415,6 +20415,14 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
                           NonTrivialCUnionContext::FunctionReturn,
                           NTCUK_Destruct | NTCUK_Copy);
 
+  /*TO_UPSTREAM(BoundsSafety) ON*/
+  // A block body has its own CFG and ParentMap, so it is analyzed here rather
+  // than from the enclosing declaration's traversal, which deliberately does
+  // not descend into it. Run while CurContext is still the BlockDecl.
+  if (LangOpts.BoundsSafety)
+    DynamicCountPointerAssignmentAnalysis(*this, BD).run();
+  /*TO_UPSTREAM(BoundsSafety) OFF*/
+
   PopDeclContext();
 
   // Set the captured variables on the block.

--- a/clang/test/BoundsSafety/AST/counted-by-assignment-in-block.c
+++ b/clang/test/BoundsSafety/AST/counted-by-assignment-in-block.c
@@ -1,0 +1,140 @@
+// Checks generated with clang/utils/simplify_ast_dump_for_checks.py.
+
+// RUN: %clang_cc1 -ast-dump -fbounds-safety -fblocks %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -ast-dump -fbounds-safety -fblocks -x objective-c -fexperimental-bounds-safety-objc %s 2>&1 | FileCheck %s
+
+#include <ptrcheck.h>
+
+typedef unsigned long size_t;
+
+struct accumulator {
+  size_t total_size;
+  void *__sized_by(total_size) payload;
+};
+
+struct accumulator *new_accumulator(void);
+
+typedef void *(^create_b)(void);
+int find_or_create(create_b create);
+
+int test_pair_in_block(size_t n, void *__sized_by(n) buf) {
+  return find_or_create(^void *(void) {
+    struct accumulator *acc = new_accumulator();
+    acc->total_size = n;
+    acc->payload = buf;
+    return acc;
+  });
+}
+
+// CHECK:      {{^}}TranslationUnitDecl
+// CHECK:      {{^}}|-TypedefDecl
+// CHECK:      {{^}}| `-BuiltinType
+// CHECK:      {{^}}|-RecordDecl
+// CHECK:      {{^}}| |-FieldDecl
+// CHECK:      {{^}}| | `-DependerDeclsAttr
+// CHECK:      {{^}}| `-FieldDecl
+// CHECK:      {{^}}|-FunctionDecl [[func_new_accumulator:0x[^ ]+]] {{.+}} new_accumulator
+// CHECK:      {{^}}|-TypedefDecl
+// CHECK:      {{^}}| `-BlockPointerType
+// CHECK:      {{^}}|   `-ParenType
+// CHECK:      {{^}}|     `-FunctionProtoType
+// CHECK:      {{^}}|       `-PointerType
+// CHECK:      {{^}}|         `-BuiltinType
+// CHECK:      {{^}}|-FunctionDecl [[func_find_or_create:0x[^ ]+]] {{.+}} find_or_create
+// CHECK:      {{^}}| `-ParmVarDecl [[var_create:0x[^ ]+]]
+// CHECK:      {{^}}`-FunctionDecl [[func_test_pair_in_block:0x[^ ]+]] {{.+}} test_pair_in_block
+// CHECK-NEXT: {{^}}  |-ParmVarDecl [[var_n:0x[^ ]+]]
+// CHECK-NEXT: {{^}}  | `-DependerDeclsAttr
+// CHECK-NEXT: {{^}}  |-ParmVarDecl [[var_buf:0x[^ ]+]]
+// CHECK-NEXT: {{^}}  `-CompoundStmt
+// CHECK-NEXT: {{^}}    `-ReturnStmt
+// CHECK-NEXT: {{^}}      `-ExprWithCleanups
+// CHECK-NEXT: {{^}}        |-cleanup Block
+// CHECK-NEXT: {{^}}        `-CallExpr
+// CHECK-NEXT: {{^}}          |-ImplicitCastExpr {{.+}} 'int (*__single)(create_b)' <FunctionToPointerDecay>
+// CHECK-NEXT: {{^}}          | `-DeclRefExpr {{.+}} [[func_find_or_create]]
+// CHECK-NEXT: {{^}}          `-BlockExpr
+// CHECK-NEXT: {{^}}            `-BlockDecl
+// CHECK-NEXT: {{^}}              |-capture ParmVar
+// CHECK-NEXT: {{^}}              |-capture ParmVar
+// CHECK-NEXT: {{^}}              `-CompoundStmt
+// CHECK-NEXT: {{^}}                |-DeclStmt
+// CHECK-NEXT: {{^}}                | `-VarDecl [[var_acc:0x[^ ]+]]
+// CHECK-NEXT: {{^}}                |   `-ImplicitCastExpr {{.+}} 'struct accumulator *__bidi_indexable' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}                |     `-CallExpr
+// CHECK-NEXT: {{^}}                |       `-ImplicitCastExpr {{.+}} 'struct accumulator *__single(*__single)(void)' <FunctionToPointerDecay>
+// CHECK-NEXT: {{^}}                |         `-DeclRefExpr {{.+}} [[func_new_accumulator]]
+// CHECK-NEXT: {{^}}                |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}                | |-BoundsCheckExpr {{.+}} 'buf <= __builtin_get_pointer_upper_bound(buf) && __builtin_get_pointer_lower_bound(buf) <= buf && n <= (char *)__builtin_get_pointer_upper_bound(buf) - (char *__bidi_indexable)buf'
+// CHECK-NEXT: {{^}}                | | |-BinaryOperator {{.+}} 'size_t':'unsigned long' '='
+// CHECK-NEXT: {{^}}                | | | |-MemberExpr {{.+}} ->total_size
+// CHECK-NEXT: {{^}}                | | | | `-ImplicitCastExpr {{.+}} 'struct accumulator *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: {{^}}                | | | |   `-DeclRefExpr {{.+}} [[var_acc]]
+// CHECK-NEXT: {{^}}                | | | `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'size_t':'unsigned long'
+// CHECK:      {{^}}                | | `-BinaryOperator {{.+}} 'int' '&&'
+// CHECK-NEXT: {{^}}                | |   |-BinaryOperator {{.+}} 'int' '&&'
+// CHECK-NEXT: {{^}}                | |   | |-BinaryOperator {{.+}} 'int' '<='
+// CHECK-NEXT: {{^}}                | |   | | |-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}                | |   | | | `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'void *__bidi_indexable'
+// CHECK:      {{^}}                | |   | | |     | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'void *__single __sized_by(n)':'void *__single'
+// CHECK:      {{^}}                | |   | | |     | | |     |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'size_t':'unsigned long'
+// CHECK:      {{^}}                | |   | | `-GetBoundExpr {{.+}} upper
+// CHECK-NEXT: {{^}}                | |   | |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
+// CHECK:      {{^}}                | |   | `-BinaryOperator {{.+}} 'int' '<='
+// CHECK-NEXT: {{^}}                | |   |   |-GetBoundExpr {{.+}} lower
+// CHECK-NEXT: {{^}}                | |   |   | `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
+// CHECK:      {{^}}                | |   |   `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}                | |   |     `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
+// CHECK:      {{^}}                | |   `-BinaryOperator {{.+}} 'int' '<='
+// CHECK-NEXT: {{^}}                | |     |-OpaqueValueExpr [[ove]] {{.*}} 'size_t':'unsigned long'
+// CHECK:      {{^}}                | |     `-ImplicitCastExpr {{.+}} 'size_t':'unsigned long' <IntegralCast>
+// CHECK-NEXT: {{^}}                | |       `-BinaryOperator {{.+}} '__ptrdiff_t':'long' '-'
+// CHECK-NEXT: {{^}}                | |         |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK-NEXT: {{^}}                | |         | `-GetBoundExpr {{.+}} upper
+// CHECK-NEXT: {{^}}                | |         |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
+// CHECK:      {{^}}                | |         `-ImplicitCastExpr {{.+}} 'char *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}                | |           `-CStyleCastExpr {{.+}} 'char *__bidi_indexable' <BitCast>
+// CHECK-NEXT: {{^}}                | |             `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
+// CHECK:      {{^}}                | |-OpaqueValueExpr [[ove]]
+// CHECK-NEXT: {{^}}                | | `-ImplicitCastExpr {{.+}} 'size_t':'unsigned long' <LValueToRValue>
+// CHECK-NEXT: {{^}}                | |   `-DeclRefExpr {{.+}} [[var_n]]
+// CHECK-NEXT: {{^}}                | `-OpaqueValueExpr [[ove_1]]
+// CHECK-NEXT: {{^}}                |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}                |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}                |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
+// CHECK-NEXT: {{^}}                |     | | |-OpaqueValueExpr [[ove_2]] {{.*}} 'void *__single __sized_by(n)':'void *__single'
+// CHECK:      {{^}}                |     | | |-ImplicitCastExpr {{.+}} 'void *' <BitCast>
+// CHECK-NEXT: {{^}}                |     | | | `-BinaryOperator {{.+}} 'char *' '+'
+// CHECK-NEXT: {{^}}                |     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
+// CHECK-NEXT: {{^}}                |     | | |   | `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}                |     | | |   |   `-OpaqueValueExpr [[ove_2]] {{.*}} 'void *__single __sized_by(n)':'void *__single'
+// CHECK:      {{^}}                |     | | |   `-AssumptionExpr
+// CHECK-NEXT: {{^}}                |     | | |     |-OpaqueValueExpr [[ove_3]] {{.*}} 'size_t':'unsigned long'
+// CHECK:      {{^}}                |     | | |     `-BinaryOperator {{.+}} 'int' '>='
+// CHECK-NEXT: {{^}}                |     | | |       |-ImplicitCastExpr {{.+}} 'long' <IntegralCast>
+// CHECK-NEXT: {{^}}                |     | | |       | `-OpaqueValueExpr [[ove_3]] {{.*}} 'size_t':'unsigned long'
+// CHECK:      {{^}}                |     | | |       `-ImplicitCastExpr {{.+}} 'long' <IntegralCast>
+// CHECK-NEXT: {{^}}                |     | | |         `-IntegerLiteral {{.+}} 0
+// CHECK:      {{^}}                |     | |-OpaqueValueExpr [[ove_2]]
+// CHECK-NEXT: {{^}}                |     | | `-ImplicitCastExpr {{.+}} 'void *__single __sized_by(n)':'void *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}                |     | |   `-DeclRefExpr {{.+}} [[var_buf]]
+// CHECK-NEXT: {{^}}                |     | `-OpaqueValueExpr [[ove_3]]
+// CHECK-NEXT: {{^}}                |     |   `-ImplicitCastExpr {{.+}} 'size_t':'unsigned long' <LValueToRValue>
+// CHECK-NEXT: {{^}}                |     |     `-DeclRefExpr {{.+}} [[var_n]]
+// CHECK-NEXT: {{^}}                |     |-OpaqueValueExpr [[ove_2]] {{.*}} 'void *__single __sized_by(n)':'void *__single'
+// CHECK:      {{^}}                |     `-OpaqueValueExpr [[ove_3]] {{.*}} 'size_t':'unsigned long'
+// CHECK:      {{^}}                |-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}                | |-BinaryOperator {{.+}} 'void *__single __sized_by(total_size)':'void *__single' '='
+// CHECK-NEXT: {{^}}                | | |-MemberExpr {{.+}} ->payload
+// CHECK-NEXT: {{^}}                | | | `-ImplicitCastExpr {{.+}} 'struct accumulator *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: {{^}}                | | |   `-DeclRefExpr {{.+}} [[var_acc]]
+// CHECK-NEXT: {{^}}                | | `-ImplicitCastExpr {{.+}} 'void *__single __sized_by(total_size)':'void *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}                | |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
+// CHECK:      {{^}}                | |-OpaqueValueExpr [[ove]] {{.*}} 'size_t':'unsigned long'
+// CHECK:      {{^}}                | `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
+// CHECK:      {{^}}                `-ReturnStmt
+// XXX: __single isn't automatically added to block return type rdar://132927229
+// CHECK-NEXT: {{^}}                  `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}                    `-ImplicitCastExpr {{.+}} 'void *__bidi_indexable' <BitCast>
+// CHECK-NEXT: {{^}}                      `-ImplicitCastExpr {{.+}} 'struct accumulator *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: {{^}}                        `-DeclRefExpr {{.+}} [[var_acc]]

--- a/clang/test/BoundsSafety/Sema/bounds-attr-on-block-return-type-ignored.c
+++ b/clang/test/BoundsSafety/Sema/bounds-attr-on-block-return-type-ignored.c
@@ -1,0 +1,55 @@
+// A bounds attribute on a block literal's return type is currently accepted and
+// then silently dropped, so nothing is diagnosed here and no return size check
+// is emitted (rdar://132927229). Once the parser wiring is added, a block
+// return type will carry a bounds attribute and the assertion in
+// CheckCountAttributedDeclAssignments::TraverseReturnStmt will fire, at which
+// point this test needs updating together with that code.
+
+// RUN: %clang_cc1 -fsyntax-only -fblocks -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fblocks -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+#include <ptrcheck.h>
+
+// expected-no-diagnostics
+
+typedef unsigned long size_t;
+
+// __counted_by referring to a block parameter.
+void test_counted_by_param(void) {
+  int *(^b)(int n) = ^int *__counted_by(n)(int n) { return 0; };
+  (void)b;
+}
+
+// __counted_by with a constant count, so the count does not depend on late
+// parsing of the parameter list.
+void test_counted_by_constant(void) {
+  int *(^b)(void) = ^int *__counted_by(4)(void) { return 0; };
+  (void)b;
+}
+
+void test_counted_by_or_null(void) {
+  int *(^b)(int n) = ^int *__counted_by_or_null(n)(int n) { return 0; };
+  (void)b;
+}
+
+void test_sized_by(void) {
+  void *(^b)(size_t n) = ^void *__sized_by(n)(size_t n) { return 0; };
+  (void)b;
+}
+
+// __ended_by builds a DynamicRangePointerType rather than a
+// CountAttributedType, and is dropped the same way.
+void test_ended_by(void) {
+  void *(^b)(void *__single e) = ^void *__ended_by(e)(void *__single e) {
+    return e;
+  };
+  (void)b;
+}
+
+// A block with the parameter list omitted, so the signature as written is the
+// bare return type rather than a function type. That is the shape the
+// assertion's helper has to handle separately.
+void test_omitted_param_list(void) {
+  int *(^b)(void) = ^int *__counted_by(4) { return 0; };
+  (void)b;
+}

--- a/clang/test/BoundsSafety/Sema/bounds-attributed-return-in-objc-method-crash.m
+++ b/clang/test/BoundsSafety/Sema/bounds-attributed-return-in-objc-method-crash.m
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+#include <ptrcheck.h>
+
+// expected-no-diagnostics
+
+__attribute__((objc_root_class))
+@interface Accumulator
+- (int *__counted_by(n))take:(int)n buf:(int *__counted_by(n))buf;
+- (int *__counted_by(n))takeNull:(int)n;
+- (void *__sized_by(n))takeSized:(unsigned long)n buf:(void *__sized_by(n))buf;
+- (int)plain;
+@end
+
+@implementation Accumulator
+// A bounds-attributed return type on a method: this is what used to assert.
+- (int *__counted_by(n))take:(int)n buf:(int *__counted_by(n))buf {
+  return buf;
+}
+
+- (int *__counted_by(n))takeNull:(int)n {
+  return 0;
+}
+
+- (void *__sized_by(n))takeSized:(unsigned long)n buf:(void *__sized_by(n))buf {
+  return buf;
+}
+
+// A method without a bounds-attributed return type must keep working.
+- (int)plain {
+  return 42;
+}
+@end

--- a/clang/test/BoundsSafety/Sema/counted-by-assignment-in-block-crash.c
+++ b/clang/test/BoundsSafety/Sema/counted-by-assignment-in-block-crash.c
@@ -1,0 +1,156 @@
+// RUN: %clang_cc1 -fsyntax-only -fblocks -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fblocks -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+#include <ptrcheck.h>
+
+// expected-no-diagnostics
+
+typedef unsigned long size_t;
+
+struct accumulator {
+  size_t total_size;
+  void *__sized_by(total_size) payload;
+};
+
+struct counted {
+  int count;
+  int *__counted_by(count) buf;
+};
+
+struct accumulator *new_accumulator(void);
+int consume(void *__single p);
+
+typedef void *__single (^create_b)(void);
+int find_or_create(create_b create);
+
+// Both members of the group assigned in a block.
+int test_sized_by_pair_in_block(size_t n, void *__sized_by(n) buf) {
+  return find_or_create(^void *(void) {
+    struct accumulator *acc = new_accumulator();
+    acc->total_size = n;
+    acc->payload = buf;
+    return acc;
+  });
+}
+
+int test_counted_by_pair_in_block(int n, int *__counted_by(n) buf) {
+  return find_or_create(^void *(void) {
+    struct counted *c = (struct counted *)new_accumulator();
+    c->count = n;
+    c->buf = buf;
+    return c;
+  });
+}
+
+// The inner block must get its own ParentMap too, not the outer block's.
+int test_nested_blocks(size_t n, void *__sized_by(n) buf) {
+  return find_or_create(^void *(void) {
+    struct accumulator *outer = new_accumulator();
+    outer->total_size = n;
+    outer->payload = buf;
+    (void)find_or_create(^void *(void) {
+      struct accumulator *inner = new_accumulator();
+      inner->total_size = n;
+      inner->payload = buf;
+      return inner;
+    });
+    return outer;
+  });
+}
+
+struct const_counted {
+  int *__counted_by(4) p;
+};
+
+struct const_counted *new_const_counted(void);
+
+// Single assignment: constant count, so no paired count assignment.
+int test_single_assignment_in_block(int *__counted_by(4) buf) {
+  return find_or_create(^void *(void) {
+    struct const_counted *s = new_const_counted();
+    s->p = buf;
+    return s;
+  });
+}
+
+struct fam {
+  int count;
+  int elems[__counted_by(count)];
+};
+
+// Flexible array member count: flexible-base path.
+int test_flexible_array_member_count_in_block(struct fam *__bidi_indexable f,
+                                              int n) {
+  return find_or_create(^void *(void) {
+    f->count = n;
+    return 0;
+  });
+}
+
+// Out-parameter pair, reached through a dereference, not a member access.
+int test_out_param_pair_in_block(int *__counted_by(*out_cnt) *out_buf,
+                                 int *out_cnt, int n,
+                                 int *__counted_by(n) buf) {
+  return find_or_create(^void *(void) {
+    *out_buf = buf;
+    *out_cnt = n;
+    return 0;
+  });
+}
+
+struct range {
+  void *end;
+  void *__ended_by(end) start;
+};
+
+struct range *new_range(void);
+
+// __ended_by builds a RangeDepGroup, a different group class, same finalization.
+int test_ended_by_pair_in_block(void *s, void *e) {
+  return find_or_create(^void *(void) {
+    struct range *r = new_range();
+    r->end = e;
+    r->start = s;
+    return r;
+  });
+}
+
+// Count and pointer assigned through captured __block storage.
+int test_block_captured_locals(int n, int *__counted_by(n) buf) {
+  __block int cnt = 0;
+  __block int *__counted_by(cnt) p = 0;
+  return find_or_create(^void *(void) {
+    cnt = n;
+    p = buf;
+    return p;
+  });
+}
+
+// A plain return inside a block, with no bounds attributes anywhere. Once a
+// block body is its own analysis unit, AC.getDecl() is a BlockDecl, so this
+// reaches TraverseReturnStmt.
+int test_plain_return_in_block(void) {
+  return find_or_create(^void *(void) {
+    return 0;
+  });
+}
+
+// A local *initialized* in a block.
+int test_local_init_in_block(int *__counted_by(4) buf) {
+  return find_or_create(^void *(void) {
+    int *__counted_by(4) p = buf;
+    return p;
+  });
+}
+
+// A block nested in a statement expression.
+int test_block_in_stmt_expr(size_t n, void *__sized_by(n) buf) {
+  return ({
+    find_or_create(^void *(void) {
+      struct accumulator *acc = new_accumulator();
+      acc->total_size = n;
+      acc->payload = buf;
+      return acc;
+    });
+  });
+}

--- a/clang/utils/simplify_ast_dump_for_checks.py
+++ b/clang/utils/simplify_ast_dump_for_checks.py
@@ -139,6 +139,16 @@ class AstNode(object):
 		
 		if len(tokens) == 2 and tokens[-1] == "<<<NULL>>>":
 			tokens.append('0')
+
+		# Some lines carry a sub-kind before the address, e.g. `capture ParmVar
+		# 0x...` under a BlockDecl or `cleanup Block 0x...` under an
+		# ExprWithCleanups. Fold it into the kind so that the address stays in
+		# the position the node classes expect.
+		if (len(tokens) > 3 and not tokens[2].startswith("0x")
+		    and tokens[3].startswith("0x")):
+			tokens[1] += " " + tokens[2]
+			del tokens[2]
+
 		return (next(iter, None), cls.new(line_n, tokens))
 
 	@classmethod
@@ -165,9 +175,14 @@ class MemberNode(AstNode):
 
 class FuncDeclNode(AstNode):
 	def __init__(self, n, indent, kind, addr, begin, paren, *remainder):
-		type = remainder[-1]
-		name = remainder[-2]
-		super(FuncDeclNode, self).__init__(n, indent, kind, addr, *remainder[:-2])
+		# The type is the last quoted token. Trailing markers such as
+		# `external-linkage` or `implicit-inline` may follow it, so the type and
+		# the name cannot be taken from the end of the line.
+		rem = list(remainder)
+		type_idx = max(i for i, t in enumerate(rem) if t.startswith("'"))
+		type = rem[type_idx]
+		name = rem[type_idx - 1]
+		super(FuncDeclNode, self).__init__(n, indent, kind, addr, *rem[:type_idx - 1])
 		self.type = type
 		self.name = name
 


### PR DESCRIPTION
A __counted_by/__sized_by assignment inside a block literal aborted with

Assertion failed: (Succ), function FinalizePreAssignCheck,
file DynamicCountPointerAssignmentAnalysis.cpp, line 1326.

RecursiveASTVisitor descends into block bodies, so a dependent-assignment
group written inside a block was registered against the enclosing function,
whose CFG and ParentMap do not cover a block body. The rewrite in
FinalizePreAssignCheck then found no parent for it.

Treat a block body as its own analysis unit instead: don't descend into it
from the enclosing declaration, and run the analysis on each BlockDecl from
Sema::ActOnBlockStmtExpr, which is where AnalysisBasedWarnings already drives
the other CFG-based analyses for blocks.

Also stop assuming AC.getDecl() is a FunctionDecl in TraverseReturnStmt; it
can now be a BlockDecl, and could already be an ObjCMethodDecl.
    
rdar://182721753