### PR TITLE
clang: preserve module metadata in CAS module builds

### DIFF
--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -102,7 +102,8 @@ private:
   Expected<cas::ObjectRef>
   getObjectForFileNonCached(FileManager &FM, const SrcMgr::FileInfo &FI);
   Expected<cas::ObjectRef> getObjectForBuffer(const SrcMgr::FileInfo &FI);
-  Expected<cas::ObjectRef> addToFileList(FileManager &FM, FileEntryRef FE);
+  Expected<cas::ObjectRef> addToFileList(FileManager &FM, FileEntryRef FE,
+                                         bool UseRequestedName = false);
   Expected<cas::IncludeTree> getCASTreeForFileIncludes(FilePPState &&PPState);
   Expected<cas::IncludeTree::File> createIncludeFile(StringRef Filename,
                                                      cas::ObjectRef Contents);
@@ -759,7 +760,8 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
           M, ScanInstance.getLangOpts().APINotesModules,
           ScanInstance.getAPINotesOpts().ModuleSearchPaths);
       for (auto File : Notes) {
-        if (auto FileRef = addToFileList(ScanInstance.getFileManager(), File);
+        if (auto FileRef = addToFileList(ScanInstance.getFileManager(), File,
+                                         /*UseRequestedName=*/true);
             !FileRef)
           return FileRef.takeError();
         if (auto Buf =
@@ -896,9 +898,11 @@ IncludeTreeBuilder::getObjectForBuffer(const SrcMgr::FileInfo &FI) {
 }
 
 Expected<cas::ObjectRef> IncludeTreeBuilder::addToFileList(FileManager &FM,
-                                                           FileEntryRef FE) {
+                                                           FileEntryRef FE,
+                                                           bool UseRequestedName) {
   SmallString<128> PathStorage;
-  StringRef Filename = FE.getName();
+  StringRef Filename =
+      UseRequestedName ? FE.getNameAsRequested() : FE.getName();
   // Apply -working-directory to relative paths. This option causes filesystem
   // lookups to use absolute paths, so make paths in the include-tree filesystem
   // absolute to match.

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -839,6 +839,14 @@ static Module *prepareToBuildModule(CompilerInstance &CI,
   if (auto CacheKey = CI.getCompileJobCacheKey())
     M->setModuleCacheKey(CacheKey->toString());
 
+  StringRef OriginalModuleMap = CI.getFrontendOpts().OriginalModuleMap;
+  if (!OriginalModuleMap.empty()) {
+    M->PresumedModuleMapFile = OriginalModuleMap.str();
+    StringRef ModuleDirectory = llvm::sys::path::parent_path(OriginalModuleMap);
+    if (auto Dir = CI.getFileManager().getOptionalDirectoryRef(ModuleDirectory))
+      M->Directory = *Dir;
+  }
+
   // If we're being run from the command-line, the module build stack will not
   // have been filled in yet, so complete it now in order to allow us to detect
   // module cycles.

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -3464,6 +3464,7 @@ ASTReader::ReadControlBlock(ModuleFile &F,
       }
 
       if (!ImportedCASKey.empty()) {
+        ImportedFile = llvm::sys::path::filename(ImportedFile).str();
         if (!Listener) {
           Diag(diag::err_ast_file_not_found)
               << moduleKindForDiagnostic(ImportedKind) << ImportedFile << true

--- a/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
@@ -3,6 +3,7 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed "s|DIR|%/t|g" %t/vfs.yaml.template > %t/vfs.yaml
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
 // RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
@@ -29,11 +30,12 @@
 // WITH-APINOTES-NEXT:   - Name: top
 // WITH-APINOTES-NEXT:     Availability: none
 // WITH-APINOTES-NEXT:     AvailabilityMsg: "don't use this"
-// WITH-APINOTES: Top.apinotes
+// WITH-APINOTES-NOT: external{{[/\\]}}Top.apinotes
+// WITH-APINOTES: {{[/\\]}}Top.apinotes
 // WITHOUT-APINOTES-NOT: APINotes:
 
 // Ensure subsequent builds use the API notes captured in CAS.
-// RUN: rm %t/Top.apinotes
+// RUN: rm %t/external/Top.apinotes
 
 // Build the include-tree commands
 // RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
@@ -62,10 +64,28 @@
 [{
   "file": "DIR/tu.m",
   "directory": "DIR",
-  "command": "clang -fsyntax-only DIR/tu.m -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -fapinotes-modules -iapinotes-modules DIR"
+  "command": "clang -fsyntax-only DIR/tu.m -I DIR -ivfsoverlay DIR/vfs.yaml -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -fapinotes-modules -iapinotes-modules DIR"
 }]
 
-//--- module.modulemap
+//--- vfs.yaml.template
+{
+  "version": 0,
+  "use-external-names": true,
+  "roots": [
+    {
+      "name": "DIR/module.modulemap",
+      "type": "file",
+      "external-contents": "DIR/external/module.modulemap"
+    },
+    {
+      "name": "DIR/Top.apinotes",
+      "type": "file",
+      "external-contents": "DIR/external/Top.apinotes"
+    }
+  ]
+}
+
+//--- external/module.modulemap
 module Top { header "Top.h" export *}
 module Left { header "Left.h" export *}
 
@@ -89,7 +109,7 @@ void tu(void) {
 }
 // expected-note@Top.h:5{{'top' has been explicitly marked unavailable here}}
 
-//--- Top.apinotes
+//--- external/Top.apinotes
 Name: Top
 Functions:
   - Name: top

--- a/clang/test/ClangScanDeps/modules-include-tree-cas-import-path.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-cas-import-path.c
@@ -1,0 +1,89 @@
+// REQUIRES: ondisk_cas
+// REQUIRES: x86-registered-target
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" -e "s|CLANG|%/clang|g" %t/cdb.json.template > %t/cdb.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full \
+// RUN:   -mode preprocess-dependency-directives -optimize-args=none > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name Base > %t/Base.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Left > %t/Left.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Right > %t/Right.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// Build Base into CAS using the scanner-produced include-tree command.
+// RUN: %clang @%t/Base.rsp 2>&1 | FileCheck %s
+
+// Build two explicit modules from the filesystem. Both recover Base from the
+// same CAS key, but expose it at a path relative to their own module directory.
+// RUN: sed -E -e 's| "-fcas-include-tree" "[^"]+"||' \
+// RUN:   -e 's| "-fcache-compile-job"||' \
+// RUN:   -e 's|"-fmodule-file=Base=Base-[^"]*\.pcm"|"-fmodule-file=%/t/Left/Base.pcm"|' \
+// RUN:   -e 's|"Base-[^"]*\.pcm"|"%/t/Left/Base.pcm"|g' \
+// RUN:   -e 's|"-o" "[^"]*"|"-o" "%/t/Left.pcm"|' \
+// RUN:   %t/Left.rsp > %t/Left.fs.rsp
+// RUN: echo '"%/t/Left/module.modulemap"' >> %t/Left.fs.rsp
+// RUN: sed -E -e 's| "-fcas-include-tree" "[^"]+"||' \
+// RUN:   -e 's| "-fcache-compile-job"||' \
+// RUN:   -e 's|"-fmodule-file=Base=Base-[^"]*\.pcm"|"-fmodule-file=%/t/Right/Base.pcm"|' \
+// RUN:   -e 's|"Base-[^"]*\.pcm"|"%/t/Right/Base.pcm"|g' \
+// RUN:   -e 's|"-o" "[^"]*"|"-o" "%/t/Right.pcm"|' \
+// RUN:   %t/Right.rsp > %t/Right.fs.rsp
+// RUN: echo '"%/t/Right/module.modulemap"' >> %t/Right.fs.rsp
+// RUN: %clang @%t/Left.fs.rsp
+// RUN: %clang @%t/Right.fs.rsp
+
+// Load both explicit modules from the filesystem. Their shared dependency is
+// available only through its direct CAS ID. It must be loaded as Base.pcm both
+// times, rather than relative to the two importing module directories.
+// RUN: sed -E -e 's| "-fcas-include-tree" "[^"]+"||' \
+// RUN:   -e 's| "-fcache-compile-job"||' \
+// RUN:   -e 's| "-fmodule-file-cache-key" "[^"]+" "[^"]+"||g' \
+// RUN:   -e 's| "-fmodule-file=Left=[^"]+"||g' \
+// RUN:   -e 's| "-fmodule-file=Right=[^"]+"||g' \
+// RUN:   %t/tu.rsp > %t/tu.fs.rsp
+// RUN: echo '"-fmodule-file=%/t/Left.pcm" "-fmodule-file=%/t/Right.pcm" "%/t/tu.c"' >> %t/tu.fs.rsp
+// RUN: %clang @%t/tu.fs.rsp -verify
+
+// CHECK: compile job cache miss
+
+//--- cdb.json.template
++[{
+  "file": "DIR/tu.c",
+  "directory": "DIR",
+  "command": "CLANG -fsyntax-only DIR/tu.c -I DIR/Base -I DIR/Left -I DIR/Right -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache"
+}]
+
+//--- Base/module.modulemap
+module Base { header "Base.h" export * }
+
+//--- Base/Base.h
+void base(void);
+
+//--- Left/module.modulemap
+module Left { header "Left.h" export * }
+
+//--- Left/Left.h
+#pragma clang module import Base
+void left(void);
+
+//--- Right/module.modulemap
+module Right { header "Right.h" export * }
+
+//--- Right/Right.h
+#pragma clang module import Base
+void right(void);
+
+//--- tu.c
+// expected-no-diagnostics
+#pragma clang module import Left
+#pragma clang module import Right
+
+void tu(void) {
+  base();
+  left();
+  right();
+}


### PR DESCRIPTION
Include API notes in the include-tree file list using their requested paths so VFS-mapped module layouts remain available during CAS replay.

When reconstructing a module from an include tree, restore its presumed module-map path and directory from OriginalModuleMap. This allows lazy API-notes lookups to resolve the notes through the attached CAS filesystem without Swift-specific plumbing.

CAS-backed imported modules are identified by an action key or object ID, not by their reconstructed filesystem location. Materialize these imports under their canonical filename so that a PCM imported through modules with different base directories retains a single identity.