### PR TITLE
[lldb][test] Accept the non-Darwin test build dir in the clean rule guard

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -737,7 +737,7 @@ include $(wildcard $(PREREQS) $(DYLIB_PREREQS))
 dsym:	$(DSYM)
 all:	$(EXE) $(DSYM)
 clean::
-ifeq "$(findstring lldb-test-build.noindex, $(BUILDDIR))" ""
+ifeq "$(findstring lldb-test-build, $(BUILDDIR))" ""
 	$(error Trying to invoke the clean rule, but not using the default build tree layout)
 else
 	$(call RM_RF,$(wildcard $(BUILDDIR)/*))


### PR DESCRIPTION
`b6f0fb6c2423` (#197237) dropped the `.noindex` suffix from the test build directory on non-Darwin, but the guard on the `clean` rule still looks for `lldb-test-build.noindex`, so every test that invokes it fails off Darwin:

```
Makefile.rules:741: *** Trying to invoke the clean rule, but not using the default build tree layout.  Stop.
```

Match `lldb-test-build` instead, which covers both layouts and keeps the guard's intent of not letting the rule loose on an arbitrary directory.