### PR TITLE
[BoundsSafety] Unify ParseLexedAttributeTokens

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1532,11 +1532,11 @@ private:
                                ParsedAttributes &OutAttrs);
 
   /// Parse cached tokens for a late-parsed attribute and return the parsed
-  /// attributes. Shared implementation used by both ParseLexedCAttribute and
+  /// attributes. Shared implementation used by both ParseLexedAttribute and
   /// ParseLexedTypeAttribute.
-  ParsedAttributes ParseLexedCAttributeTokens(LateParsedAttribute &LA,
-                                              // TO_UPSTREAM(BoundsSafety)
-                                              bool EnterScope);
+  ParsedAttributes ParseLexedAttributeTokens(LateParsedAttribute &LPA,
+                                             // TO_UPSTREAM(BoundsSafety)
+                                             bool EnterScope);
 
   /// Helper function to move LateParsedTypeAttribute pointers from one list
   /// to another. Filters type attributes from \p From and appends them to \p

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -718,22 +718,6 @@ void Parser::ParseLexedAttributeList(LateParsedAttrList &LAs, Decl *D,
 void Parser::ParseLexedAttribute(LateParsedAttribute &LPA, bool EnterScope,
                                  bool OnDefinition,
                                  ParsedAttributes *OutAttrs) {
-  // Create a fake EOF so that attribute parsing won't go off the end of the
-  // attribute.
-  Token AttrEnd;
-  AttrEnd.startToken();
-  AttrEnd.setKind(tok::eof);
-  AttrEnd.setLocation(Tok.getLocation());
-  AttrEnd.setEofData(LPA.Toks.data());
-  LPA.Toks.push_back(AttrEnd);
-
-  // Append the current token at the end of the new token stream so that it
-  // doesn't get lost.
-  LPA.Toks.push_back(Tok);
-  PP.EnterTokenStream(LPA.Toks, true, /*IsReinject=*/true);
-  // Consume the previously pushed token.
-  ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
-
   ParsedAttributes Attrs(AttrFactory);
 
   if (LPA.Decls.size() > 0) {
@@ -760,52 +744,23 @@ void Parser::ParseLexedAttribute(LateParsedAttribute &LPA, bool EnterScope,
       Actions.ActOnReenterFunctionContext(Actions.CurScope, D);
     }
 
-    ParseGNUAttributeArgs(&LPA.AttrName, LPA.AttrNameLoc, Attrs,
-                          /*EndLoc=*/nullptr, /*ScopeName=*/nullptr,
-                          SourceLocation(), ParsedAttr::Form::GNU(),
-                          /*D=*/nullptr,
-                          // TO_UPSTREAM(BoundsSafety)
-                          LPA.NestedTypeLevel);
+    ParsedAttributes Parsed =
+        ParseLexedAttributeTokens(LPA, /*EnterScope=*/false);
+    Attrs.takeAllAppendingFrom(Parsed);
 
     if (HasFuncScope)
       Actions.ActOnExitFunctionContext();
-  } else if (OutAttrs) {
-    // A late C attribute may be parsed without a decl, in which case the
-    // parsed attribute is collected into OutAttrs.
-    ParseGNUAttributeArgs(&LPA.AttrName, LPA.AttrNameLoc, Attrs,
-                          /*EndLoc=*/nullptr, /*ScopeName=*/nullptr,
-                          SourceLocation(), ParsedAttr::Form::GNU(),
-                          /*D=*/nullptr,
-                          // TO_UPSTREAM(BoundsSafety)
-                          LPA.NestedTypeLevel);
   } else {
-    Diag(Tok, diag::warn_attribute_no_decl) << LPA.AttrName.getName();
+    Diag(LPA.AttrNameLoc, diag::warn_attribute_no_decl)
+        << LPA.AttrName.getName();
   }
 
   if (OnDefinition && !Attrs.empty() && !Attrs.begin()->isCXX11Attribute() &&
       Attrs.begin()->isKnownToGCC())
     Diag(Tok, diag::warn_attribute_on_function_definition) << &LPA.AttrName;
 
-  /* TO_UPSTREAM(BoundsSafety) ON */
-  if (LPA.MacroII) {
-    const auto &SM = PP.getSourceManager();
-    CharSourceRange ExpansionRange = SM.getExpansionRange(LPA.AttrNameLoc);
-    for (unsigned i = 0; i < Attrs.size(); ++i)
-      Attrs[i].setMacroIdentifier(LPA.MacroII, ExpansionRange.getBegin(),
-                                  SM.isInSystemMacro(LPA.AttrNameLoc));
-  }
-  /* TO_UPSTREAM(BoundsSafety) OFF */
-
   for (auto *D : LPA.Decls)
     Actions.ActOnFinishDelayedAttribute(getCurScope(), D, Attrs);
-
-  // Due to a parsing error, we either went over the cached tokens or
-  // there are still cached tokens left, so we skip the leftover tokens.
-  while (Tok.isNot(tok::eof))
-    ConsumeAnyToken();
-
-  if (Tok.is(tok::eof) && Tok.getEofData() == AttrEnd.getEofData())
-    ConsumeAnyToken();
 
   if (OutAttrs)
     OutAttrs->takeAllAppendingFrom(Attrs);

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -5055,34 +5055,32 @@ void Parser::ParseStructDeclaration(
   }
 }
 
-ParsedAttributes Parser::ParseLexedCAttributeTokens(LateParsedAttribute &LA,
-                                                    // TO_UPSTREAM(BoundsSafety)
-                                                    bool EnterScope) {
+ParsedAttributes Parser::ParseLexedAttributeTokens(LateParsedAttribute &LPA,
+                                                   // TO_UPSTREAM(BoundsSafety)
+                                                   bool EnterScope) {
   // Create a fake EOF so that attribute parsing won't go off the end of the
   // attribute.
   Token AttrEnd;
   AttrEnd.startToken();
   AttrEnd.setKind(tok::eof);
   AttrEnd.setLocation(Tok.getLocation());
-  AttrEnd.setEofData(LA.Toks.data());
-  LA.Toks.push_back(AttrEnd);
+  AttrEnd.setEofData(LPA.Toks.data());
+  LPA.Toks.push_back(AttrEnd);
 
   // Append the current token at the end of the new token stream so that it
   // doesn't get lost.
-  LA.Toks.push_back(Tok);
-  PP.EnterTokenStream(LA.Toks, /*DisableMacroExpansion=*/true,
+  LPA.Toks.push_back(Tok);
+  PP.EnterTokenStream(LPA.Toks, /*DisableMacroExpansion=*/true,
                       /*IsReinject=*/true);
+
   // Drop the current token and bring the first cached one. It's the same token
   // as when we entered this function.
   ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
 
   ParsedAttributes Attrs(AttrFactory);
 
-  assert(LA.Decls.size() <= 1 &&
-         "late field attribute expects to have at most one declaration.");
-
   /* TO_UPSTREAM(BoundsSafety) ON */
-  Decl *D = LA.Decls.empty() ? nullptr : LA.Decls[0];
+  Decl *D = LPA.Decls.empty() ? nullptr : LPA.Decls[0];
 
   // If the Decl is on a function, add function parameters to the scope.
   {
@@ -5098,9 +5096,9 @@ ParsedAttributes Parser::ParseLexedCAttributeTokens(LateParsedAttribute &LA,
     // Dispatch based on the attribute and parse it
     /* TO_UPSTREAM(BoundsSafety) ON */
     // NestedTypeLevel is not passed in upstream
-    ParseGNUAttributeArgs(&LA.AttrName, LA.AttrNameLoc, Attrs, nullptr, nullptr,
-                          SourceLocation(), ParsedAttr::Form::GNU(), nullptr,
-                          LA.NestedTypeLevel);
+    ParseGNUAttributeArgs(&LPA.AttrName, LPA.AttrNameLoc, Attrs, nullptr,
+                          nullptr, SourceLocation(), ParsedAttr::Form::GNU(),
+                          nullptr, LPA.NestedTypeLevel);
     /* TO_UPSTREAM(BoundsSafety) OFF */
 
     /* TO_UPSTREAM(BoundsSafety) ON */
@@ -5111,12 +5109,12 @@ ParsedAttributes Parser::ParseLexedCAttributeTokens(LateParsedAttribute &LA,
   }
 
   /* TO_UPSTREAM(BoundsSafety) ON */
-  if (LA.MacroII) {
+  if (LPA.MacroII) {
     const auto &SM = PP.getSourceManager();
-    CharSourceRange ExpansionRange = SM.getExpansionRange(LA.AttrNameLoc);
+    CharSourceRange ExpansionRange = SM.getExpansionRange(LPA.AttrNameLoc);
     for (unsigned i = 0; i < Attrs.size(); ++i)
-      Attrs[i].setMacroIdentifier(LA.MacroII, ExpansionRange.getBegin(),
-                                  SM.isInSystemMacro(LA.AttrNameLoc));
+      Attrs[i].setMacroIdentifier(LPA.MacroII, ExpansionRange.getBegin(),
+                                  SM.isInSystemMacro(LPA.AttrNameLoc));
   }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
@@ -5136,7 +5134,10 @@ void Parser::ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
                                      // TO_UPSTREAM(BoundsSafety)
                                      bool EnterScope,
                                      ParsedAttributes &OutAttrs) {
-  ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA, EnterScope);
+  assert(LA.Decls.size() <= 1 &&
+         "late field attribute expects to have at most one declaration.");
+
+  ParsedAttributes Attrs = ParseLexedAttributeTokens(LA, EnterScope);
   OutAttrs.takeAllAppendingFrom(Attrs);
 }
 


### PR DESCRIPTION
Move the replay of a late-parsed attribute's cached tokens into one shared helper.

- Rename `ParseLexedCAttributeTokens` to `ParseLexedAttributeTokens` and call it from
  both `ParseLexedAttribute` and `ParseLexedTypeAttribute`.
- `ParseLexedAttribute` still sets up its own C++ scope (`this`, template and
  function parameters), so it calls the helper with `EnterScope=false`.
- Set the macro identifier only in the helper, dropping the copy in
  `ParseLexedAttribute`.
- Remove the unused `OutAttrs` branch from `ParseLexedAttribute`; no caller passes
  a non-null `OutAttrs`.
- Move the "at most one declaration" assert into `ParseLexedTypeAttribute`, since
  the C++ path can attach one attribute to several declarations.
- Report `warn_attribute_no_decl` at the attribute name.