### PR TITLE
[lldb] Build the unit tests for check-lldb-swift

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -347,11 +347,15 @@ add_lit_testsuite(check-lldb "Running lldb lit test suite"
     lldb-unit-test-deps)
 
 # BEGIN SWIFT MOD
+# lldb-unit-test-deps is what builds LLDBUnitTests; the filter selects
+# Swift-specific unit tests as well as API and Shell tests.
 add_lit_testsuite(check-lldb-swift
   "Running swift tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   ARGS "--filter=[sS]wift"
-  DEPENDS lldb-test-deps)
+  DEPENDS
+    lldb-test-deps
+    lldb-unit-test-deps)
 # END SWIFT MOD
 
 if(LLDB_BUILT_STANDALONE)


### PR DESCRIPTION
check-lldb-swift runs lit over the same directory as check-lldb, which includes the Unit suite, but it only depended on lldb-test-deps. That target is an alias for lldb-test-depends and does not build LLDBUnitTests; only lldb-unit-test-deps does.

Assisted-by: claude