### PR TITLE
[lldb] Cherry-pick safe auto-load scripting ressource work to stable/21.x 

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -69,7 +69,6 @@ class Process;
 class Stream;
 class SymbolContext;
 class Target;
-class Debugger;
 
 #ifndef NDEBUG
 /// Global properties used in the LLDB testsuite.
@@ -85,7 +84,7 @@ struct TestingProperties : public Properties {
   void AppendSafeAutoLoadPaths(FileSpec path);
 
 private:
-  friend Debugger;
+  friend Target;
 
   /// Callers should use Debugger::GetSafeAutoLoadPaths since it
   /// accounts for default paths configured via CMake.
@@ -145,12 +144,6 @@ public:
 
   static void AssertCallback(llvm::StringRef message, llvm::StringRef backtrace,
                              llvm::StringRef prompt);
-
-  /// Get the list of paths that LLDB will consider automatically loading
-  /// scripting resources from. Currently whether to load scripts
-  /// unconditionally is controlled via the
-  /// `target.load-script-from-symbol-file` setting.
-  static FileSpecList GetSafeAutoLoadPaths();
 
   void Clear();
 
@@ -669,6 +662,8 @@ public:
     std::string message;
   };
   std::optional<ProgressReport> GetCurrentProgressReport() const;
+
+  static const FileSpecList &GetDefaultSafeAutoLoadPaths();
 
 protected:
   friend class CommandInterpreter;

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -1004,6 +1004,13 @@ public:
 
   LocateModuleCallback GetLocateModuleCallback() const;
 
+  /// Returns a \c FileSpecList of safe paths to auto-load scripting resources
+  /// from for a particular platform.
+  virtual llvm::Expected<FileSpecList>
+  GetSafeAutoLoadPaths(const Target &target) const {
+    return FileSpecList();
+  }
+
 protected:
   /// Create a list of ArchSpecs with the given OS and a architectures. The
   /// vendor field is left as an "unspecified unknown".

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -2031,6 +2031,12 @@ public:
 
   void SaveScriptedLaunchInfo(lldb_private::ProcessInfo &process_info);
 
+  /// Get the list of paths that LLDB will consider automatically loading
+  /// scripting resources from. Currently whether to load scripts
+  /// unconditionally is controlled via the
+  /// `target.load-script-from-symbol-file` setting.
+  FileSpecList GetSafeAutoLoadPaths() const;
+
   /// Add a signal for the target.  This will get copied over to the process
   /// if the signal exists on that target.  Only the values with Yes and No are
   /// set, Calculate values will be ignored.

--- a/lldb/include/lldb/Utility/FileSpecList.h
+++ b/lldb/include/lldb/Utility/FileSpecList.h
@@ -132,6 +132,12 @@ public:
   ///     A new file to append to this file list.
   void Append(const FileSpec &file);
 
+  /// Appends all elements of \c other to the end of this list
+  /// (regardless of whether a \c FileSpec already exists in the list).
+  void Append(const FileSpecList &other) {
+    m_files.insert(end(), std::begin(other), std::end(other));
+  }
+
   /// Append a FileSpec object if unique.
   ///
   /// Appends \a file to the end of the file list if it doesn't already exist

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -211,7 +211,7 @@ enum {
 };
 #endif
 
