### PR TITLE
[Cherry-pick into next] [lldb] Decide that `self` is unavailable before realizing its type

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -581,6 +581,15 @@ AddRequiredAliases(Block *block, lldb_private::StackFrame &stack_frame,
   if (!self_var_sp)
     return llvm::Error::success();
 
+  // Don't inject a `self` without a value. In this case the outer
+  // layer is downgrading the expression method to a freestanding
+  // function.
+  if (lldb::ValueObjectSP valobj_sp =
+          stack_frame.GetValueObjectForFrameVariable(self_var_sp,
+                                                     lldb::eNoDynamicValues))
+    if (valobj_sp->GetError().Fail() && self_var_sp->IsArtificial())
+      return llvm::Error::success();
+
   auto *swift_runtime =
       SwiftLanguageRuntime::Get(stack_frame.GetThread()->GetProcess());
   CompilerType self_type = SwiftExpressionParser::ResolveVariable(
@@ -666,9 +675,11 @@ AddRequiredAliases(Block *block, lldb_private::StackFrame &stack_frame,
     LLDB_LOG(GetLog(LLDBLog::Types | LLDBLog::Expressions),
              "Couldn't get SwiftASTContext type for self type {0}.",
              imported_self_type.GetDisplayTypeName());
-    return llvm::createStringError(
-        "Unable to add the aliases the expression needs because the Swift "
-        "expression parser couldn't get the Swift type for self.");
+    return llvm::joinErrors(
+        llvm::createStringError(
+            "Unable to add the aliases the expression needs because the Swift "
+            "expression parser couldn't get the Swift type for self."),
+        swift_self_type.takeError());
   }
   if (!swift_self_type.get())
     return llvm::createStringError("null self type");

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -360,6 +360,16 @@ static llvm::Error AddVariableInfo(
   if (!variable_sp || !variable_sp->GetType())
     return llvm::Error::success();
 
+  // Stash diagnostics for missing locations.
+  Status variable_status;
+  if (lldb::ValueObjectSP valobj_sp =
+          stack_frame_sp->GetValueObjectForFrameVariable(
+              variable_sp, lldb::eNoDynamicValues)) {
+    variable_status = valobj_sp->GetError().Clone();
+    if (variable_status.Fail() && variable_sp->IsArtificial())
+      return llvm::Error::success();
+  }
+
   CompilerType target_type;
   bool should_not_bind_generic_types =
       !SwiftASTManipulator::ShouldBindGenericTypes(bind_generic_types);
@@ -453,16 +463,6 @@ static llvm::Error AddVariableInfo(
                   static_cast<void *>(swift_type.getPointer()),
                   static_cast<void *>(*ast_context.GetASTContext()), s.c_str());
     }
-
-  // Stash diagnostics for missing locations.
-  Status variable_status;
-  if (lldb::ValueObjectSP valobj_sp =
-          stack_frame_sp->GetValueObjectForFrameVariable(
-              variable_sp, lldb::eNoDynamicValues)) {
-    variable_status = valobj_sp->GetError().Clone();
-    if (variable_status.Fail() && variable_sp->IsArtificial())
-      return llvm::Error::success();
-  }
 
   // A one-off clone of variable_sp with the type replaced by target_type.
   auto patched_variable_sp = std::make_shared<lldb_private::Variable>(

--- a/lldb/test/API/lang/swift/expression/unrealizable_self/Lib.swift
+++ b/lldb/test/API/lang/swift/expression/unrealizable_self/Lib.swift
@@ -1,0 +1,5 @@
+// Module Lib: defines the type that gets extended from another module.
+public struct Root {
+  public var value: Int
+  public init(value: Int) { self.value = value }
+}

--- a/lldb/test/API/lang/swift/expression/unrealizable_self/Makefile
+++ b/lldb/test/API/lang/swift/expression/unrealizable_self/Makefile
@@ -1,0 +1,31 @@
+# LLDB replays the compiler invocation recorded in the debug info. With explicit
+# modules that names Lib.swiftmodule by path, so taking it away below would fail
+# every import instead of only the types that come from Lib.
+export SWIFT_ENABLE_EXPLICIT_MODULES := NO
+
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -I.
+LD_EXTRAS = -L. -Xlinker -rpath -Xlinker $(BUILDDIR) -lLib
+
+all: clean dylib a.out hide-module
+
+include Makefile.rules
+
+# DYLIB_HIDE_SWIFTMODULE together with no reflection metadata makes it
+# impossible to lay out `self`.
+.PHONY: dylib
+dylib: Lib.swift \
+       $(call tool_prereq,$(SWIFTC_PATH)) $(call tool_prereq,$(SWIFT_FRONTEND_PATH))
+	"$(MAKE)" -f $(MAKEFILE_RULES) -C $(BUILDDIR) VPATH=$(SRCDIR) \
+		CC=$(CC) SWIFTC=$(SWIFTC) ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		DYLIB_HIDE_SWIFTMODULE=YES \
+		DYLIB_ONLY=YES \
+		DYLIB_NAME=Lib \
+		DYLIB_SWIFT_SOURCES=Lib.swift \
+		SWIFTFLAGS_EXTRAS="-Xfrontend -disable-reflection-metadata -enable-library-evolution"
+
+# Now that main.swift has been compiled against it, take away everything LLDB
+# could reconstruct Lib.Root from.
+.PHONY: hide-module
+hide-module: a.out
+	$(call RM_F,Lib.swiftmodule Lib.swiftinterface Lib.private.swiftinterface)

--- a/lldb/test/API/lang/swift/expression/unrealizable_self/TestSwiftUnrealizableSelf.py
+++ b/lldb/test/API/lang/swift/expression/unrealizable_self/TestSwiftUnrealizableSelf.py
@@ -1,0 +1,38 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftUnrealizableSelf(TestBase):
+    @requireNotEmbeddedSwift
+    @swiftTest
+    def test_unrealizable_self_does_not_break_frame(self):
+        """
+        Test expression evaluation in a frame whose `self` can neither be read nor have
+        its type realized.
+        """
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        # Verify that `self` is indeed not available.
+        self_var = self.frame().FindVariable("self")
+        self.assertTrue(self_var.IsValid(), "expected a 'self' variable")
+        self.assertEqual(self_var.GetType().GetName(), "Lib.Root")
+        self.assertTrue(
+            self_var.GetError().Fail(),
+            "expected 'self' to have no usable value, got %s" % self_var.GetValue(),
+        )
+
+        # A local variable is not a member of `self`, so it must still resolve --
+        # and materialize -- even though `self` was dropped from the wrapper.
+        factor = self.frame().EvaluateExpression("factor")
+        self.assertSuccess(factor.GetError())
+        self.assertEqual(factor.GetValue(), "7")
+
+        # Expressions that need `self` must fail with a diagnostic about `self`.
+        error = self.frame().EvaluateExpression("self").GetError().GetCString() or ""
+        self.assertIn("cannot find 'self' in scope", error)
+        self.assertNotIn("$__lldb_injected_self", error)

--- a/lldb/test/API/lang/swift/expression/unrealizable_self/main.swift
+++ b/lldb/test/API/lang/swift/expression/unrealizable_self/main.swift
@@ -1,0 +1,12 @@
+import Lib
+
+// An extension of Lib.Root compiled into this module: `self` is a type from
+// another module, so LLDB has to go through Lib to make sense of it.
+extension Root {
+  var doubled: Int {
+    let factor = 7
+    return value * factor // break here
+  }
+}
+
+print(Root(value: 21).doubled)


### PR DESCRIPTION
```
commit 1a74a2479881bef7e94eb186adfccc8a778c6d5a
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Sep 4 15:16:49 2026 -0700

    [lldb] Decide that `self` is unavailable before realizing its type
    
    AddVariableInfo dropped a variable with no value in the frame only
    after it had realized its type. For self a type error there is fatal,
    so an expression could fail over a type it never uses instead of being
    downgraded to a freestanding function, which is what the caller does
    when self is absent.
    
    This patch moves the check ahead of the type work.
    
    Assisted-by: Claude
    rdar://186454193
```
