### PR TITLE
[lldb] Fix handling of scalars in dynamic type resolution

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1885,7 +1885,10 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
 
   // Prepare to project the enum to get the active case.
   MemoryReaderLocalBufferHolder holder;
-  auto [addr, address_type] = valobj.GetAddressOf(false);
+  // Storage for the Scalar case below.
+  uint64_t scalar_storage = 0;
+  auto [addr, address_type] =
+      valobj.GetAddressOf(/*scalar_is_load_address=*/false);
   if (addr == LLDB_INVALID_ADDRESS || addr == 0) {
     Value &value = valobj.GetValue();
     switch (value.GetValueType()) {
@@ -1902,8 +1905,9 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
       break;
     }
     case Value::ValueType::Scalar: {
-      addr = value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
-      holder = PushLocalBuffer((uint64_t)&addr, sizeof(addr));
+      scalar_storage = value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
+      addr = (uint64_t)&scalar_storage;
+      holder = PushLocalBuffer(addr, sizeof(scalar_storage));
       break;
     }
     }
@@ -3499,7 +3503,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
       bound_type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
   if (!size)
     return false;
-  auto [val_address, address_type] = in_value.GetAddressOf(true);
+  auto [val_address, address_type] = in_value.GetAddressOf(false);
   // If we couldn't find a load address, but the value object has a local
   // buffer, use that.
   if (val_address == LLDB_INVALID_ADDRESS && address_type == eAddressTypeHost) {
@@ -3519,7 +3523,16 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
     local_buffer = in_value_buffer;
     return true;
   }
-  if (*size && (!val_address || val_address == LLDB_INVALID_ADDRESS))
+  if (val_address == LLDB_INVALID_ADDRESS) {
+    if (*size) {
+      return false;
+    }
+    // This is a zero-sized type so there is nothing to read. Report it as load
+    // address (this is safe because val_address is LLDB_INVALID_ADDRESS) so the
+    // generic type parameters are still bound.
+    address_type = eAddressTypeLoad;
+  }
+  if (*size && !val_address)
     return false;
 
   value_type = Value::GetValueTypeFromAddressType(address_type);

--- a/lldb/test/API/lang/swift/variables/optional_in_register/Makefile
+++ b/lldb/test/API/lang/swift/variables/optional_in_register/Makefile
@@ -1,0 +1,8 @@
+SWIFT_SOURCES := main.swift
+
+# -O is required: the parameters only end up in registers (a DW_OP_regN
+# location rather than a memory one) in optimized code. The test asserts that
+# the location really is a register.
+SWIFTFLAGS_EXTRAS := -O
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/optional_in_register/TestSwiftOptionalInRegister.py
+++ b/lldb/test/API/lang/swift/variables/optional_in_register/TestSwiftOptionalInRegister.py
@@ -1,0 +1,42 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftOptionalInRegister(TestBase):
+    def value_in_register(self, thread, name):
+        """Fetch a variable from the parent frame, asserting it really is held
+        in a register."""
+        frame = thread.GetFrameAtIndex(1)
+        self.assertIn("caller", frame.GetFunctionName())
+        value = frame.FindVariable(name)
+        self.assertTrue(value.IsValid(), "no variable named " + name)
+        self.assertEqual(
+            value.GetLocation(),
+            "scalar",
+            "%s should be in a register, but its location is '%s'; the "
+            "optimizer may have spilled it, which would stop this test from "
+            "exercising the bug" % (name, value.GetLocation()),
+        )
+        return value
+
+    @skipEmbeddedSwiftOnWindows
+    @swiftTest
+    def test_optional_in_register(self):
+        self.build()
+        _, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        optional = self.value_in_register(thread, "optionalBytes")
+        self.assertEqual(optional.GetSummary(), "3 values")
+        self.assertEqual([c.GetValue() for c in optional], ["1", "2", "3"])
+
+        plain = self.value_in_register(thread, "plainBytes")
+        self.assertEqual(plain.GetSummary(), "4 values")
+
+        process.Continue()
+        optional = self.value_in_register(thread, "optionalBytes")
+        self.assertEqual(optional.GetSummary(), "nil")
+        self.assertEqual(optional.GetNumChildren(), 0)

--- a/lldb/test/API/lang/swift/variables/optional_in_register/main.swift
+++ b/lldb/test/API/lang/swift/variables/optional_in_register/main.swift
@@ -1,0 +1,15 @@
+var sideEffect = 0
+
+@inline(never)
+func callee() {
+  sideEffect += 1 // break here
+}
+
+@inline(never)
+func caller(_ optionalBytes: [UInt8]?, _ plainBytes: [UInt8]) -> Int {
+  callee()
+  return (optionalBytes?.count ?? 0) + plainBytes.count
+}
+
+sideEffect = caller([1, 2, 3], [4, 5, 6, 7])
+sideEffect = caller(nil, [8, 9])


### PR DESCRIPTION
Dynamic type resolution was mishandling scalars by assuming that they
were load addresses, when in reality they represent the value literally,
not as an address.

We've never hit this issue before because unoptimized code always stores
variables in stack slots.

Assisted-by: Claude

rdar://186711021
