### PR TITLE
[Sema] Don't crash filling TypeLoc for a reused AttributedType (#220139)

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -1016,6 +1016,10 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   represent in `size_t`. The `err_struct_too_large` check now scales the
   threshold to the target's `size_t` width instead of using a fixed
   threshold of `1 << 60` regardless of the target.
+- Fixed a crash when filling in the ``TypeLoc`` for an ``AttributedType``
+  that was inherited from a different declarator, for example when
+  ``__typeof__`` resolves to the type of another, already-processed
+  declaration. (#GH217489)
 - Fixed an assertion failure when instantiating a block that captures
   `this` via a member access through a dependent base class.
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -357,7 +357,11 @@ namespace {
         }
       }
 
-      llvm_unreachable("no Attr* for AttributedType*");
+      // The AttributedType can be inherited from another declarator, for
+      // example when __typeof__ reuses a type built for a different
+      // declaration, in which case there is no entry for it in this
+      // TypeProcessingState. Return null in that case.
+      return nullptr;
     }
 
     /* TO_UPSTREAM(BoundsSafety) ON*/

--- a/clang/test/Sema/nullability.c
+++ b/clang/test/Sema/nullability.c
@@ -250,3 +250,11 @@ void arraysInBlocks(void) {
 }
 
 struct _Nullable NotCplusplusClass {}; // expected-error {{'_Nullable' attribute only applies to classes}}
+
+// This code used to crash in TypeProcessingState::takeAttrForAttributedType.
+struct NullabilityAtomicTypeofS {
+  int * _Nonnull f1;
+};
+void nullabilityAtomicTypeof(const struct NullabilityAtomicTypeofS *s) {
+  (void)(__typeof__(s->f1) _Atomic *)(&s->f1);
+}


### PR DESCRIPTION
TypeProcessingState::takeAttrForAttributedType assumed every AttributedType encountered while filling a declarator's TypeLoc had an (AttributedType*, Attr*) pair registered earlier in the same TypeProcessingState's AttrsForTypes.

That assumption doesn't hold when the AttributedType is inherited from another declarator, for example when __typeof__ reuses a type built for a different declaration. In that case,
TypeProcessingState::getAttributedType, the function that registers the pair, is never called.

Return a null Attr* instead of calling llvm_unreachable when no entry is found. This is the Attr* that AttributedTypeLoc uses for the current declarator's TypeLoc, and null is right here because the current declarator never spelled the attribute itself.

Fixes #217489

rdar://184781693