### PR TITLE
[lldb] Accept duplicate Swift runtime symbols that share an address

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -311,20 +311,21 @@ FindSymbolForSwiftObject(Process &process, RuntimeKind runtime_kind,
 
   SymbolContextList sc_list;
   image->FindSymbolsWithNameAndType(ConstString(object), sym_type, sc_list);
-  if (sc_list.GetSize() != 1)
+  if (sc_list.GetSize() == 0)
     return {};
 
-  SymbolContext SwiftObject_Class;
-  if (!sc_list.GetContextAtIndex(0, SwiftObject_Class))
-    return {};
-  if (!SwiftObject_Class.symbol)
-    return {};
-  lldb::addr_t addr =
-      SwiftObject_Class.symbol->GetAddress().GetLoadAddress(&target);
-  if (addr && addr != LLDB_INVALID_ADDRESS)
-    return addr;
-
-  return {};
+  std::optional<lldb::addr_t> unique_addr;
+  for (const SymbolContext &sc : sc_list) {
+    if (!sc.symbol)
+      return {};
+    lldb::addr_t addr = sc.symbol->GetAddress().GetLoadAddress(&target);
+    if (!addr || addr == LLDB_INVALID_ADDRESS)
+      return {};
+    if (unique_addr && *unique_addr != addr)
+      return {};
+    unique_addr = addr;
+  }
+  return unique_addr;
 }
 
 using CurrentTaskStorageKind = SwiftLanguageRuntime::CurrentTaskStorageKind;


### PR DESCRIPTION
`FindSymbolForSwiftObject` bailed whenever a name matched more than one symbol, so on Windows `_swift_disableExclusivityChecking` was never found: swiftCore.dll's symtab lists it twice (export table entry plus the regular symbol), both at the same address. Exclusivity-check disabling silently stopped working, which breaks expression evaluation that touches exclusive access.

Accept any number of matches as long as every one resolves to the same load address, and keep rejecting genuinely ambiguous names.