### PR TITLE
[Cherry-pick into stable/23.x] lldb: Basic support for Swift `Builtin.Borrow` values. (#12476)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1266,7 +1266,7 @@ llvm::Error SwiftLanguageRuntime::GetObjectDescription(Stream &str,
   if (GetProcess().GetTarget().GetSwiftUseContextFreePrintObject()) {
     if (auto err = PrintObjectViaPointer(str, object, GetProcess())) {
       LLDB_LOG_ERROR(log, std::move(err),
-                     "stringForPrintObject(_:mangledTypeName) failed: {0}");
+                     "stringForPrintObject(_:mangledTypeName:) failed: {0}");
     } else {
       LLDB_LOG(log, "stringForPrintObject(_:mangledTypeName:) succeeded");
       return llvm::Error::success();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -46,6 +46,7 @@
 #include "swift/Demangling/ManglingFlavor.h"
 #include "swift/RemoteInspection/DescriptorFinder.h"
 #include "swift/RemoteInspection/ReflectionContext.h"
+#include "swift/RemoteInspection/TypeLowering.h"
 #include "swift/RemoteInspection/TypeRefBuilder.h"
 #include "swift/Strings.h"
 
@@ -1630,6 +1631,63 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
           return err;
     return success;
   }
+
+  if (auto *bti = llvm::dyn_cast_or_null<swift::reflection::BorrowTypeInfo>(ti)) {
+    if (count_only)
+      return 1;
+    
+    CompilerType rep_type;
+    const char *child_name;
+    
+
+    auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+        m_type.GetMangledTypeName().GetStringRef());
+
+    if (bti->usesValueRepresentation()) {
+      swift::Demangle::Demangler dem;
+      swift::Demangle::NodePointer global =
+          dem.demangleSymbol(m_type.GetMangledTypeName().GetStringRef());
+      using Kind = Node::Kind;
+      auto *dem_target_type = swift_demangle::ChildAtPath(
+          global, {Kind::TypeMangling, Kind::Type, Kind::BuiltinBorrow});
+      if (!dem_target_type || dem_target_type->getNumChildren() != 1)
+        return llvm::createStringError("Expected borrow, but found: " +
+                                       m_type.GetMangledTypeName().GetString());
+      rep_type =
+          ts.RemangleAsType(dem, dem_target_type->getChild(0), flavor);
+      child_name = "targetValue";
+    } else {
+      auto ts =
+          m_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwiftTypeRef>();
+      if (!ts)
+        return llvm::createStringError("no type system");
+      rep_type = ts->GetRawPointerType(flavor);
+      child_name = "targetPointer";
+    }
+
+    auto get_name = [&]() -> std::string { return child_name; };
+    auto get_info = [&]() -> llvm::Expected<ChildInfo> {
+      ChildInfo child;
+      child.byte_size = bti->getSize();
+      child.byte_offset = 0;
+
+      child.bitfield_bit_size = 0;
+      child.bitfield_bit_offset = 0;
+      child.is_base_class = false;
+      child.is_deref_of_parent = false;
+      child.language_flags = 0;
+      return child;
+    };
+
+    if (!visit_only || *visit_only == 0) {
+      if (auto err = visit_callback(rep_type, 0, get_name, get_info)) {
+        return err;
+      }
+    }
+
+    return success;
+  }
+
   if (llvm::dyn_cast_or_null<swift::reflection::BuiltinTypeInfo>(ti)) {
     Flags type_flags(m_type.GetTypeInfo());
     // This might be an enum declared with @objc or @c. They cannot carry

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2413,6 +2413,11 @@ uint32_t TypeSystemSwiftTypeRef::CollectTypeInfo(
     case Node::Kind::SILPackIndirect:
       swift_flags |= eTypeIsPack;
       return swift_flags;
+
+    case Node::Kind::BuiltinBorrow:
+      swift_flags |= eTypeHasChildren;
+      break;
+  
     default:
       break;
     }


### PR DESCRIPTION
```
commit 16ce9115be3f0b673498c7118c2365420742e6d4
Author: Joe Groff <arcata@gmail.com>
Date:   Fri Mar 6 12:15:37 2026 -0800

    lldb: Basic support for Swift `Builtin.Borrow` values. (#12476)
    
    Depending on the `Builtin.Borrow` target type's representation, have LLDB show
    the value as having either a single `targetValue` child, which presents a
    borrowed value stored inline, or a single `targetPointer` child, which
    presents the address of the borrowed value stored elsewhere. This should
    provide enough baseline functionality for standard-library-level data formatters
    for the user-facing `Swift.Borrow` type to present the target value.
```
