### PR TITLE
[Cherry-pick into next] Add HiddenTypeLayoutInfo to exhaustive switch

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5548,6 +5548,7 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::Decl *decl) {
     case swift::DeclKind::Missing:
     case swift::DeclKind::MissingMember:
     case swift::DeclKind::Using:
+    case swift::DeclKind::HiddenTypeLayoutInfo:
       break;
 
     case swift::DeclKind::InfixOperator:


### PR DESCRIPTION
```
commit f70494a3ba841d41c4d58979ac2c324c7fe97206
Author: Nuri Amari <nuriamari@meta.com>
Date:   Thu Aug 6 09:06:39 2026 -0500

    Add HiddenTypeLayoutInfo to exhaustive switch
    
    A new kind of decl has been added, and we need to add it to this switch
    statement to make sure all cases are handled, otherwise it won't
    compile.
```
