### PR TITLE
[Cherry-pick into next] [lldb][test] Use lldbutil launch helpers in Swift API tests (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -14,7 +14,6 @@ import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
-import os
 
 class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
     @requireNotEmbeddedSwift
@@ -24,28 +23,14 @@ class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
     @swiftTest
     def test(self):
         self.build()
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target.
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints.
-        foo_breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here', lldb.SBFileSpec('Foo.swift'))
-        bar_breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here', lldb.SBFileSpec('Bar.swift'))
-        self.assertTrue(foo_breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
-        self.assertTrue(bar_breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
-
-        # Launch.
-        process = target.LaunchSimple(None, None, os.getcwd())
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('Foo.swift'))
 
         # This test tests that the search paths from all swiftmodules
         # that are part of the main binary are honored.
         self.expect("fr var foo", "expected result", substrs=["23"])
         self.expect("expression foo", "expected result", substrs=["$R0", "i", "23"])
-        process.Continue()
+        lldbutil.continue_to_source_breakpoint(
+            self, process, 'break here', lldb.SBFileSpec('Bar.swift'))
         self.expect("fr var bar", "expected result", substrs=["42"])
         self.expect("expression bar", "expected result", substrs=["j", "42"])

--- a/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
@@ -16,7 +16,6 @@ import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
-import os
 
 
 class TestExpressionErrors(TestBase):
@@ -66,32 +65,9 @@ class TestExpressionErrors(TestBase):
 
     def do_test(self):
         """Tests that swift expressions resolve scoped variables correctly"""
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.target = target
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        global_scope_bkpt = target.BreakpointCreateBySourceRegex(
-            'Set a breakpoint here to run expressions', self.main_source_spec)
-        self.assertTrue(
-            global_scope_bkpt.GetNumLocations() > 0,
-            VALID_BREAKPOINT)
-
-        # Launch the process, and do not stop at the entry point.
-        process = target.LaunchSimple(None, None, os.getcwd())
-        self.process = process
-
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Frame #0 should be at our breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            process, global_scope_bkpt)
-
-        self.assertTrue(len(threads) == 1)
+        self.target, self.process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, 'Set a breakpoint here to run expressions',
+            self.main_source_spec)
 
         options = lldb.SBExpressionOptions()
         options.SetFetchDynamicValue(lldb.eDynamicCanRunTarget)

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -35,29 +35,8 @@ class TestSwiftFixIts(TestBase):
 
     def do_test(self):
         """Tests that we can break and display simple types"""
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here to test fixits', self.main_source_spec)
-        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
-
-        # Launch the process, and do not stop at the entry point.
-        self.process = target.LaunchSimple(None, None, os.getcwd())
-
-        self.assertTrue(self.process, PROCESS_IS_VALID)
-
-        # Frame #0 should be at our breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            self.process, breakpoint)
-
-        self.assertTrue(len(threads) == 1)
-        self.thread = threads[0]
+        _, self.process, self.thread, _ = lldbutil.run_to_source_breakpoint(
+            self, 'break here to test fixits', self.main_source_spec)
 
         frame = self.thread.frames[0]
 

--- a/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
+++ b/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
@@ -16,7 +16,6 @@ import lldb
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
-import os
 
 
 class TestSwiftInstancePointerSetSP(lldbtest.TestBase):
@@ -37,28 +36,8 @@ class TestSwiftInstancePointerSetSP(lldbtest.TestBase):
 
     def do_test(self):
         """Test that we correctly track instance pointers in ValueObjectPrinter"""
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, lldbtest.VALID_TARGET)
-
-        # Set the breakpoints
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here', self.main_source_spec)
-        self.assertTrue(
-            breakpoint.GetNumLocations() > 0,
-            lldbtest.VALID_BREAKPOINT)
-
-        # Launch the process, and do not stop at the entry point.
-        process = target.LaunchSimple(None, None, os.getcwd())
-
-        self.assertTrue(process, lldbtest.PROCESS_IS_VALID)
-
-        # Frame #0 should be at our breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            process, breakpoint)
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', self.main_source_spec)
 
         self.expect(
             "frame variable -d run -- o",

--- a/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -16,7 +16,6 @@ import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
-import os
 
 
 class TestSwiftOneCaseEnum(TestBase):
@@ -34,26 +33,8 @@ class TestSwiftOneCaseEnum(TestBase):
 
     def do_test(self):
         """Test that an enum with only one case does not crash LLDB"""
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            'Set breakpoint here', self.main_source_spec)
-        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
-
-        # Launch the process, and do not stop at the entry point.
-        process = target.LaunchSimple(None, None, os.getcwd())
-
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Frame #0 should be at our breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            process, breakpoint)
+        lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', self.main_source_spec)
 
         maybeEvent = self.frame().FindVariable("maybeEvent")
         event = self.frame().FindVariable("event")

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -16,7 +16,6 @@ import lldb
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
-import os
 import platform
 
 class TestSwiftStepping(lldbtest.TestBase):
@@ -74,30 +73,9 @@ class TestSwiftStepping(lldbtest.TestBase):
 
     def do_test(self):
         """Tests that we can step reliably in swift code."""
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, 'Stop here first in main', self.main_source_spec)
 
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, lldbtest.VALID_TARGET)
-
-        # Set the breakpoints
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            'Stop here first in main', self.main_source_spec)
-        self.assertTrue(
-            breakpoint.GetNumLocations() > 0, lldbtest.VALID_BREAKPOINT)
-
-        # Launch the process, and do not stop at the entry point.
-        process = target.LaunchSimple(None, None, os.getcwd())
-
-        self.assertTrue(process, lldbtest.PROCESS_IS_VALID)
-
-        # Frame #0 should be at our breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            process, breakpoint)
-
-        self.assertTrue(len(threads) == 1)
-        thread = threads[0]
         frame = thread.frames[0]
         self.assertTrue(frame, "Frame 0 is valid.")
 

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -69,15 +69,8 @@ class TestSwiftStructChangeRerun(TestBase):
         shutil.copyfile("main2.swift", copied_main_swift)
         self.build()
 
-        # Launch the process, and do not stop at the entry point.
-        process = target.LaunchSimple(None, None, os.getcwd())
-
-        self.assertTrue(process, PROCESS_IS_VALID)
-        # Frame #0 should be at our breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            process, breakpoint)
-
-        self.assertTrue(len(threads) == 1)
+        # Relaunch the rebuilt binary and run to the same breakpoint.
+        lldbutil.run_to_breakpoint_do_run(self, target, breakpoint)
 
         var_a = self.frame().EvaluateExpression("a")
         var_a_a = var_a.GetChildMemberWithName("a")


### PR DESCRIPTION
```
commit 42ce917467dfa739ff1341be606a812897dd8ef1
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Sep 9 12:54:09 2026 -0700

    [lldb][test] Use lldbutil launch helpers in Swift API tests (NFC)
    
    Replace hand-rolled CreateTarget/BreakpointCreateBySourceRegex/
    LaunchSimple sequences with run_to_source_breakpoint, and the relaunch
    after rebuild in TestSwiftStructChangeRerun with
    run_to_breakpoint_do_run.
    
    This improves error handling and flexibility when testing on remote platforms.
    
    Assisted-by: Claude
```
