### PR TITLE
[Cherry-pick into next] Skip test on Windows

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules_part02.py
@@ -17,6 +17,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
     # imported.
     @skipIf(setting=("symbols.use-swift-clangimporter", "false"),
             bugnumber="rdar://118337109")
+    @skipIfWindows # rdar://186975412, FoundationEssentials.__DataStorage.init symbol not found
     def test_import(self):
         """Test an implicit import inside an explicit build"""
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")


### PR DESCRIPTION
```
commit e1870f426fc4a8c2483e71a8f986d7ede65bc6cb
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Sep 10 10:12:45 2026 -0700

    Skip test on Windows
    
    Many but not all CI runs fail with a symbol lookup error during expression evaluation: FoundationEssentials.__DataStorage.init
    
    rdar://186975412
```
