### PR TITLE
[lldb][test] Skip the embedded Swift variants of the generic tests on Windows

### DIFF
--- a/lldb/test/API/lang/swift/generic_error/TestGenericError.py
+++ b/lldb/test/API/lang/swift/generic_error/TestGenericError.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipEmbeddedSwiftOnWindows])


### PR DESCRIPTION
The swiftembed variants of `generic_error`, `generic_error_tuple` and `generic_existentials` cannot build on Windows: the SDK ships no Embedded Swift stdlib, so the frontend rejects the module with `"mixes Embedded Swift and non-embedded Swift"`. 
Add `skipEmbeddedSwiftOnWindows`, which 139 other tests already use for exactly this. The `clang_swift` and `noclang_swift` variants keep running, so no coverage is lost.