### PR TITLE
🍒[stable/23.x][BoundsSafety][Sema] Make counted_by on arrays of flexible-array-member structs a downgradable error and fix assertion failure

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7317,7 +7317,8 @@ def note_counted_by_consider_using_sized_by : Note<
 
 def warn_counted_by_attr_elt_type_unknown_size :
   Warning<err_counted_by_attr_pointee_unknown_size.Summary>,
-  InGroup<BoundsSafetyCountedByEltTyUnknownSize>;
+  InGroup<BoundsSafetyCountedByEltTyUnknownSize>,
+  DefaultError;
 
 // __builtin_counted_by_ref diagnostics:
 def err_builtin_counted_by_ref_invalid_arg

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -336,6 +336,7 @@ bool Sema::ValidateBoundsAttrTypeShape(QualType Ty, SourceLocation AttrLoc,
       // Emit a warning that this is a GNU extension.
       Diag(AttrLoc, diag::ext_gnu_counted_by_void_ptr) << Kind;
       Diag(AttrLoc, diag::note_gnu_counted_by_void_ptr_use_sized_by) << Kind;
+      assert(!Ty->isArrayType() && "sized_by is not allowed on arrays");
       Flags.CountInBytes = true;
       return true;
     }
@@ -369,9 +370,10 @@ bool Sema::ValidateBoundsAttrTypeShape(QualType Ty, SourceLocation AttrLoc,
                           << (ShouldWarn ? 1 : 0) << Kind << AttrRange;
     if (ShouldWarn)
       return true;
-    if (getLangOpts().hasBoundsSafetyAttributes()) {
+    if (getLangOpts().hasBoundsSafetyAttributes() && !Ty->isArrayType()) {
       // Under BoundsSafety, recover by switching to byte count so that
       // type construction can proceed and emit follow-up diagnostics.
+      // We don't do this for arrays because `__sized_by` is not allowed.
       Flags.CountInBytes = true;
       return true;
     }

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -347,13 +347,18 @@ bool Sema::ValidateBoundsAttrTypeShape(QualType Ty, SourceLocation AttrLoc,
     InvalidTypeKind = CountedByInvalidPointeeTypeKind::FUNCTION;
   } else if (!Flags.CountInBytes &&
              PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
-    if (Ty->isArrayType() && !getLangOpts().BoundsSafety) {
+    if (Ty->isArrayType()) {
       // This is a workaround for the Linux kernel that has already adopted
       // `counted_by` on a FAM where the pointee is a struct with a FAM. This
       // should be an error because computing the bounds of the array cannot
       // be done correctly without manually traversing every struct object in
       // the array at runtime. To allow the code to be built this error is
       // downgraded to a warning.
+
+      // FIXME: This is also a workaround for other projects that are using
+      // __counted_by on a FAM where the array element is also a FAM
+      // (rdar://186580568). We need to make this a hard error
+      // (rdar://187230108).
       ShouldWarn = true;
     }
     InvalidTypeKind = CountedByInvalidPointeeTypeKind::FLEXIBLE_ARRAY_MEMBER;

--- a/clang/test/BoundsSafety/Sema/nested-fam.c
+++ b/clang/test/BoundsSafety/Sema/nested-fam.c
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-error=bounds-safety-counted-by-elt-type-unknown-size -verify=downgrade %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-error=bounds-safety-counted-by-elt-type-unknown-size -x objective-c -fexperimental-bounds-safety-objc -verify=downgrade %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-bounds-safety-counted-by-elt-type-unknown-size -verify=suppress %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -Wno-bounds-safety-counted-by-elt-type-unknown-size -x objective-c -fexperimental-bounds-safety-objc -verify=suppress %s
 #include <ptrcheck.h>
 
 typedef struct {
@@ -7,15 +11,44 @@ typedef struct {
     char inner_arr[__counted_by(count)];
 } InnerFam;
 
+// For FAMs the diagnostic is an error by default but can be downgraded to a warning or suppressed completely.
 typedef struct {
     int count;
-    // expected-error@+1{{'counted_by' cannot be applied to an array with element of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    // suppressed for `-Wno-bounds-safety-counted-by-elt-type-unknown-size`
+    // downgrade-warning@+2{{'counted_by' should not be applied to an array with element of unknown size because 'InnerFam' is a struct type with a flexible array member. This will be an error in a future compiler version}}
+    // expected-error@+1{{'counted_by' should not be applied to an array with element of unknown size because 'InnerFam' is a struct type with a flexible array member. This will be an error in a future compiler version}}
     InnerFam outer_arr[__counted_by(count)];
 } OuterFam;
 
+// For counted_by pointers the diagnostic is always an error.
+typedef struct {
+    int count;
+    // suppress-error@+3{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    // downgrade-error@+2{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    // expected-error@+1{{'counted_by' cannot be applied to a pointer with pointee of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    InnerFam*__counted_by(count) outer;
+} OuterPtrCb;
 
 typedef struct {
     int count;
-    // expected-error@+1{{cannot be applied to a pointer with pointee of unknown size because 'InnerFam' is a struct type with a flexible array member}}
-    InnerFam*__counted_by(count) outer;
-} OuterPtr;
+    // suppress-error@+3{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    // downgrade-error@+2{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    // expected-error@+1{{'counted_by_or_null' cannot be applied to a pointer with pointee of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    InnerFam*__counted_by_or_null(count) outer;
+} OuterPtrCbon;
+
+// Ok for sized_by, sized_by_or_null, ended_by
+typedef struct {
+    int size;
+    InnerFam*__sized_by(size) outer;
+} OuterPtrSb;
+
+typedef struct {
+    int size;
+    InnerFam*__sized_by_or_null(size) outer;
+} OuterPtrSbon;
+
+typedef struct {
+    InnerFam* end;
+    InnerFam*__ended_by(end) start;
+} OuterPtrEb;

--- a/clang/test/BoundsSafety/Sema/nested-fam.c
+++ b/clang/test/BoundsSafety/Sema/nested-fam.c
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+#include <ptrcheck.h>
+
+typedef struct {
+    int count;
+    char inner_arr[__counted_by(count)];
+} InnerFam;
+
+typedef struct {
+    int count;
+    // expected-error@+1{{'counted_by' cannot be applied to an array with element of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    InnerFam outer_arr[__counted_by(count)];
+} OuterFam;
+
+
+typedef struct {
+    int count;
+    // expected-error@+1{{cannot be applied to a pointer with pointee of unknown size because 'InnerFam' is a struct type with a flexible array member}}
+    InnerFam*__counted_by(count) outer;
+} OuterPtr;

--- a/clang/test/Sema/attr-counted-by-bounds-safety-vlas.c
+++ b/clang/test/Sema/attr-counted-by-bounds-safety-vlas.c
@@ -1,8 +1,3 @@
-// XFAIL: *
-// The test fails because the full parsing logic isn't upstreamed yet, and
-// in downstream we have separate functions to handle the counted_by attribute in parsing with
-// and without -f(experimental-)bounds-safety enabled. rdar://126708352
-
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety -fexperimental-late-parse-attributes -verify %s
 //

--- a/clang/test/Sema/attr-counted-by-bounds-safety-vlas.c
+++ b/clang/test/Sema/attr-counted-by-bounds-safety-vlas.c
@@ -1,5 +1,11 @@
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety -fexperimental-late-parse-attributes -verify %s
+// TO_UPSTREAM(BoundsSafety) ON
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=bounds-safety-counted-by-elt-type-unknown-size -fexperimental-bounds-safety -verify=downgrade %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=bounds-safety-counted-by-elt-type-unknown-size -fexperimental-bounds-safety -fexperimental-late-parse-attributes -verify=downgrade %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-bounds-safety-counted-by-elt-type-unknown-size -fexperimental-bounds-safety -verify=suppress %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-bounds-safety-counted-by-elt-type-unknown-size -fexperimental-bounds-safety -fexperimental-late-parse-attributes -verify=suppress %s
+// TO_UPSTREAM(BoundsSafety) OFF
 //
 // This is a portion of the `attr-counted-by-vla.c` test but is checked
 // under the semantics of `-fexperimental-bounds-safety` which has different
@@ -17,22 +23,30 @@ struct has_annotated_VLA {
   char buffer[] __counted_by(count);
 };
 
+// TO_UPSTREAM(BoundsSafety) ON
+
+// suppress-no-diagnostics
 struct buffer_of_structs_with_unnannotated_vla {
   int count;
-  // expected-error@+1{{'counted_by' cannot be applied to an array with element of unknown size because 'struct has_unannotated_VLA' is a struct type with a flexible array member}}
+  // downgrade-warning@+2{{'counted_by' should not be applied to an array with element of unknown size because 'struct has_unannotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
+  // expected-error@+1{{'counted_by' should not be applied to an array with element of unknown size because 'struct has_unannotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
   struct has_unannotated_VLA Arr[] __counted_by(count);
 };
 
 
 struct buffer_of_structs_with_annotated_vla {
   int count;
-  // expected-error@+1{{'counted_by' cannot be applied to an array with element of unknown size because 'struct has_annotated_VLA' is a struct type with a flexible array member}}
+  // downgrade-warning@+2{{'counted_by' should not be applied to an array with element of unknown size because 'struct has_annotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
+  // expected-error@+1{{'counted_by' should not be applied to an array with element of unknown size because 'struct has_annotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
   struct has_annotated_VLA Arr[] __counted_by(count);
 };
 
 struct buffer_of_const_structs_with_annotated_vla {
   int count;
   // Make sure the `const` qualifier is printed when printing the element type.
-  // expected-error@+1{{'counted_by' cannot be applied to an array with element of unknown size because 'const struct has_annotated_VLA' is a struct type with a flexible array member}}
+  // downgrade-warning@+2{{'counted_by' should not be applied to an array with element of unknown size because 'const struct has_annotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
+  // expected-error@+1{{'counted_by' should not be applied to an array with element of unknown size because 'const struct has_annotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
   const struct has_annotated_VLA Arr[] __counted_by(count);
 };
+
+// TO_UPSTREAM(BoundsSafety) OFF

--- a/clang/test/Sema/attr-counted-by-vla.c
+++ b/clang/test/Sema/attr-counted-by-vla.c
@@ -173,26 +173,71 @@ struct has_annotated_VLA {
   char buffer[] __counted_by(count);
 };
 
+// TO_UPSTREAM(BoundsSafety) ON
 struct buffer_of_structs_with_unnannotated_vla {
   int count;
-  // Treating this as a warning is a temporary fix for existing attribute adopters. It **SHOULD BE AN ERROR**.
+  // Treating this as a warning (defaults as error) is a temporary fix for existing attribute adopters. It **SHOULD BE AN ERROR**.
+  // expected-error@+1{{'counted_by' should not be applied to an array with element of unknown size because 'struct has_unannotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
+  struct has_unannotated_VLA Arr[] __counted_by(count);
+};
+struct buffer_of_structs_with_annotated_vla {
+  int count;
+  // Treating this as a warning (defaults as error) is a temporary fix for existing attribute adopters. It **SHOULD BE AN ERROR**.
+  // expected-error@+1{{'counted_by' should not be applied to an array with element of unknown size because 'struct has_annotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
+  struct has_annotated_VLA Arr[] __counted_by(count);
+};
+struct buffer_of_const_structs_with_annotated_vla {
+  int count;
+  // Treating this as a warning (defaults as error) is a temporary fix for existing attribute adopters. It **SHOULD BE AN ERROR**.
+  // Make sure the `const` qualifier is printed when printing the element type.
+  // expected-error@+1{{'counted_by' should not be applied to an array with element of unknown size because 'const struct has_annotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
+  const struct has_annotated_VLA Arr[] __counted_by(count);
+};
+
+// Test downgrade
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wbounds-safety-counted-by-elt-type-unknown-size"
+struct buffer_of_structs_with_unnannotated_vla_downgrade {
+  int count;
+  // Treating this as a warning (defaults as error) is a temporary fix for existing attribute adopters. It **SHOULD BE A HARD ERROR**.
   // expected-warning@+1{{'counted_by' should not be applied to an array with element of unknown size because 'struct has_unannotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
   struct has_unannotated_VLA Arr[] __counted_by(count);
 };
 
-
-struct buffer_of_structs_with_annotated_vla {
+struct buffer_of_structs_with_annotated_vla_downgrade {
   int count;
-  // Treating this as a warning is a temporary fix for existing attribute adopters. It **SHOULD BE AN ERROR**.
+  // Treating this as a warning (defaults as error) is a temporary fix for existing attribute adopters. It **SHOULD BE A HARD ERROR**.
   // expected-warning@+1{{'counted_by' should not be applied to an array with element of unknown size because 'struct has_annotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
   struct has_annotated_VLA Arr[] __counted_by(count);
 };
 
-struct buffer_of_const_structs_with_annotated_vla {
+struct buffer_of_const_structs_with_annotated_vla_downgrade {
   int count;
-  // Treating this as a warning is a temporary fix for existing attribute adopters. It **SHOULD BE AN ERROR**.
+  // Treating this as a warning (defaults as error) is a temporary fix for existing attribute adopters. It **SHOULD BE A HARD ERROR**.
   // Make sure the `const` qualifier is printed when printing the element type.
   // expected-warning@+1{{'counted_by' should not be applied to an array with element of unknown size because 'const struct has_annotated_VLA' is a struct type with a flexible array member. This will be an error in a future compiler version}}
   const struct has_annotated_VLA Arr[] __counted_by(count);
 };
 
+// Test suppression
+#pragma clang diagnostic pop
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbounds-safety-counted-by-elt-type-unknown-size"
+struct buffer_of_structs_with_unnannotated_vla_suppressed {
+  int count;
+  struct has_unannotated_VLA Arr[] __counted_by(count);
+};
+
+struct buffer_of_structs_with_annotated_vla_suppressed {
+  int count;
+  struct has_annotated_VLA Arr[] __counted_by(count);
+};
+
+struct buffer_of_const_structs_with_annotated_vla_suppressed {
+  int count;
+  const struct has_annotated_VLA Arr[] __counted_by(count);
+};
+
+#pragma clang diagnostic pop
+
+// TO_UPSTREAM(BoundsSafety) OFF


### PR DESCRIPTION
Cherry-picks #14186 to `stable/23.x`.