### PR TITLE
[Windows][lldb-dap] drop stale SetupPythonRuntimeLibrary call

### DIFF
--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -746,16 +746,6 @@ int main(int argc, char *argv[]) {
                         "~/Library/Logs/DiagnosticReports/.\n");
 #endif
 
-#ifdef _WIN32
-  if (llvm::Error error = SetupPythonRuntimeLibrary()) {
-    llvm::WithColor::error() << llvm::toString(std::move(error)) << '\n';
-    // BEGIN SWIFT
-    llvm::WithColor::note() << g_python_installation_note;
-    return 1;
-    // END SWIFT
-  }
-#endif
-
   llvm::SmallString<256> program_path(argv[0]);
   llvm::sys::fs::make_absolute(program_path);
   DAP::debug_adapter_path = program_path;


### PR DESCRIPTION
ff65d814129d removed the `SetupPythonRuntimeLibrary` method however the cherry-picking commit did not remove it from the `// BEGIN SWIFT` block. Remove it to fix the build error.