### PR TITLE
clang: load imported module API notes from CAS

### DIFF
--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -759,6 +759,9 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
           M, ScanInstance.getLangOpts().APINotesModules,
           ScanInstance.getAPINotesOpts().ModuleSearchPaths);
       for (auto File : Notes) {
+        if (auto FileRef = addToFileList(ScanInstance.getFileManager(), File);
+            !FileRef)
+          return FileRef.takeError();
         if (auto Buf =
                 ScanInstance.getSourceManager().getMemoryBufferForFileOrNone(
                     File)) {

--- a/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
@@ -29,7 +29,11 @@
 // WITH-APINOTES-NEXT:   - Name: top
 // WITH-APINOTES-NEXT:     Availability: none
 // WITH-APINOTES-NEXT:     AvailabilityMsg: "don't use this"
+// WITH-APINOTES: Top.apinotes
 // WITHOUT-APINOTES-NOT: APINotes:
+
+// Ensure subsequent builds use the API notes captured in CAS.
+// RUN: rm %t/Top.apinotes
 
 // Build the include-tree commands
 // RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS


### PR DESCRIPTION
Teach APINotesManager to lazily recover API notes from the include tree attached to an imported PCM. CompilerInstance wires the loader directly using the existing module-file include-tree ID and CAS object store, keeping the behavior transparent to clients of Sema::ProcessAPINotes and avoiding a new public API.