### PR TITLE
[Cherry-pick into stable/23.x] [lldb] Avoid a crash on an unmangleable type name in BuildDeclContext

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -995,7 +995,9 @@ BuildDeclContext(llvm::StringRef mangled_name,
                  swift::Demangle::Demangler &dem) {
   std::vector<CompilerContext> context;
   auto *node = GetDemangledType(dem, mangled_name);
-  
+  if (!node)
+    return {};
+
   /// Builtin names belong to the builtin module, and are stored only with their
   /// mangled name.
   if (node->getKind() == Node::Kind::BuiltinTypeName) {


### PR DESCRIPTION
```
commit 8e0ff9b689babb34160656bef2e8481fa7722ae5
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Sep 1 13:57:21 2026 -0700

    [lldb] Avoid a crash on an unmangleable type name in BuildDeclContext
    
    Assisted-by: claude
    
    rdar://186316904
```
