### PR TITLE
[clang][tmo][nfc] Move handleTypedMemoryAttr into SemaTypedMemory.cpp

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5707,6 +5707,8 @@ public:
                                  const FunctionDecl *Target,
                                  ParamIdx InferredParameterIdx);
 
+  void handleTypedMemoryAttr(Decl *D, const ParsedAttr &AL);
+
   /// Check if IdxExpr is a valid parameter index for a function or
   /// instance method D.  May output an error.
   ///

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8928,119 +8928,6 @@ static void handleEnforceTCBAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   D->addAttr(AttrTy::Create(S.Context, Argument, AL));
 }
 
-static void handleTypedMemory(Sema &S, Decl *D, const ParsedAttr &AL) {
-  if (!S.getLangOpts().TypedMemoryOperations)
-    return;
-
-  FunctionDecl *SourceDecl = D->getAsFunction();
-  if (isFunctionOrMethodVariadic(D) || isInstanceMethod(D)) {
-    S.Diag(SourceDecl->getBeginLoc(), diag::err_tmo_function_kind_error)
-        << 0 << SourceDecl
-        << (isFunctionOrMethodVariadic(D) ? diag::TMOErrorKind::Variadic
-                                          : diag::TMOErrorKind::InstanceMethod);
-    AL.setInvalid();
-    return;
-  }
-
-  auto Loc = AL.getLoc();
-  if (!SourceDecl) {
-    auto *ND = cast<NamedDecl>(D);
-    S.Diag(Loc, diag::err_tmo_function_kind_error)
-        << 0 << ND << diag::TMOErrorKind::NotAFunction;
-    AL.setInvalid();
-    return;
-  }
-  if (AL.getNumArgs() < 2) {
-    S.Diag(Loc, diag::err_attribute_too_few_arguments) << AL;
-    AL.setInvalid();
-    return;
-  }
-  if (AL.getNumArgs() > 3) {
-    S.Diag(Loc, diag::err_attribute_too_many_arguments) << AL;
-    AL.setInvalid();
-    return;
-  }
-  Expr *TargetExpr = AL.getArgAsExpr(0);
-  FunctionDecl *TargetDecl = nullptr;
-  DeclarationNameInfo TargetName;
-  if (auto *DRE = dyn_cast<DeclRefExpr>(TargetExpr)) {
-    TargetDecl = dyn_cast<FunctionDecl>(DRE->getDecl());
-    TargetName = DRE->getNameInfo();
-    if (!TargetDecl) {
-      S.Diag(Loc, diag::err_tmo_function_kind_error)
-          << DRE->getSourceRange() << 1 << DRE->getNameInfo().getName()
-          << diag::TMOErrorKind::NotAFunction;
-      AL.setInvalid();
-      return;
-    }
-  } else if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(TargetExpr)) {
-    TargetDecl = S.ResolveSingleFunctionTemplateSpecialization(ULE, true);
-    TargetName = ULE->getNameInfo();
-    if (!TargetDecl) {
-      S.Diag(Loc, diag::err_tmo_rewrite_target_is_overloaded)
-          << TargetName.getName();
-      if (ULE->getType() == S.Context.OverloadTy)
-        S.NoteAllOverloadCandidates(ULE);
-      AL.setInvalid();
-      return;
-    }
-  } else {
-    S.Diag(Loc, diag::err_tmo_function_kind_error)
-        << TargetExpr->getSourceRange() << 1 << TargetExpr
-        << diag::TMOErrorKind::NotAFunction;
-    AL.setInvalid();
-    return;
-  }
-
-  TargetDecl = TargetDecl->getCanonicalDecl();
-  ParamIdx InferredParameterIdx;
-  if (!S.checkFunctionOrMethodParameterIndex(D, AL, 1, AL.getArgAsExpr(1),
-                                             InferredParameterIdx))
-    return;
-
-  auto *InferredParam =
-      SourceDecl->getParamDecl(InferredParameterIdx.getASTIndex());
-  auto SizeType = InferredParam->getType();
-  auto isIntegerOrDependentNonArrayType = [](QualType QT) -> bool {
-    auto *T = QT->getUnqualifiedDesugaredType();
-    if (T->isIntegerType())
-      return true;
-    if (T->isDependentSizedArrayType())
-      return false;
-    return T->isDependentType();
-  };
-  if (!isIntegerOrDependentNonArrayType(SizeType)) {
-    S.Diag(Loc, diag::err_tmo_invalid_inferred_parameter_type)
-        << InferredParameterIdx.getSourceIndex() << SizeType
-        << InferredParam->getLocation();
-    AL.setInvalid();
-    return;
-  }
-
-  if (!hasFunctionProto(TargetDecl) || isFunctionOrMethodVariadic(TargetDecl) ||
-      isInstanceMethod(TargetDecl)) {
-    auto MessageSelector = !hasFunctionProto(TargetDecl)
-                               ? diag::TMOErrorKind::NoPrototype
-                           : isFunctionOrMethodVariadic(TargetDecl)
-                               ? diag::TMOErrorKind::Variadic
-                               : diag::TMOErrorKind::InstanceMethod;
-    S.Diag(Loc, diag::err_tmo_function_kind_error)
-        << 1 << TargetDecl << MessageSelector;
-    AL.setInvalid();
-    return;
-  }
-
-  if (S.checkTypedMemorySignature(AL, SourceDecl, TargetDecl,
-                                  InferredParameterIdx)) {
-    AL.setInvalid();
-    return;
-  }
-
-  auto *TMA = ::new (S.Context)
-      TypedMemoryAttr(S.Context, AL, TargetDecl, InferredParameterIdx);
-  D->addAttr(TMA);
-}
-
 template <typename AttrTy, typename ConflictingAttrTy>
 static AttrTy *mergeEnforceTCBAttrImpl(Sema &S, Decl *D, const AttrTy &AL) {
   // Check if the new redeclaration has different leaf-ness in the same TCB.
@@ -10245,7 +10132,7 @@ ProcessDeclAttribute(Sema &S, Decl *D, const ParsedAttr &AL,
     break;
 
   case ParsedAttr::AT_TypedMemory:
-    handleTypedMemory(S, D, AL);
+    S.handleTypedMemoryAttr(D, AL);
     break;
 
   case ParsedAttr::AT_BuiltinAlias:

--- a/clang/lib/Sema/SemaTypedMemory.cpp
+++ b/clang/lib/Sema/SemaTypedMemory.cpp
@@ -21,6 +21,7 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/Attr.h"
 #include "clang/Sema/Initialization.h"
+#include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/SemaHLSL.h"
 #include "clang/Sema/SemaObjC.h"
 #include "clang/Sema/SemaRISCV.h"
@@ -353,4 +354,117 @@ void TypedMemoryCallsiteContext::recordTMOInferenceCandidate(Sema &S,
     return;
   Calls.push_back(CE);
   ShouldSearchCasts = true;
+}
+
+void Sema::handleTypedMemoryAttr(Decl *D, const ParsedAttr &AL) {
+  if (!getLangOpts().TypedMemoryOperations)
+    return;
+
+  FunctionDecl *SourceDecl = D->getAsFunction();
+  if (isFunctionOrMethodVariadic(D) || isInstanceMethod(D)) {
+    Diag(SourceDecl->getBeginLoc(), diag::err_tmo_function_kind_error)
+        << 0 << SourceDecl
+        << (isFunctionOrMethodVariadic(D) ? diag::TMOErrorKind::Variadic
+                                          : diag::TMOErrorKind::InstanceMethod);
+    AL.setInvalid();
+    return;
+  }
+
+  auto Loc = AL.getLoc();
+  if (!SourceDecl) {
+    auto *ND = cast<NamedDecl>(D);
+    Diag(Loc, diag::err_tmo_function_kind_error)
+        << 0 << ND << diag::TMOErrorKind::NotAFunction;
+    AL.setInvalid();
+    return;
+  }
+  if (AL.getNumArgs() < 2) {
+    Diag(Loc, diag::err_attribute_too_few_arguments) << AL;
+    AL.setInvalid();
+    return;
+  }
+  if (AL.getNumArgs() > 3) {
+    Diag(Loc, diag::err_attribute_too_many_arguments) << AL;
+    AL.setInvalid();
+    return;
+  }
+  Expr *TargetExpr = AL.getArgAsExpr(0);
+  FunctionDecl *TargetDecl = nullptr;
+  DeclarationNameInfo TargetName;
+  if (auto *DRE = dyn_cast<DeclRefExpr>(TargetExpr)) {
+    TargetDecl = dyn_cast<FunctionDecl>(DRE->getDecl());
+    TargetName = DRE->getNameInfo();
+    if (!TargetDecl) {
+      Diag(Loc, diag::err_tmo_function_kind_error)
+          << DRE->getSourceRange() << 1 << DRE->getNameInfo().getName()
+          << diag::TMOErrorKind::NotAFunction;
+      AL.setInvalid();
+      return;
+    }
+  } else if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(TargetExpr)) {
+    TargetDecl = ResolveSingleFunctionTemplateSpecialization(ULE, true);
+    TargetName = ULE->getNameInfo();
+    if (!TargetDecl) {
+      Diag(Loc, diag::err_tmo_rewrite_target_is_overloaded)
+          << TargetName.getName();
+      if (ULE->getType() == Context.OverloadTy)
+        NoteAllOverloadCandidates(ULE);
+      AL.setInvalid();
+      return;
+    }
+  } else {
+    Diag(Loc, diag::err_tmo_function_kind_error)
+        << TargetExpr->getSourceRange() << 1 << TargetExpr
+        << diag::TMOErrorKind::NotAFunction;
+    AL.setInvalid();
+    return;
+  }
+
+  TargetDecl = TargetDecl->getCanonicalDecl();
+  ParamIdx InferredParameterIdx;
+  if (!checkFunctionOrMethodParameterIndex(D, AL, 1, AL.getArgAsExpr(1),
+                                           InferredParameterIdx))
+    return;
+
+  auto *InferredParam =
+      SourceDecl->getParamDecl(InferredParameterIdx.getASTIndex());
+  auto SizeType = InferredParam->getType();
+  auto isIntegerOrDependentNonArrayType = [](QualType QT) -> bool {
+    auto *T = QT->getUnqualifiedDesugaredType();
+    if (T->isIntegerType())
+      return true;
+    if (T->isDependentSizedArrayType())
+      return false;
+    return T->isDependentType();
+  };
+  if (!isIntegerOrDependentNonArrayType(SizeType)) {
+    Diag(Loc, diag::err_tmo_invalid_inferred_parameter_type)
+        << InferredParameterIdx.getSourceIndex() << SizeType
+        << InferredParam->getLocation();
+    AL.setInvalid();
+    return;
+  }
+
+  if (!hasFunctionProto(TargetDecl) || isFunctionOrMethodVariadic(TargetDecl) ||
+      isInstanceMethod(TargetDecl)) {
+    auto MessageSelector = !hasFunctionProto(TargetDecl)
+                               ? diag::TMOErrorKind::NoPrototype
+                           : isFunctionOrMethodVariadic(TargetDecl)
+                               ? diag::TMOErrorKind::Variadic
+                               : diag::TMOErrorKind::InstanceMethod;
+    Diag(Loc, diag::err_tmo_function_kind_error)
+        << 1 << TargetDecl << MessageSelector;
+    AL.setInvalid();
+    return;
+  }
+
+  if (checkTypedMemorySignature(AL, SourceDecl, TargetDecl,
+                                InferredParameterIdx)) {
+    AL.setInvalid();
+    return;
+  }
+
+  auto *TMA = ::new (Context)
+      TypedMemoryAttr(Context, AL, TargetDecl, InferredParameterIdx);
+  D->addAttr(TMA);
 }


### PR DESCRIPTION
As part of the TMO robustification work, I needed to make handleTypedMemoryAttr accessible outside of SemaDeclAttr.cpp. Given that this meant it was no longer able to be a TU static function, I moved it to SemaTypedMemory.cpp as I've also been working to cleanly separate out the TMO code.

The robustification also results in changes to this code though, so to make the review less obnoxious I'm preflighting the code motion on its own.