### PR TITLE
[clang][APINotes] Do not drop attributes applied after a definition

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3169,6 +3169,17 @@ static void checkNewAttributesAfterDef(Sema &S, Decl *New, const Decl *Old) {
       continue; // regular attr merging will take care of validating this.
     }
 
+    if (NewAttribute->getLocation().isInvalid()) {
+      // An attribute with no source location was not written by the user. API
+      // notes, in particular, are matched against whichever declaration the
+      // compiler reaches, which can be a redeclaration that follows the
+      // definition, possibly in a different module. There is nothing for the
+      // user to correct, and erasing the attribute would silently change what
+      // the annotated API means.
+      ++I;
+      continue;
+    }
+
     if (isa<C11NoReturnAttr>(NewAttribute)) {
       // C's _Noreturn is allowed to be added to a function after it is defined.
       ++I;

--- a/clang/test/APINotes/Inputs/Headers/RedeclAnnotation.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/RedeclAnnotation.apinotes
@@ -1,0 +1,5 @@
+Name: RedeclAnnotation
+Functions:
+- Name: redeclaredAfterDefinition
+  Availability: none
+  AvailabilityMsg: not available

--- a/clang/test/APINotes/Inputs/Headers/RedeclAnnotation.h
+++ b/clang/test/APINotes/Inputs/Headers/RedeclAnnotation.h
@@ -1,0 +1,3 @@
+#include "RedeclDefinition.h"
+
+int redeclaredAfterDefinition(int x);

--- a/clang/test/APINotes/Inputs/Headers/RedeclDefinition.h
+++ b/clang/test/APINotes/Inputs/Headers/RedeclDefinition.h
@@ -1,0 +1,1 @@
+inline int redeclaredAfterDefinition(int x) { return x; }

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -87,3 +87,12 @@ module WhereParametersSema {
   header "WhereParametersSema.h"
   export *
 }
+
+module RedeclDefinition {
+  header "RedeclDefinition.h"
+}
+
+module RedeclAnnotation {
+  header "RedeclAnnotation.h"
+  export *
+}

--- a/clang/test/APINotes/redecl-after-definition.c
+++ b/clang/test/APINotes/redecl-after-definition.c
@@ -1,0 +1,10 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers %s -verify
+
+#include "RedeclDefinition.h"
+#include "RedeclAnnotation.h"
+
+void test(void) {
+  redeclaredAfterDefinition(1); // expected-error{{'redeclaredAfterDefinition' is unavailable: not available}}
+  // expected-note@Inputs/Headers/RedeclAnnotation.h:3{{'redeclaredAfterDefinition' has been explicitly marked unavailable here}}
+}


### PR DESCRIPTION
API notes are matched against whichever declaration the compiler reaches, which can be a redeclaration that follows the definition. When the definition lives in one module and the annotated redeclaration in another, that is exactly what happens: checkNewAttributesAfterDef() warns "attribute declaration must precede definition" and erases the attribute, so the annotation is silently lost.

The warning exists to tell users that an attribute they wrote has no effect. Attributes from API notes are not written in the source, so the warning has nowhere to point and there is nothing for the user to correct. Skip attributes with an invalid location, alongside the existing exceptions.

rdar://186930250