### PR TITLE
[modules] Avoid redefinition errors when access modular header as non-modular. (#214345)

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -16313,11 +16313,12 @@ public:
   /// Determine if \p D has a definition which allows we redefine it in current
   /// TU. \p Suggested is the definition that should be made visible to expose
   /// the definition.
-  bool isRedefinitionAllowedFor(NamedDecl *D, NamedDecl **Suggested,
-                                bool &Visible);
-  bool isRedefinitionAllowedFor(const NamedDecl *D, bool &Visible) {
+  bool isRedefinitionAllowedFor(NamedDecl *D, SourceLocation NewDefinitionLoc,
+                                NamedDecl **Suggested, bool &Visible);
+  bool isRedefinitionAllowedFor(const NamedDecl *D, SourceLocation NewLoc,
+                                bool &Visible) {
     NamedDecl *Hidden;
-    return isRedefinitionAllowedFor(const_cast<NamedDecl *>(D), &Hidden,
+    return isRedefinitionAllowedFor(const_cast<NamedDecl *>(D), NewLoc, &Hidden,
                                     Visible);
   }
 
@@ -16337,6 +16338,14 @@ public:
     NamedDecl *Hidden;
     return hasAcceptableDefinition(D, &Hidden, Kind);
   }
+
+  /// Determine if a definition at \p NewLoc coincides with \p PrevD.
+  ///
+  /// Including the same header as a non-modular and a modular allows to process
+  /// its content twice despite guards against multiple inclusions. To handle
+  /// such cases this method allows to detect if a currently-parsed decl is at
+  /// the same location as an existing decl imported from a module.
+  bool isFromSameSingleIncludeHeader(const Decl *PrevD, SourceLocation NewLoc);
 
   /// Try to parse the conditional expression attached to an effect attribute
   /// (e.g. 'nonblocking'). (c.f. Sema::ActOnNoexceptSpec). Return an empty

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -5788,7 +5788,8 @@ void Sema::notePreviousDefinition(const NamedDecl *Old, SourceLocation New) {
 }
 
 bool Sema::checkVarDeclRedefinition(VarDecl *Old, VarDecl *New) {
-  if (!hasVisibleDefinition(Old) &&
+  if ((!hasVisibleDefinition(Old) ||
+       isFromSameSingleIncludeHeader(Old, New->getLocation())) &&
       (New->getFormalLinkage() == Linkage::Internal || New->isInline() ||
        isa<VarTemplateSpecializationDecl>(New) ||
        New->getDescribedVarTemplate() ||
@@ -17372,7 +17373,9 @@ Sema::CheckForFunctionRedefinition(FunctionDecl *FD,
     return;
 
   bool DefinitionVisible = false;
-  if (SkipBody && isRedefinitionAllowedFor(Definition, DefinitionVisible) &&
+  if (SkipBody &&
+      isRedefinitionAllowedFor(Definition, FD->getLocation(),
+                               DefinitionVisible) &&
       (Definition->getFormalLinkage() == Linkage::Internal ||
        Definition->isInlined() || Definition->getDescribedFunctionTemplate() ||
        !Definition->getTemplateParameterLists().empty())) {
@@ -19865,9 +19868,9 @@ Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,
                 // check in C11 6.2.7/1 (or 6.1.2.6/1 in C89).
                 NamedDecl *Hidden = nullptr;
                 bool HiddenDefVisible = false;
-                if (SkipBody &&
-                    (isRedefinitionAllowedFor(Def, &Hidden, HiddenDefVisible) ||
-                     getLangOpts().C23)) {
+                if (SkipBody && (isRedefinitionAllowedFor(Def, NameLoc, &Hidden,
+                                                          HiddenDefVisible) ||
+                                 getLangOpts().C23)) {
                   // There is a definition of this tag, but it is not visible.
                   // We explicitly make use of C++'s one definition rule here,
                   // and assume that this definition is identical to the hidden
@@ -22560,8 +22563,9 @@ bool Sema::shouldIgnoreInHostDeviceCheck(FunctionDecl *Callee) {
          CUDA().IdentifyTarget(Callee) == CUDAFunctionTarget::Global;
 }
 
-bool Sema::isRedefinitionAllowedFor(NamedDecl *D, NamedDecl **Suggested,
-                                    bool &Visible) {
+bool Sema::isRedefinitionAllowedFor(NamedDecl *D,
+                                    SourceLocation NewDefinitionLoc,
+                                    NamedDecl **Suggested, bool &Visible) {
   Visible = hasVisibleDefinition(D, Suggested);
   // Accoding to [basic.def.odr]p16, it is not allowed to have duplicated definition
   // for declaratins which is attached to named modules.
@@ -22571,6 +22575,8 @@ bool Sema::isRedefinitionAllowedFor(NamedDecl *D, NamedDecl **Suggested,
       D->isInNamedModule())
     return false;
   // The redefinition of D in the **current** TU is allowed if D is invisible or
-  // D is defined in the global module of other module units.
-  return D->isInAnotherModuleUnit() || !Visible;
+  // D is defined in the global module of other module units or D is defined in
+  // the same header in a different module.
+  return D->isInAnotherModuleUnit() || !Visible ||
+         isFromSameSingleIncludeHeader(D, NewDefinitionLoc);
 }

--- a/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/clang/lib/Sema/SemaDeclObjC.cpp
@@ -1083,7 +1083,8 @@ ObjCInterfaceDecl *SemaObjC::ActOnStartClassInterface(
   if (PrevIDecl) {
     // Class already seen. Was it a definition?
     if (ObjCInterfaceDecl *Def = PrevIDecl->getDefinition()) {
-      if (SkipBody && !SemaRef.hasVisibleDefinition(Def)) {
+      if (SkipBody && (!SemaRef.hasVisibleDefinition(Def) ||
+                       SemaRef.isFromSameSingleIncludeHeader(Def, ClassLoc))) {
         SkipBody->CheckSameAsPrevious = true;
         SkipBody->New = IDecl;
         SkipBody->Previous = Def;
@@ -1263,7 +1264,8 @@ ObjCProtocolDecl *SemaObjC::ActOnStartProtocolInterface(
                                      ProtocolLoc, AtProtoInterfaceLoc,
                                      /*PrevDecl=*/Def);
 
-    if (SkipBody && !SemaRef.hasVisibleDefinition(Def)) {
+    if (SkipBody && (!SemaRef.hasVisibleDefinition(Def) ||
+                     SemaRef.isFromSameSingleIncludeHeader(Def, ProtocolLoc))) {
       SkipBody->CheckSameAsPrevious = true;
       SkipBody->New = PDecl;
       SkipBody->Previous = Def;

--- a/clang/lib/Sema/SemaModule.cpp
+++ b/clang/lib/Sema/SemaModule.cpp
@@ -1598,3 +1598,25 @@ void Sema::checkReferenceToTULocalFromOtherTU(
   PendingCheckReferenceForTULocal.push_back(
       std::make_pair(FD, PointOfInstantiation));
 }
+
+bool Sema::isFromSameSingleIncludeHeader(const Decl *PrevD,
+                                         SourceLocation NewLoc) {
+  if (!PrevD->isFromASTFile())
+    return false;
+  SourceLocation PrevLoc = PrevD->getLocation();
+  if (!PrevLoc.isValid() || !NewLoc.isValid())
+    return false;
+  SourceManager &SM = getSourceManager();
+  auto [PrevFileID, PrevOffset] = SM.getDecomposedExpansionLoc(PrevLoc);
+  auto [NewFileID, NewOffset] = SM.getDecomposedExpansionLoc(NewLoc);
+  if (PrevOffset != NewOffset)
+    return false;
+  OptionalFileEntryRef PrevFileRef = SM.getFileEntryRefForID(PrevFileID),
+                       NewFileRef = SM.getFileEntryRefForID(NewFileID);
+  if (*PrevFileRef != *NewFileRef)
+    return false;
+  const HeaderFileInfo *HFI =
+      getPreprocessor().getHeaderSearchInfo().getExistingFileInfo(*PrevFileRef);
+  return (HFI->isPragmaOnce || HFI->isImport ||
+          HFI->LazyControllingMacro.isValid());
+}

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2168,7 +2168,7 @@ DeclResult Sema::CheckClassTemplate(
         NamedDecl *Hidden = nullptr;
         bool HiddenDefVisible = false;
         if (SkipBody &&
-            isRedefinitionAllowedFor(Def, &Hidden, HiddenDefVisible)) {
+            isRedefinitionAllowedFor(Def, NameLoc, &Hidden, HiddenDefVisible)) {
           SkipBody->ShouldSkip = true;
           SkipBody->Previous = Def;
           if (!HiddenDefVisible && Hidden) {
@@ -9076,7 +9076,8 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
     NamedDecl *Hidden = nullptr;
     bool HiddenDefVisible = false;
     if (Def && SkipBody &&
-        isRedefinitionAllowedFor(Def, &Hidden, HiddenDefVisible)) {
+        isRedefinitionAllowedFor(Def, TemplateNameLoc, &Hidden,
+                                 HiddenDefVisible)) {
       SkipBody->ShouldSkip = true;
       SkipBody->Previous = Def;
       if (!HiddenDefVisible && Hidden)

--- a/clang/test/Modules/reentered-header-duplicate.m
+++ b/clang/test/Modules/reentered-header-duplicate.m
@@ -1,0 +1,218 @@
+// Check handling definitions from a file that is accessed both as non-modular and modular.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-c -I %t/headers-c/sub %t/test.c -verify
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-c -I %t/headers-c/sub %t/test.c -verify \
+// RUN:   -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/modules.cache
+
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-objc -I %t/headers-objc/sub %t/test.m -verify
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-objc -I %t/headers-objc/sub %t/test.m -verify \
+// RUN:   -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/modules.cache
+
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-cxx -I %t/headers-cxx/sub %t/test.cpp -verify
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-cxx -I %t/headers-cxx/sub %t/test.cpp -verify \
+// RUN:   -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/modules.cache
+
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-unguarded -I %t/headers-unguarded/sub %t/unguarded.c -verify
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-unguarded -I %t/headers-unguarded/sub %t/unguarded.c -verify \
+// RUN:   -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/modules.cache
+
+// RUN: %clang_cc1 -fsyntax-only -I %t/headers-mismatched -I %t/headers-mismatched/sub %t/mismatched.c -verify \
+// RUN:   -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/modules.cache
+
+//--- headers-c/top.h
+#ifndef TOP_H
+#define TOP_H
+
+#include <sub/sub.h>
+
+#endif
+
+//--- headers-c/sub/sub.h
+#ifndef SUB_H
+#define SUB_H
+
+#include <top.h>
+typedef int TestTypedef;
+
+struct TestStruct {
+  int a;
+  int b: 3;
+};
+
+union TestUnion {
+  int x;
+  float y;
+};
+
+struct WithAnonymous {
+  struct {
+    char p;
+  };
+  struct {
+    int z;
+  } nested;
+};
+
+#define CUSTOM_STRUCT(name) struct name##Struct
+
+CUSTOM_STRUCT(MacroBased) {
+  int m;
+};
+
+enum Seasons {
+  kSeasonWinter = 0,
+  kSeasonSpring,
+};
+
+inline int square(int x) {
+  return x * x;
+}
+
+#endif
+
+//--- headers-c/module.modulemap
+module top_c {
+  header "top.h"
+  export *
+}
+
+//--- test.c
+// expected-no-diagnostics
+// Access 'sub/sub.h' in non-modular way.
+#include <sub.h>
+
+
+//--- headers-objc/top.h
+#import <sub/sub.h>
+
+//--- headers-objc/sub/sub.h
+#import <top.h>
+
+@protocol TestProto
+- (void)testProtocolMethod;
+@end
+
+__attribute__((objc_root_class))
+@interface TestClass {
+  int _a;
+}
+- (void)testMethod:(float)b;
+@end
+
+//--- headers-objc/module.modulemap
+module top_objc {
+  header "top.h"
+  export *
+}
+
+//--- test.m
+// expected-no-diagnostics
+// Access 'sub/sub.h' in non-modular way.
+#import <sub.h>
+
+
+//--- headers-cxx/top.h
+#pragma once
+#import <sub/sub.h>
+
+//--- headers-cxx/sub/sub.h
+#pragma once
+#include <top.h>
+
+inline int GlobalVar = 3;
+
+template <class T> class GenericClass {
+  T field;
+};
+
+template <bool B, class T, class F> struct condition { using type = F; };
+template <class T, class F> struct condition<true, T, F> { using type = T; };
+
+template <typename T> void printGeneric(const T &val) {
+  // empty
+}
+
+template <> void printGeneric<int>(const int &val) {
+  // still empty
+}
+
+//--- headers-cxx/module.modulemap
+module top_cxx {
+  header "top.h"
+  export *
+}
+
+//--- test.cpp
+// expected-no-diagnostics
+// Access 'sub/sub.h' in non-modular way.
+#import <sub.h>
+
+
+//--- headers-unguarded/top.h
+#ifndef TOP_H
+#define TOP_H
+#include <sub/sub.h>
+#endif
+
+//--- headers-unguarded/sub/sub.h
+#include <top.h>
+
+struct UnguardedStruct {
+  float x;
+  int y;
+};
+
+//--- headers-unguarded/module.modulemap
+module top_unguarded {
+  header "top.h"
+  export *
+}
+
+//--- unguarded.c
+// Access 'sub/sub.h' in non-modular way.
+#include <sub.h>
+// expected-error@sub.h:* {{redefinition of 'UnguardedStruct'}}
+// expected-note@top.h:* {{sub.h' included multiple times, additional include site}}
+// expected-note@unguarded.c:* {{sub.h' included multiple times, additional include site}}
+// expected-note@sub.h:* {{unguarded header; consider using #ifdef guards or #pragma once}}
+#if __has_feature(modules)
+// expected-note@module.modulemap:* {{top_unguarded defined here}}
+#endif
+
+
+//--- headers-mismatched/top.h
+#ifndef TOP_H
+#define TOP_H
+#include <sub/sub.h>
+#endif
+
+//--- headers-mismatched/sub/sub.h
+#ifndef SUB_H
+#define SUB_H
+
+#include <top.h>
+
+struct MismatchedStruct {
+  int x;
+#ifdef EXTRA_FIELD
+  char z;
+#endif
+};
+
+#endif
+
+//--- headers-mismatched/module.modulemap
+module top_mismatched {
+  header "top.h"
+  export *
+}
+
+//--- mismatched.c
+#define EXTRA_FIELD 1
+#include <sub.h>
+// expected-error@sub.h:* {{type 'struct MismatchedStruct' has incompatible definitions}}
+// expected-note@sub.h:* {{field 'z' has type 'char' here}}
+// expected-note@sub.h:* {{no corresponding field here}}


### PR DESCRIPTION
Despite mechanisms to enforce a single inclusion (e.g., header guards, pragma once) treating the same header as modular and non-modular can defeat these mechanisms. Primarily it is caused by the fact that a module has a separate preprocessor state that's not shared with the includer. In practice it causes redefinition errors where both definitions are in the same file, at the same location. And it is very confusing and unactionable to clang users.

In most cases both definitions are identical and the error doesn't provide any value. Don't reject such redefinitions immediately and re-use the same mechanism when we detect a definition with the same name as in a hidden submodule, i.e., check the definitions are identical and use one of them.

rdar://183938264
(cherry picked from commit 593d6710ca06f2113b6644d8581154df6089189b)