### PR TITLE
[🍒21.x][TSan][Darwin][Test-only] Fix crash in write-interpose.c test (#222656)

### DIFF
--- a/compiler-rt/test/tsan/Darwin/write-interpose.c
+++ b/compiler-rt/test/tsan/Darwin/write-interpose.c
@@ -32,7 +32,10 @@ struct interpose_substitution {
 static ssize_t my_write(int fd, const void *buf, size_t count) {
   struct os_unfair_lock_s lock = OS_UNFAIR_LOCK_INIT;
   os_unfair_lock_lock(&lock);
-  printf("Interposed write called: fd=%d, count=%zu\n", fd, count);
+  char logbuf[80];
+  int len = snprintf(logbuf, sizeof(logbuf),
+                     "Interposed write called: fd=%d, count=%zu\n", fd, count);
+  write(1, logbuf, len);
   ssize_t res = write(fd, buf, count);
   os_unfair_lock_unlock(&lock);
   return res;


### PR DESCRIPTION
Due to this test running with verbosity turned up, an early 'Report' happened to get caught by the test's write interceptor, and on newer macOS versions the interceptor's call to printf was attempting to allocate before the allocator was initialized - leading to a crash.

This patch instead uses snprintf to a stack allocated buffer in order to avoid allocating in the interceptor.

rdar://184804426
(cherry picked from commit be9584e0dfc480193fa47645b302f630f41fb772)