### PR TITLE
[lldb] Fall back to the module's SDK path when the host has no Xcode SDK

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2742,6 +2742,11 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
                    serialized_sdk_path.str().c_str());
 
       std::string sdk_path = GetSDKPathFromDebugInfo(m_description, module);
+      // The host SDK lookup only knows about Xcode SDKs; fall back to the path
+      // recorded in the module.
+      if (!FileSystem::Instance().Exists(sdk_path) &&
+          FileSystem::Instance().Exists(serialized_sdk_path))
+        sdk_path = serialized_sdk_path.str();
       if (FileSystem::Instance().Exists(sdk_path)) {
         // Note that this is not final. InitializeSearchPathOptions()
         // will set the SDK path based on the triple if this fails.


### PR DESCRIPTION
`DeserializeAllCompilerFlags` reads the SDK path out of the serialized Swift AST and immediately clears it, expecting `GetSDKPathFromDebugInfo` to deduce an equivalent path later. That deduction goes through `HostInfo::GetSDKRoot`, which only knows how to resolve Xcode SDKs, so on Windows it always fails:

```
SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetSDKPath() -- Error while searching for SDK (XcodeSDK: )
error: Error while searching for SDK: HostInfoError
SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   SDK path :
```

`SwiftASTContext` then runs with no SDK path at all, and expression evaluation fails to build the Clang importer for anything that needs the SDK's module maps:

```
error: failed to create ClangImporter
Could not import Swift modules for translation unit: failed to get module "Swift" from AST context:
error: missing required module 'SwiftShims'
```

Use the path recorded in the module when the host lookup produces nothing and that path exists. This only takes effect when the host lookup already failed, so Darwin behaviour is unchanged.

Fixes 18 tests in the lldb Swift API suite on Windows (`clangimporter/*`, `cxx_interop/forward/*`, `dwarfimporter/*`, `c_type_ivar`, `union`, `optional_cstruct`).