### PR TITLE
[Clang] Add API notes to CAS include-tree file lists

### DIFF
--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -767,6 +767,9 @@ Expected<cas::IncludeTreeRoot> IncludeTreeBuilder::finishIncludeTree(
           M, ScanInstance.getLangOpts().APINotesModules,
           ScanInstance.getAPINotesOpts().ModuleSearchPaths);
       for (auto File : Notes) {
+        if (auto FileRef = addToFileList(ScanInstance.getFileManager(), File);
+            !FileRef)
+          return FileRef.takeError();
         if (auto Buf =
                 ScanInstance.getSourceManager().getMemoryBufferForFileOrNone(
                     File)) {

--- a/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
@@ -29,7 +29,11 @@
 // WITH-APINOTES-NEXT:   - Name: top
 // WITH-APINOTES-NEXT:     Availability: none
 // WITH-APINOTES-NEXT:     AvailabilityMsg: "don't use this"
+// WITH-APINOTES: Top.apinotes
 // WITHOUT-APINOTES-NOT: APINotes:
+
+// Ensure subsequent builds use the API notes captured in CAS.
+// RUN: rm %t/Top.apinotes
 
 // Build the include-tree commands
 // RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS


### PR DESCRIPTION
Record API notes in the include tree's file list under their canonical path in addition to attaching their contents to the root. Imported module file lists are propagated into consuming include trees, allowing the existing FileManager-based API notes lookup to resolve the captured file without consulting the raw filesystem.

(cherry picked from commit 25a4a9d90d8fe17dc56c612c07c6d5479c227df2)