-static const FileSpecList &GetDefaultSafeAutoLoadPaths() {
+const FileSpecList &Debugger::GetDefaultSafeAutoLoadPaths() {
   static const FileSpecList sSafePaths = [] {
     // FIXME: in c++20 this could be a std::array (with CTAD deduced size)
     // and we could statically assert that all members are non-empty.
@@ -2538,14 +2538,3 @@ llvm::ThreadPoolInterface &Debugger::GetThreadPool() {
   return *g_thread_pool;
 }
 
-FileSpecList Debugger::GetSafeAutoLoadPaths() {
-  FileSpecList fspecs = GetDefaultSafeAutoLoadPaths();
-
-#ifndef NDEBUG
-  for (const auto &fspec :
-       TestingProperties::GetGlobalTestingProperties().GetSafeAutoLoadPaths())
-    fspecs.Append(fspec);
-#endif
-
-  return fspecs;
-}

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -14,6 +14,7 @@
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/DataBuffer.h"
 #include "lldb/Utility/DataExtractor.h"
+#include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Timer.h"

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1571,7 +1571,9 @@ PlatformDarwin::GetSafeAutoLoadPaths(const Target &target) const {
 
   XcodeSDK::Type sdk_type =
       XcodeSDK::GetSDKTypeForTriple(target.GetArchitecture().GetTriple());
-  XcodeSDK sdk(XcodeSDK::Info{sdk_type, {}});
+  XcodeSDK::Info info;
+  info.type = sdk_type;
+  XcodeSDK sdk(info);
 
   auto sdk_root_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!sdk_root_or_err) {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1564,3 +1564,36 @@ PlatformDarwin::ResolveSDKPathFromDebugInfo(CompileUnit &unit) {
 
   return path_or_err->str();
 }
+
+llvm::Expected<FileSpecList>
+PlatformDarwin::GetSafeAutoLoadPaths(const Target &target) const {
+  Log *log = GetLog(LLDBLog::Modules | LLDBLog::Platform);
+
+  XcodeSDK::Type sdk_type =
+      XcodeSDK::GetSDKTypeForTriple(target.GetArchitecture().GetTriple());
+  XcodeSDK sdk(XcodeSDK::Info{sdk_type, {}});
+
+  auto sdk_root_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+  if (!sdk_root_or_err) {
+    LLDB_LOG_ERROR(log, sdk_root_or_err.takeError(),
+                   "Failed to resolve SDK root for triple '{1}': {0}",
+                   target.GetArchitecture().GetTriple().str());
+
+    // Fall back to any macOS SDK.
+    sdk = XcodeSDK::GetAnyMacOS();
+    LLDB_LOG(log, "Falling back to SDK '{0}'", sdk.GetString());
+    sdk_root_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+  }
+
+  if (!sdk_root_or_err)
+    return sdk_root_or_err.takeError();
+
+  // $SDKROOT/usr/share/lldb is an auto-loadable path.
+  llvm::SmallString<256> resolved(*sdk_root_or_err);
+  llvm::sys::path::append(resolved, "usr", "share", "lldb");
+
+  FileSpecList fspecs;
+  fspecs.Append(FileSpec(resolved));
+
+  return fspecs;
+}

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -159,6 +159,9 @@ public:
                                              const Target &target,
                                              const FileSpec &symfile_spec);
 
+  llvm::Expected<FileSpecList>
+  GetSafeAutoLoadPaths(const Target &target) const override;
+
 protected:
   static const char *GetCompatibleArch(ArchSpec::Core core, size_t idx);
 

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -190,7 +190,7 @@ Platform::LocateExecutableScriptingResourcesFromSafePaths(
           ->GetSanitizedScriptingModuleName(
               module_spec.GetFileNameStrippingExtension().GetStringRef());
 
-  FileSpecList paths = Debugger::GetSafeAutoLoadPaths();
+  FileSpecList paths = target.GetSafeAutoLoadPaths();
 
   // Iterate in reverse so we consider the latest appended path first.
   for (FileSpec path : llvm::reverse(paths)) {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -6328,6 +6328,18 @@ void Target::DumpSectionLoadList(Stream &s) {
 FileSpecList Target::GetSafeAutoLoadPaths() const {
   FileSpecList fspecs = Debugger::GetDefaultSafeAutoLoadPaths();
 
+  // Add platform-specific safe-paths.
+  if (m_platform_sp) {
+    if (auto platform_fspecs_or_err =
+            m_platform_sp->GetSafeAutoLoadPaths(*this))
+      fspecs.Append(*platform_fspecs_or_err);
+    else
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Modules | LLDBLog::Platform),
+                     platform_fspecs_or_err.takeError(),
+                     "Skipping safe auto-load: {0}");
+  }
+
+  // Properties for testing get added last so they take priority.
 #ifndef NDEBUG
   for (const auto &fspec :
        TestingProperties::GetGlobalTestingProperties().GetSafeAutoLoadPaths())

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -6325,6 +6325,18 @@ void Target::DumpSectionLoadList(Stream &s) {
   GetSectionLoadList().Dump(s, this);
 }
 
+FileSpecList Target::GetSafeAutoLoadPaths() const {
+  FileSpecList fspecs = Debugger::GetDefaultSafeAutoLoadPaths();
+
+#ifndef NDEBUG
+  for (const auto &fspec :
+       TestingProperties::GetGlobalTestingProperties().GetSafeAutoLoadPaths())
+    fspecs.Append(fspec);
+#endif
+
+  return fspecs;
+}
+
 // FIXME: the language plugin should expression options dynamically and
 // we should validate here (by asking the language plugin) that the options
 // being set/retrieved are actually valid options.

--- a/lldb/unittests/Platform/CMakeLists.txt
+++ b/lldb/unittests/Platform/CMakeLists.txt
@@ -14,6 +14,7 @@ add_lldb_unittest(LLDBPlatformTests
     lldbPluginPlatformMacOSX
     lldbPluginPlatformNetBSD
     lldbUtilityHelpers
+    LLVMTestingSupport
   )
 
 add_subdirectory(Android)

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Testing/Support/Error.h"
 
 #include <memory>
 #include <tuple>
@@ -767,3 +768,20 @@ INSTANTIATE_TEST_SUITE_P(PlatformDarwinLocateWithSpecialCharsTest,
                          PlatformDarwinLocateWithSpecialCharsTestFixture,
                          testing::ValuesIn(std::vector<SpecialCharTestCase>{
                              {' ', '_'}, {'.', '_'}, {'-', '_'}, {'+', 'x'}}));
+
+TEST_F(PlatformDarwinLocateTest, GetSafeAutoLoadPaths) {
+  // Tests PlatformDarwin::GetSafeAutoLoadPaths returns a path into the SDK on
+  // Darwin platforms.
+
+  auto paths_or_err = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                          ->GetSafeAutoLoadPaths(*m_target_sp);
+
+  ASSERT_THAT_EXPECTED(paths_or_err, llvm::Succeeded());
+
+  ASSERT_EQ(paths_or_err->GetSize(), 1u);
+
+  // The returned path should be $SDKROOT/usr/share/lldb.
+  FileSpec path = paths_or_err->GetFileSpecAtIndex(0);
+  EXPECT_TRUE(llvm::StringRef(path.GetPath()).ends_with("/usr/share/lldb"))
+      << "Unexpected path: " << path.GetPath();
+}

--- a/lldb/unittests/Utility/FileSpecListTest.cpp
+++ b/lldb/unittests/Utility/FileSpecListTest.cpp
@@ -301,6 +301,58 @@ TEST(SupportFileListTest, DifferentBasename) {
   EXPECT_EQ(ret, UINT32_MAX);
 }
 
+TEST(FileSpecListTest, AppendFileSpecList) {
+  // Test appending a FileSpecList to an existing FileSpecList.
+
+  FileSpecList list_a;
+  list_a.Append(PosixSpec("/a/foo.h"));
+  list_a.Append(PosixSpec("/a/bar.h"));
+
+  FileSpecList list_b;
+  list_b.Append(PosixSpec("/b/baz.h"));
+  list_b.Append(PosixSpec("/b/qux.h"));
+
+  // Duplicate gets appended too.
+  list_b.Append(PosixSpec("/a/foo.h"));
+
+  list_a.Append(list_b);
+  ASSERT_EQ(list_a.GetSize(), 5u);
+  EXPECT_EQ(list_a.GetFileSpecAtIndex(0), PosixSpec("/a/foo.h"));
+  EXPECT_EQ(list_a.GetFileSpecAtIndex(1), PosixSpec("/a/bar.h"));
+  EXPECT_EQ(list_a.GetFileSpecAtIndex(2), PosixSpec("/b/baz.h"));
+  EXPECT_EQ(list_a.GetFileSpecAtIndex(3), PosixSpec("/b/qux.h"));
+  EXPECT_EQ(list_a.GetFileSpecAtIndex(4), PosixSpec("/a/foo.h"));
+}
+
+TEST(FileSpecListTest, AppendEmptyFileSpecList) {
+  // Test appending an empty FileSpecList to an existing FileSpecList.
+
+  FileSpecList list_a;
+  list_a.Append(PosixSpec("/a/foo.h"));
+
+  FileSpecList empty;
+  list_a.Append(empty);
+
+  ASSERT_EQ(list_a.GetSize(), 1u);
+  EXPECT_EQ(list_a.GetFileSpecAtIndex(0), PosixSpec("/a/foo.h"));
+}
+
+TEST(FileSpecListTest, AppendToEmptyFileSpecList) {
+  // Test appending to an empty FileSpecList to an existing FileSpecList.
+
+  FileSpecList list_a;
+  FileSpecList list_b;
+  list_b.Append(list_a);
+
+  ASSERT_EQ(list_b.GetSize(), 0u);
+
+  list_a.Append(PosixSpec("/a/foo.h"));
+  list_b.Append(list_a);
+
+  ASSERT_EQ(list_b.GetSize(), 1u);
+  EXPECT_EQ(list_b.GetFileSpecAtIndex(0), PosixSpec("/a/foo.h"));
+}
+
 // No prefixes are configured.
 // The support file and the breakpoint file are different.
 // Should find it incompatible.


### PR DESCRIPTION
This cherry-picks various commits to auto-load scripting resources in lldb from a safe location (SDK):
- https://github.com/llvm/llvm-project/pull/191446
- https://github.com/llvm/llvm-project/pull/192703
- https://github.com/llvm/llvm-project/pull/191454
- https://github.com/llvm/llvm-project/pull/192934