### PR TITLE
[lldb][python] Add the package dir to the DLL search path on Windows

### DIFF
--- a/lldb/bindings/python/python.swig
+++ b/lldb/bindings/python/python.swig
@@ -55,6 +55,11 @@ except ImportError:
     # is still constructing the lldb module itself.
     # Simply importing anything using `from . import` constitutes
     # a cyclic importing.
+    import os
+    # Since Python 3.8 the loader no longer searches PATH for the DLLs the
+    # extension links against, which are staged next to this file.
+    if hasattr(os, 'add_dll_directory'):
+        os.add_dll_directory(os.path.dirname(os.path.abspath(__file__)))
     from .native import $module"
 %enddef
 

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -44,6 +44,11 @@ except ImportError:
     # is still constructing the lldb module itself.
     # Simply importing anything using `from . import` constitutes
     # a cyclic importing.
+    import os
+    # Since Python 3.8 the loader no longer searches PATH for the DLLs the
+    # extension links against, which are staged next to this file.
+    if hasattr(os, 'add_dll_directory'):
+        os.add_dll_directory(os.path.dirname(os.path.abspath(__file__)))
     from .native import _lldb
 
 import builtins as __builtin__


### PR DESCRIPTION
`_lldb.pyd` is staged in `site-packages/lldb/native/`, but the DLLs it links against (`liblldb`'s dependencies, the Swift runtime, ...) are staged one level up in `site-packages/lldb/`. Since Python 3.8 the loader no longer searches `PATH` for an extension module's dependencies, so `import lldb` fails:

```
File "site-packages/lldb/__init__.py", line 47, in <module>
    from .native import _lldb
ImportError: DLL load failed while importing _lldb: The specified module could not be found.
```

On Windows this makes the whole API test suite unrunnable - every test errors out in `dotest.py` at `import lldb`.

Register the package directory with `os.add_dll_directory()` before importing the extension. `static-binding/lldb.py` is updated to match, since that is what ships when `LLDB_USE_STATIC_BINDINGS=YES`.