### PR TITLE
[lldb] Add test variants to build directory name

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -823,9 +823,19 @@ class Base(unittest.TestCase):
 
     def getBuildDirBasename(self):
         if self.SHARED_BUILD_TESTCASE:
-            return self.__class__.__module__
+            return self.__class__.__module__ + self._getVariantSuffix()
         else:
             return self.__class__.__module__ + "." + self.testMethodName
+
+    def _getVariantSuffix(self) -> str:
+        """Return a suffix identifying the active build variants."""
+        parts = []
+        if debug_info := self.getDebugInfo():
+            parts.append(debug_info)
+        for variant in _test_variants:
+            if value := self.getVariant(variant.name):
+                parts.append(value)
+        return "." + "_".join(parts) if parts else ""
 
     def getBuildDir(self):
         """Return the full path to the current test."""
@@ -2283,9 +2293,6 @@ class LLDBTestCaseFactory(type):
 
             else:
                 newattrs[attrname] = attrvalue
-
-        if original_testcase.TEST_WITH_PDB_DEBUG_INFO:
-            newattrs["SHARED_BUILD_TESTCASE"] = False
 
         return super(LLDBTestCaseFactory, cls).__new__(cls, name, bases, newattrs)
 

--- a/lldb/test/API/symstore/TestSymStore.py
+++ b/lldb/test/API/symstore/TestSymStore.py
@@ -253,6 +253,10 @@ class SlowHTTPHandler(http.server.BaseHTTPRequestHandler):
 
 class SymStoreTests(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    # Build artifacts can't be shared across test functions because
+    # MockedSymStore moves the built PDB out of the build directory to simulate
+    # it being absent from the normal lookup path.
+    SHARED_BUILD_TESTCASE = False
 
     def build_inferior(self):
         if self.getDebugInfo() != "pdb":


### PR DESCRIPTION
Fix testing with shared build directories to no longer share build directories between build variants.

For example, use a different build directory for dwarf and dsym variants, to prevent one variant's build artifacts from being used by the other.

Assisted-by: claude
(cherry picked from commit 9c809473e1a2c39b3b78e8c155e85d58f302bd79)