### PR TITLE
Unified LLVM+Swift+LLDB build: pin swiftc resource-dir and forward ninja to sub-builds

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -137,6 +137,17 @@ ifeq "$(USESWIFTDRIVER)" "1"
 		SWIFTFLAGS += -sdk "$(SWIFTSDKROOT)"
 	endif
 	SWIFTFLAGS += -tools-directory "$(shell dirname $(CC))"
+	# `-tools-directory` also directs the swift driver to look up
+	# `swift-frontend` there. In a unified LLVM+Swift build that directory
+	# contains a partial Swift install (produced by
+	# LLVM_EXTERNAL_PROJECTS=swift) whose lib/swift is missing modules like
+	# `_Concurrency` that live in the full standalone stdlib. On non-Windows
+	# hosts pin the resource-dir to the stdlib next to $(SWIFTC) so module
+	# lookup uses the complete build tree regardless of which swift-frontend
+	# runs. Windows already sets -resource-dir above.
+	ifneq "$(OS)" "Windows_NT"
+		SWIFTFLAGS += -resource-dir "$(shell dirname $(SWIFTC))/../lib/swift"
+	endif
 endif
 
 #----------------------------------------------------------------------

--- a/llvm/cmake/modules/AddLLVMSwiftDriver.cmake
+++ b/llvm/cmake/modules/AddLLVMSwiftDriver.cmake
@@ -88,6 +88,7 @@ function(llvm_add_swift_driver_external_project root)
     -DCMAKE_Swift_COMPILER=${_host_swiftc}
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
   )
   if(APPLE AND _sdk_path)
     list(APPEND _common -DCMAKE_OSX_SYSROOT=${_sdk_path})


### PR DESCRIPTION
Two fixes needed to make the swift preset
`buildbot_all_platforms,tools=RA,stdlib=RA,unified_llvm` produce green LLDB API tests.

lldb: Swift.rules — in a unified build, `LLVM_EXTERNAL_PROJECTS=swift` compiles a `swift-frontend` into `llvm-macosx-arm64/bin`. The LLDB test harness passes `-tools-directory "$(dirname $(CC))"` to swiftc, so the driver dispatches to *that* frontend, which defaults its resource-dir to `llvm-macosx-arm64/lib/swift` — a partial stdlib missing modules like `_Concurrency` that only exist in the full standalone stdlib. Pin `-resource-dir` to the stdlib next to `$(SWIFTC)` so module lookup uses the complete tree regardless of which swift-frontend the driver picks. Non-Windows only; Windows already sets its own resource-dir above.

AddLLVMSwiftDriver.cmake — forward `CMAKE_MAKE_PROGRAM` to the four ExternalProject_Add sub-configures (llbuild, argparser, tsc, swift-driver). Without it those sub-cmakes can't find ninja when the parent build uses an in-tree ninja that isn't on PATH.