### PR TITLE
[lldb] Give NSNotification.Name a summary off Darwin

### DIFF
--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -75,8 +75,11 @@ bool lldb_private::formatters::swift::Date_SummaryProvider(
 bool lldb_private::formatters::swift::NotificationName_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
   static ConstString g__rawValue("_rawValue");
+  static ConstString g_rawValue("rawValue");
 
   ValueObjectSP underlying_name_sp(valobj.GetChildAtNamePath({g__rawValue}));
+  if (!underlying_name_sp)
+    underlying_name_sp = valobj.GetChildAtNamePath({g_rawValue});
 
   if (!underlying_name_sp)
     return false;

--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -78,6 +78,11 @@ bool lldb_private::formatters::swift::NotificationName_SummaryProvider(
   static ConstString g_rawValue("rawValue");
 
   ValueObjectSP underlying_name_sp(valobj.GetChildAtNamePath({g__rawValue}));
+  // On Darwin, NSNotification.Name is imported from Objective-C and uses the
+  // underscored `_rawValue` property. On non-Darwin platforms,
+  // Notification.Name is a native Swift struct declared in
+  // swift-corelibs-foundation, which uses the non-underscored `rawValue`
+  // property instead.
   if (!underlying_name_sp)
     underlying_name_sp = valobj.GetChildAtNamePath({g_rawValue});
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -717,6 +717,12 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "Notification.Name summary provider",
       ConstString("Foundation.Notification.Name"),
       TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
+  lldb_private::formatters::AddCXXSummary(
+      swift_category_sp,
+      lldb_private::formatters::swift::NotificationName_SummaryProvider,
+      "Notification.Name summary provider",
+      ConstString("Foundation.NSNotification.Name"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
 
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::URL_SummaryProvider,


### PR DESCRIPTION
`Notification.Name` is a typealias for `NSNotification.Name`, which off Darwin resolves to swift-corelibs-foundation's Swift struct. A type name the summary provider was never registered for it, so `GetSummary()` returned `null`.

Register it for `Foundation.NSNotification.Name`, and fall back to `rawValue` since the Swift declaration spells the stored property without the leading underscore the imported one uses.

Fixes `TestSwiftFoundationTypeNotification` and applies to any corelibs-foundation platform.