### PR TITLE
[lldb] fix lang/swift/originally_defined_in test on macOS

### DIFF
--- a/lldb/test/API/lang/swift/originally_defined_in/main.swift
+++ b/lldb/test/API/lang/swift/originally_defined_in/main.swift
@@ -91,6 +91,10 @@ func f() {
     let h = ClassPair(t: Prop(), u: Prop2())
     let i = (A(), F(), Prop())
     let complex = Pair(t: E.t(Pair(t: Prop2(), u: C.D())), u: E.t(Prop()))
+    // The stack zero-init for `complex` is attributed to the next line
+    // instead of the declaration above, so "break here" resolves into the
+    // prologue, before `complex` is initialized. rdar://184762794
+    print("prologue")
     print("break here")
 }
 


### PR DESCRIPTION
complex's stack zero-init is attributed to the first statement after the declarations, so the "break here" breakpoint resolved into the prologue, before anything was initialized (a = (i = 0)). Add a throwaway statement to take that location instead, and note the suspected root cause (rdar://184762794).